### PR TITLE
docs: improve installation instructions with workflow details and heartbeat config

### DIFF
--- a/docs/src/content/docs/get-started/five-minute-start.md
+++ b/docs/src/content/docs/get-started/five-minute-start.md
@@ -30,10 +30,19 @@ You'll see:
 ```
 ✅ Squad installed.
    .github/agents/squad.agent.md — coordinator agent
-   .squad/templates/ — 11 template files
+   .github/workflows/            — 5 GitHub workflows (heartbeat, triage, CI, etc.)
+   .squad/templates/             — 11 template files
 
 Open GitHub Copilot and select Squad from the agent list.
 ```
+
+> **Don't forget:** Commit the generated files — workflows won't run until they're on your default branch.
+>
+> ```bash
+> git add .github/ .squad/
+> git commit -m "chore: initialize squad team"
+> git push
+> ```
 
 ---
 

--- a/docs/src/content/docs/get-started/installation.md
+++ b/docs/src/content/docs/get-started/installation.md
@@ -153,8 +153,71 @@ This creates:
 
 ```
 .github/agents/squad.agent.md  — coordinator agent
+.github/workflows/             — GitHub workflows (see below)
 .squad/                        — team state directory
+.squad/templates/              — template files for casting, routing, ceremonies
 ```
+
+### What `squad init` installs
+
+Beyond the coordinator agent and team state, `squad init` creates GitHub workflows in `.github/workflows/`:
+
+| Workflow | Purpose |
+|----------|---------|
+| `squad-heartbeat.yml` | Ralph's triage loop — auto-assigns issues to squad members based on routing rules |
+| `squad-triage.yml` | Issue triage automation |
+| `squad-issue-assign.yml` | Auto-assign issues to squad members |
+| `squad-label-enforce.yml` | Label state machine enforcement |
+| `squad-ci.yml` | Build & test integration |
+
+> **Important:** These workflows are created but may need a separate commit. If `squad init` is run inside a Copilot session, the generated workflow files are staged but not committed. Commit them explicitly:
+>
+> ```bash
+> git add .github/workflows/ .github/agents/ .squad/
+> git commit -m "chore: initialize squad team"
+> ```
+
+### Enabling the heartbeat schedule
+
+The heartbeat workflow runs Ralph's triage automatically. By default, the cron schedule is **disabled** — it only triggers on issue/PR events and manual dispatch. To enable periodic triage:
+
+1. Open `.github/workflows/squad-heartbeat.yml`
+2. Uncomment the `schedule` block:
+
+```yaml
+on:
+  schedule:
+    # Every 30 minutes — adjust to your team's pace
+    - cron: '*/30 * * * *'
+```
+
+**Common schedule examples:**
+
+| Schedule | Cron Expression |
+|----------|----------------|
+| Every 30 minutes | `*/30 * * * *` |
+| Every hour | `0 * * * *` |
+| Every 4 hours during business hours | `0 9-17/4 * * 1-5` |
+| Once daily at 9 AM UTC | `0 9 * * *` |
+
+### Adding Squad to an existing project
+
+Already have a running project? `squad init` works the same way — it won't overwrite your existing files:
+
+```bash
+cd my-existing-project
+squad init
+```
+
+**Tip:** After initializing, give Squad context about your project in your first session:
+
+```
+> This is a React + Node.js task management app. We use PostgreSQL,
+> deploy to AWS, and follow trunk-based development. The main entry
+> points are src/server/index.ts and src/client/App.tsx.
+```
+
+Squad uses this to form a team matched to your stack and write accurate routing rules. See [Adding Squad to an Existing Repo](../scenarios/existing-repo.md) for a detailed walkthrough.
 
 ### Configuration (optional)
 


### PR DESCRIPTION
## Summary

Addresses #456 — installation instructions were missing key steps around workflow files, heartbeat configuration, and integrating Squad into existing projects.

## Changes

### \docs/src/content/docs/get-started/installation.md\
- **Expanded \squad init\ output** to show workflows and templates created
- **Added workflow table** listing the 5 GitHub workflows created during init
- **Added commit reminder** — workflows are staged but not committed during Copilot sessions
- **Added heartbeat schedule section** with instructions to uncomment cron and common schedule examples (30 min, hourly, business hours, daily)
- **Added 'existing project' section** with example prompt showing how to give Squad context about an existing codebase
- **Linked to existing-repo.md** for the full walkthrough

### \docs/src/content/docs/get-started/five-minute-start.md\
- Updated init output to mention workflow files
- Added commit/push step so workflows are deployed to the default branch

## Why This Matters

New users running \squad init\ didn't know:
1. Workflow files need a separate commit to work
2. The heartbeat cron is disabled by default and how to enable it
3. How to add Squad to an existing project (not just greenfield)