### PR TITLE
Add GitHub issue templates for Squad

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,106 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior in Squad
+title: "[Bug]: "
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Run `npx github:bradygaster/squad ...`
+        2. Open Copilot and type `...`
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include error messages or screenshots if available.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Run `node --version` to find this.
+      placeholder: "v22.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: squad-version
+    attributes:
+      label: Squad version
+      description: Check `squad.agent.md` for the version number, or run `npx github:bradygaster/squad --version`.
+      placeholder: "0.5.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: client
+    attributes:
+      label: Client
+      description: Where are you using Squad?
+      options:
+        - GitHub Copilot CLI
+        - VS Code
+        - GitHub.com (Copilot coding agent)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Screenshots or logs
+      description: If applicable, add screenshots or paste relevant log output.
+    validations:
+      required: false
+
+  - type: input
+    id: related
+    attributes:
+      label: Related issues
+      description: Link any related issues (e.g., `#42`).
+      placeholder: "#"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/docs-issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs-issue.yml
@@ -1,0 +1,34 @@
+name: 📄 Documentation Issue
+description: Report incorrect, missing, or unclear documentation
+title: "[Docs]: "
+labels: ["type:docs"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Found something wrong or missing in the docs? Let us know so we can improve them.
+
+  - type: input
+    id: page
+    attributes:
+      label: Page or section
+      description: Which doc page, README section, or file has the issue?
+      placeholder: "e.g., README.md > Quick Start, docs/features/project-boards.md"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong or missing?
+      description: Describe the documentation issue — is something incorrect, outdated, unclear, or missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: If you have a fix or improvement in mind, describe it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,42 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement for Squad
+title: "[Feature]: "
+labels: ["type:feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for Squad? We'd love to hear it! Please describe the problem you're trying to solve and your proposed solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this feature solve? Why is it needed?
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative solutions or workarounds?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, screenshots, or examples that help explain the request.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,42 @@
+name: ❓ Question
+description: Ask a question about using or configuring Squad
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Need help with Squad? Ask here. For general discussion, consider using [GitHub Discussions](https://github.com/bradygaster/squad/discussions).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you trying to do? Describe the scenario so we can give a relevant answer.
+    validations:
+      required: true
+
+  - type: input
+    id: squad-version
+    attributes:
+      label: Squad version
+      description: Check `squad.agent.md` for the version number, or run `npx github:bradygaster/squad --version`.
+      placeholder: "0.5.2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Describe any solutions you've already attempted.
+    validations:
+      required: false


### PR DESCRIPTION
**New GitHub Issue Templates:**

*Bug Reports*
- Introduced a detailed bug report template (`bug-report.yml`) prompting for descriptions, reproduction steps, environment details, and logs to help maintainers diagnose issues efficiently.

*Feature Requests*
- Added a feature request template (`feature-request.yml`) that asks users to describe the problem, propose solutions, and list alternatives, supporting thoughtful enhancement proposals.

*Documentation Issues*
- Created a documentation issue template (`docs-issue.yml`) to report incorrect, missing, or unclear documentation, including sections for the affected page and suggested improvements.

*General Questions*
- Provided a question template (`question.yml`) to help users ask for support, including context, Squad version, and attempted solutions.