### PR TITLE
docs: add .squad directory explainer to first-session guide

### DIFF
--- a/docs/get-started/first-session.md
+++ b/docs/get-started/first-session.md
@@ -86,7 +86,25 @@ Say "yes" or skip straight to a task (which is implicit confirmation):
 > Yes. Dallas, set up the Express server with basic routing.
 ```
 
-Squad creates the `.squad/` directory structure — team roster, routing rules, casting state, ceremony config, agent charters, and histories — all seeded with your project context. Then it spawns Dallas:
+Squad creates the `.squad/` directory structure — team roster, routing rules, casting state, ceremony config, agent charters, and histories — all seeded with your project context.
+
+### What's inside .squad/?
+
+| File/Directory | Purpose |
+|---|---|
+| `team.md` | Team roster, roles, and member info |
+| `routing.md` | Work routing rules (which agent handles what) |
+| `decisions.md` | Team decisions — all agents read this before working |
+| `agents/` | Each agent's charter and history (their memory) |
+| `ceremonies.md` | Ceremony schedule (retrospectives, reviews, etc.) |
+| `casting/` | Team formation history and casting state |
+| `skills/` | Reusable capabilities agents can learn |
+
+**You own these files.** Edit them anytime — change roles, add routing rules, fix decisions. Squad reads them before every spawn.
+
+**Commit `.squad/` to version control.** It's your team's brain. Anyone who clones the repo gets the team with all their knowledge.
+
+Then it spawns Dallas:
 
 ```
 🔧 Dallas — setting up Express server with routing


### PR DESCRIPTION
## What this PR does

Adds a **'What's inside .squad/?'** section to the [First Session guide](docs/get-started/first-session.md), giving new users a quick reference for the files and directories Squad creates.

### Changes

After the line where Squad creates the \.squad/\ directory, a new subsection explains:

| File/Directory | Purpose |
|---|---|
| \	eam.md\ | Team roster — who's on the squad and their roles |
| \outing.md\ | Work routing rules — how tasks get assigned |
| \decisions.md\ | Shared decision log — the team's institutional memory |
| \gents/\ | Agent charters and histories — each member's identity and learnings |
| \ceremonies.md\ | Team ceremony definitions — standups, retros, design reviews |
| \casting/\ | Name registry — persistent agent-to-name mappings |

Also confirms that users **can and should edit** these files, and that they should be **committed to version control**.

### Context

New users weren't sure what the \.squad/\ directory contained or whether they should touch it. This explainer builds confidence right at the moment the directory is created.

Closes #289

**Suggested reviewers:** @diberry, @bradygaster