### PR TITLE
docs: recommend --yolo in README Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ gh auth login
 
 ### 4. Open Copilot and go
 
+**Recommended:** start Copilot with `--yolo`.
+
 ```
-copilot
+copilot --yolo
 ```
+
+> **Why use `--yolo`?** Squad makes many tool calls in a typical session. Without it, Copilot will prompt you to approve each one.
 
 **In the GitHub Copilot CLI**, type `/agent` and select **Squad**.
 **In VS Code**, type `/agents` and select **Squad**.


### PR DESCRIPTION
## Summary

Adds a prominent recommendation to use \copilot --yolo\ in step 4 of the Quick Start guide.

## Why

Squad sessions involve many tool calls (agent spawns, file reads, git operations). Without \--yolo\, Copilot prompts for approval on each one, which breaks the flow. This is the single most impactful UX tip for new users and should be front-and-center.

## Changes

- Changed the startup command from \copilot\ to \copilot --yolo\
- Added a **Recommended** callout above the code block for scannability
- Added a brief \> Why use --yolo?\ explanation below

## What it looks like

**Before:**
\\\
copilot
\\\

**After:**
\\\
**Recommended:** start Copilot with --yolo.

copilot --yolo

> Why use --yolo? Squad makes many tool calls in a typical session...
\\\

No other sections of the README were changed.