### PR TITLE
docs: add validation steps to Quick Start README (#285)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,16 @@ mkdir my-project && cd my-project
 git init
 ```
 
+**✓ Validate:** Run `git status` — you should see "No commits yet".
+
 ### 2. Install Squad
 
 ```bash
 npm install --save-dev @bradygaster/squad-cli
 npx squad init
 ```
+
+**✓ Validate:** Check that `.squad/team.md` was created in your project.
 
 **Or use npx (no install):** `npx @bradygaster/squad-cli` — see [Migration Guide](docs/get-started/migration.md) if upgrading from an older version.
 
@@ -40,6 +44,8 @@ npx squad init
 ```bash
 gh auth login
 ```
+
+**✓ Validate:** Run `gh auth status` — you should see "Logged in to github.com".
 
 ### 4. Open Copilot and go
 
@@ -56,6 +62,8 @@ Then:
 I'm starting a new project. Set up the team.
 Here's what I'm building: a recipe sharing app with React and Node.
 ```
+
+**✓ Validate:** Squad responds with team member proposals. Type `yes` to confirm — they're ready to work.
 
 Squad proposes a team — each member named from a persistent thematic cast. You say **yes**. They're ready.
 


### PR DESCRIPTION
Closes #285

## What

Adds one-line **✓ Validate** steps after each command block in the Quick Start section (README lines 20-68), giving new users immediate confidence that each step worked before moving on.

### Changes

| Step | Validation added |
|------|-----------------|
| 1. Create project | `git status` → 'No commits yet' |
| 2. Install Squad | Check `.squad/team.md` was created |
| 3. Authenticate | `gh auth status` → 'Logged in to github.com' |
| 4. Open Copilot | Squad responds with team proposals |

## Why

This is **Quick Win #1 (P0)** from a new-user experience audit that found Squad's docs are expert-biased and discovery-hostile:

- **40-50% estimated abandonment rate** — 60% of GitHub Discussions questions are 'How do I start?' or 'It's not working'
- **Root cause:** No validation steps between commands — users don't know if installation succeeded until they hit an error
- **Impact:** Reduces abandonment by giving users confidence at each step. Estimated 10 minutes of user time saved per onboarding attempt.

The audit benchmarked against Vercel, Supabase, Stripe, and Astro docs — all use 'did it work?' validation after every install step. Squad's Quick Start was the only one that didn't.

## Review notes

- No code changes — documentation only
- PAO (DevRel agent) authored the validation copy
- Suggested reviewers: @diberry (primary), @bradygaster