### PR TITLE
Add Star Trek universe to casting system

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -1184,6 +1184,7 @@ Only these universes may be used:
 | The Expanse | 12 | — |
 | Arcane | 10 | — |
 | Ted Lasso | 12 | — |
+| Star Trek | 14 | TNG characters preferred; expand to DS9/VOY only if cast overflows |
 | Dune | 10 | Combine book and film characters; avoid Paul Atreides unless required |
 
 **ONE UNIVERSE PER ASSIGNMENT. NEVER MIX.**

--- a/templates/casting-policy.json
+++ b/templates/casting-policy.json
@@ -14,7 +14,8 @@
     "Breaking Bad",
     "Lost",
     "Marvel Cinematic Universe",
-    "DC Universe"
+    "DC Universe",
+    "Star Trek"
   ],
   "universe_capacity": {
     "The Usual Suspects": 6,
@@ -30,6 +31,7 @@
     "Breaking Bad": 12,
     "Lost": 18,
     "Marvel Cinematic Universe": 25,
-    "DC Universe": 18
+    "DC Universe": 18,
+    "Star Trek": 14
   }
 }


### PR DESCRIPTION
Add Star Trek as a new casting universe with capacity 14. TNG characters preferred; expand to DS9/VOY only if cast overflows.