### PR TITLE
Docs update: Add decision framework for when to add human members

### DIFF
--- a/docs/src/content/docs/concepts/your-team.md
+++ b/docs/src/content/docs/concepts/your-team.md
@@ -97,6 +97,8 @@ Sarah appears on the roster with a 👤 Human badge.
 
 When work routes to a human, Squad **pauses** and tells you someone needs to act. You relay the task outside of Squad, then report back what happened. Stale reminders keep things moving.
 
+Not sure whether someone should be a roster member or just a normal GitHub collaborator? See [When to add a human member](../features/human-team-members.md#when-to-add-a-human-member) for a decision framework.
+
 ---
 
 ## Work Routing

--- a/docs/src/content/docs/features/human-team-members.md
+++ b/docs/src/content/docs/features/human-team-members.md
@@ -77,6 +77,24 @@ Their entry moves to `.squad/agents/_alumni/`. They can be re-added later.
 
 ---
 
+## When to add a human member
+
+Not every collaborator needs a roster entry. Use this table to decide:
+
+| Scenario | Add to roster? | Why |
+|----------|---------------|-----|
+| Approves architecture decisions before implementation | ✅ Yes | Decision gate — agents route and wait |
+| Reviews all docs PRs as a standing reviewer | ✅ Yes | Recurring review gate |
+| Makes the final ship/no-ship call | ✅ Yes | Approval gate |
+| Occasionally reviews PRs when tagged | ❌ No | Use @mention on the PR instead |
+| Files issues and contributes code | ❌ No | Normal GitHub collaboration |
+
+**Litmus test:** If you want agents to *stop and wait* for someone's input before proceeding, add them. If they review asynchronously through normal GitHub flows, a roster entry adds no value.
+
+**You don't need to add yourself.** Squad reads `git config user.name` every session, so the team always knows who's driving. Adding yourself to the roster is optional — it formalizes routing and review tracking but isn't required for day-to-day interaction.
+
+---
+
 ## Tips
 
 - Use human members for approval gates — design review, compliance, final sign-off.


### PR DESCRIPTION
## Summary

Adds a decision framework to help users understand when to add someone as a human team member versus leaving them as a normal GitHub collaborator.

## Changes

### `docs/src/content/docs/features/human-team-members.md`
- New **When to add a human member** section before Tips
- Decision table with 5 scenarios (approval gates vs. casual collaboration)
- Litmus test: "If you want agents to *stop and wait*, add them"
- Note about automatic identification via `git config user.name`

### `docs/src/content/docs/concepts/your-team.md`
- Cross-reference link from Human Team Members section to the new decision framework

## Why

The existing docs explain *how* to add human members (mechanics, pausing, routing) but not *when* or *why*. New users don't have a clear signal for the decision. This was identified during onboarding.

Closes #313

cc @bradygaster - cannot request reviewers from fork, requesting review via mention.
