### PR TITLE
feat: add identity layer (wisdom.md + now.md) to .squad/ structure

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -96,7 +96,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **⚠️ CRITICAL RULE: Every agent interaction MUST use the `task` tool to spawn a real agent. You MUST call the `task` tool — never simulate, role-play, or inline an agent's work. If you did not call the `task` tool, the agent was NOT spawned. No exceptions.**
 
-**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Pass the team root into every spawn prompt as `TEAM_ROOT` and the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work.
+**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Pass the team root into every spawn prompt as `TEAM_ROOT` and the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
 **⚡ Context caching:** After the first message in a session, `team.md`, `routing.md`, and `registry.json` are already in your context. Do NOT re-read them on subsequent messages — you already have the roster, routing rules, and cast names. Only re-read if the user explicitly modifies the team (adds/removes members, changes routing).
 
@@ -641,6 +641,8 @@ prompt: |
   
   Read .squad/agents/{name}/history.md (your project knowledge).
   Read .squad/decisions.md (team decisions to respect).
+  If .squad/identity/wisdom.md exists, read it before starting work.
+  If .squad/identity/now.md exists, read it at spawn time.
   If .squad/skills/ has relevant SKILL.md files, read them before working.
   
   {only if MCP tools detected — omit entirely if none:}

--- a/templates/identity/now.md
+++ b/templates/identity/now.md
@@ -1,0 +1,9 @@
+---
+updated_at: {timestamp}
+focus_area: {brief description}
+active_issues: []
+---
+
+# What We're Focused On
+
+{Narrative description of current focus — 1-3 sentences. Updated by coordinator at session start.}

--- a/templates/identity/wisdom.md
+++ b/templates/identity/wisdom.md
@@ -1,0 +1,15 @@
+---
+last_updated: {timestamp}
+---
+
+# Team Wisdom
+
+Reusable patterns and heuristics learned through work. NOT transcripts — each entry is a distilled, actionable insight.
+
+## Patterns
+
+<!-- Append entries below. Format: **Pattern:** description. **Context:** when it applies. -->
+
+## Anti-Patterns
+
+<!-- Things we tried that didn't work. **Avoid:** description. **Why:** reason. -->

--- a/test/init-flow.test.js
+++ b/test/init-flow.test.js
@@ -247,3 +247,67 @@ describe('Init Mode prompt structure (#66)', () => {
     });
   });
 });
+
+describe('Identity layer files (now.md, wisdom.md) — #107', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanDir(tmpDir);
+  });
+
+  it('init creates .squad/identity/now.md', () => {
+    initSquad(tmpDir);
+    const nowPath = path.join(tmpDir, '.squad', 'identity', 'now.md');
+    assert.ok(fs.existsSync(nowPath), '.squad/identity/now.md should exist after init');
+    
+    const content = fs.readFileSync(nowPath, 'utf8');
+    assert.ok(content.includes('updated_at:'), 'now.md should contain updated_at field');
+    assert.ok(content.includes('focus_area:'), 'now.md should contain focus_area field');
+    assert.ok(content.includes('What We\'re Focused On'), 'now.md should contain heading');
+  });
+
+  it('init creates .squad/identity/wisdom.md', () => {
+    initSquad(tmpDir);
+    const wisdomPath = path.join(tmpDir, '.squad', 'identity', 'wisdom.md');
+    assert.ok(fs.existsSync(wisdomPath), '.squad/identity/wisdom.md should exist after init');
+    
+    const content = fs.readFileSync(wisdomPath, 'utf8');
+    assert.ok(content.includes('last_updated:'), 'wisdom.md should contain last_updated field');
+    assert.ok(content.includes('Team Wisdom'), 'wisdom.md should contain heading');
+    assert.ok(content.includes('## Patterns'), 'wisdom.md should contain Patterns section');
+    assert.ok(content.includes('## Anti-Patterns'), 'wisdom.md should contain Anti-Patterns section');
+  });
+
+  it('upgrade creates missing identity files', () => {
+    // First init
+    initSquad(tmpDir);
+    
+    // Modify squad.agent.md to simulate an old version
+    const agentPath = path.join(tmpDir, '.github', 'agents', 'squad.agent.md');
+    let agentContent = fs.readFileSync(agentPath, 'utf8');
+    agentContent = agentContent.replace(/<!-- version: [^>]+ -->/, '<!-- version: 0.4.0 -->');
+    agentContent = agentContent.replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+)?/, '- **Version:** 0.4.0');
+    fs.writeFileSync(agentPath, agentContent);
+    
+    // Delete identity files to simulate old installation
+    const identityDir = path.join(tmpDir, '.squad', 'identity');
+    fs.rmSync(identityDir, { recursive: true, force: true });
+    
+    // Run upgrade
+    const result = runSquad(['upgrade'], tmpDir);
+    assert.equal(result.exitCode, 0, `upgrade should succeed: ${result.stdout}`);
+    
+    // Check files were created - upgrade creates them because directory creation happens every time
+    const nowPath = path.join(tmpDir, '.squad', 'identity', 'now.md');
+    const wisdomPath = path.join(tmpDir, '.squad', 'identity', 'wisdom.md');
+    
+    // The directory is created, and files are scaffolded if missing
+    assert.ok(fs.existsSync(identityDir), 'upgrade should create identity directory');
+    assert.ok(fs.existsSync(nowPath), 'upgrade should create missing now.md');
+    assert.ok(fs.existsSync(wisdomPath), 'upgrade should create missing wisdom.md');
+  });
+});


### PR DESCRIPTION
Fixes #107

- Add .squad/identity/now.md template (current focus tracking)
- Add .squad/identity/wisdom.md template (learned heuristics)
- Scaffold both files in squad init and squad upgrade
- Update spawn template in squad.agent.md to read identity files

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>