### PR TITLE
feat: GitHub Issues intake, PRD mode, and human team members

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -452,3 +452,131 @@ describe('edge cases', () => {
     assert.equal(result.exitCode, 0, 're-init should exit 0');
   });
 });
+
+// --- squad.agent.md prompt content validation ---
+
+describe('squad.agent.md prompt content', () => {
+  const agentMd = fs.readFileSync(path.join(ROOT, '.github', 'agents', 'squad.agent.md'), 'utf8');
+
+  describe('GitHub Issues Mode', () => {
+    it('contains the GitHub Issues Mode section', () => {
+      assert.ok(agentMd.includes('## GitHub Issues Mode'), 'missing ## GitHub Issues Mode section');
+    });
+
+    it('contains issue trigger table', () => {
+      assert.ok(agentMd.includes('"pull issues from {owner/repo}"'), 'missing pull issues trigger');
+      assert.ok(agentMd.includes('"work on issue #N"'), 'missing work on issue trigger');
+      assert.ok(agentMd.includes('"merge PR #N"'), 'missing merge PR trigger');
+    });
+
+    it('contains Issue Source storage format', () => {
+      assert.ok(agentMd.includes('## Issue Source'), 'missing ## Issue Source section in team.md format');
+    });
+
+    it('documents the branch naming convention', () => {
+      assert.ok(agentMd.includes('squad/{issue-number}-{slug}'), 'missing branch naming convention');
+    });
+
+    it('documents PR submission with issue linking', () => {
+      assert.ok(agentMd.includes('Closes #'), 'missing Closes # issue linking in PR flow');
+    });
+
+    it('documents PR review handling', () => {
+      assert.ok(agentMd.includes('PR REVIEW FEEDBACK'), 'missing PR review feedback spawn prompt');
+    });
+
+    it('documents PR merge flow', () => {
+      assert.ok(agentMd.includes('gh pr merge'), 'missing gh pr merge command');
+    });
+  });
+
+  describe('PRD Mode', () => {
+    it('contains the PRD Mode section', () => {
+      assert.ok(agentMd.includes('## PRD Mode'), 'missing ## PRD Mode section');
+    });
+
+    it('contains PRD trigger table', () => {
+      assert.ok(agentMd.includes('"here\'s the PRD"'), 'missing PRD trigger phrase');
+      assert.ok(agentMd.includes('"read the PRD at {path}"'), 'missing file path trigger');
+    });
+
+    it('documents PRD storage in team.md', () => {
+      assert.ok(agentMd.includes('## PRD'), 'missing ## PRD section in team.md format');
+    });
+
+    it('documents Lead agent decomposition', () => {
+      assert.ok(agentMd.includes('Decompose PRD into work items'), 'missing PRD decomposition prompt');
+    });
+
+    it('documents work item format', () => {
+      assert.ok(agentMd.includes('WI-{number}'), 'missing work item ID format');
+    });
+
+    it('documents mid-project PRD updates', () => {
+      assert.ok(agentMd.includes('Mid-Project PRD Updates'), 'missing mid-project PRD update section');
+    });
+  });
+
+  describe('Human Team Members', () => {
+    it('contains the Human Team Members section', () => {
+      assert.ok(agentMd.includes('## Human Team Members'), 'missing ## Human Team Members section');
+    });
+
+    it('contains human trigger table', () => {
+      assert.ok(agentMd.includes('"add {Name} as {role}"'), 'missing add human trigger');
+      assert.ok(agentMd.includes('"I\'m on the team as {role}"'), 'missing self-add trigger');
+    });
+
+    it('documents the human badge', () => {
+      assert.ok(agentMd.includes('👤 Human'), 'missing 👤 Human badge');
+    });
+
+    it('documents differences from AI agents', () => {
+      assert.ok(agentMd.includes('How Humans Differ from AI Agents'), 'missing human vs AI comparison');
+    });
+
+    it('documents routing to humans with pause behavior', () => {
+      assert.ok(agentMd.includes("This one's for {Name}"), 'missing human routing pause message');
+    });
+
+    it('documents stale reminder', () => {
+      assert.ok(agentMd.includes('Still waiting on {Name}'), 'missing stale reminder message');
+    });
+
+    it('shows multiple humans example', () => {
+      assert.ok(agentMd.includes('Multiple Humans'), 'missing multiple humans section');
+    });
+  });
+
+  describe('Init Mode integration', () => {
+    it('asks about PRD during init', () => {
+      assert.ok(agentMd.includes('Do you have a PRD or spec document?'), 'missing PRD question in Init Mode');
+    });
+
+    it('asks about GitHub issues during init', () => {
+      assert.ok(agentMd.includes('Is there a GitHub repo with issues I should pull from?'), 'missing issues question in Init Mode');
+    });
+
+    it('asks about human members during init', () => {
+      assert.ok(agentMd.includes('Are any humans joining the team?'), 'missing humans question in Init Mode');
+    });
+
+    it('documents post-setup wiring', () => {
+      assert.ok(agentMd.includes('Post-setup wiring'), 'missing post-setup wiring step');
+    });
+  });
+
+  describe('Routing table integration', () => {
+    it('includes GitHub Issues routing signal', () => {
+      assert.ok(agentMd.includes('Follow GitHub Issues Mode'), 'missing issues routing signal');
+    });
+
+    it('includes PRD routing signal', () => {
+      assert.ok(agentMd.includes('Follow PRD Mode'), 'missing PRD routing signal');
+    });
+
+    it('includes Human Members routing signal', () => {
+      assert.ok(agentMd.includes('Follow Human Team Members'), 'missing human members routing signal');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three new capabilities added to the Squad coordinator prompt (`squad.agent.md`), plus 27 validation tests.

### 1. 🐙 GitHub Issues Mode
Connect Squad to a GitHub repo's issues and manage the full lifecycle:

- **Connect:** User says "pull issues from owner/repo" → Squad lists open issues as a backlog table
- **Filter:** Optional label/milestone filtering
- **Route:** User picks issues → coordinator routes to agents based on `routing.md`
- **Branch:** Agents create `squad/{issue-number}-{slug}` feature branches
- **PR:** Agents open PRs with `Closes #{issue-number}` linking
- **Review:** User says "there's feedback on PR #X" → coordinator spawns agent to address comments
- **Merge:** User says "merge PR #X" → `gh pr merge --squash --delete-branch`, auto-closes linked issue

Issue source is stored in `team.md` under a new `## Issue Source` section.

### 2. 📄 PRD Mode
Ingest a Product Requirements Document and use it to drive the team's work:

- **File path:** "read the PRD at docs/prd.md" → reads and processes
- **Inline:** User pastes spec content directly in chat
- **Decomposition:** Lead agent (sync) breaks PRD into prioritized work items (WI-1, WI-2, etc.) with size estimates, agent assignments, and dependencies
- **Approval gate:** Work items presented to user before routing begins
- **Mid-project updates:** "the PRD changed" → Lead diffs old vs new decomposition, surfaces added/modified/removed items

PRD reference stored in `team.md` under a new `## PRD` section.

### 3. 👤 Human Team Members
Humans can join the Squad roster alongside AI agents:

- **Add:** "add Brady as PM" or "I'm on the team as designer"
- **Roster:** Humans get a `👤 Human` badge (vs `✅ Active` for AI agents)
- **No casting:** Humans use their real names — not drawn from fictional universes
- **No charter:** Humans don't have charter.md or history.md files
- **Routing:** When work routes to a human, coordinator pauses: "This one's for {Name} — {what's needed}. Let me know when it's done."
- **Blocked tracking:** Coordinator tracks items waiting on humans, sends stale reminders
- **Multiple humans:** Fully supported (e.g., Brady as PM, Sarah as Designer)

### 4. 🔧 Init Mode Updates
Init Mode (step 3) now asks three new questions after "What are you building?":
- "Do you have a PRD or spec document?"
- "Is there a GitHub repo with issues I should pull from?"
- "Are any humans joining the team?"

All are optional/skippable. Post-setup wiring (step 9) automatically runs the relevant intake flows.

### 5. 🗺️ Routing Table
Three new routing signals added to the Team Mode routing table for issues, PRD, and human member management.

---

## Files Changed

| File | Change |
|------|--------|
| `.github/agents/squad.agent.md` | +316 lines — three new sections, Init Mode updates, routing table entries |
| `test/index.test.js` | +128 lines — 27 new prompt validation tests |

---

## How to Test

### Automated tests (prompt validation)
```bash
# All 55 tests should pass (28 existing + 27 new)
node --test test/*.test.js
```

The 27 new tests validate that `squad.agent.md` contains all expected sections, trigger phrases, formats, and routing entries. They catch regressions if sections are accidentally removed during upgrades.

### Manual smoke test — GitHub Issues Mode
```bash
# 1. Create a test project
mkdir /tmp/squad-issues-test && cd /tmp/squad-issues-test && git init

# 2. Install squad (from this branch)
npx github:spboyer/squad#feature/issues-prd-humans

# 3. Open Copilot, select Squad agent
copilot

# 4. Try these prompts:
#    "I'm building a Node.js API"              → normal init
#    "Pull issues from owner/repo"               → should list open issues
#    "Work on issue #1"                           → should route to agent, create branch, open PR
#    "There's feedback on PR #2"               → should spawn agent for review comments
#    "Merge PR #2"                                → should merge and close linked issue
#    "Show the backlog"                           → should re-list open issues
```

### Manual smoke test — PRD Mode
```bash
# In same or new test project with Squad initialized:

# Option A: File path
#    Create a docs/prd.md with requirements, then:
#    "Read the PRD at docs/prd.md"
#    → Lead should decompose into work items table
#    → Should ask for approval before routing

# Option B: Inline
#    Paste requirements text, then say "here's the PRD"
#    → Same decomposition flow
```

### Manual smoke test — Human Team Members
```bash
# In a Squad-initialized project:
#    "Add Brady as PM"                            → should add to roster with 👤 badge
#    "Sarah is our designer"                      → should add second human
#    Route work that matches a human's domain   → should pause, not spawn
#    "Brady approved" or "Brady is done"          → should unblock waiting items
```

### Manual smoke test — Init Mode
```bash
# Fresh project, run Squad init:
#    After "What are you building?" answer, Squad should ask about:
#    1. PRD or spec document
#    2. GitHub repo with issues
#    3. Human team members
#    Skipping all three should work (backward compatible)
```

---

## Design Decisions

- **Agent prompt only** — all features live in `squad.agent.md`. No CLI changes, no new template files. Keeps the tool lightweight.
- **`gh` CLI dependency** — GitHub Issues features use `gh` CLI at runtime. This is already available in Copilot CLI environments.
- **Humans are roster-only** — they appear in team.md and routing.md but can't be spawned. The coordinator pauses and waits for user relay.
- **PRD decomposition is gated** — the Lead proposes work items, but the user must approve before agents start. Prevents runaway work from a misunderstood spec.
- **Backward compatible** — all new Init Mode questions are optional. Existing squads work unchanged.