### PR TITLE
fix: align baseBranch config and docs to dev

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "dev",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ Update help text and README for npm distribution. Add squad status command to do
 
 ### Release Workflow
 
-The team runs changesets on the `main` branch (via GitHub Actions):
+The team runs changesets on the `dev` branch (via GitHub Actions):
 
 ```bash
 npx changeset publish


### PR DESCRIPTION
Closes #350

**Changes (2 files, 2 lines each):**
- \.changeset/config.json\: \aseBranch\ changed from \main\ → \dev\
- \CONTRIBUTING.md\: Release workflow section updated to reference \dev\

Both now consistently point to \dev\ as the integration branch.