### PR TITLE
feat: add Squad Hooks Template Library

### DIFF
--- a/templates/hooks/README.md
+++ b/templates/hooks/README.md
@@ -1,0 +1,115 @@
+# Squad Hooks Template Library
+
+This directory provides ready-to-use GitHub Actions workflow templates that integrate with the Squad SDK's `defineHooks()` API.
+
+## What Are Squad Hooks?
+
+Squad hooks connect GitHub events (issue opened, PR merged, label applied) to Squad workflows, letting your agents react to repository activity without manual triggering.
+
+```typescript
+// squad.config.ts — SDK-first hook registration
+import { defineSquad, defineHooks } from '@bradygaster/squad-sdk';
+
+export default defineSquad({
+  // ... team and agent definitions
+  hooks: defineHooks({
+    configFile: '.github/hooks/hooks.json',
+  }),
+});
+```
+
+## Template Files
+
+| File | Trigger | Purpose |
+|------|---------|---------|
+| `hooks.json.example` | — | Declarative hook configuration file |
+| `squad-auto-triage.yml` | `issues.opened` | Auto-label and route new issues to the right agent |
+| `squad-board-sync.yml` | `pull_request.merged` | Close linked issues and update board when PRs merge |
+| `squad-route.yml` | `issues.labeled` | Assign squad agents when routing labels are applied |
+
+## Setup
+
+### Step 1: Copy workflows
+
+Copy the `.yml` files you need into your repository's `.github/workflows/` directory:
+
+```bash
+cp templates/hooks/squad-auto-triage.yml .github/workflows/
+cp templates/hooks/squad-board-sync.yml .github/workflows/
+cp templates/hooks/squad-route.yml .github/workflows/
+```
+
+### Step 2: Create your hooks configuration
+
+```bash
+mkdir -p .github/hooks
+cp templates/hooks/hooks.json.example .github/hooks/hooks.json
+```
+
+Edit `.github/hooks/hooks.json` to match the workflows you installed.
+
+### Step 3: Customize routing rules
+
+In `squad-auto-triage.yml`, update the `routingRules` array with your team's actual agent names:
+
+```javascript
+const routingRules = [
+  { keyword: 'bug', label: 'squad:engineer', agent: 'YourEngineerName' },
+  { keyword: 'docs', label: 'squad:scribe', agent: 'YourScribeName' },
+];
+```
+
+### Step 4: Create Squad labels
+
+Run `squad init` or manually create the labels your routing rules reference:
+- `squad:engineer`
+- `squad:researcher`
+- `squad:scribe`
+- `squad:tester`
+- `squad:done`
+
+## The `hooks.json` Format
+
+```json
+{
+  "hooks": [
+    {
+      "event": "issues.opened",
+      "workflow": ".github/workflows/squad-auto-triage.yml",
+      "description": "Human-readable description of what this hook does"
+    }
+  ]
+}
+```
+
+Supported event values follow GitHub's `<resource>.<action>` convention:
+- `issues.opened`, `issues.closed`, `issues.labeled`, `issues.assigned`
+- `pull_request.opened`, `pull_request.merged`, `pull_request.closed`
+- `push`, `release.published`
+
+## Integration with `squad.config.ts`
+
+When using SDK-first mode, register your hooks in `squad.config.ts`:
+
+```typescript
+import { defineSquad, defineTeam, defineAgent, defineHooks } from '@bradygaster/squad-sdk';
+
+export default defineSquad({
+  team: defineTeam({ name: 'My Squad' }),
+  agents: [
+    defineAgent({ name: 'keaton', role: 'Engineer' }),
+  ],
+  hooks: defineHooks({
+    configFile: '.github/hooks/hooks.json',
+    // Optional: inline hooks without a config file
+    inline: [
+      {
+        event: 'issues.opened',
+        workflow: '.github/workflows/squad-auto-triage.yml',
+      }
+    ]
+  }),
+});
+```
+
+Run `squad build` to validate your hook configuration.

--- a/templates/hooks/hooks.json.example
+++ b/templates/hooks/hooks.json.example
@@ -1,0 +1,19 @@
+{
+  "hooks": [
+    {
+      "event": "issues.opened",
+      "workflow": ".github/workflows/squad-triage.yml",
+      "description": "Auto-triage new issues to the right squad agent"
+    },
+    {
+      "event": "pull_request.merged",
+      "workflow": ".github/workflows/squad-board-sync.yml",
+      "description": "Update Squad Work Board when PRs are merged"
+    },
+    {
+      "event": "issues.labeled",
+      "workflow": ".github/workflows/squad-route.yml",
+      "description": "Route issues to squad agents based on labels"
+    }
+  ]
+}

--- a/templates/hooks/squad-auto-triage.yml
+++ b/templates/hooks/squad-auto-triage.yml
@@ -1,0 +1,49 @@
+name: Squad Auto-Triage
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Squad Triage
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+
+            // Route based on labels or keywords in title/body
+            const routingRules = [
+              { keyword: 'bug', label: 'squad:engineer', agent: "B'Elanna" },
+              { keyword: 'research', label: 'squad:researcher', agent: 'Brahms' },
+              { keyword: 'docs', label: 'squad:scribe', agent: 'Scribe-R' },
+              { keyword: 'test', label: 'squad:tester', agent: 'Torres' },
+              { keyword: 'design', label: 'squad:designer', agent: 'Seven' },
+            ];
+
+            const text = [issue.title, issue.body || ''].join(' ').toLowerCase();
+
+            for (const rule of routingRules) {
+              if (text.includes(rule.keyword)) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: [rule.label]
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `🤖 Squad auto-triage: routed to **${rule.agent}** (label: \`${rule.label}\`)`
+                });
+                break;
+              }
+            }

--- a/templates/hooks/squad-board-sync.yml
+++ b/templates/hooks/squad-board-sync.yml
@@ -1,0 +1,44 @@
+name: Squad Board Sync
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  sync:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync linked issues when PR merges
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            // Extract linked issue numbers from PR body (Closes #N, Fixes #N, Resolves #N)
+            const linkedIssues = [...body.matchAll(/(?:closes|fixes|resolves)\s+#(\d+)/gi)]
+              .map(m => parseInt(m[1], 10));
+
+            for (const issueNumber of linkedIssues) {
+              // Add a 'squad:done' label to signal completion
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['squad:done']
+              }).catch(() => {}); // Label may not exist; ignore errors
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `✅ Squad board sync: PR #${pr.number} merged. Marking issue complete.`
+              });
+            }

--- a/templates/hooks/squad-route.yml
+++ b/templates/hooks/squad-route.yml
@@ -1,0 +1,51 @@
+name: Squad Route by Label
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  route:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Route issue to squad agent based on label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = context.payload.label.name;
+            const issue = context.payload.issue;
+
+            // Map squad labels to agent assignments
+            // Customize this map for your team's cast names
+            const labelToAgent = {
+              'squad:engineer': null,   // auto-assign via @copilot or your engineer agent
+              'squad:researcher': null,
+              'squad:scribe': null,
+              'squad:tester': null,
+              'squad:designer': null,
+            };
+
+            if (!(label in labelToAgent)) return;
+
+            const assignee = labelToAgent[label];
+            if (assignee) {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                assignees: [assignee]
+              });
+            }
+
+            // Optionally post routing notification
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `🏷️ Squad routing: label \`${label}\` applied — issue queued for the matching squad agent.`
+            });


### PR DESCRIPTION
Adds templates/hooks/ with ready-to-use GitHub Actions workflows bridging defineHooks() in the Squad SDK to declarative .github/hooks/hooks.json config files. Includes auto-triage, board-sync, and label-routing templates.