### PR TITLE
fix(docs): add concepts/ and cookbook/ to build, fix broken links (#266)

### DIFF
--- a/docs/build.js
+++ b/docs/build.js
@@ -38,6 +38,8 @@ const SECTIONS = [
   { dir: 'features', title: 'Features' },
   { dir: 'reference', title: 'Reference' },
   { dir: 'scenarios', title: 'Scenarios' },
+  { dir: 'concepts', title: 'Concepts' },
+  { dir: 'cookbook', title: 'Cookbook' },
   { dir: 'blog', title: 'Blog' },
 ];
 
@@ -57,6 +59,8 @@ const SECTION_ORDER = {
   ],
   'reference': ['cli', 'sdk', 'config'],
   'scenarios': ['existing-repo', 'solo-dev', 'issue-driven-dev', 'monorepo', 'ci-cd-integration', 'team-of-humans', 'aspire-dashboard'],
+  'concepts': ['your-team', 'memory-and-knowledge', 'parallel-work', 'github-workflow', 'portability'],
+  'cookbook': ['recipes'],
 };
 
 // Parse optional YAML-style frontmatter (--- fenced)

--- a/docs/sdk-first-mode.md
+++ b/docs/sdk-first-mode.md
@@ -832,5 +832,5 @@ export default defineSquad({
 ## See Also
 
 - [SDK Reference](./reference/sdk.md) — all SDK exports
-- [Routing Guide](./concepts/routing.md) — deep dive on routing tiers
+- [Routing Guide](./features/routing.md) — deep dive on routing tiers
 - [Governance & Hooks](./sdk/tools-and-hooks.md) — hook pipeline and governance


### PR DESCRIPTION
## Summary

Fixes the 403/404 error on the docs site when navigating to Recipes & Advanced Scenarios or any Concepts page.

**Root cause:** \docs/build.js\ SECTIONS array didn't include \concepts/\ or \cookbook/\ directories — those markdown source files existed but were never built into HTML pages.

## Changes

- **\docs/build.js\** — Added \concepts\ (5 pages) and \cookbook\ (1 page) to SECTIONS and SECTION_ORDER
- **\docs/sdk-first-mode.md\** — Fixed dead link: \concepts/routing.md\ → \eatures/routing.md\ (the file didn't exist)

## Broken links fixed (8+)

| Source file | Broken link | Status |
|---|---|---|
| reference/cli.md | cookbook/recipes.html | ✅ Fixed (now builds) |
| reference/sdk.md | cookbook/recipes.html | ✅ Fixed (now builds) |
| get-started/first-session.md | concepts/your-team.html | ✅ Fixed (now builds) |
| get-started/first-session.md | concepts/memory-and-knowledge.html | ✅ Fixed (now builds) |
| features/github-issues.md | concepts/github-workflow.html | ✅ Fixed (now builds) |
| features/human-team-members.md | concepts/your-team.html | ✅ Fixed (now builds) |
| features/plugins.md | concepts/your-team.html, memory-and-knowledge.html | ✅ Fixed (now builds) |
| sdk-first-mode.md | concepts/routing.md (didn't exist) | ✅ Redirected to features/routing.md |

## Verified

- \
ode docs/build.js\ generates 99 pages including all 6 new ones
- All previously-404 pages now build: concepts/your-team, concepts/memory-and-knowledge, concepts/parallel-work, concepts/github-workflow, concepts/portability, cookbook/recipes

Closes #266