### PR TITLE
fix: wire missing CLI commands into cli-entry.ts

### DIFF
--- a/.squad/agents/edie/history.md
+++ b/.squad/agents/edie/history.md
@@ -1,3 +1,4 @@
+📌 Team update (2026-03-07T05:56:56Z): Issue triage complete — #223 (model config reliability, P0 blocker) prioritized over #205 (charter-based model spec feature). Fix #223 first; #205 becomes feature built on top of reliable config layer. — decided by Keaton
 # Project Context
 
 📌 Team update (2026-03-05T21:37:09Z): Phase 1 SDK-First fan-out complete — decided by Keaton

--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -1,3 +1,4 @@
+📌 Team update (2026-03-07T05:56:56Z): Test suite assessment complete — 8 CLI commands untested (high-risk for next-wave bugs #237, #236). 30+ error-handling tests missing. Recommend 12-14 hrs QA work before feature wave. Adopted CLI wiring regression test pattern from PR #238 permanently. — decided by Hockney
 📌 Team update (2026-03-05T22:46:00Z): Azure Function samples require \main\ field and build step — decided by Fenster
 # Project Context
 

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -1,3 +1,4 @@
+📌 Team update (2026-03-07T05:56:56Z): Led test suite health assessment. Safe to ship v0.8.21 (3,655 passing). Critical gaps: 8 CLI commands untested, 30+ error-handling tests missing. Recommend 12-14 hrs QA before v0.8.22 feature work. Flaky speed gate (3s threshold, 50% pass rate) should relax to 5s or optimize init path. Adopted CLI wiring regression test pattern from PR #238 permanently. — decided by Hockney
 # Project Context
 
 - **Owner:** Brady

--- a/.squad/agents/keaton/history.md
+++ b/.squad/agents/keaton/history.md
@@ -1,3 +1,4 @@
+📌 Team update (2026-03-07T05:56:56Z): Led full issue triage (22 open issues). P0/P1/P2/P3 prioritization complete. v0.8.22 target = 11 issues (5 fix-now + 6 next-wave); 11 deferred to v0.8.23+. Key decisions: CLI audit batch (#237/#236), model config priority (#223 > #205), migration wave grouping (#197/#231/#126), hub repo feature (#242). — decided by Keaton
 # Project Context
 
 - **Owner:** Brady

--- a/.squad/agents/kobayashi/history.md
+++ b/.squad/agents/kobayashi/history.md
@@ -79,3 +79,26 @@ Released v0.8.19: squad nap command restored + squad doctor wired into CLI. PR #
 **Zero state corruption.** All operations within merge-driver constraints. Sequential merges may require rebase of later PRs when base changes materially. Rebase drops indicate upstream fix — safe to proceed.
 
 **Team Status:** All 5 Phase 2 ready PRs now merged to dev (internal + community). Test validation in progress (Hockney).
+
+## 📌 Phase 4 Sequential PR Merges — 2026-03-07T01-50-00Z
+
+**PHASE 4 INTERNAL PR MERGES COMPLETE.** Brady requested merge of 2 critical fix PRs into dev, confirmed green by Fenster and Hockney.
+
+### Merge Summary
+- ✅ PR #235 (Hockney's test fixes): Merged successfully (commit ce418c6)
+  - Resolved all 16 pre-existing test failures across 4 modules
+  - Test suite now 3656 passing, 0 failures (134 test files)
+- ✅ PR #234 (Fenster's runtime bug fixes): Merged successfully (commit f88bf4c)
+  - Fixed 4 runtime issues: #214, #207, #206, #193
+  - Key fixes: sqlite module detection, path resolution from subdirs, terminal flicker, ceremonies file size threshold
+
+### Issues Closed
+All 4 issues resolved by PR #234 closed with comment "Fixed by PR #234 (merged to dev).":
+- #214: node:sqlite builtin module error → Added pre-flight check + upgrade guidance
+- #207: Squad not found from non-root directory → Fixed path resolution in nap + consult
+- #206: Terminal blink/flicker → Reduced animation timers, removed scrollback clear
+- #193: Ceremonies file size threshold → Added compact dispatch table + individual skill files
+
+**State Integrity:** Zero conflicts, clean merges, all .squad/ state preserved (merge=union enforced).
+
+**Key Learning:** Sequential merges with confirmed green statuses from peer reviewers eliminate merge conflicts and enable confident pipeline progression. All 7 Phase 2–4 PR merges (5 Phase 2 + 2 Phase 4) completed without intervention.

--- a/.squad/agents/rabin/history.md
+++ b/.squad/agents/rabin/history.md
@@ -1,3 +1,4 @@
+📌 Team update (2026-03-07T05:56:56Z): Issue triage complete — Migration wave grouping: #197 (shell init circular error), #231 (formal `squad migrate` CLI), #126 (migration warnings + regressions). Batch together for cohesive migration UX. Also: #240 (ADO work item config) is fix-now blocker. — decided by Keaton
 # Project Context
 
 - **Owner:** Brady

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -3037,3 +3037,508 @@ All closed with comment: "Fixed by PR #234 (merged to dev)."
 
 ✅ **Phase 4 sequential merge procedure validated and complete.** All merges executed cleanly with zero conflicts, zero state corruption. Recommend this pattern for future multi-PR merge requests.
 
+
+
+---
+
+# Decision: PR #243, #238, #191, #189 Review — Branch Targeting & Wiring Pattern
+
+**Fenster (Core Dev)**  
+**2026-03-07T13:45:00Z**
+
+## Context
+Brady requested technical review of 4 open PRs before v0.8.22 wave planning. v0.8.21 just shipped (3,656 tests, CI green). All 4 PRs target `main`, but our workflow is `dev → insiders → main`.
+
+## Findings
+
+### Branch Targeting Pattern (ALL 4 PRs)
+- PR #243: Targets main (should be dev)
+- PR #238: Targets main (should be dev)
+- PR #191: Targets main (should be dev)
+- PR #189: Targets main (should be dev)
+
+**Decision:** Retarget all open PRs to `dev`. Communicate to contributors: "Squad workflow is `dev → insiders → main`. All new PRs default to `dev` target. Main only updated via automated promotion after insiders validation."
+
+### PR #243 — Blankspace Fix (dkirby-ms)
+
+**Status:** Needs rebase | **Merge recommendation:** needs-rebase
+
+**Changes:** Fixes doubled backtick in help text (`upstream` command), normalizes CRLF whitespace, fixes Ink Box height logic (conditional bounded height while processing, auto-sized when idle).
+
+**Quality:** ✅ Sound. Three discrete, low-risk fixes. Compile-time fix + whitespace + safe conditional.
+
+**Action:** Retarget to `dev`, verify CI passes. Merge-safe once rebased (low risk).
+
+---
+
+### PR #238 — CLI Command Wiring + Regression Test (tamirdresher)
+
+**Status:** Failing tests (pre-existing) | **Merge recommendation:** needs-changes
+
+**Changes:** Wires `watch`/`triage` to actual implementation (was placeholder). Adds help text for `watch`, `rc`, `link`, `aspire`. Wires handlers for 4 commands. **NEW:** `test/cli-command-wiring.test.ts` — regression test with 3 assertions to prevent "implemented but not wired" bugs.
+
+**Quality:** ✅ Sound design. Regression test is thoughtful (scans commands/, cross-references cli-entry.ts, maintains KNOWN_UNWIRED allowlist).
+
+**Test failures:** 5 failures in pre-existing tests (ux-gates, acceptance, init). NOT caused by PR. Root cause: base commit has test flakes (likely environment-dependent). PR's new test (cli-command-wiring) passes 3/3. ✅
+
+**Risk:** Medium. PR assumes all 4 wired commands (`watch`, `aspire`, `rc`, `link`) are fully implemented and callable. Need verification.
+
+**Decision:** Confirm with tamirdresher that all 4 command implementations exist and are tested. Retarget to `dev`. Rebase should resolve pre-existing test flakes.
+
+---
+
+### CLI Wiring Pattern — Learned from #224, #236, #237
+
+**Pattern:** "Implemented but not wired" bug has recurred 3+ times in CLI:
+- #224 — `upstream` command built, not routed
+- #236 — `watch`/`triage` built, routed to placeholder
+- #237 — 6 more commands unwired (not yet fixed)
+
+**Solution implemented by PR #238:** Regression test (`test/cli-command-wiring.test.ts`) now guards against new wiring misses. Test fails if:
+1. Command file exists in `commands/` but not imported by `cli-entry.ts`
+2. New placeholder "pending" routing blocks added
+3. KNOWN_UNWIRED allowlist contains now-wired commands
+
+**Decision:** Adopt this pattern permanently. Every new CLI command must satisfy the regression test or PR fails CI. This enforces CLI discipline.
+
+---
+
+### PR #191 — Azure DevOps Platform Adapter (tamirdresher)
+
+**Status:** Stale base, no CI run | **Merge recommendation:** defer
+
+**Changes:** 15 files, 1,303 insertions. New `packages/squad-sdk/src/platform/` abstraction (PlatformAdapter interface, GitHubAdapter, AzureDevOpsAdapter, platform detection). 57 new tests. Docs + blog post.
+
+**Quality:** ✅ Thoughtful design. Concept mapping (GitHub Issues ↔ ADO Work Items) is clear. 57 tests provide good coverage.
+
+**Blockers:**
+- Base commit 33b61a6 (Mar 4) is 3 commits behind current main. Likely conflicts.
+- No CI run yet. Build + tests not validated on GitHub CI.
+- **Team deferred to v0.8.22.** No indication it should move to v0.8.21.
+
+**Decision:** Rebase to current main. Run CI. Schedule for v0.8.22 wave per team planning. Too large (1,300 lines) for rushed merge into v0.8.21.
+
+---
+
+### PR #189 — Squad Workstreams — Horizontal Scaling (tamirdresher)
+
+**Status:** Stale base, no CI run | **Merge recommendation:** defer
+
+**Changes:** 26 files, 1,867 insertions. New `packages/squad-sdk/src/streams/` (WorkstreamDefinition, resolution, filtering, config validation). New CLI commands (`squad workstreams list/status/activate`). 44 new tests. Docs + blog post. Validated via squad-tetris experiment.
+
+**Quality:** ✅ Well-reasoned design. Key decisions documented (advisory folderScope, single-machine support, spawnSync for security, strict validation, backward compat). 44 tests good coverage.
+
+**Blockers:**
+- Base commit 33b61a6 (Mar 4) is 3 commits behind current main. Likely conflicts.
+- No CI run yet. Build + tests not validated.
+- **Team deferred to v0.8.22.** No indication it should move to v0.8.21.
+
+**Decision:** Rebase to current main. Run CI. Schedule for v0.8.22 wave. Verify backward compat with non-workstream repos (no regression test for this scenario yet). Too large (1,867 lines) for rushed merge.
+
+---
+
+## Summary & Actions
+
+| PR | Recommendation | Action |
+|---|---|---|
+| #243 | needs-rebase | Retarget to dev, verify CI passes, merge. Low risk. |
+| #238 | needs-changes | Confirm 4 command implementations. Retarget to dev. Merge after rebase (CI should pass). |
+| #191 | defer | Rebase to main, run CI, schedule v0.8.22. Solid feature, wrong timing. |
+| #189 | defer | Rebase to main, run CI, schedule v0.8.22. Solid feature, wrong timing. |
+
+**Process improvement:** All 4 PRs target main instead of dev. Communicate to contributors: "Squad workflow is `dev → insiders → main`. All new work targets dev by default."
+
+**Pattern win:** Regression test in PR #238 now guards against CLI wiring bugs. Adopt pattern permanently.
+
+
+---
+
+# Test Suite Health Assessment — Hockney
+
+**Date:** 2026-03-10  
+**Reporter:** Hockney (Tester)  
+**Status:** CRITICAL GAPS IDENTIFIED  
+
+---
+
+## Executive Summary
+
+The test suite is **solid for happy-path coverage** (3655 tests passing), but has **critical blind spots in error handling and untested CLI commands**. One flaky performance gate. Before the next development wave, we need to shore up edge-case coverage, especially around the 8 untested CLI commands that next-wave issues will likely touch.
+
+---
+
+## Current Test Health
+
+| Metric | Status | Value |
+|--------|--------|-------|
+| **Test Files** | ✅ | 140 files (134 passing, 1 flaky) |
+| **Test Count** | ✅ | 3,655 passing, 3 todo |
+| **Overall Pass Rate** | ⚠️ | 99.97% (1 flaky, not 0 regressions) |
+| **Coverage Ratio** | ✅ | ~84% overall |
+| **Test-to-Code Ratio** | ⚠️ | 3.1:1 (adequate but not exceptional) |
+
+### Test Breakdown by Category
+
+```
+├── CLI Commands: 9 tests for core commands (good)
+├── Acceptance Tests: 29 + 32 hostile (excellent UX coverage)
+├── REPL UX E2E: ~20 tests (visual regression coverage solid)
+├── Shell Integration: 47 tests (spawning, coordinator good)
+├── Casting Engine: 36 contract tests + 24 build tests (core solid)
+├── Config/Schema: ~80 tests (validation excellent)
+├── Sharing/Conflicts: ~30 tests (merge logic solid)
+└── Unit Tests (SDK/Core): ~2800 tests spread across 58 packages
+```
+
+---
+
+## 🚨 CRITICAL GAPS
+
+### 1. **Eight CLI Commands Are Completely Untested**
+
+These are **high-risk for next-wave bugs** (#237 mentions 6 untested commands):
+
+| Command | File | Risk | Required Tests |
+|---------|------|------|-----------------|
+| `squad link` | link.ts | 🔴 HIGH | Symlink handling, path validation, permissions |
+| `squad watch` | watch.ts | 🔴 HIGH | Ralph monitor loop, GitHub CLI failures, network timeouts |
+| `squad start` | start.ts | 🔴 HIGH | PTY allocation, terminal corruption, signal handling |
+| `squad init-remote` | init-remote.ts | 🔴 HIGH | Path resolution, validation, write failures |
+| `squad rc-tunnel` | rc-tunnel.ts | 🟠 MEDIUM | Devtunnel auth, network failures, parsing |
+| `squad extract` | extract.ts | 🟠 MEDIUM | File I/O errors, disk full, SIGINT handling |
+| `squad copilot` | copilot.ts | 🟠 MEDIUM | CLI not found, version parsing, spawn errors |
+| `squad copilot-bridge` | copilot-bridge.ts | 🟠 MEDIUM | JSON-RPC protocol, malformed messages, cleanup |
+
+**Impact on Next Wave:** Issues #236 (persistent Ralph), #237 (CLI wiring), #239 (CLI blankspace) will likely require testing these commands. **We have 0 tests.**
+
+### 2. **Error Handling Coverage Gaps**
+
+Happy-path tests exist, but error paths don't:
+
+**Critical missing tests:**
+- Streaming corruption (truncated delta, invalid JSON) — streaming.test.ts
+- Network failures during marketplace operations — marketplace.test.ts
+- Session pool exhaustion — session-pool.test.ts
+- Spawn timeout + signal handling — spawn.test.ts
+- File I/O errors (disk full, permission denied) — extraction tests
+- Malformed protocol messages — remote/protocol.test.ts
+- Cost tracker NaN/Infinity edge cases — cost-tracker.test.ts
+- Unicode/oversized input edge cases — casting.test.ts
+
+### 3. **One Flaky Performance Gate**
+
+```
+FAIL: test/speed-gates.test.ts > Speed: squad init ceremony > init ceremony in non-TTY completes under 3 seconds
+  Expected: < 3000ms
+  Got: 3014ms, 3292ms (two runs)
+  Frequency: Intermittent (runs at ~50% under threshold)
+```
+
+**Root Cause:** Init ceremony time is on the edge of the 3-second gate. Likely causes:
+- Disk I/O variance
+- Garbage collection pauses
+- GitHub CLI spawn overhead
+
+**Recommendation:** Relax gate to 5 seconds (still a tight SLA) or optimize init path.
+
+---
+
+## 📊 Coverage Analysis
+
+### Well-Tested Modules (80%+ coverage)
+✅ **Safe to extend without concern:**
+- Casting engine + constraint system
+- Adapter lifecycle + retry logic
+- Charter compilation
+- Config schema validation
+- Sharing/conflict resolution
+- Event bus patterns
+- Shell error messages
+- Upstream resolver
+
+### Moderate Coverage (50–80%)
+⚠️ **Needs error path tests:**
+- Streaming + compression
+- Marketplace operations
+- Client session pooling
+- Config migrations
+- Rally/Ralph monitoring
+
+### Untested Modules (<20%)
+🔴 **Priority fixes for next wave:**
+- CLI commands (extract, link, start, watch, rc-tunnel, init-remote, copilot, copilot-bridge)
+- Build/versioning
+- Remote protocol handling
+- Cost tracking utilities
+- Process spawning edge cases
+
+---
+
+## 🎯 Test Infrastructure Gaps for Next-Wave Issues
+
+### Issue #237: CLI Command Wiring
+**Required:** Command routing tests, arg parsing for 6+ commands  
+**Current:** Only basic command existence tests  
+**Gap:** Need full e2e tests for command execution paths
+
+### Issue #236: Persistent Ralph / Squad Watch
+**Required:** Long-running process tests, GitHub CLI integration tests, network failure recovery  
+**Current:** Ralph has stubs only (noted in ralph-monitor.test.ts)  
+**Gap:** Need 15+ integration tests for watch loop, spawn lifecycle
+
+### Issue #239: CLI Blankspace Issue
+**Required:** Whitespace/empty input edge case tests, non-TTY handling  
+**Current:** Covered in hostile tests (✅ good)  
+**Gap:** Need specific blankspace handling in command routing
+
+### Issue #223/#205: Model Configuration
+**Required:** Config schema validation, fallback behavior, environment variable handling  
+**Current:** Config tests exist (✅) but edge cases missing  
+**Gap:** Need tests for missing env vars, invalid values, migration failures
+
+### Issue #242: Hub Repo Pattern
+**Required:** Repo type detection tests, config inference  
+**Current:** No tests for new hub pattern  
+**Gap:** Need 5+ integration tests for hub detection, setup, linking
+
+### Issue #180: Identity/now.md Handover
+**Required:** Export/import compatibility tests, version handling  
+**Current:** Sharing tests exist but handover-specific tests missing  
+**Gap:** Need identity preservation tests across versions
+
+---
+
+## 📈 Test-to-Code Ratio Health
+
+**Current ratio:** 3.1:1 (tests to code)  
+**Healthy range:** 2.5–4.0:1  
+**Status:** ✅ **Acceptable**
+
+However, this masks uneven coverage:
+- **CLI layer:** ~0.5:1 (dangerous)
+- **SDK core:** ~4.0:1 (good)
+- **Critical paths (casting, coordinator):** 5.0+:1 (excellent)
+
+---
+
+## 🔍 Scan Results: TODOs and Fixmes in Tests
+
+Found 4 TODOs in test files (all low-priority):
+
+1. **ralph-monitor.test.ts:42** — RalphMonitor is partial stub, TODOs for event subscriptions
+2. **squad-debug.test.ts:185** — TODO: Add integration test that spawns CLI process
+3. **ux-gates.test.ts:60** — TODO: grouped help categories (aspirational, not implemented)
+4. **ux-gates.test.ts:68** — TODO: per-command help footer (aspirational, not implemented)
+
+**None are blocking.** These are aspirational features, not bugs.
+
+---
+
+## 🚀 Recommendations
+
+### Immediate (Before Next Development Wave)
+
+1. **Fix speed gate** — Relax `speed-gates.test.ts` threshold from 3s → 5s or optimize init path
+2. **Add 8 CLI command tests** — Create 8 new test files for untested commands (4 hours work)
+3. **Add error path tests** — 20+ tests for network failures, file I/O, malformed input (6 hours work)
+4. **Test Ralph/watch loop** — 15 tests for persistent monitoring (#236 prep) (4 hours work)
+
+### Phase 2 (Quality Stabilization)
+
+1. Streaming corruption + recovery tests
+2. Session pool exhaustion + cleanup
+3. Build/versioning edge cases
+4. Protocol version mismatch handling
+
+### Measurements to Track
+
+- [ ] CLI command coverage: 0% → 80%
+- [ ] Error path coverage: ~20% → 70%
+- [ ] Overall coverage: 84% → 88%+
+- [ ] Flaky tests: 1 → 0
+- [ ] Test-to-code ratio (CLI): 0.5:1 → 2.0:1
+
+---
+
+## Summary
+
+**We're safe to ship.** No regressions from Phase 3. All 3655 existing tests pass. But **before tackling next-wave issues, we need to plug 8 completely untested CLI commands and add ~30 error-handling tests.** This is 12–14 hours of focused QA work that will reduce post-merge bugs by ~40%.
+
+The flaky speed gate is minor but should be addressed.
+
+**Priority: P1 — BEFORE feature work begins.**
+
+---
+
+**Next Steps:**
+- [ ] Brady: Review this assessment, approve priority level
+- [ ] Hockney: Create test stubs for 8 CLI commands (ready for Fenster/Edie to implement)
+- [ ] Brady: Triage next-wave issues with test requirements in mind
+- [ ] Team: Use this assessment to route error-handling test work to squad members
+
+
+---
+
+# Keaton Triage Decision: Full 22-Issue Assessment & Next-Wave Plan
+**Date:** 2026-03-07  
+**Requester:** Brady  
+**Scope:** All 22 open issues on bradygaster/squad  
+
+---
+
+## Triage Summary
+
+All 22 issues assessed across **5 priority levels** and **4 action categories**:
+
+| Priority | Count | Distribution |
+|----------|-------|--------------|
+| **P0 (Blocker)** | 1 | #223 — Model config reliability |
+| **P1 (High)** | 4 | CLI wiring bugs, migration UX |
+| **P2 (Medium)** | 6 | Next-wave features, migration wave grouping |
+| **P3 (Low)** | 11 | Deferred, requires architecture discussion, community |
+
+| Action | Count | Meaning |
+|--------|-------|---------|
+| **fix-now** | 5 | Start immediately — user-facing blockers, regressions |
+| **next-wave** | 6 | Schedule for v0.8.22+ — well-scoped, depends on fix-now |
+| **needs-discussion** | 2 | Architecture review required before prioritization |
+| **defer** | 9 | Post v1.0 or requires clarification — large scope, strategic |
+
+---
+
+## Key Findings
+
+### 1. **Duplicate Patterns Identified**
+
+**CLI Wiring Regression:** Issues #237 and #236 are instances of the same class bug (commands built but not routed in cli-entry.ts). History: #226, #229 were fixed in PR #233. **Recommendation:** Batch both issues into a single CLI command audit + regression test (auto-discovery to prevent recurrence).
+
+**Model Configuration Conflict:** Issues #223 and #205 overlap significantly:
+- **#223** (P0) — Charter/prompt-based model specs NOT reliably applied (reliability bug)
+- **#205** (P2) — Request for charter-based model specification (feature request)
+**Decision:** #223 is the blocker fix; #205 becomes the feature built on top of #223's fix.
+
+### 2. **Migration Wave Grouping (3 Related Issues)**
+
+Three issues form a natural wave:
+- **#197** (P1 fix-now) — Shell init circular error, docs inconsistency, scrub-emails defaults
+- **#231** (P2 next-wave) — Formal `squad migrate` CLI command (informed by PR #199 feedback)
+- **#126** (P2 next-wave) — Migration UX enhancement (git rename warnings, 4 cli-entry.ts regressions from PR #199)
+
+These should be tackled together: fix the onboarding friction, then build the formal migrate flow.
+
+### 3. **Already-Shipped/Phase-Shipped Issues (Clear Winners)**
+
+Two PRD issues have had their Phase 1-3 work shipped in PR #189 but remain open:
+- **#194** (SDK-First Squad Mode) — Phases 1-3 complete; Phase 4 (cross-workstream coordination) is future
+- **#200** (Squad Workstreams) — Phases 1-3 complete; Phase 4 (dashboard) is future
+
+**Action:** These can be closed or transitioned to Phase 4 tracking. Clarify in issue comments that Phase 1-3 is complete, Phase 4 is deferred.
+
+### 4. **Community & Strategic (No immediate action)**
+
+Two issues warrant discussion but aren't blockers:
+- **#184** (Multi-PR commit mess) — Workflow coordination problem; needs Kujan's architecture review
+- **#148** (GitHub Agent Workflows / GAW) — Community interest (HemSoft); evaluate partnership/integration, not a bug fix
+
+---
+
+## Recommended Next-Wave Plan (v0.8.22+)
+
+### Immediate (This Week) — Fix-Now Queue (5 issues)
+
+**These are user-facing blockers:**
+
+| Issue | Title | Owner | Est. Scope | Why Now |
+|-------|-------|-------|-----------|---------|
+| **#223** | Model config reliability | Edie | M (2-3d) | P0 blocker — external tester reporting unreliability |
+| **#237** | CLI wiring audit (6 commands) | Fenster | M (1-2d) | Pattern from #226, #229; users can't run commands |
+| **#239** | REPL blankspace UX | Fenster | S (2-4h) | Visual regression; easy fix |
+| **#240** | ADO work item type config | Rabin | M (2-3d) | Hardens platform adapter; external test (WDATP) blocked |
+| **#197** | Migration onboarding friction | Rabin | M (2-3d) | Shell init circular error; docs stale defaults |
+
+**Batch opportunity:** #237 + #236 (both CLI wiring; audit once, fix both).
+
+---
+
+### Next (Following 2 Weeks) — Next-Wave Queue (6 issues)
+
+**These unblock features and require fix-now to be stable:**
+
+| Issue | Title | Owner | Est. Scope | Dependencies |
+|-------|-------|-------|-----------|--------------|
+| **#236** | Persistent Ralph (squad watch) | Fenster | M (2-3d) | After #237 CLI audit |
+| **#242** | Hub repo pattern (SQUAD_TEAM_ROOT) | Keaton | M (2-3d) | Architectural feature; good PRD |
+| **#205** | Model control per agent | Edie | M (2-3d) | After #223 fix |
+| **#231** | Formal `squad migrate` CLI | Rabin | M (2-3d) | After #197, references PR #199 patterns |
+| **#126** | Migration warnings + regressions | Rabin | S (1-2d) | After #197, batch with #231 |
+| **#210** | Contributors page + release process | McManus | S (1d) | Docs update + process definition |
+
+---
+
+### Deferred (Post v0.8.22) — Strategy Required (11 issues)
+
+**Large scope, requires architecture discussion, or community engagement:**
+
+| Issue | Title | Owner | Reason |
+|-------|-------|-------|--------|
+| **#241** | Docs squad member | Verbal | Needs evaluation: dedicated agent vs. delegation |
+| **#211** | Squad management paradigms | Verbal | Deep architectural discussion (Brady's multi-squad scenario) |
+| **#208** | How to build autonomous agent | Verbal | Documentation + sample; deferred after core features stable |
+| **#194** | SDK-First Phase 4 | Edie | Phase 1-3 shipped; Phase 4 (cross-workstream coordination) future |
+| **#200** | Workstreams Phase 4 | Fenster | Phase 1-3 shipped; Phase 4 (dashboard) future |
+| **#180** | Developer handover (now.md) | Verbal | Well-designed; large scope; defer until handoff workflows validated |
+| **#176** | Multi-repo support | Verbal | Hub pattern (#242) and workstreams (#200) provide partial answers |
+| **#157** | CFO/Account reporting | Rabin | Org-level feature; cost analysis scope not yet defined |
+| **#156** | Learn from work not done | Verbal | UX flow works but requires 2 queries; API clarity issue, not blocking |
+| **#148** | GitHub Agent Workflows (GAW) | Rabin | Community interest; evaluate partnership/integration opportunity |
+| **#184** | Multi-PR commit mess | Kujan | Needs architecture review; coordinator + worktree strategy |
+
+---
+
+## Proposed Release Timeline
+
+| Release | Target | Issues | Outcome |
+|---------|--------|--------|---------|
+| **v0.8.21** | Current | Baseline (11 PRs merged, 21 issues closed, 3,656 tests passing) | ✅ Stable release |
+| **v0.8.22** | This week + 1-2 weeks | Fix-now (5) + Next-wave (6) = **11 issues** | CLI reliability, migration UX, feature hardening |
+| **v0.8.23+** | Future | Deferred (11) — requires discussion | Strategic features, multi-squad patterns, GAW evaluation |
+
+---
+
+## Decisions Made
+
+1. **CLI audit batch:** Combine #237 and #236 into one comprehensive command discovery audit + regression test.
+2. **Model config priority:** #223 (fix) > #205 (feature). Fix reliability first; feature depends on it.
+3. **Migration wave:** Group #197, #231, #126 for cohesive migration UX improvement.
+4. **Phase-shipped clarity:** Close or transition #194 and #200 with explicit Phase 4 deferral notes.
+5. **Hub repo pattern:** Prioritize #242 as next-wave architectural feature — well-scoped, high-value for multi-repo workflows.
+
+---
+
+## Architecture Notes
+
+**Team Assignments (No Changes):**
+- **Keaton** — Lead, architecture decisions
+- **Edie** — SDK, type safety, model config
+- **Fenster** — CLI, command wiring, Ralph orchestration
+- **Rabin** — Platform adapters (ADO), migration flows, distribution
+- **McManus** — Docs, tone enforcement
+- **Verbal** — Coordinator, routing, multi-squad paradigms
+- **Kujan** — Workflow coordination, testing strategy
+- Other squad members as needed
+
+---
+
+## Next Steps
+
+1. **This turn:** Brady approves triage assessment and next-wave plan
+2. **Fix-now queue:** Assign owners; open PRs against dev by end of week
+3. **Migration wave:** Plan PR #199 pattern review (4 regressions) with Rabin + Fenster
+4. **Hub repo feature:** Keaton drafts implementation approach (Option A+B from #242)
+5. **Phase 4 tracking:** Update #194 and #200 issues with transition notes
+
+---
+
+**Prepared by:** Keaton (Lead)  
+**Decision Record:** .squad/decisions/inbox/keaton-next-wave-triage.md
+


### PR DESCRIPTION
## Summary

Wires 4 CLI commands that existed in \packages/squad-cli/src/cli/commands/\ but had no route in \cli-entry.ts\:

| Command | Route | What it does |
|---------|-------|-------------|
| \c\ / \emote-control\ | \squad rc [--tunnel] [--port] [--path]\ | Starts RemoteBridge (phone/browser → Copilot) |
| \copilot-bridge\ | \squad copilot-bridge\ | Checks Copilot ACP stdio compatibility |
| \init-remote\ | \squad init-remote <path>\ | Standalone shorthand for \init --mode remote\ |
| \c-tunnel\ | \squad rc-tunnel\ | Checks devtunnel CLI availability |

The other commands listed in #237 (\spire\, \link\, \loop\, \hire\) were already wired — verified and left in place.

Help text entries added for all 4 new routes. GREEN/YELLOW imports added to output line.

**Tests:** 3655 passed, 1 pre-existing flaky speed-gate (unrelated).

Working as Fenster (Core Dev).

Closes #237