### PR TITLE
Fix runtime crash by declaring @opentelemetry/api as required dependency

### DIFF
--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -161,15 +161,8 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@github/copilot-sdk": "^0.1.29"
-  },
-  "peerDependencies": {
+    "@github/copilot-sdk": "^0.1.29",
     "@opentelemetry/api": "^1.9.0"
-  },
-  "peerDependenciesMeta": {
-    "@opentelemetry/api": {
-      "optional": true
-    }
   },
   "optionalDependencies": {
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.57.2",
@@ -183,7 +176,6 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.9.0",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.13",
     "typescript": "^5.7.0"


### PR DESCRIPTION
## Fix runtime crash by declaring `@opentelemetry/api` as a runtime dependency

### Problem
`squad-sdk` imports `@opentelemetry/api` at module load time (runtime path), but it is not guaranteed to be installed in fresh consumer installs.

This causes:
- `npx squad init` to fail with `ERR_MODULE_NOT_FOUND`
- users to manually install `@opentelemetry/api` as a workaround

### Change
- Add `@opentelemetry/api` to `dependencies` in `packages/squad-sdk/package.json`
- Remove it from optional peer-only resolution path (if present)

### Why this is correct
Because the package is imported at runtime, it must be resolvable as a runtime dependency.

### Validation
- Fresh install of `@bradygaster/squad-cli`
- Run `npx squad init`
- Confirm init completes without extra installs