### PR TITLE
docs: dedup notification setup in github-workflow.md

### DIFF
--- a/docs/src/content/docs/concepts/github-workflow.md
+++ b/docs/src/content/docs/concepts/github-workflow.md
@@ -175,18 +175,7 @@ Board sync runs on label changes, issue close, PR merge, and a 30-minute schedul
 
 Your squad pings you when they need input, hit an error, or finish work. Squad uses MCP-based notification servers — you bring your own delivery channel.
 
-The flow:
-1. **Skill** (`human-notification`) tells agents when to ping
-2. **Agent** invokes your configured MCP server
-3. **MCP server** (Teams, Discord, iMessage, webhook) delivers the message
-
-| Trigger | Example |
-|---------|---------|
-| Blocked on input | "Keaton needs your decision on the API approach" |
-| Error hit | "McManus got an auth error — needs credentials" |
-| Work complete | "Fenster finished the test suite — 142 tests passing" |
-
-Configure in `.vscode/mcp.json` or `.copilot/mcp-config.json`. See the [MCP setup section in Portability & Extensions](portability.md) for configuration details.
+See the [Notifications Guide](../features/notifications.md) for [platform setup](../features/notifications.md#quick-start-teams-simplest-path) (Teams, Discord, iMessage, webhooks), [trigger configuration](../features/notifications.md#what-triggers-a-notification), and [sample MCP configs](../features/notifications.md#sample-mcp-configs).
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces duplicated notification content in `concepts/github-workflow.md` with a cross-link to the canonical Notifications Guide.

### Change

**`docs/src/content/docs/concepts/github-workflow.md`** - 1 file, +1/-12 lines

### Deduplication Traceability

| Removed Content | Was At | Kept At (canonical) |
|---|---|---|
| 3-step notification flow (Skill > Agent > MCP server) | github-workflow.md lines 178-181 | [notifications.md - How It Works](https://github.com/bradygaster/squad/blob/dev/docs/src/content/docs/features/notifications.md#L26) ([rendered](https://squad.dev/docs/features/notifications/#how-it-works)) |
| Triggers table (Blocked/Error/Complete) | github-workflow.md lines 183-187 | [notifications.md - What Triggers a Notification](https://github.com/bradygaster/squad/blob/dev/docs/src/content/docs/features/notifications.md#L239) ([rendered](https://squad.dev/docs/features/notifications/#what-triggers-a-notification)) |
| Config file reference (mcp.json / mcp-config.json) | github-workflow.md line 189 | [notifications.md - Quick Start: Teams](https://github.com/bradygaster/squad/blob/dev/docs/src/content/docs/features/notifications.md#L39) ([rendered](https://squad.dev/docs/features/notifications/#quick-start-teams-simplest-path)) |

### What is Preserved

- The intro sentence stays and gives context
- Cross-link to the Notifications Guide covers: setup walkthrough, platform options, triggers, sample configs

### Scope

Docs only. No code changes.
