### PR TITLE
feat(docs): implement 10 Astro feature items from PAO audit

### DIFF
--- a/docs/.astro/collections/blog.schema.json
+++ b/docs/.astro/collections/blog.schema.json
@@ -13,6 +13,34 @@
         "date": {
           "type": "string"
         },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "author": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date-time"
+            },
+            {
+              "type": "string",
+              "format": "date"
+            },
+            {
+              "type": "integer",
+              "format": "unix-time"
+            }
+          ]
+        },
+        "status": {
+          "type": "string"
+        },
         "$schema": {
           "type": "string"
         }

--- a/docs/.astro/collections/docs.schema.json
+++ b/docs/.astro/collections/docs.schema.json
@@ -13,6 +13,34 @@
         "order": {
           "type": "number"
         },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "author": {
+          "type": "string"
+        },
+        "updatedAt": {
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "date-time"
+            },
+            {
+              "type": "string",
+              "format": "date"
+            },
+            {
+              "type": "integer",
+              "format": "unix-time"
+            }
+          ]
+        },
+        "status": {
+          "type": "string"
+        },
         "$schema": {
           "type": "string"
         }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,11 +1,13 @@
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
+import sitemap from '@astrojs/sitemap';
 import { remarkRewriteLinks } from './src/plugins/remark-rewrite-links.mjs';
 import { rehypePagefindAttrs } from './src/plugins/rehype-pagefind-attrs.mjs';
 
 export default defineConfig({
   site: 'https://bradygaster.github.io',
   base: '/squad/',
+  integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,6 +8,8 @@
       "name": "squad-docs",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/rss": "^4.0.17",
+        "@astrojs/sitemap": "^3.7.1",
         "@tailwindcss/vite": "^4.1.0",
         "astro": "^5.7.0",
         "sharp": "^0.34.5",
@@ -69,6 +71,46 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.17.tgz",
+      "integrity": "sha512-eV+wdMbeVKC9+sPaV0LN8JL1LGo9YAh3GKl4Ou4nzMNLmXM/aswYpSGxVEAuHilgBZ6/++/Pv08ICmuOqX107w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "5.4.1",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/rss/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.1.tgz",
+      "integrity": "sha512-IzQqdTeskaMX+QDZCzMuJIp8A8C1vgzMBp/NmHNnadepHYNHcxQdGLQZYfkbd2EbRXUfOS+UDIKx8sKg0oWVdw==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1898,6 +1940,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2020,6 +2080,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3262,6 +3328,40 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4993,6 +5093,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -5454,6 +5569,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
@@ -5484,6 +5618,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -5530,6 +5670,18 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
+      "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/svgo": {
       "version": "4.0.1",
@@ -5695,6 +5847,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,8 @@
     "test:e2e": "npx playwright test"
   },
   "dependencies": {
+    "@astrojs/rss": "^4.0.17",
+    "@astrojs/sitemap": "^3.7.1",
     "@tailwindcss/vite": "^4.1.0",
     "astro": "^5.7.0",
     "sharp": "^0.34.5",

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+Sitemap: https://squad.dev/sitemap-index.xml
+

--- a/docs/src/components/TableOfContents.astro
+++ b/docs/src/components/TableOfContents.astro
@@ -1,0 +1,46 @@
+---
+// Client-side Table of Contents — reads h2/h3 from the article after render
+---
+
+<nav id="toc" class="toc sticky top-8 text-sm" aria-label="On this page" data-pagefind-ignore>
+  <p class="font-semibold text-surface-700 dark:text-surface-300 mb-2 text-xs uppercase tracking-wide">On this page</p>
+  <ul id="toc-list" class="space-y-1 text-surface-500 dark:text-surface-400">
+    <!-- Populated by client script -->
+  </ul>
+</nav>
+
+<script is:inline>
+  function buildToc() {
+    const article = document.querySelector('article[data-pagefind-body]');
+    const list = document.getElementById('toc-list');
+    if (!article || !list) return;
+
+    const headings = Array.from(article.querySelectorAll('h2, h3'));
+    if (headings.length === 0) {
+      document.getElementById('toc')?.classList.add('hidden');
+      return;
+    }
+
+    list.innerHTML = '';
+    headings.forEach((h) => {
+      if (!h.id) {
+        h.id = h.textContent
+          ?.toLowerCase()
+          .replace(/[^\w\s-]/g, '')
+          .replace(/\s+/g, '-') || '';
+      }
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = '#' + h.id;
+      a.textContent = h.textContent || '';
+      a.className = h.tagName === 'H3'
+        ? 'block pl-3 py-0.5 hover:text-squad-600 dark:hover:text-squad-400 transition-colors'
+        : 'block py-0.5 hover:text-squad-600 dark:hover:text-squad-400 transition-colors font-medium';
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+  }
+
+  document.addEventListener('astro:page-load', buildToc);
+  buildToc();
+</script>

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -7,6 +7,10 @@ const docs = defineCollection({
     title: z.string().optional(),
     description: z.string().optional(),
     order: z.number().optional(),
+    tags: z.array(z.string()).optional(),
+    author: z.string().optional(),
+    updatedAt: z.coerce.date().optional(),
+    status: z.string().optional(),
   }),
 });
 
@@ -16,6 +20,10 @@ const blog = defineCollection({
     title: z.string().optional(),
     description: z.string().optional(),
     date: z.coerce.string().optional(),
+    tags: z.array(z.string()).optional(),
+    author: z.string().optional(),
+    updatedAt: z.coerce.date().optional(),
+    status: z.string().optional(),
   }),
 });
 

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -4,6 +4,7 @@ interface Props {
   description?: string;
 }
 
+import { ViewTransitions } from 'astro:transitions';
 import squadLogo from '../assets/images/squad-logo.png';
 const { title, description = 'Squad — Your AI Development Team. Describe what you\'re building. Get a team of specialists that live in your repo.' } = Astro.props;
 const fullTitle = `${title} — Squad Docs`;
@@ -29,10 +30,13 @@ const ogImage = Astro.site ? new URL(squadLogo.src, Astro.site).href : squadLogo
     {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
 
     <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
+
+    <ViewTransitions />
+
     <script is:inline>
       const theme = localStorage.getItem('theme');
       if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
@@ -42,6 +46,28 @@ const ogImage = Astro.site ? new URL(squadLogo.src, Astro.site).href : squadLogo
   </head>
   <body class="min-h-screen bg-white dark:bg-surface-950 text-surface-900 dark:text-surface-100 antialiased">
     <slot />
+    <!-- Code block copy button -->
+    <script is:inline>
+      function initCopyButtons() {
+        document.querySelectorAll('pre').forEach((pre) => {
+          if (pre.querySelector('.copy-btn')) return;
+          const btn = document.createElement('button');
+          btn.className = 'copy-btn absolute top-2 right-2 px-2 py-1 text-xs rounded bg-surface-700 text-surface-100 hover:bg-squad-600 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100';
+          btn.setAttribute('aria-label', 'Copy code');
+          btn.textContent = 'Copy';
+          pre.classList.add('relative', 'group');
+          pre.appendChild(btn);
+          btn.addEventListener('click', async () => {
+            const code = pre.querySelector('code')?.innerText ?? pre.innerText;
+            await navigator.clipboard.writeText(code);
+            btn.textContent = 'Copied!';
+            setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
+          });
+        });
+      }
+      document.addEventListener('astro:page-load', initCopyButtons);
+      initCopyButtons();
+    </script>
   </body>
 </html>
 <style is:global>

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -3,20 +3,28 @@ import BaseLayout from './BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Sidebar from '../components/Sidebar.astro';
 import Footer from '../components/Footer.astro';
+import TableOfContents from '../components/TableOfContents.astro';
 import { NAV_SECTIONS } from '../navigation';
 
 interface Props {
   title: string;
   description?: string;
   currentSlug?: string;
+  updatedAt?: Date;
+  prevPage?: { title: string; slug: string } | null;
+  nextPage?: { title: string; slug: string } | null;
 }
 
-const { title, description, currentSlug } = Astro.props;
+const { title, description, currentSlug, updatedAt, prevPage, nextPage } = Astro.props;
 
 // Derive section name from the URL path for Pagefind metadata
 const sectionDir = currentSlug?.split('/')[0] || '';
 const navSection = NAV_SECTIONS.find(s => s.dir === sectionDir);
 const section = navSection?.title || 'Docs';
+
+const editUrl = currentSlug
+  ? `https://github.com/bradygaster/squad/edit/dev/docs/src/content/docs/${currentSlug}.md`
+  : null;
 ---
 
 <BaseLayout title={title} description={description}>
@@ -25,9 +33,63 @@ const section = navSection?.title || 'Docs';
     <Sidebar currentSlug={currentSlug} />
     <main class="flex-1 min-w-0">
       <div class="max-w-4xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
-        <article class="prose" data-pagefind-body data-pagefind-meta={`section:${section}`}>
-          <slot />
-        </article>
+        <div class="lg:flex lg:gap-8">
+          <div class="flex-1 min-w-0">
+            <article class="prose" data-pagefind-body data-pagefind-meta={`section:${section}`}>
+              <slot />
+            </article>
+
+            {updatedAt && (
+              <p class="mt-4 text-xs text-surface-500 dark:text-surface-400">
+                Last updated: {updatedAt.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+              </p>
+            )}
+
+            <!-- Prev/Next navigation -->
+            {(prevPage || nextPage) && (
+              <nav class="mt-8 pt-6 border-t border-surface-200 dark:border-surface-700 flex justify-between gap-4" aria-label="Page navigation" data-pagefind-ignore>
+                {prevPage ? (
+                  <a href={`${import.meta.env.BASE_URL}docs/${prevPage.slug}/`} class="flex items-center gap-2 text-sm text-surface-500 dark:text-surface-400 hover:text-squad-600 dark:hover:text-squad-400 transition-colors">
+                    <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M11 17l-5-5m0 0l5-5m-5 5h12" />
+                    </svg>
+                    <span>{prevPage.title}</span>
+                  </a>
+                ) : <span />}
+                {nextPage && (
+                  <a href={`${import.meta.env.BASE_URL}docs/${nextPage.slug}/`} class="flex items-center gap-2 text-sm text-surface-500 dark:text-surface-400 hover:text-squad-600 dark:hover:text-squad-400 transition-colors ml-auto">
+                    <span>{nextPage.title}</span>
+                    <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                    </svg>
+                  </a>
+                )}
+              </nav>
+            )}
+
+            <!-- Edit this page -->
+            {editUrl && (
+              <div class="mt-6 pt-4 border-t border-surface-200 dark:border-surface-700" data-pagefind-ignore>
+                <a
+                  href={editUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="edit-this-page inline-flex items-center gap-1.5 text-xs text-surface-400 dark:text-surface-500 hover:text-squad-600 dark:hover:text-squad-400 transition-colors"
+                >
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                  Edit this page on GitHub
+                </a>
+              </div>
+            )}
+          </div>
+
+          <!-- Right column ToC (wide screens) -->
+          <aside class="hidden lg:block w-56 shrink-0" data-pagefind-ignore>
+            <TableOfContents />
+          </aside>
+        </div>
       </div>
       <Footer />
     </main>

--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import DocsLayout from '../../layouts/DocsLayout.astro';
+import { NAV_SECTIONS } from '../../navigation';
 
 export async function getStaticPaths() {
   const docs = await getCollection('docs');
@@ -15,8 +16,21 @@ const { Content } = await render(entry);
 
 // Extract title from frontmatter or first H1
 const title = entry.data.title || entry.id.split('/').pop()?.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase()) || 'Documentation';
+
+// Compute prev/next from NAV_SECTIONS order
+const allItems = NAV_SECTIONS.flatMap(s => s.items);
+const currentIndex = allItems.findIndex(item => item.slug === entry.id);
+const prevPage = currentIndex > 0 ? allItems[currentIndex - 1] : null;
+const nextPage = currentIndex >= 0 && currentIndex < allItems.length - 1 ? allItems[currentIndex + 1] : null;
 ---
 
-<DocsLayout title={title} description={entry.data.description} currentSlug={entry.id}>
+<DocsLayout
+  title={title}
+  description={entry.data.description}
+  currentSlug={entry.id}
+  updatedAt={entry.data.updatedAt}
+  prevPage={prevPage}
+  nextPage={nextPage}
+>
   <Content />
 </DocsLayout>

--- a/docs/src/pages/rss.xml.js
+++ b/docs/src/pages/rss.xml.js
@@ -1,0 +1,22 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+
+export async function GET(context) {
+  const posts = await getCollection('blog');
+  const sorted = posts
+    .filter((p) => p.data.date)
+    .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
+
+  return rss({
+    title: 'Squad Docs - Blog',
+    description: 'Updates, releases, and stories from the Squad team.',
+    site: context.site ?? 'https://bradygaster.github.io/squad/',
+    items: sorted.map((post) => ({
+      title: post.data.title ?? post.id,
+      pubDate: new Date(post.data.date),
+      description: post.data.description ?? '',
+      link: '/squad/blog/' + post.id + '/',
+    })),
+    customData: '<language>en-us</language>',
+  });
+}

--- a/docs/tests/astro-features.test.mjs
+++ b/docs/tests/astro-features.test.mjs
@@ -1,0 +1,139 @@
+/**
+ * Astro feature tests — validates 10 PAO audit items are implemented.
+ * Run with: node --test tests/astro-features.test.mjs
+ * NOTE: Build-output tests require npm run build to have run first.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DOCS_ROOT = path.resolve(import.meta.dirname, '..');
+const SRC = path.join(DOCS_ROOT, 'src');
+const DIST = path.join(DOCS_ROOT, 'dist');
+
+// 1. sitemap
+describe('sitemap integration', () => {
+  it('package.json includes @astrojs/sitemap dependency', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(DOCS_ROOT, 'package.json'), 'utf-8'));
+    assert.ok(pkg.dependencies?.['@astrojs/sitemap'] || pkg.devDependencies?.['@astrojs/sitemap'], '@astrojs/sitemap should be in package.json');
+  });
+  it('astro.config.mjs imports and registers sitemap integration', () => {
+    const config = fs.readFileSync(path.join(DOCS_ROOT, 'astro.config.mjs'), 'utf-8');
+    assert.ok(config.includes('@astrojs/sitemap'), 'config should import @astrojs/sitemap');
+    assert.ok(config.includes('sitemap()') || config.includes('sitemap({'), 'config should register sitemap');
+  });
+  it('sitemap-index.xml exists in dist after build', () => {
+    if (!fs.existsSync(DIST)) { console.log('  SKIP: dist/ not found'); return; }
+    assert.ok(fs.existsSync(path.join(DIST, 'sitemap-index.xml')) || fs.existsSync(path.join(DIST, 'sitemap.xml')), 'sitemap should exist in dist/');
+  });
+});
+
+// 2. copy button
+describe('code block copy button', () => {
+  it('BaseLayout.astro contains copy button script', () => {
+    const layout = fs.readFileSync(path.join(SRC, 'layouts', 'BaseLayout.astro'), 'utf-8');
+    assert.ok(layout.includes('copy-btn') || layout.includes('Copy code'), 'BaseLayout should include copy button');
+    assert.ok(layout.includes('clipboard.writeText'), 'BaseLayout should have clipboard.writeText');
+  });
+});
+
+// 3. twitter card
+describe('twitter card meta tag', () => {
+  it('BaseLayout.astro uses summary_large_image', () => {
+    const layout = fs.readFileSync(path.join(SRC, 'layouts', 'BaseLayout.astro'), 'utf-8');
+    assert.ok(layout.includes('summary_large_image'), 'twitter:card should be summary_large_image');
+    assert.ok(!layout.includes('"summary"'), 'twitter:card should NOT be plain summary');
+  });
+});
+
+// 4. edit this page
+describe('"Edit this page" link', () => {
+  it('DocsLayout.astro contains edit-this-page link', () => {
+    const layout = fs.readFileSync(path.join(SRC, 'layouts', 'DocsLayout.astro'), 'utf-8');
+    assert.ok(layout.includes('edit-this-page') || layout.includes('Edit this page'), 'DocsLayout should include Edit this page link');
+    assert.ok(layout.includes('github.com/bradygaster/squad/edit'), 'Edit link should point to GitHub edit URL');
+  });
+});
+
+// 5. robots.txt
+describe('robots.txt', () => {
+  it('public/robots.txt exists', () => {
+    assert.ok(fs.existsSync(path.join(DOCS_ROOT, 'public', 'robots.txt')), 'docs/public/robots.txt should exist');
+  });
+  it('robots.txt contains correct directives', () => {
+    const content = fs.readFileSync(path.join(DOCS_ROOT, 'public', 'robots.txt'), 'utf-8');
+    assert.ok(content.includes('User-agent: *'), 'robots.txt should have User-agent: *');
+    assert.ok(content.includes('Allow: /'), 'robots.txt should have Allow: /');
+    assert.ok(content.includes('Sitemap:'), 'robots.txt should reference Sitemap');
+  });
+});
+
+// 6. table of contents
+describe('Table of Contents', () => {
+  it('TableOfContents.astro component file exists', () => {
+    assert.ok(fs.existsSync(path.join(SRC, 'components', 'TableOfContents.astro')), 'src/components/TableOfContents.astro should exist');
+  });
+  it('TableOfContents component is imported in DocsLayout', () => {
+    const layout = fs.readFileSync(path.join(SRC, 'layouts', 'DocsLayout.astro'), 'utf-8');
+    assert.ok(layout.includes('TableOfContents'), 'DocsLayout should import and use TableOfContents');
+  });
+});
+
+// 7. RSS
+describe('RSS feed', () => {
+  it('package.json includes @astrojs/rss dependency', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(DOCS_ROOT, 'package.json'), 'utf-8'));
+    assert.ok(pkg.dependencies?.['@astrojs/rss'] || pkg.devDependencies?.['@astrojs/rss'], '@astrojs/rss should be in package.json');
+  });
+  it('rss.xml.js endpoint file exists', () => {
+    assert.ok(fs.existsSync(path.join(SRC, 'pages', 'rss.xml.js')), 'src/pages/rss.xml.js should exist');
+  });
+  it('rss.xml.js uses @astrojs/rss and pulls from blog collection', () => {
+    const rssFile = fs.readFileSync(path.join(SRC, 'pages', 'rss.xml.js'), 'utf-8');
+    assert.ok(rssFile.includes('@astrojs/rss'), 'rss.xml.js should import from @astrojs/rss');
+    assert.ok(rssFile.includes('blog'), 'rss.xml.js should reference the blog collection');
+  });
+});
+
+// 8. next/prev
+describe('Next/Prev page navigation', () => {
+  it('docs catch-all route computes prevPage and nextPage', () => {
+    const slug = fs.readFileSync(path.join(SRC, 'pages', 'docs', '[...slug].astro'), 'utf-8');
+    assert.ok(slug.includes('prevPage'), 'catch-all route should compute prevPage');
+    assert.ok(slug.includes('nextPage'), 'catch-all route should compute nextPage');
+    assert.ok(slug.includes('NAV_SECTIONS'), 'catch-all route should use NAV_SECTIONS');
+  });
+  it('DocsLayout renders prev/next navigation links', () => {
+    const layout = fs.readFileSync(path.join(SRC, 'layouts', 'DocsLayout.astro'), 'utf-8');
+    assert.ok(layout.includes('prevPage'), 'DocsLayout should render prevPage link');
+    assert.ok(layout.includes('nextPage'), 'DocsLayout should render nextPage link');
+  });
+});
+
+// 9. richer frontmatter
+describe('Richer frontmatter schema', () => {
+  it('config.ts adds optional tags, author, updatedAt, status fields', () => {
+    const config = fs.readFileSync(path.join(SRC, 'content', 'config.ts'), 'utf-8');
+    assert.ok(config.includes('tags'), 'docs schema should include tags');
+    assert.ok(config.includes('author'), 'docs schema should include author');
+    assert.ok(config.includes('updatedAt'), 'docs schema should include updatedAt');
+    assert.ok(config.includes('status'), 'docs schema should include status');
+  });
+  it('DocsLayout displays updatedAt when present', () => {
+    const layout = fs.readFileSync(path.join(SRC, 'layouts', 'DocsLayout.astro'), 'utf-8');
+    assert.ok(layout.includes('updatedAt'), 'DocsLayout should display updatedAt');
+  });
+});
+
+// 10. view transitions
+describe('View Transitions', () => {
+  it('BaseLayout.astro imports ViewTransitions from astro:transitions', () => {
+    const layout = fs.readFileSync(path.join(SRC, 'layouts', 'BaseLayout.astro'), 'utf-8');
+    assert.ok(layout.includes('ViewTransitions') && layout.includes('astro:transitions'), 'BaseLayout should import ViewTransitions from astro:transitions');
+  });
+  it('BaseLayout.astro renders <ViewTransitions /> in the <head>', () => {
+    const layout = fs.readFileSync(path.join(SRC, 'layouts', 'BaseLayout.astro'), 'utf-8');
+    assert.ok(layout.includes('<ViewTransitions />') || layout.includes('<ViewTransitions/>'), 'BaseLayout should render <ViewTransitions />');
+  });
+});


### PR DESCRIPTION
## Summary

Implements all 10 items from PAO's docs site audit. ALL changes are inside docs/.

Working as EECOM (Core Dev)

### Changes

1. @astrojs/sitemap - Installed, integrated, sitemap-index.xml generated on build
2. Code block copy button - Global JS in BaseLayout, clipboard API, Tailwind styled
3. Twitter Card - Changed to summary_large_image in BaseLayout
4. Edit this page link - GitHub edit URL in DocsLayout footer
5. robots.txt - Created docs/public/robots.txt with Allow: / and Sitemap reference
6. Table of Contents - TableOfContents.astro client-side component, right column on wide screens
7. @astrojs/rss - Installed, src/pages/rss.xml.js endpoint from blog collection
8. Next/Prev navigation - Computed from NAV_SECTIONS in [...slug].astro, rendered in DocsLayout
9. Richer frontmatter - Added tags, author, updatedAt, status to docs + blog schemas; updatedAt displayed in DocsLayout
10. View Transitions - ViewTransitions component in BaseLayout head

### Tests

docs/tests/astro-features.test.mjs - 19/19 pass
Existing build-output.test.mjs - 13/13 pass

Build: astro build succeeded, 138 pages + sitemap-index.xml + rss.xml generated.

@bradygaster - tagging you for review. Requested by Dina.