### PR TITLE
docs: add installation method decision tree

### DIFF
--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -59,6 +59,21 @@ npm install -g @bradygaster/squad-cli@latest
 
 ---
 
+## Which method should I use?
+
+Pick based on what you're doing:
+
+| **You want to...** | **Use** | **Why** |
+|--------------------|---------|---------|
+| Try Squad quickly | **CLI** with `npx` | No install needed. Run `npx @bradygaster/squad-cli init` and you're testing it. |
+| Use Squad across all projects | **CLI** with `--global` | One install. Works everywhere. Run `squad` from any terminal. |
+| Work inside VS Code | **VS Code** (just open your project) | Already using Copilot? Squad just works. Same `.squad/` directory as CLI. |
+| Build tools on top of Squad | **SDK** | Typed APIs, routing config, agent lifecycle hooks. Programmatic access to everything. |
+
+Can't decide? → Start with **CLI**. You can always add VS Code or the SDK later. Your `.squad/` directory works identically everywhere.
+
+---
+
 ## 2. VS Code
 
 Squad works in VS Code through GitHub Copilot. Your `.squad/` directory works identically in both CLI and VS Code — same agents, same decisions, same memory.


### PR DESCRIPTION
## What this PR does

Adds a **'Which method should I use?'** decision table to the [Installation Guide](docs/get-started/installation.md), helping new users choose between the four installation methods based on their goals.

### Changes

| Goal | Recommended Method | Why |
|------|-------------------|-----|
| Try Squad quickly | CLI (npx) | Zero install, instant start |
| Use Squad regularly | CLI (global) | Available everywhere, faster startup |
| Stay in your editor | VS Code extension | Inline AI assistance while coding |
| Build programmatically | SDK (npm package) | Full API access for custom workflows |

Includes a fallback recommendation for undecided users: *Start with the CLI.*

### Context

This addresses a gap identified in new-user experience testing: after the installation overview, users weren't sure which of the three methods to pick. The decision table provides quick guidance without requiring users to read all three sections.

Closes #287

**Suggested reviewers:** @diberry, @bradygaster