### PR TITLE
docs: audit and refresh Teams MCP integration docs

### DIFF
--- a/docs/src/content/docs/concepts/portability.md
+++ b/docs/src/content/docs/concepts/portability.md
@@ -236,7 +236,7 @@ MCP (Model Context Protocol) servers extend Squad with external services. Agents
   "mcpServers": {
     "github": {
       "command": "node",
-      "args": ["/path/to/github-mcp.js"],
+      "args": ["/absolute/path/to/github-mcp.js"],
       "env": {
         "GITHUB_TOKEN": "$GITHUB_TOKEN"
       }

--- a/docs/src/content/docs/features/mcp.md
+++ b/docs/src/content/docs/features/mcp.md
@@ -72,7 +72,7 @@ Paste this base structure:
   "mcpServers": {
     "github": {
       "command": "node",
-      "args": ["path/to/github-mcp.js"],
+      "args": ["/absolute/path/to/github-mcp.js"],
       "env": {
         "GITHUB_TOKEN": "your-github-token-here"
       }
@@ -81,7 +81,7 @@ Paste this base structure:
 }
 ```
 
-Replace `path/to/github-mcp.js` with the actual path to your MCP server script. The `env` object passes environment variables to the server.
+Replace `/absolute/path/to/github-mcp.js` with the actual path to your MCP server script. The `env` object passes environment variables to the server.
 
 ### Step 3: Add your GitHub token
 
@@ -145,7 +145,7 @@ Click **"Edit in settings.json"** to see the raw configuration:
 "copilot.mcp.servers": {
   "github": {
     "command": "node",
-    "args": ["path/to/github-mcp.js"],
+    "args": ["/absolute/path/to/github-mcp.js"],
     "env": {
       "GITHUB_TOKEN": "${env:GITHUB_TOKEN}"
     }
@@ -153,7 +153,7 @@ Click **"Edit in settings.json"** to see the raw configuration:
 }
 ```
 
-The `${env:GITHUB_TOKEN}` syntax reads from your shell environment.
+The `${env:GITHUB_TOKEN}` syntax reads from your shell environment. Replace `/absolute/path/to/github-mcp.js` with the actual path to your MCP server script.
 
 ### Step 4: Add environment variables
 
@@ -182,7 +182,7 @@ Most Squad installs come with GitHub MCP pre-configured. Here's what it looks li
   "mcpServers": {
     "github": {
       "command": "node",
-      "args": ["/path/to/github-mcp.js"],
+      "args": ["/absolute/path/to/github-mcp.js"],
       "env": {
         "GITHUB_TOKEN": "$GITHUB_TOKEN"
       }
@@ -191,6 +191,8 @@ Most Squad installs come with GitHub MCP pre-configured. Here's what it looks li
 }
 ```
 
+Replace `/absolute/path/to/github-mcp.js` with the actual path to your GitHub MCP server script.
+
 ### VS Code: `.vscode/settings.json`
 
 ```json
@@ -198,7 +200,7 @@ Most Squad installs come with GitHub MCP pre-configured. Here's what it looks li
   "copilot.mcp.servers": {
     "github": {
       "command": "node",
-      "args": ["/path/to/github-mcp.js"],
+      "args": ["/absolute/path/to/github-mcp.js"],
       "env": {
         "GITHUB_TOKEN": "${env:GITHUB_TOKEN}"
       }
@@ -206,6 +208,8 @@ Most Squad installs come with GitHub MCP pre-configured. Here's what it looks li
   }
 }
 ```
+
+Replace `/absolute/path/to/github-mcp.js` with the actual path to your GitHub MCP server script.
 
 **What it does:**
 - List issues, PRs, and branches in your repo
@@ -235,7 +239,7 @@ Trello MCP lets agents interact with your Trello boards — create cards, move t
   "mcpServers": {
     "trello": {
       "command": "node",
-      "args": ["/path/to/trello-mcp.js"],
+      "args": ["/absolute/path/to/trello-mcp.js"],
       "env": {
         "TRELLO_API_KEY": "your-api-key",
         "TRELLO_TOKEN": "your-token",
@@ -245,6 +249,8 @@ Trello MCP lets agents interact with your Trello boards — create cards, move t
   }
 }
 ```
+
+Replace `/absolute/path/to/trello-mcp.js` with the actual path to your Trello MCP server script.
 
 Find your **board ID** by opening any card on Trello and looking at the URL: `trello.com/c/{{CARD_ID}}/{{BOARD_ID}}/`.
 
@@ -275,7 +281,7 @@ Your project should have a dashboard running (usually `http://localhost:18888`).
   "mcpServers": {
     "aspire": {
       "command": "node",
-      "args": ["/path/to/aspire-mcp.js"],
+      "args": ["/absolute/path/to/aspire-mcp.js"],
       "env": {
         "ASPIRE_URL": "http://localhost:18888",
         "ASPIRE_API_KEY": "optional-api-key"
@@ -284,6 +290,8 @@ Your project should have a dashboard running (usually `http://localhost:18888`).
   }
 }
 ```
+
+Replace `/absolute/path/to/aspire-mcp.js` with the actual path to your Aspire MCP server script.
 
 ### Step 3: Use it
 
@@ -320,9 +328,9 @@ Agents don't need special setup to discover tools. Here's the flow:
 
 1. **Verify the command path:**
    ```bash
-   ls -la /path/to/mcp-server.js
+   ls -la /absolute/path/to/mcp-server.js
    ```
-   The file must exist and be executable.
+   The file must exist and be executable. Replace `/absolute/path/to/mcp-server.js` with your actual MCP server path.
 
 2. **Verify Node.js is installed:**
    ```bash
@@ -366,9 +374,9 @@ Agents don't need special setup to discover tools. Here's the flow:
 
 3. **Test the MCP server directly:**
    ```bash
-   node /path/to/mcp-server.js
+   node /absolute/path/to/mcp-server.js
    ```
-   It should start without errors. If it crashes, there's a server-side issue.
+   It should start without errors. If it crashes, there's a server-side issue. Replace `/absolute/path/to/mcp-server.js` with your actual MCP server path.
 
 ### Authentication Errors
 
@@ -414,13 +422,13 @@ Agents don't need special setup to discover tools. Here's the flow:
      "mcpServers": {
        "github": {
          "command": "node",
-        "args": ["/path/to/github-mcp.js"],
+        "args": ["/absolute/path/to/github-mcp.js"],
         "lazy": true
       }
     }
   }
    ```
-   This starts the server only when its first tool is called.
+   This starts the server only when its first tool is called. Replace `/absolute/path/to/github-mcp.js` with your actual MCP server path.
 
 ---
 

--- a/docs/src/content/docs/features/notifications.md
+++ b/docs/src/content/docs/features/notifications.md
@@ -38,7 +38,7 @@ This means Squad works with any notification service. Pick your favorite messagi
 
 ## Quick Start: Teams (Simplest Path)
 
-### Option A: Teams Incoming Webhook (No Auth Setup)
+### Teams Incoming Webhook
 
 Teams webhooks are the fastest setup — just a URL.
 
@@ -52,14 +52,23 @@ Teams webhooks are the fastest setup — just a URL.
    - Give it a name (e.g., "Squad Notifications")
    - Copy the webhook URL
 
-3. **Configure Squad:**
-   - Create or edit `.vscode/mcp.json` in your workspace:
+3. **Get the MCP server:**
+   
+   You need to create or download a Teams webhook MCP server. You have options:
+   
+   - **Community reference implementation:** [benleane83's teams-webhook-mcp.js](https://gist.github.com/benleane83/f37b5bc1ed3d00e320ba48886109b82a) — a working, production-ready implementation
+   - **Build your own:** Use the reference as a starting point and customize for your needs
+   - **Search MCP marketplace:** Look for Teams-compatible MCP servers at https://mcpmarket.com
+
+4. **Configure Squad:**
+   
+   Create or edit `.vscode/mcp.json` in your workspace:
    ```json
    {
      "mcpServers": {
        "notifications": {
          "command": "node",
-         "args": ["path/to/teams-webhook-mcp.js"],
+         "args": ["/absolute/path/to/teams-webhook-mcp.js"],
          "env": {
            "TEAMS_WEBHOOK_URL": "https://outlook.webhook.office.com/webhookb2/..."
          }
@@ -67,47 +76,12 @@ Teams webhooks are the fastest setup — just a URL.
      }
    }
    ```
+   
+   Replace `/absolute/path/to/teams-webhook-mcp.js` with the actual path to your downloaded or created MCP server script.
 
-4. **Use it:**
+5. **Use it:**
    - Start a Squad session with `copilot squad`
    - When an agent needs input, your Teams channel lights up
-
-### Option B: Microsoft's Official Teams MCP Server (Full Auth)
-
-For integration with your Azure tenant and full Teams API access:
-
-1. **Register an Azure AD app:**
-   - Go to https://portal.azure.com → "Azure Active Directory" → "App registrations"
-   - New registration: name it "Squad Notifications"
-   - Copy the **Application (client) ID**
-
-2. **Set up credentials:**
-   - "Certificates & secrets" → "New client secret"
-   - Copy the secret value
-
-3. **Grant permissions:**
-   - "API permissions" → "Add a permission" → "Microsoft Graph"
-   - Add `Chat.Send`, `ChannelMessage.Send`
-   - Grant admin consent
-
-4. **Configure Squad:**
-   - Install Microsoft's Teams MCP server: https://github.com/microsoft/IF-MCP-Server-for-Microsoft-Teams
-   - Configure in `.vscode/mcp.json`:
-   ```json
-   {
-     "mcpServers": {
-       "teams": {
-         "command": "node",
-         "args": ["path/to/teams-mcp.js"],
-         "env": {
-           "AZURE_CLIENT_ID": "your-client-id",
-           "AZURE_CLIENT_SECRET": "your-secret",
-           "AZURE_TENANT_ID": "your-tenant-id"
-         }
-       }
-     }
-   }
-   ```
 
 ---
 
@@ -121,7 +95,7 @@ iMessage is built into macOS. If you're on a Mac, this is the fastest personal s
    - System allows Copilot to control Messages (grant permission when prompted)
 
 2. **Install the iMessage MCP server:**
-   - Get it from https://mcpmarket.com/server/imessage
+   - Search https://mcpmarket.com for "imessage" or compatible MCP servers
    - Follow its setup steps
 
 3. **Configure Squad:**
@@ -131,7 +105,7 @@ iMessage is built into macOS. If you're on a Mac, this is the fastest personal s
      "mcpServers": {
        "imessage": {
          "command": "node",
-         "args": ["path/to/imessage-mcp.js"],
+         "args": ["/absolute/path/to/imessage-mcp.js"],
          "env": {
            "IMESSAGE_TARGET": "your-phone-number-or-email"
          }
@@ -139,6 +113,8 @@ iMessage is built into macOS. If you're on a Mac, this is the fastest personal s
      }
    }
    ```
+   
+   Replace `/absolute/path/to/imessage-mcp.js` with the actual path to your downloaded MCP server script.
 
 4. **Test:**
    - Start a Squad session
@@ -212,7 +188,7 @@ For any HTTP endpoint (custom service, Zapier, IFTTT, etc.):
      "mcpServers": {
        "notifications": {
          "command": "node",
-         "args": ["path/to/webhook-mcp.js"],
+         "args": ["/absolute/path/to/webhook-mcp.js"],
          "env": {
            "WEBHOOK_URL": "https://your-service.com/notify"
          }
@@ -220,6 +196,8 @@ For any HTTP endpoint (custom service, Zapier, IFTTT, etc.):
      }
    }
    ```
+   
+   Replace `/absolute/path/to/webhook-mcp.js` with the actual path to your MCP server script.
 
 3. **Your endpoint receives POST:**
    ```json
@@ -402,7 +380,7 @@ Below are complete, copy-pasteable `.copilot/mcp-config.json` examples for each 
   "mcpServers": {
     "notifications": {
       "command": "node",
-      "args": ["path/to/teams-webhook-mcp.js"],
+      "args": ["/absolute/path/to/teams-webhook-mcp.js"],
       "env": {
         "TEAMS_WEBHOOK_URL": "https://outlook.webhook.office.com/webhookb2/YOUR_WEBHOOK_URL_HERE"
       }
@@ -411,7 +389,10 @@ Below are complete, copy-pasteable `.copilot/mcp-config.json` examples for each 
 }
 ```
 
-**Setup:** Get your webhook URL from Teams channel settings (right-click channel → Manage → Connectors → Incoming Webhook).
+**Setup:** 
+1. Get your webhook URL from Teams channel settings (right-click channel → Manage → Connectors → Incoming Webhook)
+2. Download a Teams webhook MCP server (see [community reference implementation](https://gist.github.com/benleane83/f37b5bc1ed3d00e320ba48886109b82a))
+3. Replace `/absolute/path/to/teams-webhook-mcp.js` with the actual path to your MCP server script
 
 ---
 
@@ -422,7 +403,7 @@ Below are complete, copy-pasteable `.copilot/mcp-config.json` examples for each 
   "mcpServers": {
     "notifications": {
       "command": "node",
-      "args": ["path/to/imessage-mcp.js"],
+      "args": ["/absolute/path/to/imessage-mcp.js"],
       "env": {
         "IMESSAGE_TARGET": "+1234567890"
       }
@@ -431,7 +412,10 @@ Below are complete, copy-pasteable `.copilot/mcp-config.json` examples for each 
 }
 ```
 
-Replace `+1234567890` with your phone number or email address registered in iCloud.
+**Setup:**
+1. Download an iMessage MCP server from https://mcpmarket.com
+2. Replace `/absolute/path/to/imessage-mcp.js` with the actual path to your MCP server script
+3. Replace `+1234567890` with your phone number or email address registered in iCloud
 
 ---
 
@@ -442,7 +426,7 @@ Replace `+1234567890` with your phone number or email address registered in iClo
   "mcpServers": {
     "notifications": {
       "command": "node",
-      "args": ["path/to/discord-webhook-mcp.js"],
+      "args": ["/absolute/path/to/discord-webhook-mcp.js"],
       "env": {
         "DISCORD_WEBHOOK_URL": "https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN"
       }
@@ -451,7 +435,10 @@ Replace `+1234567890` with your phone number or email address registered in iClo
 }
 ```
 
-**Setup:** In Discord, right-click channel → Edit Channel → Integrations → Webhooks → New Webhook → copy the URL.
+**Setup:** 
+1. In Discord, right-click channel → Edit Channel → Integrations → Webhooks → New Webhook → copy the URL
+2. Download or create a Discord webhook MCP server (see mcp-notifications package or build your own)
+3. Replace `/absolute/path/to/discord-webhook-mcp.js` with the actual path to your MCP server script
 
 ---
 
@@ -462,7 +449,7 @@ Replace `+1234567890` with your phone number or email address registered in iClo
   "mcpServers": {
     "notifications": {
       "command": "node",
-      "args": ["path/to/webhook-mcp.js"],
+      "args": ["/absolute/path/to/webhook-mcp.js"],
       "env": {
         "WEBHOOK_URL": "https://your-service.com/notify",
         "WEBHOOK_AUTH_HEADER": "Authorization: Bearer YOUR_API_KEY",
@@ -473,7 +460,10 @@ Replace `+1234567890` with your phone number or email address registered in iClo
 }
 ```
 
-Your endpoint receives POST requests with agent name, message, and context.
+**Setup:**
+1. Create or download a generic webhook MCP server
+2. Replace `/absolute/path/to/webhook-mcp.js` with the actual path to your MCP server script
+3. Your endpoint receives POST requests with agent name, message, and context
 
 ---
 


### PR DESCRIPTION
## Summary

End-to-end audit of Teams MCP integration documentation per #258.

### Changes Made

**Fixed broken references:**
- Removed incorrect reference to microsoft/IF-MCP-Server-for-Microsoft-Teams (that repo is actually a Court Listener demo, not a general Teams MCP server)
- Added link to working community reference implementation: [benleane83's teams-webhook-mcp.js gist](https://gist.github.com/benleane83/f37b5bc1ed3d00e320ba48886109b82a)

**Clarified MCP server setup:**
- Updated all placeholder paths from path/to/*.js to /absolute/path/to/*.js for clarity
- Added explicit instructions that users need to download or create MCP server scripts
- Pointed users to mcpmarket.com for finding compatible MCP servers
- Simplified Teams setup to focus on webhook approach (fastest, no Azure AD setup required)

**Files updated:**
- docs/src/content/docs/features/notifications.md — main Teams integration docs
- docs/src/content/docs/features/mcp.md — MCP setup guide
- docs/src/content/docs/concepts/portability.md — MCP config example

### What Works Now

- Docs accurately reflect that MCP servers are external implementations, not bundled with Squad
- Community members can follow benleane83's working reference implementation
- Path placeholders clearly indicate they require actual file paths
- Setup instructions focus on practical, working approaches

Closes #258