### PR TITLE
docs: add link to Tamir's Squad Skills Workshop

### DIFF
--- a/docs/src/content/docs/community.md
+++ b/docs/src/content/docs/community.md
@@ -54,6 +54,14 @@ We recognize contributions including:
 
 - **Jeff Fritz** ([@csharpfritz](https://github.com/csharpfritz)) — ["Introducing your AI Dev Team Squad with GitHub Copilot"](https://www.youtube.com/watch?v=TXcL-te7ByY). First public technical deep-dive video demonstrating Squad in action.
 
+## Learning Resources
+
+### Hands-On Workshop
+
+[**Tamir's Squad Skills Workshop**](https://github.com/tamirdresher/squad-skills/tree/main/workshop) — A practical, hands-on workshop covering Squad fundamentals and advanced patterns. Great for developers who learn by building.
+
+---
+
 ## Giving Back
 
 If you're using Squad, consider:

--- a/docs/src/content/docs/get-started/installation.md
+++ b/docs/src/content/docs/get-started/installation.md
@@ -186,4 +186,12 @@ npm install @bradygaster/squad-sdk@latest
 
 ---
 
-## Ready? → [Your First Session](first-session.md)
+## Ready to Learn?
+
+New to Squad? Check out [**Tamir's Squad Skills Workshop**](https://github.com/tamirdresher/squad-skills/tree/main/workshop) for hands-on learning and practical patterns.
+
+---
+
+## Next Steps
+
+→ [Your First Session](first-session.md)


### PR DESCRIPTION
Adds a link to @tamirdresher's hands-on workshop at https://github.com/tamirdresher/squad-skills/tree/main/workshop. Added to getting started and resources pages where applicable. squad obo dina