### PR TITLE
docs: fix README migration guide link

### DIFF
--- a/.changeset/fix-readme-migration-guide-link.md
+++ b/.changeset/fix-readme-migration-guide-link.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+docs: point README migration guide links to the published docs site

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install --save-dev @bradygaster/squad-cli
 npx squad init
 ```
 
-**Or use npx (no install):** `npx @bradygaster/squad-cli` — see [Migration Guide](docs/get-started/migration.md) if upgrading from an older version.
+**Or use npx (no install):** `npx @bradygaster/squad-cli` — see [Migration Guide](https://bradygaster.github.io/squad/docs/get-started/migration/) if upgrading from an older version.
 
 ### 3. Authenticate with GitHub (for Issues, PRs, and Ralph)
 
@@ -159,7 +159,7 @@ For insider builds:
 npm install -g @bradygaster/squad-cli@insider
 ```
 
-> **Note:** GitHub-native distribution (`npx github:bradygaster/squad`) has been removed. All distribution is now via npm (see [Migration Guide](docs/get-started/migration.md) for details).
+> **Note:** GitHub-native distribution (`npx github:bradygaster/squad`) has been removed. All distribution is now via npm (see [Migration Guide](https://bradygaster.github.io/squad/docs/get-started/migration/) for details).
 
 ---
 


### PR DESCRIPTION
Closes #351

## Summary
- update README migration guide links to the published docs URL
- add the required changeset for this docs-only change
- rebase the PR branch onto dev so the diff stays isolated

## Testing
- not run (README and changeset only)
