### PR TITLE
docs: Add doc-impact review process to team workflow

### DIFF
--- a/.squad/agents/pao/charter.md
+++ b/.squad/agents/pao/charter.md
@@ -22,8 +22,10 @@
 - Every feature needs a story — if you can't explain it, it's not ready
 - Demos over descriptions — show, don't tell
 - Tone is infrastructure — inconsistent voice erodes trust
+- **MICROSOFT STYLE GUIDE (hard rule):** Follow the [Microsoft Style Guide](https://learn.microsoft.com/style-guide/welcome/) for all documentation — sentence-case headings, active voice, second person ("you"), present tense. Override only when it conflicts with the team's established voice and tone.
 - **DOCS-TEST SYNC (hard rule):** When adding new docs pages (guides, blog posts), update the corresponding test assertions in test/docs-build.test.ts in the SAME commit. Stale test assertions that block CI are a docs team failure.
 - **CONTRIBUTOR RECOGNITION (hard rule):** Each release includes an update to the Contributors Guide page. No contribution goes unappreciated.
+- **DOC-IMPACT REVIEW (hard rule):** Review every PR for documentation impact. If a change affects user-facing behavior, ensure corresponding docs are updated or flag the gap.
 
 ## Boundaries
 

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -85,6 +85,11 @@
 **What:** Booster adds CI check for stale test assertions. FIDO enforces via PR review.
 **Why:** Prevents the pattern of APIs changing without test updates.
 
+### Doc-impact review — every PR
+**By:** PAO, v0.8.25
+**What:** Every PR must be evaluated for documentation impact. PAO reviews PRs for missing or outdated docs.
+**Why:** Code changes without doc updates lead to stale guides and confused users.
+
 ---
 
 ## Release v0.8.24

--- a/.squad/routing.md
+++ b/.squad/routing.md
@@ -56,3 +56,4 @@
 4. **Two agents could handle it** → pick the one whose domain is the primary concern.
 5. **"Team, ..." → fan-out.** Spawn all relevant agents in parallel as `mode: "background"`.
 6. **Anticipate downstream.** Feature being built? Spawn tester for test cases from requirements simultaneously.
+7. **Doc-impact check → PAO.** Any PR touching user-facing code or behavior should involve PAO for doc-impact review.


### PR DESCRIPTION
## Summary
Adds a doc-impact review step to the team workflow so every PR is evaluated for documentation changes.

## Changes
- **decisions.md**: New sprint directive — every PR must be evaluated for doc impact
- **PAO charter**: DOC-IMPACT REVIEW added as a hard rule
- **routing.md**: New routing principle #7 — auto-involve PAO for doc review

## Labels
`documentation`, `P0`

Closes #291

cc @bradygaster @dfberry