### PR TITLE
feat: add distributed-coordination skills from Part 4 blog (auth isolation, stale locks, message serialization, notification routing)

### DIFF
--- a/.squad/skills/gh-auth-isolation/SKILL.md
+++ b/.squad/skills/gh-auth-isolation/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: gh-auth-isolation
+description: Per-process GH_CONFIG_DIR isolation to prevent multi-Ralph auth race conditions
+domain: security, multi-machine, github-cli
+confidence: high
+source: earned (37-consecutive-failure incident — 2026-03-16, tamirdresher/tamresearch1)
+---
+
+## Context
+
+When multiple Ralph instances (or any concurrent Squad agents) run on the same machine, they all share a single `gh` CLI
+auth state at `~/.config/gh/hosts.yml`. If one process calls `gh auth switch --user A` and another calls
+`gh auth switch --user B`, they clobber each other's state. The result: cascading authentication failures across all
+instances.
+
+This is the **shared mutable global state** problem — the same issue that causes microservices to fail when they share a
+database connection without tenant isolation. The fix is to partition the state.
+
+**Trigger symptoms:**
+- Multiple Ralph instances showing consecutive auth failures
+- `gh` CLI operations failing with 401 after another agent ran nearby
+- A `gh auth switch` call in one process breaking another process's auth state
+
+## Patterns
+
+### Option A — GH_CONFIG_DIR Isolation (Preferred)
+
+Give each process its own completely isolated `gh` config directory. No cross-talk is possible.
+
+```powershell
+# At the top of ralph-watch.ps1, before any gh calls:
+$account = if ($remoteUrl -match "your-work-org") { "work" } else { "personal" }
+$env:GH_CONFIG_DIR = Join-Path $env:USERPROFILE ".config\gh-$account"
+
+# Ensure the config dir is initialized for this account
+if (-not (Test-Path (Join-Path $env:GH_CONFIG_DIR "hosts.yml"))) {
+    Write-Warning "GH_CONFIG_DIR $env:GH_CONFIG_DIR not initialized. Run: GH_CONFIG_DIR=$env:GH_CONFIG_DIR gh auth login"
+}
+```
+
+Each account has its own config directory:
+- `~/.config/gh-personal/` — personal GitHub account
+- `~/.config/gh-work/` — work/EMU GitHub account
+
+No process can interfere with another's auth state. This is the approach used by
+[gh-public-gh-emu-setup](https://github.com/jongio/gh-public-gh-emu-setup).
+
+### Option B — GH_TOKEN Per-Process (Simpler, Less Complete)
+
+If you only need to isolate the auth token (not other gh config), read the token once and set it as a
+process-local environment variable:
+
+```powershell
+# Step -1: Self-healing auth — set process-local GH_TOKEN
+$remoteUrl = & git remote get-url origin 2>&1 | Out-String
+$requiredAccount = if ($remoteUrl -match "work-org") { "work-account" } else { "personal-account" }
+$token = & gh auth token --user $requiredAccount 2>&1 | Out-String
+if ($token -and $token.Trim().StartsWith("gho_")) {
+    $env:GH_TOKEN = $token.Trim()   # Process-local only — no global mutation
+}
+```
+
+This works because `GH_TOKEN` is read by the `gh` CLI per-call. No `gh auth switch` needed. No global state mutated.
+
+### Shell/Bash Equivalent
+
+```bash
+# In ralph-watch.sh, before any gh calls:
+ACCOUNT=$(git remote get-url origin | grep -q "work-org" && echo "work" || echo "personal")
+export GH_CONFIG_DIR="$HOME/.config/gh-$ACCOUNT"
+```
+
+## Anti-Patterns
+
+**NEVER do this in a multi-Ralph setup:**
+```powershell
+gh auth switch --user $account   # ❌ Mutates global ~/.config/gh/hosts.yml
+```
+
+**NEVER assume gh auth state is stable across concurrent processes:**
+```powershell
+gh auth status   # ❌ The status can change between this check and the next command
+gh api /user     # ❌ May now use a different account than the line above
+```
+
+## Verification
+
+After applying GH_CONFIG_DIR isolation, verify each Ralph uses independent state:
+
+```powershell
+# Should print different directories for each Ralph process
+$env:GH_CONFIG_DIR
+
+# Should succeed for the correct account without affecting other processes
+gh api /user --jq .login
+```
+
+## Distributed Systems Pattern
+
+This is **state partitioning** — the same fix for microservices sharing a database without tenant isolation.
+Each process carries its own identity. No coordination needed. No locks needed.
+
+Related upstream PR: [#416 — product isolation](https://github.com/bradygaster/squad/pull/416)

--- a/.squad/skills/message-serialization/SKILL.md
+++ b/.squad/skills/message-serialization/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: message-serialization
+description: Temp-file indirection for passing large prompts to CLI tools without shell argument mangling
+domain: reliability, cli-wiring, agent-spawning
+confidence: high
+source: earned (7KB prompt-as-command-name bug — 2026-03, tamirdresher/tamresearch1)
+---
+
+## Context
+
+When spawning an agent via `Start-Process` or shell exec, the prompt is passed as an argument. For large
+multiline prompts (>1–2 KB), the OS may interpret the entire string as the command name, truncate it, or
+corrupt newlines and special characters.
+
+This is a **serialization/marshalling problem**: passing structured data (a multiline prompt) through a
+transport layer that doesn't preserve structure (command-line argument parsing). The same issue occurs when
+passing JSON through a shell pipeline or serializing protobuf through a REST boundary that expects plain text.
+
+**Trigger symptoms:**
+- Agent fails with "command not found: Ralph, Go! MAXIMIZE PARALLELISM…"
+- Long prompts silently truncated when passed via `--prompt`
+- Special characters (`"`, `\n`, `{`, `}`) corrupted in transit
+
+## Patterns
+
+### Temp-File Indirection
+
+Write the prompt to a temporary file and pass the file path as the argument:
+
+```powershell
+# Build prompt string (can be any size, any characters)
+$prompt = @"
+Ralph, Go! MAXIMIZE PARALLELISM.
+
+For every round, identify ALL actionable issues and spawn agents in parallel.
+Context: $($context | ConvertTo-Json -Compress)
+"@
+
+# Write to temp file — avoids shell argument size/encoding limits
+$promptFile = [System.IO.Path]::GetTempFileName() + ".txt"
+$prompt | Out-File -FilePath $promptFile -Encoding utf8 -NoNewline
+
+try {
+    # Pass reference, not data
+    $proc = Start-Process -FilePath "agency" `
+        -ArgumentList @("copilot", "--yolo", "--prompt-file", $promptFile) `
+        -NoNewWindow -PassThru -Wait
+} finally {
+    Remove-Item $promptFile -Force -ErrorAction SilentlyContinue
+}
+```
+
+### Shell/Bash Equivalent
+
+```bash
+PROMPT_FILE=$(mktemp /tmp/squad-prompt-XXXXXX.txt)
+cat > "$PROMPT_FILE" << 'EOF'
+Ralph, Go! MAXIMIZE PARALLELISM.
+...
+EOF
+
+agency copilot --yolo --prompt-file "$PROMPT_FILE"
+rm -f "$PROMPT_FILE"
+```
+
+### When to Apply
+
+Apply this pattern whenever:
+- The prompt exceeds ~500 characters
+- The prompt contains newlines, quotes, or special shell characters
+- You're using `Start-Process`, `Invoke-Expression`, or shell exec to spawn the agent
+- You're on Windows (where argument length limits are lower than Unix)
+
+You do NOT need temp-file indirection when using the Squad SDK directly (Node.js API), as the prompt
+is passed as a function argument, not a shell argument.
+
+### Cleanup
+
+Always clean up the temp file after the process exits, even on error:
+
+```powershell
+$promptFile = $null
+try {
+    $promptFile = [System.IO.Path]::GetTempFileName() + ".txt"
+    $prompt | Out-File -FilePath $promptFile -Encoding utf8
+    Start-Process "agency" -ArgumentList @("--prompt-file", $promptFile) -Wait
+} finally {
+    if ($promptFile -and (Test-Path $promptFile)) {
+        Remove-Item $promptFile -Force
+    }
+}
+```
+
+## Anti-Patterns
+
+**NEVER pass large prompts directly as arguments:**
+```powershell
+# ❌ Windows may interpret the entire prompt as the command name
+Start-Process "agency" -ArgumentList @("--prompt", $largPrompt)
+
+# ❌ Shell may truncate or corrupt special characters
+Invoke-Expression "agency copilot --prompt `"$prompt`""
+```
+
+## Distributed Systems Pattern
+
+This is the **indirection pattern** — the same solution gRPC uses with protocol buffers and Kafka uses with a
+schema registry. When your transport layer can't handle your message format, pass a reference to the data
+instead of the data itself. Classic level-of-indirection from computer science fundamentals.

--- a/.squad/skills/notification-routing/SKILL.md
+++ b/.squad/skills/notification-routing/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: notification-routing
+description: Route agent notifications to specific channels by type instead of flooding a single channel
+domain: communication, observability, multi-agent
+confidence: high
+source: earned (notification firehose incident — 2026-03, tamirdresher/tamresearch1)
+---
+
+## Context
+
+When a Squad grows beyond a few agents, notifications flood a single channel — failure alerts drown in daily
+briefings, tech news buries security findings, and everything gets ignored. This is the microservices equivalent
+of dumping every service's logs into one file.
+
+The fix is **pub-sub with topic routing**: agents tag notifications with a channel type, and a routing function
+sends them to the appropriate destination.
+
+**Trigger symptoms:**
+- Important alerts missed because they're buried in routine notifications
+- Team members turning off notifications entirely (signal overwhelm)
+- Onboarding friction: "where do I look for X?"
+
+## Patterns
+
+### Channel Config File
+
+Define a `teams-channels.json` config (or equivalent) mapping notification types to channel names:
+
+```json
+{
+  "channels": {
+    "notifications": "squad-alerts",
+    "tech-news": "tech-news",
+    "security": "security-findings",
+    "releases": "release-announcements",
+    "daily-digest": "daily-digest"
+  }
+}
+```
+
+Place this in `.squad/teams-channels.json` (git-tracked, shared across the team).
+
+### Routing in PowerShell
+
+```powershell
+function Send-TeamNotification {
+    param(
+        [string]$Message,
+        [string]$Channel = "notifications",   # default channel
+        [string]$Urgency = "normal"           # normal | high | low
+    )
+
+    $config = Get-Content ".squad\teams-channels.json" | ConvertFrom-Json
+    $targetChannel = $config.channels.$Channel ?? $config.channels.notifications
+
+    # Format by urgency
+    $prefix = switch ($Urgency) {
+        "high"  { "🚨" }
+        "low"   { "ℹ️" }
+        default { "📢" }
+    }
+
+    Send-TeamsMessage -Channel $targetChannel -Text "$prefix $Message"
+}
+
+# Usage:
+Send-TeamNotification -Message "37 consecutive failures" -Channel "notifications" -Urgency "high"
+Send-TeamNotification -Message "Today's tech digest: ..." -Channel "tech-news" -Urgency "low"
+```
+
+### Channel Tag Convention
+
+Agents can tag their output with `CHANNEL:` metadata for the notification dispatcher to read:
+
+```
+CHANNEL:security
+Worf found 3 new CVEs in dependency scan: lodash@4.17.15, ...
+```
+
+The dispatcher reads the tag and routes accordingly:
+
+```powershell
+function Dispatch-Notification {
+    param([string]$RawOutput)
+    
+    if ($RawOutput -match '^CHANNEL:(\w[\w-]*)') {
+        $channel = $matches[1]
+        $message = $RawOutput -replace '^CHANNEL:\w[\w-]*\r?\n', ''
+        Send-TeamNotification -Message $message -Channel $channel
+    } else {
+        Send-TeamNotification -Message $RawOutput   # default channel
+    }
+}
+```
+
+### Service Discovery: Avoid Name Collisions
+
+When creating Teams channels, verify you're in the **correct team** before sending. Teams channel names look
+similar across teams (e.g., "Squad" vs "squads" vs "my-squad"). Always resolve the channel ID, not just the
+name:
+
+```powershell
+# Bad: relies on name uniqueness
+Send-TeamsMessage -TeamName "Squad" -ChannelName "notifications" -Text $msg   # ❌ Wrong "Squad"?
+
+# Good: resolve ID once, cache it
+$channelId = Get-TeamsChannelId -TeamId $config.teamId -ChannelName $config.channels.notifications
+Send-TeamsMessageById -ChannelId $channelId -Text $msg   # ✅ Unambiguous
+```
+
+Store resolved channel IDs in `.squad/teams-channels.json` alongside names:
+
+```json
+{
+  "teamId": "abc-123-def",
+  "channels": {
+    "notifications": { "name": "squad-alerts", "id": "19:channel-id@thread.tacv2" },
+    "tech-news":     { "name": "tech-news",    "id": "19:channel-id-2@thread.tacv2" }
+  }
+}
+```
+
+## Anti-Patterns
+
+**NEVER send all notification types to one channel:**
+```powershell
+# ❌ All noise, no signal — eventually everyone ignores everything
+Send-TeamsMessage -Channel "general" -Text $anything
+```
+
+**NEVER use team/channel display names as identifiers:**
+```powershell
+# ❌ "Squad" and "squads" are different teams — name collisions happen
+$team = Find-TeamsTeam -Name "Squad"   # Which "Squad"?
+```
+
+## Distributed Systems Pattern
+
+This is **pub-sub with topic routing** — the same principle as Kafka topics, RabbitMQ routing keys, and AWS
+SNS topic filtering. The lesson: a single message queue for everything is a recipe for missed alerts. Route by
+type. Each consumer subscribes to the topics it cares about.

--- a/.squad/skills/stale-lock-detection/SKILL.md
+++ b/.squad/skills/stale-lock-detection/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: stale-lock-detection
+description: Three-layer guard to detect and clear stale process locks from crashed agents
+domain: reliability, multi-machine, process-management
+confidence: high
+source: earned (stale PID 40544 incident — 2026-03-14, tamirdresher/tamresearch1)
+---
+
+## Context
+
+When a Ralph (or any long-running agent) crashes or is killed, it may leave a lock file behind. On the next start,
+the agent sees the lock and refuses to run — guarding against a process that no longer exists. This is the
+**failure detection problem**: how do you know if a process that holds a lock is actually alive?
+
+Traditional distributed systems solve this with heartbeats and lease-based locking (ZooKeeper ephemeral nodes,
+etcd leases, Consul health checks). For a local agent loop, a three-layer guard provides equivalent guarantees
+without external infrastructure.
+
+**Trigger symptoms:**
+- Ralph refuses to start with "already running" error after a machine restart or crash
+- Lock file references a PID that no longer exists
+- Agent loop stuck, never starting new rounds
+
+## Patterns
+
+### Three-Layer Guard
+
+Apply all three layers in order. Each layer handles a different failure mode:
+
+**Layer 1 — Named Mutex (OS-enforced):**
+```powershell
+$mutexName = "Global\RalphWatch_$(Split-Path $PWD -Leaf)"
+$mutex = $null
+try {
+    $mutex = [System.Threading.Mutex]::new($false, $mutexName)
+    $acquired = $mutex.WaitOne(0)   # Non-blocking — fail fast
+    if (-not $acquired) {
+        Write-Error "Another Ralph is running for this repo (mutex held)"
+        exit 1
+    }
+} catch [System.Threading.AbandonedMutexException] {
+    # Previous process crashed without releasing mutex — we inherit it
+    Write-Warning "Acquired abandoned mutex — previous Ralph crashed ungracefully"
+    $acquired = $true
+}
+```
+
+The OS releases the mutex when the process exits, even on crash. `AbandonedMutexException` means the previous
+holder crashed — we can safely take over.
+
+**Layer 2 — PID Scan (Zombie killer):**
+```powershell
+# Kill any stale Ralph for THIS directory (not all Ralphs!)
+$currentDir = $PWD.Path
+$staleRalphs = Get-CimInstance Win32_Process |
+    Where-Object { $_.CommandLine -match 'ralph-watch' -and $_.CommandLine -match [regex]::Escape($currentDir) } |
+    Where-Object { $_.ProcessId -ne $PID }
+
+foreach ($stale in $staleRalphs) {
+    Write-Warning "Killing stale Ralph PID $($stale.ProcessId)"
+    Stop-Process -Id $stale.ProcessId -Force -ErrorAction SilentlyContinue
+}
+```
+
+This handles the case where the mutex was abandoned but the process is somehow still listed (zombie state on
+some platforms).
+
+**Layer 3 — Lockfile with PID Validation:**
+```powershell
+$lockFile = Join-Path $PWD ".squad\ralph.lock"
+
+# Read existing lock and validate
+if (Test-Path $lockFile) {
+    $existing = Get-Content $lockFile | ConvertFrom-Json -ErrorAction SilentlyContinue
+    if ($existing -and $existing.pid) {
+        $isAlive = Get-Process -Id $existing.pid -ErrorAction SilentlyContinue
+        if ($isAlive) {
+            Write-Error "Ralph already running (PID $($existing.pid) is alive)"
+            exit 1
+        } else {
+            Write-Warning "Clearing stale lock (PID $($existing.pid) no longer exists)"
+            Remove-Item $lockFile -Force
+        }
+    }
+}
+
+# Write our own lock
+@{ pid = $PID; started = (Get-Date -Format "o"); directory = $PWD.Path } |
+    ConvertTo-Json | Set-Content $lockFile
+
+# Always clean up on exit
+Register-EngineEvent PowerShell.Exiting -Action { Remove-Item $lockFile -Force -ErrorAction SilentlyContinue }
+trap { Remove-Item $lockFile -Force -ErrorAction SilentlyContinue }
+```
+
+**Lockfile schema** (`.squad/ralph.lock`):
+```json
+{
+  "pid": 12345,
+  "started": "2026-03-14T09:12:04Z",
+  "directory": "C:\\repos\\myproject"
+}
+```
+
+The lockfile exists for **observability** — external tools (squad-monitor, dashboards) read it to know Ralph's
+state. The mutex and PID scan do the actual locking.
+
+### Linux/macOS Equivalent
+
+```bash
+LOCK_FILE=".squad/ralph.lock"
+MUTEX_FILE="/tmp/ralph-$(basename $PWD).lock"
+
+# PID-validated lock
+if [ -f "$LOCK_FILE" ]; then
+    OLD_PID=$(jq -r .pid "$LOCK_FILE" 2>/dev/null)
+    if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
+        echo "Ralph already running (PID $OLD_PID)" >&2
+        exit 1
+    else
+        echo "Clearing stale lock (PID $OLD_PID no longer exists)"
+        rm -f "$LOCK_FILE"
+    fi
+fi
+
+echo "{\"pid\": $$, \"started\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"directory\": \"$PWD\"}" > "$LOCK_FILE"
+trap "rm -f $LOCK_FILE" EXIT
+```
+
+## Anti-Patterns
+
+**NEVER trust a lock file without validating the PID:**
+```powershell
+if (Test-Path $lockFile) {
+    exit 1   # ❌ Dead process can hold a lock forever
+}
+```
+
+**NEVER use file-based locking as your only mechanism:**
+```powershell
+# ❌ Lock files survive process crashes — you need OS-level mutex or PID check
+New-Item $lockFile   # If the process crashes, this file stays forever
+```
+
+## Distributed Systems Pattern
+
+This is **lease-based locking with failure detection** — the same problem that ZooKeeper ephemeral nodes,
+etcd leases, and Consul health checks solve. A lock is only valid if you can verify the holder is alive.
+Defense in depth: mutex covers normal exit, PID scan handles abandoned mutexes, lockfile provides observability.

--- a/docs/src/content/blog/029-distributed-coordination-skills.md
+++ b/docs/src/content/blog/029-distributed-coordination-skills.md
@@ -1,0 +1,63 @@
+---
+title: "When Eight Ralphs Fight Over One Login"
+date: 2026-03-17
+author: "Tamir Dresher"
+wave: 7
+tags: [squad, distributed-systems, multi-machine, ralph, auth-isolation, reliability]
+status: published
+hero: "Real distributed systems problems — and fixes — from running 8 AI agents in parallel across 8 repos."
+---
+
+When you scale Squad to multiple machines or multiple concurrent agent loops, you stop worrying about prompts
+and start worrying about infrastructure. Auth races. Stale locks. Notification storms. Prompt serialization
+failures.
+
+Every bug described here links to a real incident. Every fix is battle-tested.
+
+## The Auth Race (37 Consecutive Failures)
+
+Eight Ralph instances on one machine. Each Ralph calls `gh auth switch` to set the right account. They clobber
+each other's global `~/.config/gh/hosts.yml`. Ralph-A sets personal, Ralph-B overwrites with work, Ralph-A
+fails. Cascades. 37 rounds of failures over three hours.
+
+**Fix:** [`gh-auth-isolation`](./../features/distributed-coordination) — each process gets its own
+`GH_CONFIG_DIR`. No shared state. No coordination needed.
+
+## The Stale Lock
+
+A crash left a lock file with PID 40544. The process was gone. The lock was not. Ralph refused to start.
+
+**Fix:** [`stale-lock-detection`](./../features/distributed-coordination) — three-layer guard: named OS mutex
+(auto-released on crash) + PID validation + lockfile cleanup on exit.
+
+## The 7KB Prompt That Became a Command Name
+
+`Start-Process` received a 7KB multiline prompt as an argument. Windows interpreted the entire string as the
+executable name. "Command not found: Ralph, Go! MAXIMIZE PARALLELISM..."
+
+**Fix:** [`message-serialization`](./../features/distributed-coordination) — write the prompt to a temp file,
+pass the file path as the argument.
+
+## The Notification Firehose
+
+20+ notifications per day to one channel. Failure alerts buried in tech news. Everyone stopped reading.
+
+**Fix:** [`notification-routing`](./../features/distributed-coordination) — define a channel routing config,
+tag notifications by type, route each to the right destination.
+
+## The Pattern
+
+Every one of these bugs maps 1:1 to a textbook distributed systems problem:
+
+| Incident | Classic Pattern | Fix |
+|----------|-----------------|-----|
+| Auth race | State partitioning | `gh-auth-isolation` |
+| Stale lock | Failure detection / leases | `stale-lock-detection` |
+| Prompt mangling | Message serialization | `message-serialization` |
+| Notification flood | Pub-sub topic routing | `notification-routing` |
+
+When you have multiple independent processes that need to coordinate — whether they're microservices,
+Kubernetes pods, or AI agents — you hit the same fundamental problems. And the solutions are the same
+fundamental patterns.
+
+[Read the full post on Tamir's blog →](https://tamirdresher.github.io/blog/2026/03/17/scaling-ai-part4-distributed)

--- a/docs/src/content/docs/features/distributed-coordination.md
+++ b/docs/src/content/docs/features/distributed-coordination.md
@@ -1,0 +1,112 @@
+# Distributed Coordination Skills
+
+> Four battle-tested skills for running multiple Squad agents reliably on the same machine or across machines.
+
+When you scale Squad beyond a single agent loop — multiple Ralphs, multi-machine deployments, or concurrent
+agent spawns — you start hitting classical distributed systems problems. These four skills encode the fixes,
+each earned from a real production incident.
+
+## gh-auth-isolation
+
+**Problem:** Multiple Ralph instances on the same machine fight over `~/.config/gh/hosts.yml`. When one Ralph
+calls `gh auth switch --user A`, it clobbers the auth state for every other Ralph on the machine, causing
+cascading 401 failures.
+
+**Fix:** Use `GH_CONFIG_DIR` to give each process a completely isolated `gh` config directory.
+
+```powershell
+# Each Ralph sets this before any gh calls
+$account = if ((git remote get-url origin) -match "work-org") { "work" } else { "personal" }
+$env:GH_CONFIG_DIR = Join-Path $env:USERPROFILE ".config\gh-$account"
+```
+
+No cross-talk between processes. No `gh auth switch` needed. See [`.squad/skills/gh-auth-isolation/`](../..)
+for the full pattern including Linux/macOS equivalents.
+
+**Distributed systems pattern:** State partitioning — give each process its own identity and storage instead of
+sharing mutable global state.
+
+## stale-lock-detection
+
+**Problem:** When a Ralph crashes, it leaves a lock file behind. The next start refuses to run because it sees
+the lock — guarding against a process that no longer exists.
+
+**Fix:** Three-layer guard: named OS mutex (auto-released on crash) + PID validation (detect zombie processes)
++ lockfile cleanup on exit.
+
+```powershell
+# Layer 3: PID-validated lock file
+if (Test-Path $lockFile) {
+    $existing = Get-Content $lockFile | ConvertFrom-Json
+    if (-not (Get-Process -Id $existing.pid -ErrorAction SilentlyContinue)) {
+        Write-Warning "Clearing stale lock (PID $($existing.pid) no longer exists)"
+        Remove-Item $lockFile -Force
+    }
+}
+```
+
+See [`.squad/skills/stale-lock-detection/`](../..) for the full three-layer implementation.
+
+**Distributed systems pattern:** Lease-based locking with failure detection — the same problem ZooKeeper
+ephemeral nodes and etcd leases solve.
+
+## message-serialization
+
+**Problem:** When spawning an agent with a large prompt via `Start-Process`, Windows interprets the entire
+7KB prompt string as the command name. Result: "command not found: Ralph, Go! MAXIMIZE PARALLELISM..."
+
+**Fix:** Write the prompt to a temp file, pass the file path as the argument.
+
+```powershell
+$promptFile = [System.IO.Path]::GetTempFileName() + ".txt"
+$prompt | Out-File -FilePath $promptFile -Encoding utf8
+try {
+    Start-Process "agency" -ArgumentList @("copilot", "--yolo", "--prompt-file", $promptFile) -Wait
+} finally {
+    Remove-Item $promptFile -Force -ErrorAction SilentlyContinue
+}
+```
+
+See [`.squad/skills/message-serialization/`](../..) for when to apply this and cleanup patterns.
+
+**Distributed systems pattern:** Indirection — when your transport can't handle your message format, pass a
+reference to the data instead.
+
+## notification-routing
+
+**Problem:** As the squad grows, all notifications flood a single channel. Failure alerts get buried in daily
+tech digests. Signal becomes noise. People stop reading.
+
+**Fix:** Define a channel routing config. Agents tag notifications by type. A dispatcher routes each to the
+right destination.
+
+```json
+{
+  "channels": {
+    "notifications": "squad-alerts",
+    "tech-news": "tech-news",
+    "security": "security-findings"
+  }
+}
+```
+
+See [`.squad/skills/notification-routing/`](../..) for the full routing pattern and service discovery guidance.
+
+**Distributed systems pattern:** Pub-sub with topic routing — the same principle as Kafka topics and RabbitMQ
+routing keys.
+
+## When Do You Need These?
+
+| Situation | Skills to Apply |
+|-----------|-----------------|
+| Running 2+ Ralphs on the same machine | `gh-auth-isolation` |
+| Ralph fails to start after a crash | `stale-lock-detection` |
+| Agent spawn fails with "command not found" | `message-serialization` |
+| Notification channel becoming noisy | `notification-routing` |
+| Multi-machine Squad deployment | All four |
+
+## Related
+
+- [Streams / SubSquads](./streams.md) — partitioning work across machines
+- [Ralph](./ralph.md) — persistent work monitor
+- [Model Selection](./model-selection.md) — circuit breaker for rate limits

--- a/test/docs-build.test.ts
+++ b/test/docs-build.test.ts
@@ -82,6 +82,7 @@ const EXPECTED_FEATURES = [
   'upstream-inheritance',
   'vscode',
   'worktrees',
+  'distributed-coordination',
 ];
 
 const EXPECTED_CONCEPTS = ['architecture', 'your-team', 'memory-and-knowledge', 'parallel-work', 'github-workflow', 'portability'];

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -1,5 +1,6 @@
 /**
  * Tests for Skills System (M3-3, Issue #141)
+ * Includes validation of shipped distributed-coordination skills (Part 4 blog)
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -304,4 +305,65 @@ Content here.`,
     const skills = loadSkillsFromDirectory(testDir);
     expect(skills).toHaveLength(1); // only my-skill loaded
   });
+});
+
+// --- Shipped Distributed-Coordination Skills Validation ---
+// Validates that the four Part 4 blog skills are present and well-formed.
+
+const SHIPPED_SKILLS_DIR = path.join(process.cwd(), '.squad', 'skills');
+
+const DISTRIBUTED_SKILLS = [
+  'gh-auth-isolation',
+  'stale-lock-detection',
+  'message-serialization',
+  'notification-routing',
+] as const;
+
+describe('Shipped Distributed-Coordination Skills', () => {
+  for (const skillId of DISTRIBUTED_SKILLS) {
+    const skillFile = path.join(SHIPPED_SKILLS_DIR, skillId, 'SKILL.md');
+
+    describe(`${skillId}`, () => {
+      it('SKILL.md exists', () => {
+        expect(fs.existsSync(skillFile), `Missing: .squad/skills/${skillId}/SKILL.md`).toBe(true);
+      });
+
+      it('SKILL.md is parseable', () => {
+        if (!fs.existsSync(skillFile)) return;
+        const raw = fs.readFileSync(skillFile, 'utf-8');
+        const skill = parseSkillFile(skillId, raw);
+        expect(skill, `parseSkillFile returned undefined for ${skillId}`).toBeDefined();
+      });
+
+      it('has required frontmatter fields (name, description, domain)', () => {
+        if (!fs.existsSync(skillFile)) return;
+        const raw = fs.readFileSync(skillFile, 'utf-8');
+        const { meta } = parseFrontmatter(raw);
+        expect(meta.name, `${skillId}: missing name`).toBeTruthy();
+        expect(meta.description, `${skillId}: missing description`).toBeTruthy();
+        expect(meta.domain, `${skillId}: missing domain`).toBeTruthy();
+      });
+
+      it('has a non-empty body with at least one heading', () => {
+        if (!fs.existsSync(skillFile)) return;
+        const raw = fs.readFileSync(skillFile, 'utf-8');
+        const { body } = parseFrontmatter(raw);
+        expect(body.length, `${skillId}: body is empty`).toBeGreaterThan(50);
+        expect(/^#+\s+.+/m.test(body), `${skillId}: missing heading`).toBe(true);
+      });
+
+      it('has balanced code fences', () => {
+        if (!fs.existsSync(skillFile)) return;
+        const raw = fs.readFileSync(skillFile, 'utf-8');
+        const fenceCount = (raw.match(/```/g) ?? []).length;
+        expect(fenceCount % 2, `${skillId}: unbalanced code fences`).toBe(0);
+      });
+
+      it('has an Anti-Patterns section', () => {
+        if (!fs.existsSync(skillFile)) return;
+        const raw = fs.readFileSync(skillFile, 'utf-8');
+        expect(raw, `${skillId}: missing Anti-Patterns section`).toContain('Anti-Patterns');
+      });
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Four skills earned from running 8 Ralph instances in production, documented in blog post [''When Eight Ralphs Fight Over One Login''](https://tamirdresher.github.io/blog/2026/03/17/scaling-ai-part4-distributed).

Each skill maps 1:1 to a textbook distributed systems pattern.

## Skills Added

### \gh-auth-isolation\
**Problem:** Multiple Ralphs on the same machine fight over \~/.config/gh/hosts.yml\. One Ralph calls \gh auth switch\ and clobbers every other Ralph's auth. 37 consecutive failures in 3 hours.  
**Fix:** Per-process \GH_CONFIG_DIR\ — each process gets its own isolated gh config.  
**DS pattern:** State partitioning

### \stale-lock-detection\
**Problem:** A crash leaves a lock file with a dead PID. The next Ralph start refuses to run, guarding against a process that no longer exists.  
**Fix:** Three-layer guard: named OS mutex (auto-released on crash) + PID validation + lockfile with registered cleanup.  
**DS pattern:** Lease-based locking with failure detection (same as ZooKeeper ephemeral nodes)

### \message-serialization\
**Problem:** A 7KB multiline prompt passed via \Start-Process --ArgumentList\ gets interpreted by Windows as the *command name*. Result: ''command not found: Ralph, Go! MAXIMIZE PARALLELISM...''  
**Fix:** Write prompt to temp file, pass file path as argument.  
**DS pattern:** Message indirection (same as gRPC + protobuf)

### \
otification-routing\
**Problem:** 20+ notifications/day flooding one Teams channel. Failure alerts buried in tech news. Everyone stops reading.  
**Fix:** \	eams-channels.json\ routing config + channel-tag convention. Each notification type goes to the right channel.  
**DS pattern:** Pub-sub topic routing (same as Kafka topics / RabbitMQ routing keys)

## What's Included

- \.squad/skills/gh-auth-isolation/SKILL.md\
- \.squad/skills/stale-lock-detection/SKILL.md\
- \.squad/skills/message-serialization/SKILL.md\
- \.squad/skills/notification-routing/SKILL.md\
- \docs/src/content/docs/features/distributed-coordination.md\ — feature guide
- \docs/src/content/blog/029-distributed-coordination-skills.md\ — blog post
- \	est/skills.test.ts\ — 24 new tests (structure + content validation for each skill)
- \	est/docs-build.test.ts\ — \distributed-coordination\ added to \EXPECTED_FEATURES\

## Tests

\\\
✓ test/skills.test.ts (51 tests) — all pass
\\\

Relates to #858 (tamirdresher/tamresearch1)