### PR TITLE
feat: Ralph idle-watch mode — auto-poll for new work after board clears

### DIFF
--- a/docs/features/ralph.md
+++ b/docs/features/ralph.md
@@ -14,9 +14,9 @@ When you're in a Copilot session, Ralph self-chains the coordinator's work loop:
 2. Ralph checks GitHub for more: untriaged issues, assigned-but-unstarted items, draft PRs, failing CI
 3. Work found → triage, assign, spawn agents
 4. Results collected → Ralph checks again **immediately** — no pause, no asking permission
-5. Board clear → Ralph idles
+5. Board clear → Ralph enters **idle-watch** — polls every 10 minutes (configurable) for new work
 
-**Ralph never stops on his own while work remains.** He keeps cycling through the backlog until every issue is closed, every PR is merged, and CI is green. The only things that stop Ralph: the board is clear, you say "idle", or the session ends.
+**Ralph never stops on his own while work remains.** He keeps cycling through the backlog until every issue is closed, every PR is merged, and CI is green. When the board clears, Ralph doesn't fully stop — he enters idle-watch mode and periodically checks for new work. The only things that fully stop Ralph: you say "idle"/"stop", or the session ends.
 
 ### Between Sessions (GitHub Actions Heartbeat)
 
@@ -36,7 +36,8 @@ This creates a fully autonomous loop for `@copilot` — heartbeat triages → as
 | "Ralph, go" / "Ralph, start monitoring" | Activates the work-check loop |
 | "Keep working" / "Work until done" | Activates Ralph |
 | "Ralph, status" / "What's on the board?" | Runs one check cycle, reports results |
-| "Ralph, idle" / "Take a break" | Stops the loop |
+| "Ralph, check every N minutes" | Sets the idle-watch polling interval (e.g., "Ralph, check every 30 minutes") |
+| "Ralph, idle" / "Take a break" | Fully stops the loop and idle-watch polling |
 | "Ralph, scope: just issues" | Monitors only issues, skips PRs/CI |
 
 ## What Ralph Monitors
@@ -61,7 +62,43 @@ Ralph doesn't run silently forever. Every 3-5 rounds, Ralph reports and **keeps 
    Continuing... (say "Ralph, idle" to stop)
 ```
 
-Ralph does **not** ask permission to continue — he keeps working. The only things that stop Ralph: the board is clear, you say "idle"/"stop", or the session ends.
+Ralph does **not** ask permission to continue — he keeps working. The only things that fully stop Ralph: you say "idle"/"stop", or the session ends. A clear board puts Ralph into idle-watch mode, not full stop.
+
+## Idle-Watch Mode
+
+When the board clears, Ralph doesn't fully stop. He enters **idle-watch** — a polling mode that automatically re-checks for new work on a timer.
+
+```
+📋 Board is clear. Ralph is watching — next check in 10 minutes.
+   (say "Ralph, idle" to fully stop)
+```
+
+### How it works
+
+1. Board clears → Ralph enters idle-watch
+2. After {poll_interval} minutes (default: 10), Ralph re-scans GitHub
+3. New work found → resumes the active work loop automatically
+4. Still no work → waits another {poll_interval} minutes and checks again
+5. Repeats until you say "Ralph, idle" or the session ends
+
+### Configuring the interval
+
+You can adjust the polling interval at any time:
+
+| What you say | Interval |
+|---|---|
+| "Ralph, check every 5 minutes" | 5 min |
+| "Ralph, check every 15 minutes" | 15 min |
+| "Ralph, poll every 30 minutes" | 30 min |
+
+The default is **10 minutes**. The interval only affects idle-watch — when actively processing work, Ralph scans immediately after each batch.
+
+### Idle-watch vs. full idle
+
+| Mode | Behavior | How to enter |
+|---|---|---|
+| **Idle-watch** | Polls for new work every N minutes | Automatic when board clears |
+| **Full idle** | Completely stopped, no polling | Say "Ralph, idle" or "stop" |
 
 ## Ralph's Board View
 
@@ -100,7 +137,7 @@ on:
 
 ## Notes
 
-- Ralph is session-scoped — his state (active/idle, round count, stats) resets each session
+- Ralph is session-scoped — his state (active/idle/watching, round count, poll interval, stats) resets each session
 - Ralph appears on the roster like Scribe: `| Ralph | Work Monitor | — | 🔄 Monitor |`
 - Ralph is exempt from universe casting — always "Ralph"
 - The heartbeat workflow is the between-session complement to in-session Ralph


### PR DESCRIPTION
## Summary

When Ralph is active in a Copilot CLI session and clears the board, he previously entered a full idle state — meaning the user had to manually say "Ralph, go" again when new work appeared. This PR adds **idle-watch mode**: when the board clears, Ralph automatically re-checks for new work on a configurable timer instead of fully stopping.

## Problem

Ralph's work loop was one-shot: scan → work → scan → board clear → stop. If new issues were filed while Ralph was idle, nobody noticed until the user manually triggered another scan. This created a gap between "the board is clear" and "new work arrives" where the team sat idle unnecessarily.

## Solution: Idle-Watch Mode

When Ralph clears the board, he now enters **idle-watch** instead of full idle:

1. Board clears → Ralph reports: *"📋 Board is clear. Ralph is watching — next check in 10 minutes."*
2. After the poll interval, Ralph re-scans GitHub
3. New work found → resumes the active work loop automatically
4. Still no work → waits and checks again
5. Repeats until the user explicitly says "Ralph, idle" or the session ends

### Configurable Interval

The default poll interval is **10 minutes**, configurable via natural language:

| Command | Effect |
|---|---|
| `Ralph, check every 5 minutes` | Sets interval to 5 min |
| `Ralph, check every 30 minutes` | Sets interval to 30 min |
| `Ralph, poll every 15 minutes` | Sets interval to 15 min |

The interval can be set at any time — during active mode, idle-watch, or before activation.

### Idle-Watch vs. Full Idle

| Mode | Behavior | How to enter |
|---|---|---|
| **Idle-watch** | Polls for new work every N minutes | Automatic when board clears |
| **Full idle** | Completely stopped, no polling | Explicit "Ralph, idle" or "stop" |

## Changes

### `.github/agents/squad.agent.md`
- Updated critical behavior block to describe idle-watch semantics
- Added `Ralph, check every N minutes` to intent router and triggers table
- Added new **Idle-Watch Mode** section with full behavioral spec
- Updated Ralph State to include `poll_interval` and three-state model (active/idle/watching)
- Updated Integration with Follow-Up Work pipeline to show idle-watch steps 6-10
- Updated "No work found" action from full idle to idle-watch entry

### `docs/features/ralph.md`
- Updated in-session flow to show idle-watch as step 5
- Added `Ralph, check every N minutes` to Talking to Ralph table
- Added complete **Idle-Watch Mode** section with how-it-works, configuration, and comparison table
- Updated Notes section to reflect three-state model and poll interval in session state

## Testing

This is a behavioral spec change (agent markdown) — no code logic to unit test. The changes are validated by reviewing the spec for consistency across all Ralph references in both files.