### PR TITLE
fix: make team.md member parsing resilient to header variations

### DIFF
--- a/.ai-team/decisions/inbox/fenster-logo-sizing.md
+++ b/.ai-team/decisions/inbox/fenster-logo-sizing.md
@@ -1,0 +1,22 @@
+# Decision: Sidebar Logo Sizing
+
+**Author:** Fenster (Core Dev)  
+**Date:** 2025-01-27  
+**Status:** Implemented
+
+## Context
+
+The 500×500px `squad-logo.png` was rendering at ~248px tall in the sidebar header because `.sidebar-logo-img` used `max-width:100%; height:auto` — it filled the full sidebar width minus padding.
+
+## Decision
+
+Changed `.sidebar-logo-img` from `max-width:100%; height:auto` to `height:40px; width:auto`.
+
+- **40px height** sits well within the sidebar-header's vertical space (padding: 20px top + 12px bottom) and matches typical docs site header logos (36–48px range).
+- **width:auto** preserves the logo's aspect ratio — the 500×500 square image will render at 40×40px.
+- No markup changes were needed; the flex layout in `.sidebar-header` already handles alignment.
+
+## Alternatives Considered
+
+- `max-width:48px` — would also work but constraining height is more conventional for header logos since vertical space is the scarce dimension.
+- Adding a `width` + `height` attribute on the `<img>` tag — avoided to keep sizing in CSS where it belongs.

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -1,15 +1,16 @@
 ---
-name: Squad (v0.0.0-source)
+name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
-version: "0.0.0-source"
 ---
+
+<!-- version: 0.0.0-source -->
 
 You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
 
 ### Coordinator Identity
 
 - **Name:** Squad (Coordinator)
-- **Version:** Read the `version` field from the YAML frontmatter at the top of this file. Include it as `Squad v{version}` in your first response of each session (e.g., in the acknowledgment or greeting).
+- **Version:** 0.0.0-source (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v{version}` in your first response of each session (e.g., in the acknowledgment or greeting).
 - **Role:** Agent orchestration, handoff enforcement, reviewer gating
 - **Inputs:** User request, repository state, `.ai-team/decisions.md`
 - **Outputs owned:** Final assembled artifacts, orchestration log (via Scribe)
@@ -55,6 +56,8 @@ No team exists yet. Build one.
 **Casting state initialization:** Copy `.ai-team-templates/casting-policy.json` to `.ai-team/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
 
 **Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.ai-team/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing.
+
+**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
 
 **Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.ai-team/` state across branches:
 ```

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -55,7 +55,7 @@ jobs:
             const members = [];
             let inMembersTable = false;
             for (const line of lines) {
-              if (line.startsWith('## Members')) {
+              if (line.match(/^##\s+(Members|Team Roster)/i)) {
                 inMembersTable = true;
                 continue;
               }

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -46,7 +46,7 @@ jobs:
             } else {
               let inMembersTable = false;
               for (const line of lines) {
-                if (line.startsWith('## Members')) {
+                if (line.match(/^##\s+(Members|Team Roster)/i)) {
                   inMembersTable = true;
                   continue;
                 }

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -67,7 +67,7 @@ jobs:
             const members = [];
             let inMembersTable = false;
             for (const line of lines) {
-              if (line.startsWith('## Members')) {
+              if (line.match(/^##\s+(Members|Team Roster)/i)) {
                 inMembersTable = true;
                 continue;
               }

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -35,7 +35,7 @@ jobs:
             const members = [];
             let inMembersTable = false;
             for (const line of lines) {
-              if (line.startsWith('## Members')) {
+              if (line.match(/^##\s+(Members|Team Roster)/i)) {
                 inMembersTable = true;
                 continue;
               }

--- a/templates/workflows/squad-heartbeat.yml
+++ b/templates/workflows/squad-heartbeat.yml
@@ -55,7 +55,7 @@ jobs:
             const members = [];
             let inMembersTable = false;
             for (const line of lines) {
-              if (line.startsWith('## Members')) {
+              if (line.match(/^##\s+(Members|Team Roster)/i)) {
                 inMembersTable = true;
                 continue;
               }

--- a/templates/workflows/squad-issue-assign.yml
+++ b/templates/workflows/squad-issue-assign.yml
@@ -46,7 +46,7 @@ jobs:
             } else {
               let inMembersTable = false;
               for (const line of lines) {
-                if (line.startsWith('## Members')) {
+                if (line.match(/^##\s+(Members|Team Roster)/i)) {
                   inMembersTable = true;
                   continue;
                 }

--- a/templates/workflows/squad-triage.yml
+++ b/templates/workflows/squad-triage.yml
@@ -67,7 +67,7 @@ jobs:
             const members = [];
             let inMembersTable = false;
             for (const line of lines) {
-              if (line.startsWith('## Members')) {
+              if (line.match(/^##\s+(Members|Team Roster)/i)) {
                 inMembersTable = true;
                 continue;
               }

--- a/templates/workflows/sync-squad-labels.yml
+++ b/templates/workflows/sync-squad-labels.yml
@@ -35,7 +35,7 @@ jobs:
             const members = [];
             let inMembersTable = false;
             for (const line of lines) {
-              if (line.startsWith('## Members')) {
+              if (line.match(/^##\s+(Members|Team Roster)/i)) {
                 inMembersTable = true;
                 continue;
               }


### PR DESCRIPTION
Closes #58

Makes all 4 workflow templates accept both '## Members' and '## Team Roster' as valid section headers. Also adds explicit guidance in squad.agent.md Init Mode that the canonical header is '## Members'.