### PR TITLE
docs: fix remaining README migration guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ squad init
 
 **✓ Validate:** Check that `.squad/team.md` was created in your project.
 
-**Or use npx (no install):** `npx @bradygaster/squad-cli` — see [Migration Guide](docs/get-started/migration.md) if upgrading from an older version.
+**Or use npx (no install):** `npx @bradygaster/squad-cli` — see [Migration Guide](https://bradygaster.github.io/squad/docs/get-started/migration/) if upgrading from an older version.
 
 ### 3. Authenticate with GitHub (for Issues, PRs, and Ralph)
 


### PR DESCRIPTION
Fixes #351

This PR corrects the remaining broken migration guide link in README.md that was still pointing to the legacy repo blob URL. It now points to the published documentation URL for consistency with PR #349.