### PR TITLE
docs: add Squad Contributors Guide page (#276)

### DIFF
--- a/.squad/agents/mcmanus/history.md
+++ b/.squad/agents/mcmanus/history.md
@@ -36,6 +36,30 @@
 
 ## Learnings
 
+### 2026-03-16: Squad Contributors Guide — Docs Page (#276)
+
+**Status:** Complete. Created dedicated contributors guide page in docs site Guide section.
+
+**Summary:**
+Created `docs/guide/contributors.md` to honor every community contributor to Squad. Issue #276 requested a proper docs page thanking everyone who has contributed, whether through merged PRs or impactful issues/discussions. The page lists all contributors in reverse-chronological order (most recent first) to keep it current and acknowledge recent work prominently.
+
+**Implementation:**
+- Created comprehensive contributors guide with two sections:
+  - **Code Contributors** (11 people): merged PRs from @tamirdresher (4 PRs), @williamhallatt (5 PRs), @EmmittJ, @jsturtevant, @aadnesd, @CarlosSardo, @codebytes, @spboyer, @digitaldrummerj, @danielscholl, @csharpfritz
+  - **Community Contributors** (25+ people): issues/discussions that drove improvements, including @lbouriez (credential leak → secret guardrails), @eric-vanartsdalen (docs 403), @LasseAtSparkron (ESM crash), @swnger (skill-based orchestration → defineSkill()), and many more
+- Updated `docs/build.js` to add 'contributors' to the guide section order, right after 'contributing'
+- Built docs successfully — new page renders at `/guide/contributors`
+- Opened PR #277 targeting main
+
+**Tone & Structure:**
+- Warm, appreciative opening: "This page honors everyone who has submitted code, filed issues, started discussions, and shared ideas that have shaped this project."
+- Each contributor section shows their GitHub handle (linked), real name when known, most recent contribution date, then bullet list of all contributions with issue/PR links
+- Closing note: "This page is updated with every release. No contribution goes unappreciated."
+- Zero hype, all substance — every line is factual and cited
+
+**DevRel Pattern Reinforced:**
+Recognition is a cornerstone of community health. Brady tracks every contributor meticulously, and now we have a permanent, public home for that gratitude. This page serves both as thanks and as social proof—new contributors can see that their work will be acknowledged. The reverse-chronological ordering keeps it fresh and relevant with each release.
+
 ### 2026-03-13: Community Discussions — Terminal Flickering & Skill-Based Orchestration
 
 **Status:** Complete. Posted warm replies to Discussions #170 (terminal flickering) and #169 (skill-based orchestration).

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -10781,3 +10781,9 @@ Added: "First-day mistakes on main are not acceptable. Process discipline starts
 
 
 ### 2026-03-08T13:28Z: User directive **By:** Brady (via Copilot) **What:** Users should NEVER have to worry about secrets being leaked by Squad agents. This is non-negotiable. Also, minimize GitHub Actions usage for security scanning — prefer local/runtime guards over CI-based scanning. **Why:** User request — captured for team memory. Actions minutes are already heavily used; prefer SDK-level enforcement that costs zero CI time.
+
+
+### 2026-03-08T16:24Z: User directive — Contributors page updated every release
+**By:** Brady (via Copilot)
+**What:** Every release must include an update to the Squad Contributors Guide page in the docs site. No contribution goes unappreciated — all issues, discussions, and PRs that led to shipped work must be acknowledged.
+**Why:** User request — captured for team memory and release checklist.

--- a/docs/build.js
+++ b/docs/build.js
@@ -46,7 +46,7 @@ const SECTIONS = [
 // Explicit ordering within sections (filename without .md → priority)
 const SECTION_ORDER = {
   'get-started': ['installation', 'first-session', 'migration'],
-  'guide': ['tips-and-tricks', 'sample-prompts', 'personal-squad', 'contributing'],
+  'guide': ['tips-and-tricks', 'sample-prompts', 'personal-squad', 'contributing', 'contributors'],
   'features': [
     'team-setup', 'routing', 'model-selection', 'response-modes',
     'parallel-execution', 'memory', 'skills', 'directives',

--- a/docs/guide/contributors.md
+++ b/docs/guide/contributors.md
@@ -1,0 +1,182 @@
+# Squad Contributors Guide
+
+Thank you to every contributor who has helped make Squad better. This page honors everyone who has submitted code, filed issues, started discussions, and shared ideas that have shaped this project. This page is updated with every release.
+
+## Code Contributors
+
+These community members submitted merged pull requests to Squad:
+
+### [@tamirdresher](https://github.com/tamirdresher) (Tamir Dresher)
+Most recent: March 8, 2026
+
+- [#272](https://github.com/bradygaster/squad/pull/272) — Renamed workstreams to SubSquads
+- [#263](https://github.com/bradygaster/squad/pull/263) — Added CommunicationAdapter
+- [#191](https://github.com/bradygaster/squad/pull/191) — Implemented Azure DevOps adapter
+- [#225](https://github.com/bradygaster/squad/pull/225) — Wired upstream command
+
+### [@EmmittJ](https://github.com/EmmittJ) (Emmitt)
+Most recent: March 7, 2026
+
+- [#230](https://github.com/bradygaster/squad/pull/230) — Wired squad link + init --remote
+
+### [@williamhallatt](https://github.com/williamhallatt) (William Hallatt)
+Most recent: March 7, 2026
+
+- [#219](https://github.com/bradygaster/squad/pull/219) — Added fork contribution docs
+- [#217](https://github.com/bradygaster/squad/pull/217) — Fixed init follow-up issue
+- [#221](https://github.com/bradygaster/squad/pull/221) — Restored CI green status
+- [#203](https://github.com/bradygaster/squad/pull/203) — Fixed init workflow
+- [#185](https://github.com/bradygaster/squad/pull/185) — Fixed template path issue
+
+### [@jsturtevant](https://github.com/jsturtevant) (James Sturtevant)
+Most recent: March 5, 2026
+
+- [#198](https://github.com/bradygaster/squad/pull/198) — Added consult mode CLI
+
+### [@aadnesd](https://github.com/aadnesd)
+Most recent: March 5, 2026
+
+- [#204](https://github.com/bradygaster/squad/pull/204) — Fixed OpenTelemetry dependency issue
+
+### [@CarlosSardo](https://github.com/CarlosSardo) (Carlos Sardo)
+Most recent: March 4, 2026
+
+- [#178](https://github.com/bradygaster/squad/pull/178) — Added GitLab Issues walkthrough
+
+### [@codebytes](https://github.com/codebytes) (Chris Ayers)
+Most recent: February 20, 2026
+
+- [#97](https://github.com/bradygaster/squad/pull/97) — Created Star Trek casting universe
+
+### [@spboyer](https://github.com/spboyer) (Shayne Boyer)
+Most recent: February 20, 2026
+
+- [#57](https://github.com/bradygaster/squad/pull/57) — Implemented squad watch — Ralph watchdog
+
+### [@digitaldrummerj](https://github.com/digitaldrummerj) (Justin James)
+Most recent: February 17, 2026
+
+- [#89](https://github.com/bradygaster/squad/pull/89) — Added MCP Discord notifications
+
+### [@danielscholl](https://github.com/danielscholl)
+Most recent: February 17, 2026
+
+- [#80](https://github.com/bradygaster/squad/pull/80) — Implemented llms.txt docs build
+
+### [@csharpfritz](https://github.com/csharpfritz) (Jeffrey T. Fritz)
+Most recent: February 13, 2026
+
+- [#55](https://github.com/bradygaster/squad/pull/55) — Added logo for docs
+
+## Community Contributors
+
+These community members filed issues and started discussions that drove improvements to Squad:
+
+### [@lbouriez](https://github.com/lbouriez) (Laurent)
+
+- [#267](https://github.com/bradygaster/squad/issues/267) — Reported credential leak (led to secret guardrails sprint)
+- [#269](https://github.com/bradygaster/squad/issues/269) — Requested migration guide link
+
+### [@eric-vanartsdalen](https://github.com/eric-vanartsdalen) (Eric VanArtsdalen)
+
+- [#266](https://github.com/bradygaster/squad/issues/266) — Reported docs 403 error (led to docs build fix)
+
+### [@LasseAtSparkron](https://github.com/LasseAtSparkron)
+
+- [#265](https://github.com/bradygaster/squad/issues/265) — Reported ESM crash (led to Node 24 fix)
+
+### [@craigb](https://github.com/craigb) (Craig Boucher)
+
+- [#262](https://github.com/bradygaster/squad/issues/262) — Reported lint failure
+
+### [@marchermans](https://github.com/marchermans) (Marc Hermans)
+
+- [#247](https://github.com/bradygaster/squad/issues/247) — Reported installation failure
+
+### [@dfberry](https://github.com/dfberry) / [@diberry](https://github.com/diberry) (Dina Berry)
+
+- [#241](https://github.com/bradygaster/squad/issues/241) — Suggested docs member
+- [#228](https://github.com/bradygaster/squad/issues/228) — Reported CI failure
+- [#211](https://github.com/bradygaster/squad/issues/211) — Discussed management paradigms
+- [#157](https://github.com/bradygaster/squad/issues/157) — Suggested CFO member
+
+### [@dkirby-ms](https://github.com/dkirby-ms) (Dale Kirby)
+
+- [#239](https://github.com/bradygaster/squad/issues/239) — Reported terminal flickering (led to TUI fix)
+
+### [@tomasherceg](https://github.com/tomasherceg) (Tomáš Herceg)
+
+- [#237](https://github.com/bradygaster/squad/issues/237) — Reported CLI wiring bug
+- [#184](https://github.com/bradygaster/squad/issues/184) — Raised multi-PR commits issue
+
+### [@uvirk](https://github.com/uvirk) (Uday)
+
+- [#229](https://github.com/bradygaster/squad/issues/229) — Reported doctor command missing
+
+### [@EirikHaughom](https://github.com/EirikHaughom) (Eirik Haughom)
+
+- [#223](https://github.com/bradygaster/squad/issues/223) — Requested model configuration (led to per-model feature)
+
+### [@tihomir-kit](https://github.com/tihomir-kit) (Tihomir Kit)
+
+- [#214](https://github.com/bradygaster/squad/issues/214) — Reported node:sqlite error
+
+### [@fboucher](https://github.com/fboucher) (Frank Boucher)
+
+- [#207](https://github.com/bradygaster/squad/issues/207) — Reported non-root path resolution issue
+
+### [@Pruthviraj36](https://github.com/Pruthviraj36)
+
+- [#206](https://github.com/bradygaster/squad/issues/206) — Reported terminal blinking
+
+### [@cobey](https://github.com/cobey) (Cody Beyer)
+
+- [#196](https://github.com/bradygaster/squad/issues/196) — Requested global init mode
+
+### [@dnoriegagoodwin](https://github.com/dnoriegagoodwin)
+
+- [#195](https://github.com/bradygaster/squad/issues/195) — Reported upgrade version stamp bug
+
+### [@wbreza](https://github.com/wbreza) (Wallace Breza)
+
+- [#193](https://github.com/bradygaster/squad/issues/193) — Discussed ceremonies threshold
+
+### [@MdeBruin93](https://github.com/MdeBruin93) (MdeBruin)
+
+- [#192](https://github.com/bradygaster/squad/issues/192) — Reported npx stopped working
+
+### [@KevinUK](https://github.com/KevinUK)
+
+- [#188](https://github.com/bradygaster/squad/issues/188) — Reported upgrade doctor missing
+
+### [@jbruce716](https://github.com/jbruce716)
+
+- [#187](https://github.com/bradygaster/squad/issues/187) — Reported command not found
+
+### [@frankhaugen](https://github.com/frankhaugen) (Frank R. Haugen)
+
+- [#183](https://github.com/bradygaster/squad/issues/183) — Reported fetch failed error
+
+### [@chrislomonico](https://github.com/chrislomonico)
+
+- [#181](https://github.com/bradygaster/squad/issues/181) — Raised developer handover question
+
+### [@johnwc](https://github.com/johnwc) (John Carew)
+
+- [#176](https://github.com/bradygaster/squad/issues/176) — Requested multi-repo support
+
+### [@swnger](https://github.com/swnger)
+
+- [Discussion #169](https://github.com/bradygaster/squad/discussions/169) — Proposed skill-based orchestration (led to defineSkill())
+
+### [@sturlath](https://github.com/sturlath)
+
+- [#156](https://github.com/bradygaster/squad/issues/156) — Discussed cross-agent learning
+
+### [@HemSoft](https://github.com/HemSoft)
+
+- [#148](https://github.com/bradygaster/squad/issues/148) — Proposed GitHub Agent Workflows concept
+
+---
+
+**This page is updated with every release. No contribution goes unappreciated.**


### PR DESCRIPTION
Closes #276

Adds a dedicated Squad Contributors Guide page to the docs site Guide section, thanking every contributor in reverse-chronological order.

- Code contributors who submitted merged PRs
- Community contributors whose issues/discussions drove improvements
- Updated with every release — no contribution goes unappreciated