### PR TITLE
feat(sdk): worktree helpers in ralph-commands (#528)

### DIFF
--- a/packages/squad-sdk/src/config/schema.ts
+++ b/packages/squad-sdk/src/config/schema.ts
@@ -12,6 +12,8 @@ export interface SquadConfig {
   hooks?: HooksConfig;
   ceremonies?: CeremonyConfig[];
   plugins?: PluginConfig;
+  /** Enable git worktree mode for branch creation (default: false) */
+  worktrees?: boolean;
 }
 
 export interface TeamConfig {

--- a/packages/squad-sdk/src/platform/index.ts
+++ b/packages/squad-sdk/src/platform/index.ts
@@ -12,7 +12,7 @@ export { AzureDevOpsAdapter } from './azure-devops.js';
 export type { AdoWorkItemConfig, WorkItemTypeInfo } from './azure-devops.js';
 export { getAvailableWorkItemTypes, validateWorkItemType } from './azure-devops.js';
 export { PlannerAdapter, mapPlannerTaskToWorkItem } from './planner.js';
-export { getRalphScanCommands } from './ralph-commands.js';
+export { getRalphScanCommands, isWorktreeEnabled, resolveWorktreePath, createWorktreeCommand, removeWorktreeCommand, setupWorktreeDepsCommand, generateWorktreeVariant } from './ralph-commands.js';
 export type { RalphCommands } from './ralph-commands.js';
 export { FileLogCommunicationAdapter } from './comms-file-log.js';
 export { GitHubDiscussionsCommunicationAdapter } from './comms-github-discussions.js';

--- a/packages/squad-sdk/src/platform/ralph-commands.ts
+++ b/packages/squad-sdk/src/platform/ralph-commands.ts
@@ -4,14 +4,130 @@
  * @module platform/ralph-commands
  */
 
+import * as path from 'node:path';
 import type { PlatformType } from './types.js';
+
+/**
+ * Check if worktree mode is enabled.
+ * Precedence: SQUAD_WORKTREES env > config > default false
+ */
+export function isWorktreeEnabled(config?: { worktrees?: boolean }): boolean {
+  const envVal = process.env.SQUAD_WORKTREES;
+  if (envVal === '1' || envVal === 'true') return true;
+  if (envVal === '0' || envVal === 'false') return false;
+  return config?.worktrees ?? false;
+}
+
+/**
+ * Resolve the worktree path for an issue.
+ * Convention: {repo-parent}/{repo-name}-{issue-number}
+ */
+export function resolveWorktreePath(
+  repoRoot: string,
+  issueNumber: string | number,
+): string {
+  const repoName = path.basename(repoRoot);
+  const parentDir = path.dirname(repoRoot);
+  return path.join(parentDir, `${repoName}-${issueNumber}`);
+}
+
+/**
+ * Create a git worktree for an issue branch.
+ * Returns the worktree path and command.
+ */
+export function createWorktreeCommand(
+  repoRoot: string,
+  branch: string,
+  baseBranch: string,
+  issueNumber: string | number,
+): { command: string; worktreePath: string } {
+  const worktreePath = resolveWorktreePath(repoRoot, issueNumber);
+  const command = `git worktree add "${worktreePath}" -b ${branch} ${baseBranch}`;
+  return { command, worktreePath };
+}
+
+/**
+ * Remove a git worktree and optionally delete the merged branch.
+ */
+export function removeWorktreeCommand(
+  worktreePath: string,
+  branch?: string,
+): string[] {
+  const commands = [`git worktree remove "${worktreePath}"`];
+  if (branch) {
+    commands.push(`git branch -d ${branch}`);
+  }
+  return commands;
+}
+
+/**
+ * Setup dependency management in a worktree (junction/symlink for node_modules).
+ * Returns the command to run.
+ */
+export function setupWorktreeDepsCommand(
+  mainRepoRoot: string,
+  worktreePath: string,
+): string {
+  const mainNodeModules = path.join(mainRepoRoot, 'node_modules');
+  const wtNodeModules = path.join(worktreePath, 'node_modules');
+
+  if (process.platform === 'win32') {
+    return `cmd /c mklink /J "${wtNodeModules}" "${mainNodeModules}"`;
+  }
+  return `ln -s "${mainNodeModules}" "${wtNodeModules}"`;
+}
+
+/**
+ * Generate worktree variant for RalphCommands.
+ * This is a helper used by all platform adapters.
+ */
+export function generateWorktreeVariant(
+  repoRoot: string,
+  branchName: string,
+  baseBranch: string,
+  issueNumber: string | number,
+): {
+  create: string;
+  path: string;
+  setupDeps: string;
+  cleanup: string[];
+} {
+  const { command, worktreePath } = createWorktreeCommand(
+    repoRoot,
+    branchName,
+    baseBranch,
+    issueNumber,
+  );
+  const setupDeps = setupWorktreeDepsCommand(repoRoot, worktreePath);
+  const cleanup = removeWorktreeCommand(worktreePath, branchName);
+
+  return {
+    create: command,
+    path: worktreePath,
+    setupDeps,
+    cleanup,
+  };
+}
+
 
 export interface RalphCommands {
   listUntriaged: string;
   listAssigned: string;
   listOpenPRs: string;
   listDraftPRs: string;
+  /** Git branch creation command (checkout variant) */
   createBranch: string;
+  /** Optional worktree variant for branch creation */
+  createBranchWorktree?: {
+    /** git worktree add command */
+    create: string;
+    /** Path to the created worktree */
+    path: string;
+    /** Command to setup dependency symlink/junction */
+    setupDeps: string;
+    /** Commands to cleanup the worktree */
+    cleanup: string[];
+  };
   createPR: string;
   mergePR: string;
   createWorkItem: string;
@@ -48,6 +164,17 @@ export function getPlannerRalphCommands(): RalphCommands {
       'echo "Planner does not manage PRs — use the repo adapter (GitHub or Azure DevOps)"',
     createBranch:
       'git checkout main && git pull && git checkout -b {branchName}',
+    createBranchWorktree: {
+      create: 'git worktree add "{worktreePath}" -b {branchName} {baseBranch}',
+      path: '{worktreePath}',
+      setupDeps: process.platform === 'win32'
+        ? 'cmd /c mklink /J "{worktreePath}\\node_modules" "{repoRoot}\\node_modules"'
+        : 'ln -s "{repoRoot}/node_modules" "{worktreePath}/node_modules"',
+      cleanup: [
+        'git worktree remove "{worktreePath}"',
+        'git branch -d {branchName}',
+      ],
+    },
     createPR:
       'echo "Planner does not manage PRs — use the repo adapter (GitHub or Azure DevOps)"',
     mergePR:
@@ -69,6 +196,17 @@ function getGitHubRalphCommands(): RalphCommands {
       'gh pr list --state open --draft --json number,title,headRefName,baseRefName,state,isDraft,reviewDecision,author --limit 20',
     createBranch:
       'git checkout main && git pull && git checkout -b {branchName}',
+    createBranchWorktree: {
+      create: 'git worktree add "{worktreePath}" -b {branchName} {baseBranch}',
+      path: '{worktreePath}',
+      setupDeps: process.platform === 'win32'
+        ? 'cmd /c mklink /J "{worktreePath}\\node_modules" "{repoRoot}\\node_modules"'
+        : 'ln -s "{repoRoot}/node_modules" "{worktreePath}/node_modules"',
+      cleanup: [
+        'git worktree remove "{worktreePath}"',
+        'git branch -d {branchName}',
+      ],
+    },
     createPR:
       'gh pr create --title "{title}" --body "{description}" --head {sourceBranch} --base {targetBranch}',
     mergePR:
@@ -90,6 +228,17 @@ function getAzureDevOpsRalphCommands(): RalphCommands {
       'az repos pr list --status active --query "[?isDraft==`true`]" --output table',
     createBranch:
       'git checkout main && git pull && git checkout -b {branchName}',
+    createBranchWorktree: {
+      create: 'git worktree add "{worktreePath}" -b {branchName} {baseBranch}',
+      path: '{worktreePath}',
+      setupDeps: process.platform === 'win32'
+        ? 'cmd /c mklink /J "{worktreePath}\\node_modules" "{repoRoot}\\node_modules"'
+        : 'ln -s "{repoRoot}/node_modules" "{worktreePath}/node_modules"',
+      cleanup: [
+        'git worktree remove "{worktreePath}"',
+        'git branch -d {branchName}',
+      ],
+    },
     createPR:
       'az repos pr create --title "{title}" --description "{description}" --source-branch {sourceBranch} --target-branch {targetBranch}',
     mergePR:

--- a/test/worktree-commands.test.ts
+++ b/test/worktree-commands.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for worktree command generation functions in ralph-commands.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import {
+  isWorktreeEnabled,
+  resolveWorktreePath,
+  createWorktreeCommand,
+  removeWorktreeCommand,
+  setupWorktreeDepsCommand,
+  generateWorktreeVariant,
+} from '../packages/squad-sdk/src/platform/ralph-commands.js';
+
+describe('worktree commands', () => {
+  describe('isWorktreeEnabled', () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+      originalEnv = process.env.SQUAD_WORKTREES;
+      delete process.env.SQUAD_WORKTREES;
+    });
+
+    afterEach(() => {
+      if (originalEnv !== undefined) {
+        process.env.SQUAD_WORKTREES = originalEnv;
+      } else {
+        delete process.env.SQUAD_WORKTREES;
+      }
+    });
+
+    it('returns false by default', () => {
+      expect(isWorktreeEnabled()).toBe(false);
+      expect(isWorktreeEnabled({})).toBe(false);
+    });
+
+    it('returns true when SQUAD_WORKTREES=1', () => {
+      process.env.SQUAD_WORKTREES = '1';
+      expect(isWorktreeEnabled()).toBe(true);
+    });
+
+    it('returns true when SQUAD_WORKTREES=true', () => {
+      process.env.SQUAD_WORKTREES = 'true';
+      expect(isWorktreeEnabled()).toBe(true);
+    });
+
+    it('returns false when SQUAD_WORKTREES=0', () => {
+      process.env.SQUAD_WORKTREES = '0';
+      expect(isWorktreeEnabled()).toBe(false);
+      expect(isWorktreeEnabled({ worktrees: true })).toBe(false);
+    });
+
+    it('returns false when SQUAD_WORKTREES=false', () => {
+      process.env.SQUAD_WORKTREES = 'false';
+      expect(isWorktreeEnabled()).toBe(false);
+      expect(isWorktreeEnabled({ worktrees: true })).toBe(false);
+    });
+
+    it('respects config when no env var', () => {
+      expect(isWorktreeEnabled({ worktrees: true })).toBe(true);
+      expect(isWorktreeEnabled({ worktrees: false })).toBe(false);
+    });
+
+    it('env var takes precedence over config', () => {
+      process.env.SQUAD_WORKTREES = '1';
+      expect(isWorktreeEnabled({ worktrees: false })).toBe(true);
+
+      process.env.SQUAD_WORKTREES = '0';
+      expect(isWorktreeEnabled({ worktrees: true })).toBe(false);
+    });
+  });
+
+  describe('resolveWorktreePath', () => {
+    it('creates sibling directory path', () => {
+      const repoRoot = '/home/user/project';
+      const issueNumber = 42;
+      const expected = path.join('/home/user', 'project-42');
+      expect(resolveWorktreePath(repoRoot, issueNumber)).toBe(expected);
+    });
+
+    it('uses repo name and issue number', () => {
+      const repoRoot = 'C:\\src\\squad';
+      const issueNumber = 528;
+      const expected = path.join('C:\\src', 'squad-528');
+      expect(resolveWorktreePath(repoRoot, issueNumber)).toBe(expected);
+    });
+
+    it('handles string issue numbers', () => {
+      const repoRoot = '/repos/myapp';
+      const issueNumber = '123';
+      const expected = path.join('/repos', 'myapp-123');
+      expect(resolveWorktreePath(repoRoot, issueNumber)).toBe(expected);
+    });
+
+    it('works with nested repo paths', () => {
+      const repoRoot = '/home/dev/work/my-project';
+      const issueNumber = 1;
+      const expected = path.join('/home/dev/work', 'my-project-1');
+      expect(resolveWorktreePath(repoRoot, issueNumber)).toBe(expected);
+    });
+  });
+
+  describe('createWorktreeCommand', () => {
+    it('generates correct git worktree add command', () => {
+      const repoRoot = '/home/user/project';
+      const branch = 'feature/new-thing';
+      const baseBranch = 'main';
+      const issueNumber = 42;
+
+      const result = createWorktreeCommand(repoRoot, branch, baseBranch, issueNumber);
+      const expectedPath = path.join('/home/user', 'project-42');
+
+      expect(result.worktreePath).toBe(expectedPath);
+      expect(result.command).toContain('git worktree add');
+      expect(result.command).toContain('feature/new-thing');
+      expect(result.command).toContain('main');
+    });
+
+    it('includes branch and base branch', () => {
+      const repoRoot = 'C:\\repos\\squad';
+      const branch = 'squad/528-worktree-ralph';
+      const baseBranch = 'dev';
+      const issueNumber = 528;
+
+      const result = createWorktreeCommand(repoRoot, branch, baseBranch, issueNumber);
+
+      expect(result.command).toContain('-b squad/528-worktree-ralph');
+      expect(result.command).toContain(' dev');
+    });
+
+    it('returns both command and path', () => {
+      const result = createWorktreeCommand('/repos/test', 'fix/bug', 'main', 99);
+      expect(result).toHaveProperty('command');
+      expect(result).toHaveProperty('worktreePath');
+      expect(typeof result.command).toBe('string');
+      expect(typeof result.worktreePath).toBe('string');
+    });
+  });
+
+  describe('removeWorktreeCommand', () => {
+    it('generates worktree remove command', () => {
+      const worktreePath = '/home/user/project-42';
+      const commands = removeWorktreeCommand(worktreePath);
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toBe('git worktree remove "/home/user/project-42"');
+    });
+
+    it('includes branch delete when branch provided', () => {
+      const worktreePath = '/home/user/project-42';
+      const branch = 'feature/test';
+      const commands = removeWorktreeCommand(worktreePath, branch);
+
+      expect(commands).toHaveLength(2);
+      expect(commands[0]).toBe('git worktree remove "/home/user/project-42"');
+      expect(commands[1]).toBe('git branch -d feature/test');
+    });
+
+    it('does not include branch delete when branch not provided', () => {
+      const commands = removeWorktreeCommand('/repos/test-1');
+      expect(commands).toHaveLength(1);
+      expect(commands[0]).toContain('git worktree remove');
+    });
+  });
+
+  describe('setupWorktreeDepsCommand', () => {
+    const originalPlatform = process.platform;
+
+    afterEach(() => {
+      // Restore original platform (note: can't actually change it in tests)
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('uses mklink /J on Windows', () => {
+      if (process.platform !== 'win32') {
+        // Skip this test on non-Windows
+        return;
+      }
+
+      const mainRepo = 'C:\\repos\\squad';
+      const worktreePath = 'C:\\repos\\squad-42';
+      const command = setupWorktreeDepsCommand(mainRepo, worktreePath);
+
+      expect(command).toContain('mklink /J');
+      expect(command).toContain('C:\\repos\\squad-42\\node_modules');
+      expect(command).toContain('C:\\repos\\squad\\node_modules');
+    });
+
+    it('uses ln -s on Unix', () => {
+      if (process.platform === 'win32') {
+        // Skip this test on Windows
+        return;
+      }
+
+      const mainRepo = '/home/user/squad';
+      const worktreePath = '/home/user/squad-42';
+      const command = setupWorktreeDepsCommand(mainRepo, worktreePath);
+
+      expect(command).toContain('ln -s');
+      expect(command).toContain('/home/user/squad/node_modules');
+      expect(command).toContain('/home/user/squad-42/node_modules');
+    });
+
+    it('generates valid symlink command structure', () => {
+      const mainRepo = '/repos/main';
+      const worktreePath = '/repos/main-1';
+      const command = setupWorktreeDepsCommand(mainRepo, worktreePath);
+
+      expect(command).toBeTruthy();
+      expect(typeof command).toBe('string');
+      expect(command.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('generateWorktreeVariant', () => {
+    it('generates complete worktree variant object', () => {
+      const repoRoot = '/home/user/project';
+      const branchName = 'feature/test';
+      const baseBranch = 'main';
+      const issueNumber = 42;
+
+      const variant = generateWorktreeVariant(repoRoot, branchName, baseBranch, issueNumber);
+
+      expect(variant).toHaveProperty('create');
+      expect(variant).toHaveProperty('path');
+      expect(variant).toHaveProperty('setupDeps');
+      expect(variant).toHaveProperty('cleanup');
+
+      expect(typeof variant.create).toBe('string');
+      expect(typeof variant.path).toBe('string');
+      expect(typeof variant.setupDeps).toBe('string');
+      expect(Array.isArray(variant.cleanup)).toBe(true);
+    });
+
+    it('returns correct path', () => {
+      const variant = generateWorktreeVariant('/repos/squad', 'fix/bug', 'dev', 100);
+      const expectedPath = path.join('/repos', 'squad-100');
+      expect(variant.path).toBe(expectedPath);
+    });
+
+    it('create command includes all parameters', () => {
+      const variant = generateWorktreeVariant('/repos/test', 'my-branch', 'develop', 5);
+      expect(variant.create).toContain('git worktree add');
+      expect(variant.create).toContain('my-branch');
+      expect(variant.create).toContain('develop');
+    });
+
+    it('cleanup includes both worktree remove and branch delete', () => {
+      const variant = generateWorktreeVariant('/repos/app', 'feature/x', 'main', 10);
+      expect(variant.cleanup).toHaveLength(2);
+      expect(variant.cleanup[0]).toContain('git worktree remove');
+      expect(variant.cleanup[1]).toContain('git branch -d');
+    });
+
+    it('setupDeps command is platform-appropriate', () => {
+      const variant = generateWorktreeVariant('/repos/test', 'branch', 'main', 1);
+      if (process.platform === 'win32') {
+        expect(variant.setupDeps).toContain('mklink /J');
+      } else {
+        expect(variant.setupDeps).toContain('ln -s');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Adds worktree variant helpers to ralph-commands.ts with 25 tests. Updates all 3 platform adapters.\n\nCloses #528