### PR TITLE
docs: rename .ai-team/ references to .squad/ across docs and templates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,24 +9,24 @@ This is the **source repository** for Squad, an AI team framework for GitHub Cop
 
 This repo has an active Squad agent at `.github/agents/squad.agent.md`. For team operations, roster management, or multi-agent work, select **Squad** from the agent picker in VS Code rather than asking Copilot directly.
 
-- Team roster: `.ai-team/team.md`
-- Routing rules: `.ai-team/routing.md`
+- Team roster: `.squad/team.md`
+- Routing rules: `.squad/routing.md`
 
 ## Repository Structure
 
 - `index.js` — CLI entry point (`npx create-squad`)
 - `.github/agents/squad.agent.md` — The Squad coordinator agent (~1,800 lines)
 - `templates/` — Files copied to consumer repos during `create-squad` init
-- `.ai-team/` — This repo's own Squad team state (live, not a template)
+- `.squad/` — This repo's own Squad team state (live, not a template)
 - `docs/` — Documentation site source
 - `test/` — Test suite (`node --test test/*.test.js`)
 
 ## Conventions
 
 - **Branch naming:** `squad/{issue-number}-{kebab-case-slug}`
-- **Decisions:** Write to `.ai-team/decisions/inbox/`
+- **Decisions:** Write to `.squad/decisions/inbox/`
 - **Testing:** Run `npm test` before opening PRs
-- **Template vs. source:** Files in `templates/` are copied verbatim by `index.js` to consumer repos. The `.ai-team/` directory here is Squad's own team — don't confuse them.
+- **Template vs. source:** Files in `templates/` are copied verbatim by `index.js` to consumer repos. The `.squad/` directory here is Squad's own team — don't confuse them.
 
 ## Quick Answers
 

--- a/.squad/templates/casting-reference.md
+++ b/.squad/templates/casting-reference.md
@@ -50,7 +50,7 @@ When creating a new team (Init Mode), follow this deterministic algorithm:
 1. **Determine team_size_bucket:** Small (1–5), Medium (6–10), Large (11+)
 2. **Determine assignment_shape** from the user's project description (pick 1 primary, 1 optional secondary): discovery, orchestration, reliability, transformation, integration, chaos
 3. **Determine resonance_profile** — derive implicitly, never prompt the user:
-   - Check prior Squad history in repo (`.ai-team/casting/history.json`)
+   - Check prior Squad history in repo (`.squad/casting/history.json`)
    - Check current session text (topics, references, tone)
    - Check repo context (README, docs, commit messages) ONLY if clearly user-authored
    - Assign resonance_confidence: HIGH / MED / LOW
@@ -60,7 +60,7 @@ When creating a new team (Init Mode), follow this deterministic algorithm:
 
 ## Casting State Files
 
-The casting system maintains state in `.ai-team/casting/`:
+The casting system maintains state in `.squad/casting/`:
 
 **policy.json** — Casting configuration:
 ```json

--- a/.squad/templates/ceremony-reference.md
+++ b/.squad/templates/ceremony-reference.md
@@ -4,7 +4,7 @@
 
 ## Ceremony Config Format
 
-Each ceremony in `.ai-team/ceremonies.md` is an `## ` heading with a config table and agenda:
+Each ceremony in `.squad/ceremonies.md` is an `## ` heading with a config table and agenda:
 
 ```markdown
 ## Design Review
@@ -51,10 +51,10 @@ prompt: |
   {paste facilitator's charter.md}
 
   TEAM ROOT: {team_root}
-  All `.ai-team/` paths are relative to this root.
+  All `.squad/` paths are relative to this root.
 
-  Read .ai-team/agents/{facilitator}/history.md and .ai-team/decisions.md.
-  If .ai-team/skills/ exists and contains SKILL.md files, read relevant ones before working.
+  Read .squad/agents/{facilitator}/history.md and .squad/decisions.md.
+  If .squad/skills/ exists and contains SKILL.md files, read relevant ones before working.
 
   **Requested by:** {current user name}
 
@@ -80,7 +80,7 @@ prompt: |
   - Synthesize ceremony summary: decisions, action items, risks, disagreements.
 
   Write the ceremony summary to:
-  .ai-team/log/{YYYY-MM-DD}-{ceremony-id}.md
+  .squad/log/{YYYY-MM-DD}-{ceremony-id}.md
 
   Format:
   # {Ceremony Name} — {date}
@@ -100,12 +100,12 @@ prompt: |
   {risks, concerns, disagreements, other discussion points}
 
   For each decision, also write to:
-  .ai-team/decisions/inbox/{facilitator}-{ceremony-id}-{brief-slug}.md
+  .squad/decisions/inbox/{facilitator}-{ceremony-id}-{brief-slug}.md
 ```
 
 ## Ceremony Execution Rules
 
-1. **Check triggers.** Before spawning a work batch, read `.ai-team/ceremonies.md`. For auto/before ceremonies, evaluate condition against current task. For after, evaluate after batch completes. Manual runs only when user asks.
+1. **Check triggers.** Before spawning a work batch, read `.squad/ceremonies.md`. For auto/before ceremonies, evaluate condition against current task. For after, evaluate after batch completes. Manual runs only when user asks.
 2. **Resolve participants.** Determine which agents attend based on the `participants` field and current task/batch.
 3. **Spawn the facilitator (sync)** using the template above.
 4. **Proceed with work.** For before: spawn work batch with ceremony summary as context. For after: results inform next iteration. Spawn Scribe (background) to record, but do NOT chain another ceremony.

--- a/.squad/templates/charter.md
+++ b/.squad/templates/charter.md
@@ -33,10 +33,10 @@
 
 ## Collaboration
 
-Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.ai-team/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
+Before starting work, run `git rev-parse --show-toplevel` to find the repo root, or use the `TEAM ROOT` provided in the spawn prompt. All `.squad/` paths must be resolved relative to this root — do not assume CWD is the repo root (you may be in a worktree or subdirectory).
 
-Before starting work, read `.ai-team/decisions.md` for team decisions that affect me.
-After making a decision others should know, write it to `.ai-team/decisions/inbox/{my-name}-{brief-slug}.md` — the Scribe will merge it.
+Before starting work, read `.squad/decisions.md` for team decisions that affect me.
+After making a decision others should know, write it to `.squad/decisions/inbox/{my-name}-{brief-slug}.md` — the Scribe will merge it.
 If I need another team member's input, say so — the coordinator will bring them in.
 
 ## Voice

--- a/.squad/templates/issue-lifecycle.md
+++ b/.squad/templates/issue-lifecycle.md
@@ -4,7 +4,7 @@
 
 ## Connecting to a Repo
 
-1. Store in `.ai-team/team.md` under `## Issue Source`:
+1. Store in `.squad/team.md` under `## Issue Source`:
 
 ```markdown
 ## Issue Source

--- a/.squad/templates/orchestration-log.md
+++ b/.squad/templates/orchestration-log.md
@@ -1,6 +1,6 @@
 # Orchestration Log Entry
 
-> One file per agent spawn. Saved to `.ai-team/orchestration-log/{timestamp}-{agent-name}.md`
+> One file per agent spawn. Saved to `.squad/orchestration-log/{timestamp}-{agent-name}.md`
 
 ---
 

--- a/.squad/templates/prd-intake.md
+++ b/.squad/templates/prd-intake.md
@@ -6,7 +6,7 @@
 
 1. **Detect source.** File path → read it. Pasted content → capture inline. Formats: .md, .txt, .docx, any text-based file.
 
-2. **Store PRD reference** in `.ai-team/team.md`:
+2. **Store PRD reference** in `.squad/team.md`:
 
 ```markdown
 ## PRD
@@ -31,7 +31,7 @@ prompt: |
   {paste charter}
 
   TEAM ROOT: {team_root}
-  Read .ai-team/agents/{lead}/history.md and .ai-team/decisions.md.
+  Read .squad/agents/{lead}/history.md and .squad/decisions.md.
 
   **Requested by:** {current user name}
 
@@ -49,7 +49,7 @@ prompt: |
   - If previous decomposition exists in decisions.md, use as baseline
 
   Write breakdown to:
-  .ai-team/decisions/inbox/{lead}-prd-decomposition.md
+  .squad/decisions/inbox/{lead}-prd-decomposition.md
 ```
 
 4. **Present for approval:**

--- a/.squad/templates/roster.md
+++ b/.squad/templates/roster.md
@@ -12,11 +12,11 @@
 
 | Name | Role | Charter | Status |
 |------|------|---------|--------|
-| {Name} | {Role} | `.ai-team/agents/{name}/charter.md` | ✅ Active |
-| {Name} | {Role} | `.ai-team/agents/{name}/charter.md` | ✅ Active |
-| {Name} | {Role} | `.ai-team/agents/{name}/charter.md` | ✅ Active |
-| {Name} | {Role} | `.ai-team/agents/{name}/charter.md` | ✅ Active |
-| Scribe | Session Logger | `.ai-team/agents/scribe/charter.md` | 📋 Silent |
+| {Name} | {Role} | `.squad/agents/{name}/charter.md` | ✅ Active |
+| {Name} | {Role} | `.squad/agents/{name}/charter.md` | ✅ Active |
+| {Name} | {Role} | `.squad/agents/{name}/charter.md` | ✅ Active |
+| {Name} | {Role} | `.squad/agents/{name}/charter.md` | ✅ Active |
+| Scribe | Session Logger | `.squad/agents/scribe/charter.md` | 📋 Silent |
 
 ## Project Context
 

--- a/.squad/templates/scribe-charter.md
+++ b/.squad/templates/scribe-charter.md
@@ -11,18 +11,18 @@
 
 ## What I Own
 
-- `.ai-team/log/` — session logs (what happened, who worked, what was decided)
-- `.ai-team/decisions.md` — the shared decision log all agents read (canonical, merged)
-- `.ai-team/decisions/inbox/` — decision drop-box (agents write here, I merge)
+- `.squad/log/` — session logs (what happened, who worked, what was decided)
+- `.squad/decisions.md` — the shared decision log all agents read (canonical, merged)
+- `.squad/decisions/inbox/` — decision drop-box (agents write here, I merge)
 - Cross-agent context propagation — when one agent's decision affects another
 
 ## How I Work
 
-**Worktree awareness:** Use the `TEAM ROOT` provided in the spawn prompt to resolve all `.ai-team/` paths. If no TEAM ROOT is given, run `git rev-parse --show-toplevel` as fallback. Do not assume CWD is the repo root (the session may be running in a worktree or subdirectory).
+**Worktree awareness:** Use the `TEAM ROOT` provided in the spawn prompt to resolve all `.squad/` paths. If no TEAM ROOT is given, run `git rev-parse --show-toplevel` as fallback. Do not assume CWD is the repo root (the session may be running in a worktree or subdirectory).
 
 After every substantial work session:
 
-1. **Log the session** to `.ai-team/log/{YYYY-MM-DD}-{topic}.md`:
+1. **Log the session** to `.squad/log/{YYYY-MM-DD}-{topic}.md`:
    - Who worked
    - What was done
    - Decisions made
@@ -30,8 +30,8 @@ After every substantial work session:
    - Brief. Facts only.
 
 2. **Merge the decision inbox:**
-   - Read all files in `.ai-team/decisions/inbox/`
-   - APPEND each decision's contents to `.ai-team/decisions.md`
+   - Read all files in `.squad/decisions/inbox/`
+   - APPEND each decision's contents to `.squad/decisions.md`
    - Delete each inbox file after merging
 
 3. **Deduplicate and consolidate decisions.md:**
@@ -52,18 +52,18 @@ After every substantial work session:
    📌 Team update ({date}): {summary} — decided by {Name}
    ```
 
-5. **Commit `.ai-team/` changes:**
+5. **Commit `.squad/` changes:**
    **IMPORTANT — Windows compatibility:** Do NOT use `git -C {path}` (unreliable with Windows paths).
    Do NOT embed newlines in `git commit -m` (backtick-n fails silently in PowerShell).
    Instead:
    - `cd` into the team root first.
-   - Stage all `.ai-team/` files: `git add .ai-team/`
+   - Stage all `.squad/` files: `git add .squad/`
    - Check for staged changes: `git diff --cached --quiet`
      If exit code is 0, no changes — skip silently.
    - Write the commit message to a temp file, then commit with `-F`:
      ```
      $msg = @"
-     docs(ai-team): {brief summary}
+     docs(squad): {brief summary}
 
      Session: {YYYY-MM-DD}-{topic}
      Requested by: {user name}
@@ -87,7 +87,7 @@ After every substantial work session:
 ## The Memory Architecture
 
 ```
-.ai-team/
+.squad/
 ├── decisions.md          # Shared brain — all agents read this (merged by Scribe)
 ├── decisions/
 │   └── inbox/            # Drop-box — agents write decisions here in parallel

--- a/.squad/templates/skills/squad-conventions/SKILL.md
+++ b/.squad/templates/skills/squad-conventions/SKILL.md
@@ -24,12 +24,12 @@ All user-facing errors use the `fatal(msg)` function which prints a red `✗` pr
 Colors are defined as constants at the top of `index.js`: `GREEN`, `RED`, `DIM`, `BOLD`, `RESET`. Use these constants — do not inline ANSI escape codes.
 
 ### File Structure
-- `.ai-team/` — Team state (user-owned, never overwritten by upgrades)
-- `.ai-team-templates/` — Template files copied from `templates/` (Squad-owned, overwritten on upgrade)
+- `.squad/` — Team state (user-owned, never overwritten by upgrades)
+- `.squad-templates/` — Template files copied from `templates/` (Squad-owned, overwritten on upgrade)
 - `.github/agents/squad.agent.md` — Coordinator prompt (Squad-owned, overwritten on upgrade)
 - `templates/` — Source templates shipped with the npm package
-- `.ai-team/skills/` — Team skills in SKILL.md format (user-owned)
-- `.ai-team/decisions/inbox/` — Drop-box for parallel decision writes
+- `.squad/skills/` — Team skills in SKILL.md format (user-owned)
+- `.squad/decisions/inbox/` — Drop-box for parallel decision writes
 
 ### Windows Compatibility
 Always use `path.join()` for file paths — never hardcode `/` or `\` separators. Squad must work on Windows, macOS, and Linux. All tests must pass on all platforms.
@@ -55,7 +55,7 @@ const agentDest = path.join(dest, '.github', 'agents', 'squad.agent.md');
 // Skip-if-exists pattern
 if (!fs.existsSync(ceremoniesDest)) {
   fs.copyFileSync(ceremoniesSrc, ceremoniesDest);
-  console.log(`${GREEN}✓${RESET} .ai-team/ceremonies.md`);
+  console.log(`${GREEN}✓${RESET} .squad/ceremonies.md`);
 } else {
   console.log(`${DIM}ceremonies.md already exists — skipping${RESET}`);
 }

--- a/docs/features/ceremonies.md
+++ b/docs/features/ceremonies.md
@@ -97,7 +97,7 @@ The ceremony remains enabled for future tasks.
 
 - Design reviews prevent agents from building conflicting implementations. Let them run on multi-agent tasks.
 - Retros produce decisions that get written to `decisions.md` — they improve future work, not just diagnose the current failure.
-- Ceremony config lives in `.ai-team/ceremonies.md`. You can edit it directly if you prefer.
+- Ceremony config lives in `.squad/ceremonies.md`. You can edit it directly if you prefer.
 - Ceremonies work well with [human team members](human-team-members.md) — add a human as a participant for approval gates.
 
 ## Sample Prompts

--- a/docs/features/copilot-coding-agent.md
+++ b/docs/features/copilot-coding-agent.md
@@ -27,7 +27,7 @@ npx github:bradygaster/squad copilot --auto-assign
 gh secret set COPILOT_ASSIGN_TOKEN
 
 # 4. Commit and push
-git add .github/ .ai-team/ && git commit -m "feat: add copilot to squad" && git push
+git add .github/ .squad/ && git commit -m "feat: add copilot to squad" && git push
 
 # 5. Test — label any issue with squad:copilot
 ```

--- a/docs/features/directives.md
+++ b/docs/features/directives.md
@@ -21,12 +21,12 @@ Directives are team rules that persist across sessions. When you say "always" or
 
 ## How Directives Work
 
-A directive is a preference, rule, or constraint the team remembers across sessions. When you say "always do X" or "never do Y", Squad captures it as a directive, writes it to the decisions inbox, and the Scribe merges it into `.ai-team/decisions.md` — the team's permanent memory.
+A directive is a preference, rule, or constraint the team remembers across sessions. When you say "always do X" or "never do Y", Squad captures it as a directive, writes it to the decisions inbox, and the Scribe merges it into `.squad/decisions.md` — the team's permanent memory.
 
 ## How Directives Work
 
 1. **Signal Word Detection** — The coordinator listens for: "always", "never", "from now on", "remember to", "don't", "make sure to".
-2. **Capture** — Directive is written to `.ai-team/decisions/inbox/{timestamp}-{brief-slug}.md`.
+2. **Capture** — Directive is written to `.squad/decisions/inbox/{timestamp}-{brief-slug}.md`.
 3. **Scribe Merge** — Scribe consolidates inbox files into `decisions.md` during the next coordination cycle.
 4. **Agent Awareness** — All agents read `decisions.md` before starting work. Directives shape behavior.
 
@@ -88,10 +88,10 @@ Every new API endpoint requires at least one integration test covering the happy
 
 ## Decisions Inbox
 
-New directives land in `.ai-team/decisions/inbox/` as individual files:
+New directives land in `.squad/decisions/inbox/` as individual files:
 
 ```
-.ai-team/decisions/inbox/
+.squad/decisions/inbox/
 ├── 2024-01-15-1420-single-quotes.md
 ├── 2024-01-15-1435-no-friday-deploys.md
 └── 2024-01-15-1450-api-test-coverage.md
@@ -142,7 +142,7 @@ Coordinator searches `decisions.md` for testing-related directives.
 
 Scribe edits `decisions.md` and removes that section.
 
-Or edit `.ai-team/decisions.md` directly.
+Or edit `.squad/decisions.md` directly.
 
 ## Agent Directive Compliance
 

--- a/docs/features/export-import.md
+++ b/docs/features/export-import.md
@@ -38,7 +38,7 @@ npx github:bradygaster/squad export --out ./backups/my-team.json
 | **Skills** | ✅ **All earned skills export with the team** |
 | Decisions | ✅ |
 
-> **Skills are portable**: When you export a team, all earned skills from `.ai-team/skills/` are included in the JSON manifest. After importing, skills are immediately available to all agents — no loss of knowledge.
+> **Skills are portable**: When you export a team, all earned skills from `.squad/skills/` are included in the JSON manifest. After importing, skills are immediately available to all agents — no loss of knowledge.
 
 ---
 
@@ -48,11 +48,11 @@ npx github:bradygaster/squad export --out ./backups/my-team.json
 npx github:bradygaster/squad import squad-export.json
 ```
 
-Imports the snapshot into the current repo's `.ai-team/` directory.
+Imports the snapshot into the current repo's `.squad/` directory.
 
 ### Collision detection
 
-If `.ai-team/` already exists, Squad warns you and stops. To archive the existing team and replace it:
+If `.squad/` already exists, Squad warns you and stops. To archive the existing team and replace it:
 
 ```bash
 npx github:bradygaster/squad import squad-export.json --force
@@ -78,7 +78,7 @@ Imported agents bring their skills and general knowledge without assuming your p
 | Back up before a major refactor | `npx github:bradygaster/squad export --out ./backup.json` |
 | Share a trained team with a colleague | Export, send the JSON, they import — **skills included** |
 | Move a team to a different repo | Export from old repo, import into new repo — **skills travel with agents** |
-| Reset and start fresh | Export as backup, delete `.ai-team/`, re-init |
+| Reset and start fresh | Export as backup, delete `.squad/`, re-init |
 
 ---
 
@@ -87,7 +87,7 @@ Imported agents bring their skills and general knowledge without assuming your p
 - Export before running `upgrade` if you want a rollback point.
 - The export file is JSON — you can inspect it to see exactly what your team knows.
 - Imported agents retain their names and universe. They won't be renamed.
-- Commit your `.ai-team/` directory after importing so the team is available to everyone who clones the repo.
+- Commit your `.squad/` directory after importing so the team is available to everyone who clones the repo.
 - **Skills are fully portable** — all earned skills export and import with perfect fidelity. No manual copying needed.
 
 ## Sample Prompts
@@ -102,7 +102,7 @@ Creates a `squad-export.json` snapshot of the entire team in the current directo
 import squad-export.json into this repo
 ```
 
-Imports a team snapshot into the current project's `.ai-team/` directory.
+Imports a team snapshot into the current project's `.squad/` directory.
 
 ```
 what was included in that export?
@@ -120,4 +120,4 @@ Creates a lightweight export with agent charters and skills but minimal history.
 import with --force and archive the current team
 ```
 
-Overwrites the existing `.ai-team/` directory after archiving it as a backup.
+Overwrites the existing `.squad/` directory after archiving it as a backup.

--- a/docs/features/human-team-members.md
+++ b/docs/features/human-team-members.md
@@ -70,7 +70,7 @@ Same as removing any team member — they move to alumni:
 > Remove Sarah from the team
 ```
 
-Their entry moves to `.ai-team/agents/_alumni/`. They can be re-added later.
+Their entry moves to `.squad/agents/_alumni/`. They can be re-added later.
 
 ---
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -14,7 +14,7 @@ Squad is designed for **GitHub Copilot CLI** and ships with full support. **VS C
 
 **Current state:**
 - ✅ **GitHub Copilot CLI** — fully supported. This is the primary platform. Uses the stable `task` tool for sub-agent spawning, per-spawn model selection, and background mode.
-- ✅ **VS Code Copilot** — fully supported (v0.4.0+). VS Code uses `runSubagent` for parallel execution and supports full `.ai-team/` read/write. See [Client Compatibility Matrix](scenarios/client-compatibility.md) for details.
+- ✅ **VS Code Copilot** — fully supported (v0.4.0+). VS Code uses `runSubagent` for parallel execution and supports full `.squad/` read/write. See [Client Compatibility Matrix](scenarios/client-compatibility.md) for details.
 - ❌ **Other platforms** — JetBrains IDEs and other runtimes are untested. GitHub.com web-based Copilot is untested.
 
 For a detailed feature comparison across platforms (model selection, background execution, file access, etc.), see [Client Compatibility Matrix](scenarios/client-compatibility.md).
@@ -30,10 +30,10 @@ npx github:bradygaster/squad
 **Requirements:**
 - Node.js 22+
 - GitHub Copilot (CLI, VS Code, Visual Studio, or Coding Agent)
-- A git repository (Squad stores team state in `.ai-team/`)
+- A git repository (Squad stores team state in `.squad/`)
 - **`gh` CLI** — required for GitHub Issues, PRs, Ralph, and Project Boards ([install](https://cli.github.com/))
 
-This copies `squad.agent.md` into `.github/agents/`, installs 10 GitHub Actions workflows into `.github/workflows/`, and adds templates to `.ai-team-templates/`. Your actual team (`.ai-team/`) is created at runtime when you first talk to Squad.
+This copies `squad.agent.md` into `.github/agents/`, installs 10 GitHub Actions workflows into `.github/workflows/`, and adds templates to `.squad-templates/`. Your actual team (`.squad/`) is created at runtime when you first talk to Squad.
 
 **Note:** When you select Squad from the agent picker, you'll see the version number in the name (e.g., "Squad (v0.3.0)"). This helps you confirm which version is installed.
 
@@ -92,12 +92,12 @@ When you open Copilot and select **Squad** for the first time in a repo, there's
 
 5. **You confirm** — say "yes", adjust roles, add someone, or just give a task (which counts as implicit yes).
 
-Squad then creates the `.ai-team/` directory structure with charters, histories, routing rules, casting state, and ceremony config. Each agent's `history.md` is seeded with your project description and tech stack so they have day-1 context.
+Squad then creates the `.squad/` directory structure with charters, histories, routing rules, casting state, and ceremony config. Each agent's `history.md` is seeded with your project description and tech stack so they have day-1 context.
 
 ### What gets created
 
 ```
-.ai-team/
+.squad/
 ├── team.md                    # Roster — who's on the team
 ├── routing.md                 # Who handles what
 ├── ceremonies.md              # Team meeting definitions
@@ -192,19 +192,19 @@ Squad's memory is layered. Knowledge grows with use.
 
 ### Personal memory: `history.md`
 
-Each agent has its own `history.md` in `.ai-team/agents/{name}/`. After every session, agents append what they learned — architecture decisions, conventions, user preferences, key file paths. This file is read only by that agent.
+Each agent has its own `history.md` in `.squad/agents/{name}/`. After every session, agents append what they learned — architecture decisions, conventions, user preferences, key file paths. This file is read only by that agent.
 
 After a few sessions, agents stop asking questions they've already answered.
 
 ### Shared memory: `decisions.md`
 
-Team-wide decisions live in `.ai-team/decisions.md`. Every agent reads this before working. Decisions are captured in three ways:
+Team-wide decisions live in `.squad/decisions.md`. Every agent reads this before working. Decisions are captured in three ways:
 
-1. **From agent work** — agents write decisions to `.ai-team/decisions/inbox/{name}-{slug}.md`
+1. **From agent work** — agents write decisions to `.squad/decisions/inbox/{name}-{slug}.md`
 2. **From user directives** — when you say "always use..." or "never do..."
 3. **Scribe merges** — the Scribe agent consolidates inbox entries into the canonical file, deduplicates, and propagates updates to affected agents
 
-### Skills: `.ai-team/skills/`
+### Skills: `.squad/skills/`
 
 Skill files (`SKILL.md`) encode reusable knowledge. They come in two varieties:
 
@@ -399,7 +399,7 @@ You can also create, disable, or skip ceremonies:
 > Skip the design review for this task
 ```
 
-Ceremony configuration lives in `.ai-team/ceremonies.md`.
+Ceremony configuration lives in `.squad/ceremonies.md`.
 
 ---
 
@@ -411,9 +411,9 @@ Already have Squad installed? Update to the latest version:
 npx github:bradygaster/squad upgrade
 ```
 
-This overwrites `squad.agent.md` and `.ai-team-templates/` with the latest versions. It **never touches `.ai-team/`** — your team's knowledge, decisions, casting state, and skills are safe.
+This overwrites `squad.agent.md` and `.squad-templates/` with the latest versions. It **never touches `.squad/`** — your team's knowledge, decisions, casting state, and skills are safe.
 
-Smart upgrade detects your installed version, reports what changed, and runs any needed migrations (e.g., creating `.ai-team/skills/` if it didn't exist). Migrations are additive and idempotent — safe to re-run.
+Smart upgrade detects your installed version, reports what changed, and runs any needed migrations (e.g., creating `.squad/skills/` if it didn't exist). Migrations are additive and idempotent — safe to re-run.
 
 ---
 
@@ -460,7 +460,7 @@ Squad allocates a name from the current universe, generates a charter and histor
 > Remove the designer — we're past that phase
 ```
 
-Agents are never deleted. Their charter and history move to `.ai-team/agents/_alumni/`. Knowledge is preserved. If you need them back later, they remember everything.
+Agents are never deleted. Their charter and history move to `.squad/agents/_alumni/`. Knowledge is preserved. If you need them back later, they remember everything.
 
 ---
 
@@ -484,8 +484,8 @@ Squad maintains a clear ownership model:
 | What | Owner | Safe to edit? |
 |------|-------|--------------|
 | `.github/agents/squad.agent.md` | Squad (overwritten on upgrade) | No — your changes will be lost |
-| `.ai-team-templates/` | Squad (overwritten on upgrade) | No |
-| `.ai-team/` | You and your team | Yes — this is your team's state |
+| `.squad-templates/` | Squad (overwritten on upgrade) | No |
+| `.squad/` | You and your team | Yes — this is your team's state |
 | Everything else | You | Yes |
 
 ---

--- a/docs/insider-program.md
+++ b/docs/insider-program.md
@@ -117,7 +117,7 @@ Want to go back to stable releases?
 npx github:bradygaster/squad
 ```
 
-This installs the latest stable version. Your `.ai-team/` state is safe — it'll work with any version.
+This installs the latest stable version. Your `.squad/` state is safe — it'll work with any version.
 
 ---
 
@@ -129,7 +129,7 @@ This installs the latest stable version. Your `.ai-team/` state is safe — it'l
 
 ### Q: Can I switch between insider and stable builds?
 
-**A:** Yes. Insider builds are backward compatible with stable installs. Your `.ai-team/` directory works with any version.
+**A:** Yes. Insider builds are backward compatible with stable installs. Your `.squad/` directory works with any version.
 
 ### Q: How often do insider builds update?
 
@@ -137,7 +137,7 @@ This installs the latest stable version. Your `.ai-team/` state is safe — it'l
 
 ### Q: Will my team state be preserved?
 
-**A:** Yes. `.ai-team/` is never overwritten on upgrade. All your agents, decisions, and histories are safe.
+**A:** Yes. `.squad/` is never overwritten on upgrade. All your agents, decisions, and histories are safe.
 
 ### Q: What if an insider build has a bad bug?
 

--- a/docs/scenarios/ci-cd-integration.md
+++ b/docs/scenarios/ci-cd-integration.md
@@ -45,7 +45,7 @@ jobs:
         run: npx github:bradygaster/squad heartbeat
 ```
 
-Ralph reads `.ai-team/routing.md`, looks at open issues, and applies labels:
+Ralph reads `.squad/routing.md`, looks at open issues, and applies labels:
 
 ```
 Issue #42: "Add Stripe payment integration"
@@ -167,14 +167,14 @@ Steps 2, 4, 5, 6, 7 are **automated**. You only do steps 3 and 8.
 
 When you run `npx github:bradygaster/squad`, these workflow templates are installed:
 
-- `.ai-team-templates/squad-heartbeat.yml` → Ralph runs every 6 hours
-- `.ai-team-templates/copilot-auto-assign.yml` → Triggers Copilot on `go:*` labels
-- `.ai-team-templates/pr-review-reminder.yml` → Reminds you of open PRs needing review
+- `.squad-templates/squad-heartbeat.yml` → Ralph runs every 6 hours
+- `.squad-templates/copilot-auto-assign.yml` → Triggers Copilot on `go:*` labels
+- `.squad-templates/pr-review-reminder.yml` → Reminds you of open PRs needing review
 
 To activate them:
 
 ```bash
-cp .ai-team-templates/*.yml .github/workflows/
+cp .squad-templates/*.yml .github/workflows/
 git add .github/workflows/
 git commit -m "Enable Squad workflows"
 git push
@@ -219,5 +219,5 @@ npx github:bradygaster/squad heartbeat --dry-run
 - **Ralph is your assistant between sessions.** It triages issues, applies labels, and keeps things organized while you're not in Copilot.
 - **`go:*` labels mean "approved to proceed."** Don't add them to every issue — only the ones you've reviewed and want agents to handle autonomously.
 - **Agents still need human review.** PRs created by agents should be reviewed by a human before merging.
-- **Workflows are templates.** Customize `.ai-team-templates/` to match your CI/CD setup, then copy to `.github/workflows/`.
+- **Workflows are templates.** Customize `.squad-templates/` to match your CI/CD setup, then copy to `.github/workflows/`.
 - **Heartbeat frequency is configurable.** Edit `squad-heartbeat.yml` to change from every 6 hours to daily, hourly, etc.

--- a/docs/scenarios/client-compatibility.md
+++ b/docs/scenarios/client-compatibility.md
@@ -12,8 +12,8 @@ Squad runs on multiple Copilot surfaces — each with its own agent spawning mec
 | **Background/async execution** | ✅ `mode: "background"` (fire-and-forget) | ⚠️ Sync only (parallel concurrent) | ? | ? |
 | **Parallel fan-out** | ✅ Background tasks + `read_agent` | ✅ Multiple subagents in one turn | ? | ? |
 | **File discovery (.github/agents/)** | ✅ Automatic | ✅ Automatic | ? | ? |
-| **`.ai-team/` file access (read)** | ✅ Full | ✅ Full (workspace-scoped) | ? | ? |
-| **`.ai-team/` file access (write)** | ✅ Full | ✅ Full (with approval prompt) | ? | ? |
+| **`.squad/` file access (read)** | ✅ Full | ✅ Full (workspace-scoped) | ? | ? |
+| **`.squad/` file access (write)** | ✅ Full | ✅ Full (with approval prompt) | ? | ? |
 | **SQL tool** | ✅ Available | ❌ Not available | ❌ Not available | ❌ Not available |
 | **MCP server access** | ✅ Full | ✅ Full (inherited) | ⚠️ Limited | ⚠️ Limited |
 
@@ -67,7 +67,7 @@ Squad's **primary platform**. All features are fully supported.
 ### File Discovery & Access
 
 - **Auto-discovery:** `.github/agents/squad.agent.md` is discovered automatically
-- **`.ai-team/` access:** Unrestricted (full filesystem)
+- **`.squad/` access:** Unrestricted (full filesystem)
 - **Parallel reads:** Multiple file operations in one turn supported
 - **Parallel writes:** Multiple file creates/edits in one turn supported
 
@@ -121,8 +121,8 @@ Squad runs on VS Code with **conditional support**. Key differences from CLI:
 
 - **Auto-discovery:** `.github/agents/squad.agent.md` auto-discovered from workspace on load (file watchers enabled — no restart needed on changes)
 - **Scope:** Workspace-scoped (cannot access outside workspace directory)
-- **`.ai-team/` read:** ✅ Full access via `readFile` tool
-- **`.ai-team/` write:** ✅ Full access via `createFile` / `editFiles` tools
+- **`.squad/` read:** ✅ Full access via `readFile` tool
+- **`.squad/` write:** ✅ Full access via `createFile` / `editFiles` tools
 - **First-time approval:** VS Code may prompt for file modification approval on first write (security feature)
   - **User experience:** "Always allow in this workspace" option available
   - Subsequent writes in same workspace are automatic
@@ -158,7 +158,7 @@ Squad runs on VS Code with **conditional support**. Key differences from CLI:
 ### Questions to Answer
 
 - Does JetBrains Copilot support agent spawning via a tool equivalent to `task` or `runSubagent`?
-- Can agents access workspace files and `.ai-team/` directories?
+- Can agents access workspace files and `.squad/` directories?
 - What model selection mechanisms exist?
 - Is there a background/async mode?
 
@@ -177,7 +177,7 @@ Squad runs on VS Code with **conditional support**. Key differences from CLI:
 ### Questions to Answer
 
 - Can GitHub Copilot spawn agents for background work?
-- Can agents read `.ai-team/` files from the repository?
+- Can agents read `.squad/` files from the repository?
 - Is there a GitHub-specific command protocol for delegation?
 
 ---
@@ -201,7 +201,7 @@ Squad runs on VS Code with **conditional support**. Key differences from CLI:
 **Using Both:**
 - CLI is recommended for initial Squad setup and learning
 - VS Code works for day-to-day development once Squad is established
-- They share the same `.ai-team/` state — both can read/write the same team files
+- They share the same `.squad/` state — both can read/write the same team files
 - Team state is portable — init in CLI, use in VS Code, export/import across repos
 
 ### For Squad Developers
@@ -250,7 +250,7 @@ This document is based on active research spikes (#32, #33, #34) conducted in Fe
 
 - **Proposal 032a** (Strausz): `runSubagent` API research — agent spawning mechanics on VS Code
 - **Proposal 032b** (Kujan): CLI spawn parity analysis — all 5 Squad spawn patterns mapped
-- **Proposal 033a** (Strausz): VS Code file discovery — `.ai-team/` access and workspace scoping
+- **Proposal 033a** (Strausz): VS Code file discovery — `.squad/` access and workspace scoping
 - **Proposal 034a** (Kujan): Model selection & background mode — per-agent model routing and async execution
 
 **Next steps:**

--- a/docs/scenarios/disaster-recovery.md
+++ b/docs/scenarios/disaster-recovery.md
@@ -2,7 +2,7 @@
 
 **Try this to recover from data loss:**
 ```
-My .ai-team/ directory was deleted — help me recover the team state
+My .squad/ directory was deleted — help me recover the team state
 ```
 
 **Try this to revert bad code:**
@@ -15,21 +15,21 @@ An agent wrote bad code — how do I revert it?
 The squad is confused — reset their context
 ```
 
-Recovery procedures for deleted `.ai-team/`, bad agent code, confused squads, and upgrade issues. Most problems are fixable with Git or re-init.
+Recovery procedures for deleted `.squad/`, bad agent code, confused squads, and upgrade issues. Most problems are fixable with Git or re-init.
 
 ---
 
-## 1. "I accidentally deleted `.ai-team/`"
+## 1. "I accidentally deleted `.squad/`"
 
-Recovery scenarios: deleted `.ai-team/`, bad agent code, confused squad, upgrade issues.
+Recovery scenarios: deleted `.squad/`, bad agent code, confused squad, upgrade issues.
 
 **Solution:** It's in Git. Restore it.
 
 ```bash
-git checkout .ai-team/
+git checkout .squad/
 ```
 
-If you haven't committed `.ai-team/` yet, it's gone. Rebuild:
+If you haven't committed `.squad/` yet, it's gone. Rebuild:
 
 ```bash
 npx github:bradygaster/squad
@@ -41,7 +41,7 @@ Start from scratch. If you exported your squad before, import the export:
 npx github:bradygaster/squad import squad-export-2025-07-15.zip
 ```
 
-**Prevention:** Commit `.ai-team/` early. Don't let it stay uncommitted for long.
+**Prevention:** Commit `.squad/` early. Don't let it stay uncommitted for long.
 
 ---
 
@@ -85,7 +85,7 @@ Sonny reads the code, fixes the issue, commits.
 
 ## 3. "An agent made a wrong decision"
 
-**What happened:** Neo decided to use REST when GraphQL was the better choice. The decision is logged in `.ai-team/decisions.md`.
+**What happened:** Neo decided to use REST when GraphQL was the better choice. The decision is logged in `.squad/decisions.md`.
 
 **Solution:** Add a directive to override it.
 
@@ -125,7 +125,7 @@ Agents now read the new decision and build accordingly.
 ```
 📋 Scribe — archiving recent session histories
 
-Moved to .ai-team/history-archive/:
+Moved to .squad/history-archive/:
   - Neo's session from 2025-07-14
   - Morpheus's session from 2025-07-14
   - Trinity's session from 2025-07-14
@@ -141,10 +141,10 @@ Agents **forget** the bad session. They still have their long-term skills and de
 
 ## 5. "I want to start over completely"
 
-**Solution:** Delete `.ai-team/` and reinstall.
+**Solution:** Delete `.squad/` and reinstall.
 
 ```bash
-rm -rf .ai-team/
+rm -rf .squad/
 npx github:bradygaster/squad
 ```
 
@@ -162,11 +162,11 @@ You're back to day one. Clean slate.
 
 **What happened:** You upgraded Squad to a new version, and now something doesn't work.
 
-**Solution:** Squad upgrades **never touch** `.ai-team/`. The issue is likely in:
+**Solution:** Squad upgrades **never touch** `.squad/`. The issue is likely in:
 
-1. **Workflow templates** — check `.ai-team-templates/`
+1. **Workflow templates** — check `.squad-templates/`
 2. **Squad agent definition** — check `.github/agents/squad.agent.md`
-3. **Model configuration** — check `.ai-team/model-config.json`
+3. **Model configuration** — check `.squad/model-config.json`
 
 Roll back the Squad agent definition:
 
@@ -180,7 +180,7 @@ Or reinstall the previous version:
 npx github:bradygaster/squad@0.1.5
 ```
 
-**Your team's knowledge is safe.** `.ai-team/` is untouched.
+**Your team's knowledge is safe.** `.squad/` is untouched.
 
 **Prevention:** Check the CHANGELOG before upgrading. If the upgrade is major, test in a branch first.
 
@@ -211,17 +211,17 @@ Or just close the Copilot session (Ctrl+C) and start a new one.
 
 ## 8. "Skills are outdated or wrong"
 
-**What happened:** A skill file in `.ai-team/skills/` contains outdated information. Agents are following bad advice.
+**What happened:** A skill file in `.squad/skills/` contains outdated information. Agents are following bad advice.
 
 **Solution:** Edit or delete the skill file.
 
 ```bash
 # Edit the skill
-code .ai-team/skills/auth-rate-limiting.md
+code .squad/skills/auth-rate-limiting.md
 
 # Or delete it
-rm .ai-team/skills/auth-rate-limiting.md
-git add .ai-team/skills/
+rm .squad/skills/auth-rate-limiting.md
+git add .squad/skills/
 git commit -m "Remove outdated auth rate limiting skill"
 ```
 
@@ -231,13 +231,13 @@ git commit -m "Remove outdated auth rate limiting skill"
 
 ## 9. "Decisions.md is a mess"
 
-**What happened:** `.ai-team/decisions.md` has 200 entries and it's hard to find anything.
+**What happened:** `.squad/decisions.md` has 200 entries and it's hard to find anything.
 
 **Solution:** Archive old decisions.
 
 ```
 > Scribe, archive decisions older than 3 months. Move them to
-> .ai-team/decisions-archive.md.
+> .squad/decisions-archive.md.
 ```
 
 ```
@@ -284,10 +284,10 @@ Each agent logs what they did in their `history.md`.
 
 ## Tips
 
-- **`.ai-team/` is in Git.** If you delete it, restore from Git. If it's uncommitted, it's gone.
+- **`.squad/` is in Git.** If you delete it, restore from Git. If it's uncommitted, it's gone.
 - **Code review catches bad agent code.** Use the Lead to review before merging.
 - **Override bad decisions with directives.** If an agent made the wrong call, tell the team the correct one.
 - **Archive confused histories.** If a session went badly, archive the learnings so agents forget.
-- **Upgrades don't touch `.ai-team/`.** Your team's knowledge is safe across upgrades.
+- **Upgrades don't touch `.squad/`.** Your team's knowledge is safe across upgrades.
 - **Edit skill files directly.** They're just markdown. If a skill is wrong, fix it or delete it.
 - **Agent histories are the audit log.** Check them to see what each agent did.

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -320,7 +320,7 @@ If Frontend does something one way and Backend does it another way, the decision
 Agent A: "I used kebab-case for the file names"
 Agent B: "I used PascalCase for the file names"
 
-[You check .ai-team/decisions.md]
+[You check .squad/decisions.md]
 [No decision about file naming conventions]
 
 > Here's the permanent rule: all component files are PascalCase.
@@ -332,7 +332,7 @@ Now it's in the shared brain. Next agent to work on components will see this.
 
 When a decision no longer applies, move it to a "Superseded" section.
 
-You can edit `.ai-team/decisions.md` directly:
+You can edit `.squad/decisions.md` directly:
 
 ```markdown
 ## Superseded Decisions
@@ -366,7 +366,7 @@ This happens automatically in mature teams, but you can force it anytime.
 
 ### 6. Personal History Files Build Over Time
 
-Each agent's `.ai-team/agents/{name}/history.md` grows with every session. Check it when an agent seems lost.
+Each agent's `.squad/agents/{name}/history.md` grows with every session. Check it when an agent seems lost.
 
 ```
 [Dallas's history shows]
@@ -449,14 +449,14 @@ Ralph handles the backlog, you handle the critical path.
 ❌ "I want Lead, Frontend, Backend, Tester, DevOps, Data Engineer, Designer, and a Scribe."
 ```
 
-### Pitfall 6: Lost Work Because You Didn't Commit `.ai-team/`
+### Pitfall 6: Lost Work Because You Didn't Commit `.squad/`
 
 **Problem:** You deleted the repo and lost all your team knowledge.
 
-**Solution:** **Commit `.ai-team/` to git.** It's permanent team memory.
+**Solution:** **Commit `.squad/` to git.** It's permanent team memory.
 
 ```bash
-git add .ai-team/
+git add .squad/
 git commit -m "Add squad team state"
 git push
 ```
@@ -518,7 +518,7 @@ Squad 1: "Team A, build the admin dashboard. You own features/admin/."
 Squad 2: "Team B, build the mobile app. You own features/mobile/."
 
 [Both teams work in parallel]
-[Shared decisions in .ai-team/decisions.md prevent conflicts]
+[Shared decisions in .squad/decisions.md prevent conflicts]
 ```
 
 Requires good routing rules and clear ownership, but it works.
@@ -616,7 +616,7 @@ A typical high-performing session:
 3. **Parallel execution:** Let agents work (don't interrupt)
 4. **Check logs:** Ask Scribe what happened while you were reading code
 5. **Next round:** Based on what Scribe told you, give follow-up work or start Ralph
-6. **Wrap up:** Ask Ralph for status, commit `.ai-team/`, go home
+6. **Wrap up:** Ask Ralph for status, commit `.squad/`, go home
 
 **Time to productive work: usually < 2 minutes.**
 


### PR DESCRIPTION
## Summary

The v0.5.0 release renamed `.ai-team/` to `.squad/` and `.ai-team-templates/` to `.squad-templates/`, but 21 documentation and template files still referenced the deprecated paths. This PR updates all remaining references to match the current implementation.

## Changes

**21 files updated** (122 insertions, 122 deletions — clean 1:1 replacements):

### Docs — Feature pages (5 files)
- `docs/features/ceremonies.md` — ceremony config path
- `docs/features/directives.md` — decisions inbox paths, decisions.md references
- `docs/features/copilot-coding-agent.md` — `git add` command
- `docs/features/export-import.md` — skills path, import directory, collision detection
- `docs/features/human-team-members.md` — alumni path

### Docs — Core guides (3 files)
- `docs/guide.md` — 30 lines across setup, memory, skills, upgrades, ownership table
- `docs/insider-program.md` — FAQ answers about state safety
- `docs/tips-and-tricks.md` — decisions.md, history.md, git add commands

### Docs — Scenarios (3 files)
- `docs/scenarios/disaster-recovery.md` — 46 lines, all recovery procedures
- `docs/scenarios/client-compatibility.md` — file access matrix entries
- `docs/scenarios/ci-cd-integration.md` — routing, workflow template paths

### Templates (9 files)
- `templates/scribe-charter.md` — owned paths, git add, commit prefix `docs(squad):`
- `templates/charter.md` — collaboration section paths
- `templates/roster.md` — charter path references in roster table
- `templates/prd-intake.md` — team.md, history, decisions paths
- `templates/ceremony-reference.md` — ceremony config paths
- `templates/casting-reference.md` — casting state paths
- `templates/issue-lifecycle.md` — team.md storage path
- `templates/orchestration-log.md` — log save path
- `templates/skills/squad-conventions/SKILL.md` — file structure docs

### Other (1 file)
- `.github/copilot-instructions.md` — repo structure description

## Intentionally NOT changed
- **Blog posts** — historical narratives describing events at the time
- **CHANGELOG.md** — historical release records
- **Migration guide** (`docs/migration/v0.5.0-squad-rename.md`) — references both paths by design
- **Proposals and specs** — point-in-time documents
- **README.md** — already accurate
- **`index.js` and tests** — intentional dual-path backward compatibility for `--migrate-directory`

## Verification
- Grep confirmed zero remaining `.ai-team` references in the 21 updated files
- All replacements are mechanical 1:1 path substitutions with no behavioral changes
- `npm test` — no test changes (tests intentionally reference both paths for migration testing)
