### PR TITLE
docs: add case-insensitive path comparison to windows-compatibility skill

### DIFF
--- a/packages/squad-cli/templates/skills/windows-compatibility/SKILL.md
+++ b/packages/squad-cli/templates/skills/windows-compatibility/SKILL.md
@@ -30,6 +30,23 @@ Squad runs on Windows, macOS, and Linux. Several bugs have been traced to platfo
 - **Never assume CWD is repo root:** Always use `TEAM ROOT` from spawn prompt or run `git rev-parse --show-toplevel`
 - **Use path.join() or path.resolve():** Don't manually concatenate with `/` or `\`
 
+### Path Comparison (Case Sensitivity)
+- **Never use case-sensitive `startsWith` or `===` for path comparison on Windows or macOS:** These filesystems are case-insensitive — `C:\Users\` and `c:\users\` refer to the same location
+- **Use platform-aware comparison:** Check `process.platform === 'win32' || process.platform === 'darwin'` and lowercase both sides before comparing
+- **Pattern:**
+  ```typescript
+  const CASE_INSENSITIVE = process.platform === 'win32' || process.platform === 'darwin';
+  
+  function pathStartsWith(fullPath: string, prefix: string): boolean {
+    if (CASE_INSENSITIVE) {
+      return fullPath.toLowerCase().startsWith(prefix.toLowerCase());
+    }
+    return fullPath.startsWith(prefix);
+  }
+  ```
+- **Where it matters:** Security checks (path traversal prevention), rootDir confinement, any path-contains-path validation
+- **Linux is case-sensitive:** Do NOT lowercase on Linux — `/Home/` and `/home/` are different directories
+
 ## Examples
 
 ✓ **Correct:**
@@ -72,3 +89,10 @@ exec('git commit -m "First line\nSecond line"'); // FAILS silently in PowerShell
 - Assuming Unix-style paths work everywhere
 - Using `git -C` because it "looks cleaner" (it doesn't work)
 - Skipping `git diff --cached --quiet` check (creates empty commits)
+- **Wrong — case-sensitive path check on Windows and macOS:**
+  ```typescript
+  if (!resolved.startsWith(rootDir + path.sep)) {
+    throw new Error('Path traversal blocked');
+  }
+  // Fails: 'c:\\Users\\temp\\file'.startsWith('C:\\Users\\temp\\') → false
+  ```

--- a/packages/squad-sdk/templates/skills/windows-compatibility/SKILL.md
+++ b/packages/squad-sdk/templates/skills/windows-compatibility/SKILL.md
@@ -30,6 +30,23 @@ Squad runs on Windows, macOS, and Linux. Several bugs have been traced to platfo
 - **Never assume CWD is repo root:** Always use `TEAM ROOT` from spawn prompt or run `git rev-parse --show-toplevel`
 - **Use path.join() or path.resolve():** Don't manually concatenate with `/` or `\`
 
+### Path Comparison (Case Sensitivity)
+- **Never use case-sensitive `startsWith` or `===` for path comparison on Windows or macOS:** These filesystems are case-insensitive — `C:\Users\` and `c:\users\` refer to the same location
+- **Use platform-aware comparison:** Check `process.platform === 'win32' || process.platform === 'darwin'` and lowercase both sides before comparing
+- **Pattern:**
+  ```typescript
+  const CASE_INSENSITIVE = process.platform === 'win32' || process.platform === 'darwin';
+  
+  function pathStartsWith(fullPath: string, prefix: string): boolean {
+    if (CASE_INSENSITIVE) {
+      return fullPath.toLowerCase().startsWith(prefix.toLowerCase());
+    }
+    return fullPath.startsWith(prefix);
+  }
+  ```
+- **Where it matters:** Security checks (path traversal prevention), rootDir confinement, any path-contains-path validation
+- **Linux is case-sensitive:** Do NOT lowercase on Linux — `/Home/` and `/home/` are different directories
+
 ## Examples
 
 ✓ **Correct:**
@@ -72,3 +89,10 @@ exec('git commit -m "First line\nSecond line"'); // FAILS silently in PowerShell
 - Assuming Unix-style paths work everywhere
 - Using `git -C` because it "looks cleaner" (it doesn't work)
 - Skipping `git diff --cached --quiet` check (creates empty commits)
+- **Wrong — case-sensitive path check on Windows and macOS:**
+  ```typescript
+  if (!resolved.startsWith(rootDir + path.sep)) {
+    throw new Error('Path traversal blocked');
+  }
+  // Fails: 'c:\\Users\\temp\\file'.startsWith('C:\\Users\\temp\\') → false
+  ```


### PR DESCRIPTION
## Why

During StorageProvider Phase 1, we built a path confinement system (rootDir and assertSafePath) that used \String.startsWith()\ to verify paths stay within bounds. This passed 4 rounds of security review by RETRO, architectural review by Flight, and test review by FIDO.

None of them caught that \startsWith()\ is case-sensitive, but Windows and macOS (HFS+) are case-insensitive. A path like \c:\Users\temp\file.txt\ would be incorrectly blocked when rootDir was \C:\Users\temp\.

The existing \windows-compatibility\ skill — which has **high confidence** and was earned from multiple prior bugs — covered timestamps (colons in filenames), git commands (\git -C\ failures), commit messages (PowerShell newlines), and path construction (\path.join\ vs manual concatenation). But it said nothing about **path comparison semantics**.

## What

Adds a new \Path Comparison (Case Sensitivity)\ section with:
- Platform detection pattern (\process.platform === 'win32' || process.platform === 'darwin'\)
- \pathStartsWith()\ helper that lowercases on case-insensitive platforms
- Anti-pattern example showing the exact bug we hit
- Note that Linux is case-sensitive and must NOT be lowercased

Updated in both template locations (squad-sdk and squad-cli) for template sync.

## Impact

Future agents working on any path comparison code will see this pattern via skill-aware routing, preventing the same class of bug from recurring.

squad obo dina