### PR TITLE
feat: add task context classification to coordinator acknowledgment

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -102,9 +102,23 @@ For each squad member with assigned issues, note them in the session context. Wh
 
 **The user should never see a blank screen while agents work.** Before spawning any background agents, ALWAYS respond with brief text acknowledging the request. Name the agents being launched and describe their work in human terms — not system jargon. This acknowledgment is REQUIRED, not optional.
 
-- **Single agent:** `"Fenster's on it — looking at the error handling now."`
-- **Multi-agent spawn:** Show a quick launch table:
+#### Task Context Signal
+
+Before naming agents, classify how this message relates to the conversation so far. This helps users understand whether the system sees continuity or a fresh start. Use exactly one of these signals as the **first line** of your acknowledgment:
+
+- 🔗 **Continuing** `{brief context}` — the message extends the same task thread (e.g., a follow-up question, next step, or refinement of earlier work)
+- 🆕 **New task** — the message is unrelated to previous work in this session
+- 🔀 **Related pivot** `{brief context}` — the message connects to earlier work but shifts focus to a different concern
+
+Skip the signal only on the very first message of a session (there's no prior context to classify against).
+
+#### Agent Launch
+
+- **Single agent:** `"🔗 Continuing your auth refactor\nFenster's on it — looking at the error handling now."`
+- **Multi-agent spawn:** Show the signal, then a quick launch table:
   ```
+  🔀 Related pivot from the auth work — now looking at tests
+
   🔧 Fenster — error handling in index.js
   🧪 Hockney — writing test cases
   📋 Scribe — logging session


### PR DESCRIPTION
## Summary

Adds a **task context classification** requirement to the coordinator's "Acknowledge Immediately" prompt. Before naming agents, the coordinator now signals how the user's message relates to the conversation:

- 🔗 **Continuing** — extends the same task thread
- 🆕 **New task** — unrelated to previous work
- 🔀 **Related pivot** — connected but shifts focus

Closes #359

## Motivation

In multi-turn sessions, users often can't tell whether the system recognizes their message as part of ongoing work or a fresh request. The generic agent launch table doesn't provide this context. Adding a one-line classification signal as the first line of every acknowledgment solves this without any code changes.

## What Changed

**File:** `.github/agents/squad.agent.md`
**Section:** "Acknowledge Immediately — Feels Heard"
**Change:** Added "Task Context Signal" sub-section with three classification signals and updated examples.

## UX Before / After

### Before
```
🔧 EECOM — fixing the auth handler
🧪 Sims — writing test cases
```

### After (continuing previous auth work)
```
🔗 Continuing your auth refactor

🔧 EECOM — fixing the auth handler
🧪 Sims — writing test cases
```

### After (new unrelated task)
```
🆕 New task

📝 PAO — drafting the README
```

### After (pivoting from auth to tests)
```
🔀 Related pivot from the auth work — now looking at tests

🧪 Sims — writing regression tests
📋 Scribe — logging session
```

## Documentation Impact

- The change IS documentation (prompt governance)
- No external docs affected
- Agent behavior changes immediately in new sessions; existing sessions use the old prompt until restarted

## Testing

- **No code changes** — no build, no tests needed
- Verification: Start a new Squad session, send 2+ messages, observe that the coordinator classifies each response with the appropriate signal
- First message of a session should NOT have a signal (no prior context)

## Rollback Plan

Revert the single commit — removes the sub-section, restores original examples.

## Review Checklist

- [ ] Signal wording is clear and not jargon-heavy
- [ ] Examples use current team names from the active casting universe
- [ ] The "skip on first message" rule is clear
- [ ] No breaking changes to existing coordinator behavior
