### PR TITLE
fix: wire upstream command into CLI entry point

### DIFF
--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -43,6 +43,7 @@ async function main(): Promise<void> {
     console.log(`             Overwrites: squad.agent.md, templates dir (.squad/templates/)`);
     console.log(`             Never touches: .squad/ or .ai-team/ (your team state)`);
     console.log(`             Flags: --global (upgrade personal squad), --migrate-directory (rename .ai-team/ → .squad/)`);
+    console.log(``  ${BOLD}upstream${RESET}   Manage upstream squad inheritance``);
     console.log(`  ${BOLD}status${RESET}     Show which squad is active and why`);
     console.log(`  ${BOLD}triage${RESET}     Scan for work and categorize issues`);
     console.log(`             Usage: triage [--interval <minutes>]`);
@@ -281,6 +282,12 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (cmd === 'upstream') {
+    const { upstreamCommand } = await import('./cli/commands/upstream.js');
+    await upstreamCommand(args.slice(1));
+    return;
+  }
+
   // Unknown command
   fatal(`Unknown command: ${cmd}\n       Run 'squad help' for usage information.`);
 }
@@ -293,3 +300,5 @@ main().catch(err => {
   }
   process.exit(1);
 });
+
+


### PR DESCRIPTION
Closes #224

The `upstream` command (add/remove/list/sync) was fully implemented in `upstream.ts` but never registered in `cli-entry.ts`. Running `squad upstream` returned `Unknown command`.

**Fix:** Added the `if (cmd === 'upstream')` routing block + help text entry (9 lines total).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
