### PR TITLE
fix: wire up `squad link` and `squad init --mode remote` in CLI entry point

### DIFF
--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -39,6 +39,8 @@ async function main(): Promise<void> {
     console.log(`             Flags: --global (init in personal squad directory)`);
     console.log(`  ${BOLD}init${RESET}       Initialize Squad (skip files that already exist)`);
     console.log(`             Flags: --global (init in personal squad directory)`);
+    console.log(`             Usage: init --mode remote <team-repo-path>`);
+    console.log(`             Creates .squad/config.json pointing to an external team root`);
     console.log(`  ${BOLD}upgrade${RESET}    Update Squad-owned files to latest version`);
     console.log(`             Overwrites: squad.agent.md, templates dir (.squad/templates/)`);
     console.log(`             Never touches: .squad/ or .ai-team/ (your team state)`);
@@ -77,6 +79,8 @@ async function main(): Promise<void> {
     console.log(`             Flags: --dry-run, --clean, --yes, --accept-risks`);
     console.log(`  ${BOLD}workstreams${RESET} Manage Squad Workstreams (multi-Codespace scaling)`);
     console.log(`             Usage: workstreams <list|status|activate <name>>`);
+    console.log(`  ${BOLD}link${RESET}       Link project to a remote team root`);
+    console.log(`             Usage: link <team-repo-path>`);
     console.log(`  ${BOLD}build${RESET}      Compile squad.config.ts into .squad/ markdown`);
     console.log(`             Flags: --check (validate only), --dry-run (preview), --watch (rebuild on change)`);
 
@@ -100,6 +104,21 @@ async function main(): Promise<void> {
 
   // Route subcommands
   if (cmd === 'init') {
+    const modeIdx = args.indexOf('--mode');
+    const mode = (modeIdx !== -1 && args[modeIdx + 1]) ? args[modeIdx + 1] : undefined;
+
+    if (mode === 'remote') {
+      const teamPath = args[modeIdx + 2];
+      if (!teamPath) {
+        fatal('Usage: squad init --mode remote <team-repo-path>');
+      }
+      const { writeRemoteConfig } = await import('./cli/commands/init-remote.js');
+      const dest = process.cwd();
+      writeRemoteConfig(dest, teamPath);
+      await runInit(dest);
+      return;
+    }
+
     const dest = hasGlobal ? resolveGlobalSquadPath() : process.cwd();
     runInit(dest).catch(err => {
       fatal(err.message);
@@ -298,6 +317,16 @@ async function main(): Promise<void> {
   if (cmd === 'extract') {
     const { runExtract } = await import('./cli/commands/extract.js');
     await runExtract(process.cwd(), args.slice(1));
+    return;
+  }
+
+  if (cmd === 'link') {
+    const { runLink } = await import('./cli/commands/link.js');
+    const teamPath = args[1];
+    if (!teamPath) {
+      fatal('Usage: squad link <team-repo-path>');
+    }
+    runLink(process.cwd(), teamPath);
     return;
   }
 


### PR DESCRIPTION
## Summary

Both `squad link` and `squad init --mode remote` had full implementations and tests but were never routed in `cli-entry.ts`, causing them to fall through to the "Unknown command" error.

Closes #222

## Changes

**`packages/squad-cli/src/cli-entry.ts`:**

1. **`squad link <team-repo-path>`** — Added routing that imports `runLink` from `commands/link.ts` and calls it with the provided path. Shows usage error if no path is given.

2. **`squad init --mode remote <team-repo-path>`** — Added `--mode` flag parsing in the `init` handler. When `--mode remote` is specified, imports `writeRemoteConfig` from `commands/init-remote.ts` to write `.squad/config.json` before running normal init scaffolding. Shows usage error if no team path is given.

3. **Help text** — Added both commands to the `squad help` output.

## Testing

- All 9 `test/cli/remote-mode.test.ts` tests pass
- All 43 `test/cli.test.ts` tests pass
- Manual verification: `squad link` and `squad init --mode remote` now work as documented