### PR TITLE
docs: add GitLab Issues walkthrough and feature reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,8 @@ Public-facing documentation for Squad. GitHub Pages ready.
 - [Reviewer Protocol](features/reviewer-protocol.md) — Rejection lockout and revision routing
 
 ### Workflow
-- [GitHub Issues Mode](features/github-issues.md) — Issue-driven development
+- [GitHub Issues Mode](features/github-issues.md) — GitHub issue-driven development
+- [GitLab Issues Mode](features/gitlab-issues.md) — 🧪 *Experimental* — GitLab issue-driven development
 - [PRD Mode](features/prd-mode.md) — Product requirements decomposition
 - [Labels & Triage](features/labels.md) — go:/release:/type:/priority: taxonomy
 - [Ralph — Work Monitor](features/ralph.md) — Autonomous backlog processing
@@ -40,7 +41,8 @@ Public-facing documentation for Squad. GitHub Pages ready.
 ## Walkthroughs
 
 - [First Session](tour-first-session.md) — Your first time using Squad
-- [GitHub Issues](tour-github-issues.md) — Issue-driven development walkthrough
+- [GitHub Issues](tour-github-issues.md) — GitHub issue-driven development walkthrough
+- [GitLab Issues](tour-gitlab-issues.md) — 🧪 *Experimental* — GitLab issue-driven development walkthrough 
 
 ## Scenarios
 

--- a/docs/features/gitlab-issues.md
+++ b/docs/features/gitlab-issues.md
@@ -1,0 +1,197 @@
+# GitLab Issues Mode
+
+> **🧪 Experimental.** GitLab Issues Mode is new. Commands, behavior, and integration details may change. [Feedback welcome.](https://github.com/bradygaster/squad/issues)
+
+**Try this to connect to your backlog:**
+```
+Show me the open issues for this GitLab repo
+```
+
+**Try this to start work on a specific issue:**
+```
+Work on issue #42
+```
+
+**Try this to handle MR review feedback:**
+```
+There's review feedback on MR !24
+```
+
+Squad connects to your GitLab repository, fetches issues from the backlog, routes work to the right agents, creates branches, implements changes, and opens Merge Requests — all from natural language requests.
+
+---
+
+## Requirements
+
+- **`glab` CLI** installed and authenticated — the [official GitLab CLI](https://docs.gitlab.com/cli/issue/) (`glab auth login` to authenticate, `glab auth status` to check)
+- A GitLab repository with issues
+
+---
+
+## Connect to a Repository
+
+```
+> Connect to GitLab at https://gitlab.example.com/acme/recipe-app
+```
+
+Squad stores the issue source in `team.md`. You only need to do this once per project.
+
+---
+
+## View the Backlog
+
+```
+> Show the backlog
+```
+
+Squad fetches open issues via `glab issue list` and displays them in a table:
+
+```
+#   Title                        Labels        Assignee
+12  Add user authentication      backend       —
+15  Fix responsive nav           frontend      —
+18  Write API integration tests  testing       —
+```
+
+---
+
+## Work on Issues
+
+### Single issue
+
+```
+> Work on #12
+```
+
+The coordinator routes the issue to the best-fit agent. That agent:
+
+1. Creates a branch (e.g., `12-add-user-authentication`)
+2. Implements the work
+3. Opens a Merge Request linked to the issue
+
+### Multiple issues
+
+```
+> Work on #12 and #15
+```
+
+Agents work in parallel — each issue gets its own branch and MR.
+
+---
+
+## Handle MR Review Feedback
+
+```
+> There's review feedback on MR !24
+```
+
+The agent who opened the MR reads the review comments and addresses them. Commits are pushed to the existing branch.
+
+---
+
+## Merge Completed Work
+
+```
+> Merge MR !24
+```
+
+Squad merges the MR, deletes the source branch, and closes the linked issue.
+
+---
+
+## Check Remaining Work
+
+```
+> What's left?
+```
+
+Squad refreshes the backlog and shows remaining open issues.
+
+---
+
+## Workflow Summary
+
+| You say | What happens |
+|---------|-------------|
+| `"Connect to GitLab at https://gitlab.example.com/acme/recipe-app"` | Stores issue source |
+| `"Show the backlog"` | Lists open issues |
+| `"Work on #12"` | Agent branches, implements, opens MR |
+| `"Work on #12 and #15"` | Parallel agent work on both issues |
+| `"There's review feedback on MR !24"` | Agent addresses review comments |
+| `"Merge MR !24"` | Merges MR, deletes branch, closes issue |
+| `"What's left?"` | Refreshes and shows remaining issues |
+
+---
+
+## GitLab CLI Quick Reference
+
+These are the `glab` commands Squad uses behind the scenes:
+
+| Operation | Command |
+|-----------|---------|
+| Authenticate | `glab auth login` |
+| Check auth | `glab auth status` |
+| List open issues | `glab issue list` |
+| List all issues | `glab issue list --all` |
+| View issue | `glab issue view 12` |
+| Create MR | `glab mr create -t "Fix pagination" -d "Closes #15"` |
+| Create MR (auto-fill from commits) | `glab mr create --fill` |
+| List open MRs | `glab mr list` |
+| List all MRs | `glab mr list --all` |
+| Merge MR | `glab mr merge 24` |
+
+For the full command reference, see the [official GitLab CLI documentation](https://docs.gitlab.com/cli/).
+
+---
+
+## Differences from GitHub Issues Mode
+
+| Aspect | GitHub | GitLab |
+|--------|--------|--------|
+| CLI tool | `gh` | `glab` |
+| Pull/Merge Requests | PR (`#24`) | MR (`!24`) |
+| Auth command | `gh auth login` | `glab auth login` |
+| Default branch convention | `main` | `main` (configurable) |
+| Issue linking in MR body | `Closes #N` | `Closes #N` |
+| Labels & milestones | Supported | Supported |
+
+---
+
+## Tips
+
+- You don't need to assign issues to specific agents — Squad routes based on domain expertise.
+- If `glab` isn't authenticated, Squad will tell you. Run `glab auth login` first.
+- MR descriptions include `Closes #N` so merging automatically closes the linked issue, just like on GitHub.
+- See [GitLab Issues Walkthrough](../tour-gitlab-issues.md) for a step-by-step tour.
+
+## Sample Prompts
+
+```
+connect to GitLab at https://gitlab.example.com/acme/recipe-app
+```
+
+Links Squad to a GitLab repository for issue-driven development.
+
+```
+show the backlog
+```
+
+Fetches and displays all open issues from the connected GitLab repository.
+
+```
+work on issue #23
+```
+
+Routes the issue to the appropriate agent who creates a branch, implements, and opens an MR.
+
+```
+work on all issues labeled "bug"
+```
+
+Processes multiple issues in parallel based on label filtering.
+
+```
+what's left in the backlog?
+```
+
+Refreshes the issue list and shows remaining open work items.

--- a/docs/tour-gitlab-issues.md
+++ b/docs/tour-gitlab-issues.md
@@ -1,0 +1,236 @@
+# GitLab Issues Walkthrough
+
+> **🧪 Experimental.** GitLab Issues Mode is new. Commands, behavior, and integration details may change. [Feedback welcome.](https://github.com/bradygaster/squad/issues)
+
+A step-by-step tour of Squad's GitLab Issues workflow. This connects your team to a GitLab repository's issue tracker so agents can pick up issues, create branches, open Merge Requests, and handle review feedback.
+
+**Prerequisite:** The [`glab` CLI](https://docs.gitlab.com/cli/issue/) (official GitLab CLI) must be installed and authenticated (`glab auth login`).
+
+---
+
+## 1. Connect to a Repository
+
+Tell Squad which GitLab repo to track:
+
+```
+> Connect to GitLab at https://gitlab.example.com/acme/recipe-app
+```
+
+Squad stores the issue source in team state:
+
+```
+✅ Issue source stored: https://gitlab.example.com/acme/recipe-app (GitLab)
+   Using glab CLI for issue tracking.
+```
+
+From now on, Squad can read issues from that repo and create branches and MRs against it.
+
+---
+
+## 2. View the Backlog
+
+Ask to see open issues:
+
+```
+> Show the backlog
+```
+
+Squad pulls open issues via `glab issue list` (open by default) and displays them:
+
+```
+┌─────┬──────────────────────────────────────────┬───────────┬────────────┐
+│  #  │ Title                                    │ Labels    │ Assignee   │
+├─────┼──────────────────────────────────────────┼───────────┼────────────┤
+│  12 │ Add ingredient search                    │ feature   │ —          │
+│  15 │ Fix pagination on recipe list            │ bug       │ —          │
+│  18 │ Add user profile page                    │ feature   │ —          │
+│  21 │ Rate limiting on API endpoints           │ security  │ —          │
+│  23 │ Mobile responsive layout                 │ ui        │ —          │
+└─────┴──────────────────────────────────────────┴───────────┴────────────┘
+5 open issues
+```
+
+---
+
+## 3. Work on an Issue
+
+Pick an issue for an agent to work on:
+
+```
+> Work on #12
+```
+
+Squad reads the issue details, routes it to the right agent, and kicks off the workflow:
+
+```
+🔧 Dallas — picking up #12 (Add ingredient search)
+
+Dallas is reading the issue and starting work.
+```
+
+Behind the scenes, the agent:
+
+1. **Creates a branch** — named descriptively based on the issue (e.g., `12-add-ingredient-search`)
+2. **Does the implementation work** — writes code, tests, whatever the issue requires
+3. **Opens a Merge Request** — linked back to issue #12, with a description of what was done
+
+When the agent finishes:
+
+```
+🔧 Dallas — Completed #12 (Add ingredient search)
+   Branch: 12-add-ingredient-search
+   MR: !24 opened — "Add ingredient search (#12)"
+   Files changed:
+   - src/routes/recipes.ts (added search endpoint)
+   - src/models/recipe.ts (added text index)
+   - test/search.test.ts (6 test cases)
+```
+
+---
+
+## 4. Multiple Issues in Parallel
+
+You can assign multiple issues at once:
+
+```
+> Work on #15 and #23
+```
+
+```
+🔧 Dallas  — picking up #15 (Fix pagination on recipe list)
+⚛️ Ripley  — picking up #23 (Mobile responsive layout)
+📋 Scribe  — logging session
+```
+
+Each agent creates its own branch and works independently. If your repo supports worktrees, Squad can work on multiple branches simultaneously.
+
+---
+
+## 5. Handle Review Feedback
+
+After an MR is open, reviewers may leave comments. When you see feedback:
+
+```
+> There's review feedback on MR !24
+```
+
+Squad routes the review to the agent who opened the MR:
+
+```
+🔧 Dallas — reading review comments on MR !24
+
+Dallas is addressing the feedback now.
+```
+
+The agent reads the review comments, makes the requested changes, and pushes new commits to the same branch:
+
+```
+🔧 Dallas — Addressed review feedback on MR !24
+   - Added input sanitization for search query (reviewer concern)
+   - Added test case for SQL injection attempt
+   - Pushed 2 new commits to 12-add-ingredient-search
+```
+
+---
+
+## 6. Merge Completed Work
+
+When the MR is approved and ready:
+
+```
+> Merge MR !24
+```
+
+```
+✅ MR !24 merged — "Add ingredient search (#12)"
+   Issue #12 closed.
+   Branch 12-add-ingredient-search deleted.
+```
+
+The issue is closed automatically when the MR merges (if the MR body includes `Closes #12`).
+
+---
+
+## 7. Check Remaining Work
+
+After merging, see what's left:
+
+```
+> What's left?
+```
+
+Squad refreshes the backlog:
+
+```
+┌─────┬──────────────────────────────────────────┬───────────┬────────────┐
+│  #  │ Title                                    │ Labels    │ Assignee   │
+├─────┼──────────────────────────────────────────┼───────────┼────────────┤
+│  15 │ Fix pagination on recipe list            │ bug       │ Dallas     │
+│  18 │ Add user profile page                    │ feature   │ —          │
+│  21 │ Rate limiting on API endpoints           │ security  │ —          │
+│  23 │ Mobile responsive layout                 │ ui        │ Ripley     │
+└─────┴──────────────────────────────────────────┴───────────┴────────────┘
+4 open issues (2 in progress)
+```
+
+---
+
+## Full Workflow at a Glance
+
+```
+Connect      →  "connect to GitLab at https://gitlab.example.com/acme/recipe-app"
+Browse       →  "show the backlog"
+Assign       →  "work on #12"
+  └─ Agent creates branch, implements, opens MR
+Review       →  "there's review feedback on MR !24"
+  └─ Agent reads comments, pushes fixes
+Merge        →  "merge MR !24"
+  └─ MR merged, issue closed
+Status       →  "what's left?"
+  └─ Updated backlog
+```
+
+---
+
+## Installing the GitLab CLI
+
+The `glab` CLI is the official GitLab command-line tool. It's required for all GitLab Issues Mode operations.
+
+### Install
+
+| Platform | Command |
+|----------|---------|
+| macOS (Homebrew) | `brew install glab` |
+| Windows (WinGet) | `winget install GLab.GLab` |
+| Windows (Scoop) | `scoop install glab` |
+| Linux (apt) | See [GitLab CLI docs](https://docs.gitlab.com/cli/issue/) |
+| From source | `go install gitlab.com/gitlab-org/cli/cmd/glab@main` |
+
+### Authenticate
+
+```bash
+glab auth login
+```
+
+Choose your GitLab instance (gitlab.com or self-managed), select HTTPS, and authenticate via browser or a Personal Access Token.
+
+### Verify
+
+```bash
+glab auth status
+```
+
+You should see your username and the instance you're connected to.
+
+For more details, see the [official GitLab CLI documentation](https://docs.gitlab.com/cli/issue/).
+
+---
+
+## Tips
+
+- **You don't pick the agent.** Squad routes the issue to the agent whose expertise matches the issue's domain. A bug in the API goes to the backend agent. A UI issue goes to the frontend agent.
+- **Agents name branches sensibly.** Branch names include the issue number and a slugified title, so they're easy to find in `git branch`.
+- **MRs link to issues.** The MR description includes a `Closes #N` reference so merging automatically closes the issue.
+- **Review feedback is incremental.** When you tell Squad about review feedback, the agent pushes new commits to the existing branch — no force-pushes, no new MRs.
+- **Check `decisions.md` after issue work.** Agents often record decisions while working on issues (e.g., "chose cursor pagination" or "added text index for search"). These decisions carry forward to future issues.
+- **Self-managed GitLab works too.** The `glab` CLI supports self-managed GitLab instances. Run `glab auth login` and select your instance URL during setup.


### PR DESCRIPTION
- Add docs/features/gitlab-issues.md (feature reference)
- Add docs/tour-gitlab-issues.md (step-by-step walkthrough)
- Update docs/README.md with links to both new pages
- Prerequisite: official GitLab CLI (glab) from https://docs.gitlab.com/cli/
- CLI commands verified against official glab documentation
- Mirrors structure of existing GitHub Issues docs with GitLab equivalents (MR instead of PR, glab instead of gh, self-managed instance support)