### PR TITLE
feat: conversation-aware thinking phrases in ThinkingIndicator

### DIFF
--- a/packages/squad-cli/src/cli/shell/components/App.tsx
+++ b/packages/squad-cli/src/cli/shell/components/App.tsx
@@ -314,6 +314,12 @@ export const App: React.FC<AppProps> = ({ registry, renderer, teamRoot, version,
     return undefined;
   }, [messages, processing]);
 
+  // True when there is prior conversation history (at least one agent response).
+  const hasConversation = useMemo(
+    () => messages.some(m => m.role === 'agent'),
+    [messages],
+  );
+
   // Only archived (overflow) messages go to Static scrollback.
   // Current messages stay in the live region so the user can always see
   // the recent conversation without scrolling. This prevents the
@@ -467,7 +473,7 @@ export const App: React.FC<AppProps> = ({ registry, renderer, teamRoot, version,
           count to prevent overflow into the InputPrompt area. */}
       <Box flexDirection="column" flexGrow={1}>
         <AgentPanel agents={agents} streamingContent={streamingContent} />
-        <MessageStream messages={messages} agents={agents} streamingContent={streamingContent} processing={processing} activityHint={activityHint || mentionHint} agentActivities={agentActivities} thinkingPhase={thinkingPhase} maxVisible={maxVisible} />
+        <MessageStream messages={messages} agents={agents} streamingContent={streamingContent} processing={processing} activityHint={activityHint || mentionHint} agentActivities={agentActivities} thinkingPhase={thinkingPhase} maxVisible={maxVisible} hasConversation={hasConversation} />
       </Box>
       {/* Fixed input box at bottom — Copilot/Claude style */}
       <Box marginTop={1} borderStyle={noColor ? undefined : 'round'} borderColor={noColor ? undefined : 'cyan'} paddingX={1}>

--- a/packages/squad-cli/src/cli/shell/components/MessageStream.tsx
+++ b/packages/squad-cli/src/cli/shell/components/MessageStream.tsx
@@ -53,6 +53,8 @@ interface MessageStreamProps {
   agentActivities?: Map<string, string>;
   thinkingPhase?: ThinkingPhase;
   maxVisible?: number;
+  /** When true, thinking indicator shows conversation-aware phrases. */
+  hasConversation?: boolean;
 }
 
 /** Format elapsed seconds for response timestamps. */
@@ -199,6 +201,7 @@ export const MessageStream: React.FC<MessageStreamProps> = ({
   agentActivities,
   thinkingPhase,
   maxVisible = 50,
+  hasConversation = false,
 }) => {
   const visible = messages.slice(-maxVisible);
   const visibleOffset = Math.max(0, messages.length - maxVisible);
@@ -327,6 +330,7 @@ export const MessageStream: React.FC<MessageStreamProps> = ({
           elapsedMs={elapsedMs}
           activityHint={activityHint}
           phase={thinkingPhase}
+          hasConversation={hasConversation}
         />
       )}
 

--- a/packages/squad-cli/src/cli/shell/components/ThinkingIndicator.tsx
+++ b/packages/squad-cli/src/cli/shell/components/ThinkingIndicator.tsx
@@ -19,6 +19,8 @@ export interface ThinkingIndicatorProps {
   elapsedMs: number;
   activityHint?: string;
   phase?: ThinkingPhase;
+  /** When true, cycles conversation-aware phrases instead of generic ones. */
+  hasConversation?: boolean;
 }
 
 /** Rotating thinking phrases — cycled every few seconds to keep the UI alive. */
@@ -38,6 +40,25 @@ export const THINKING_PHRASES = [
   'Crafting a plan',
   'Connecting the dots',
   'Exploring possibilities',
+];
+
+/** Context-aware phrases shown when conversation history exists. */
+export const CONVERSATION_PHRASES = [
+  'Reviewing conversation context',
+  'Connecting to previous work',
+  'Analyzing how this relates',
+  'Checking conversation thread',
+  'Considering prior context',
+  'Building on earlier discussion',
+  'Mapping to your session',
+  'Evaluating options',
+  'Consulting the team',
+  'Synthesizing a response',
+  'Weighing trade-offs',
+  'Gathering context',
+  'Crafting a plan',
+  'Connecting the dots',
+  'Reading the codebase',
 ];
 
 /** Map phase to its default label. */
@@ -72,6 +93,7 @@ export const ThinkingIndicator: React.FC<ThinkingIndicatorProps> = ({
   elapsedMs,
   activityHint,
   phase = 'routing',
+  hasConversation = false,
 }) => {
   const noColor = isNoColor();
   const [frame, setFrame] = useState(0);
@@ -86,14 +108,16 @@ export const ThinkingIndicator: React.FC<ThinkingIndicatorProps> = ({
     return () => clearInterval(timer);
   }, [isThinking, noColor]);
 
+  const phrases = hasConversation ? CONVERSATION_PHRASES : THINKING_PHRASES;
+
   // Rotate thinking phrases every 3 seconds
   useEffect(() => {
     if (!isThinking) { setPhraseIndex(0); return; }
     const timer = setInterval(() => {
-      setPhraseIndex(i => (i + 1) % THINKING_PHRASES.length);
+      setPhraseIndex(i => (i + 1) % phrases.length);
     }, 3000);
     return () => clearInterval(timer);
-  }, [isThinking]);
+  }, [isThinking, phrases]);
 
   // Reset frame when thinking starts
   useEffect(() => {
@@ -108,7 +132,7 @@ export const ThinkingIndicator: React.FC<ThinkingIndicatorProps> = ({
 
   // Resolve the display label: activity hint > rotating phrase > phase label
   const displayLabel = activityHint ?? (
-    phase === 'connecting' ? phaseLabel(phase) : `${THINKING_PHRASES[phraseIndex]}...`
+    phase === 'connecting' ? phaseLabel(phase) : `${phrases[phraseIndex]}...`
   );
 
   // NO_COLOR: no color props, use text labels


### PR DESCRIPTION
## Summary

Adds **conversation-aware thinking phrases** to the CLI's ThinkingIndicator. When a session has prior conversation history, the rotating phrases shift from generic ("Routing to agent", "Analyzing your request") to context-aware phrases ("Reviewing conversation context", "Connecting to previous work"), giving users immediate feedback that the system recognizes ongoing conversation.

Closes #360

## Motivation

During multi-turn sessions, the `[pending]` / thinking indicator shows the same generic phrases regardless of conversation state. Users can't tell whether the system treats their message as part of an ongoing thread or a fresh request. Context-aware phrases solve this at the earliest visible moment — before the coordinator even responds.

## What Changed

| File | Change |
|------|--------|
| `ThinkingIndicator.tsx` | Added `CONVERSATION_PHRASES` array (15 phrases) and `hasConversation` prop. When true, cycles conversation-aware phrases instead of generic ones. |
| `MessageStream.tsx` | Added `hasConversation` to props interface and passes it through to ThinkingIndicator. |
| `App.tsx` | Derives `hasConversation` from messages array (`true` when at least one agent response exists). Passes to MessageStream. |

**3 files changed, 38 insertions, 4 deletions.**

## UX Before / After

### First message of session (no change)
```
⠋ Routing to agent... (2s)
⠹ Analyzing your request... (5s)
⠼ Reviewing project context... (8s)
```

### Second+ message — Before
```
⠋ Routing to agent... (2s)
⠹ Analyzing your request... (5s)
⠼ Reviewing project context... (8s)
```

### Second+ message — After
```
⠋ Reviewing conversation context... (2s)
⠹ Connecting to previous work... (5s)
⠼ Analyzing how this relates... (8s)
```

## Documentation Impact

- No documentation changes needed
- Behavior is self-documenting (users see the phrases in the CLI)

## Testing

- **Build:** `npm run build` passes (0 errors)
- **Tests:** 3,944 tests passing across 150 files; 2 pre-existing failures unrelated to this change (Docker-dependent aspire test, missing astro CLI for docs build)
- **Manual verification:** Start a Squad session, send a message, observe generic phrases. Send a second message, observe conversation-aware phrases.
- Existing ThinkingIndicator tests continue to pass (they don't set `hasConversation`, so they exercise the default `false` path)

## Rollback Plan

Revert the single commit — removes `CONVERSATION_PHRASES`, `hasConversation` prop, and the derivation in App.tsx.

## Independence

This PR is **fully independent** of PR #361 (coordinator prompt change). They address different layers:
- PR #361 changes what the coordinator **says** (after thinking completes)
- This PR changes what the user **sees** (during the thinking/pending phase)

Either can be merged independently with full value.

## Review Checklist

- [ ] Conversation-aware phrases feel natural and informative
- [ ] `hasConversation` derivation is correct (checks for `role === 'agent'` in messages)
- [ ] Default behavior unchanged for first message (no regression)
- [ ] Props are properly threaded through App → MessageStream → ThinkingIndicator
