### PR TITLE
feat: add Cross-Repo Coordination template (Ralph-R protocol)

### DIFF
--- a/templates/cross-repo/README.md
+++ b/templates/cross-repo/README.md
@@ -1,0 +1,96 @@
+# Cross-Repo Squad Coordination Template
+
+This template enables coordination between a **production** squad repo and a **research/staging** squad repo using the Ralph-R protocol — a pattern pioneered in real Squad deployments.
+
+## Architecture
+
+```
+Production Repo                    Research Repo
+(yourorg/main-project)             (yourorg/main-project-research)
+        │                                   │
+        │  issues labeled                   │  research findings
+        │  'research:request'               │  posted back as comments
+        └──────────── Ralph-R ─────────────┘
+                   (monitors both,
+                    routes work,
+                    reports results)
+```
+
+- **Production repo**: Uses Squad for day-to-day operations; labels issues `research:request` to dispatch work
+- **Research repo**: Uses Squad for experimental work; agents investigate and post findings back
+- **Ralph-R agent**: Monitors both repos, routes work items, and surfaces findings across the boundary
+
+## Files in This Template
+
+| File | Purpose |
+|------|---------|
+| `cross-repo-sync.yml` | GitHub Actions workflow: mirrors labeled issues to the research repo |
+| `research-report-back.yml` | GitHub Actions workflow: posts research findings back to production |
+| `SCHEMA.md` | Cross-machine message schema for Ralph-R |
+| `ralph-r-charter.md` | Agent charter template for the Ralph-R coordinator |
+
+## Setup
+
+### Step 1: Configure secrets and variables
+
+In **both** repos, add:
+- Secret: `CROSS_REPO_TOKEN` — a GitHub PAT or fine-grained token with `issues: write` on both repos
+- Variable: `RESEARCH_REPO` — the full name of the research repo (e.g., `yourorg/main-project-research`)
+- Variable: `PRODUCTION_REPO` — the full name of the production repo (e.g., `yourorg/main-project`)
+
+### Step 2: Install workflows
+
+In your **production repo**:
+```bash
+cp templates/cross-repo/cross-repo-sync.yml .github/workflows/
+```
+
+In your **research repo**:
+```bash
+cp templates/cross-repo/research-report-back.yml .github/workflows/
+```
+
+### Step 3: Install the schema
+
+In **both repos**:
+```bash
+mkdir -p .squad/cross-machine
+cp templates/cross-repo/SCHEMA.md .squad/cross-machine/SCHEMA.md
+```
+
+### Step 4: Add Ralph-R to your research repo
+
+```bash
+mkdir -p .squad/agents/ralph-r
+cp templates/cross-repo/ralph-r-charter.md .squad/agents/ralph-r/charter.md
+```
+
+Then add Ralph-R to `.squad/team.md`:
+```markdown
+## Ralph-R
+- Role: Cross-repo coordinator
+- Expertise: Research routing, production↔research sync
+- See: .squad/agents/ralph-r/charter.md
+```
+
+### Step 5: Create labels
+
+In your production repo, create:
+- `research:request` — triggers dispatch to research repo
+- `research:active` — applied by Ralph-R when work is in progress
+- `research:complete` — applied when findings are posted back
+
+## Usage
+
+1. In your production repo, label any issue `research:request`
+2. `cross-repo-sync.yml` automatically creates a mirror issue in the research repo
+3. Your research squad works the issue; when done, they close it with a summary
+4. `research-report-back.yml` posts findings back to the original production issue
+
+## Why This Pattern?
+
+Some work is too exploratory for the main branch — new APIs, experimental architectures, risky refactors. The cross-repo protocol lets you:
+- Keep production Squad state clean and stable
+- Run experiments without cluttering the production issue tracker
+- Automatically surface findings when research completes
+- Maintain a clear paper trail across both repos

--- a/templates/cross-repo/SCHEMA.md
+++ b/templates/cross-repo/SCHEMA.md
@@ -1,0 +1,83 @@
+# Cross-Machine Message Schema (Ralph-R Protocol)
+
+This schema defines the message format used when the Ralph-R coordinator exchanges information between the production repo and the research repo.
+
+## Message Types
+
+### `research:request`
+
+Posted by the production repo when an issue is labeled `research:request`.
+
+```json
+{
+  "type": "research:request",
+  "source": {
+    "repo": "owner/production-repo",
+    "issue": 42,
+    "url": "https://github.com/owner/production-repo/issues/42"
+  },
+  "payload": {
+    "title": "Original issue title",
+    "body": "Original issue body",
+    "author": "github-username",
+    "labels": ["research:request", "feature"]
+  },
+  "timestamp": "2025-01-01T00:00:00Z"
+}
+```
+
+### `research:finding`
+
+Posted by the research repo when findings are ready to report back.
+
+```json
+{
+  "type": "research:finding",
+  "source": {
+    "repo": "owner/research-repo",
+    "issue": 7,
+    "url": "https://github.com/owner/research-repo/issues/7"
+  },
+  "target": {
+    "repo": "owner/production-repo",
+    "issue": 42
+  },
+  "payload": {
+    "summary": "One-paragraph summary of findings",
+    "recommendation": "go | no-go | needs-more-research",
+    "artifacts": [
+      {
+        "type": "pr | branch | file | note",
+        "url": "https://github.com/...",
+        "description": "What this artifact is"
+      }
+    ]
+  },
+  "timestamp": "2025-01-01T00:00:00Z"
+}
+```
+
+## Label Lifecycle
+
+```
+production issue:
+  [unlabeled] → research:request → research:active → research:complete
+
+research mirror issue:
+  [opened] → research:active → research:report-back → [closed]
+```
+
+## Ralph-R Responsibilities
+
+Ralph-R monitors both repos and is responsible for:
+
+1. **Dispatch**: Detecting `research:request` labels and ensuring a mirror issue exists
+2. **Status sync**: Keeping production issue labels current (`active` / `complete`)
+3. **Report-back**: Summarizing research findings and posting them to the production issue
+4. **Cleanup**: Closing mirror issues after findings are posted back
+
+## Notes for Squad Agents
+
+- All cross-repo messages are delivered via GitHub issue comments using the `CROSS_REPO_TOKEN` secret
+- If the token lacks permissions, the workflow will fail silently — check Actions logs
+- Ralph-R reads `.squad/cross-machine/SCHEMA.md` to understand message formats; keep this file up to date

--- a/templates/cross-repo/cross-repo-sync.yml
+++ b/templates/cross-repo/cross-repo-sync.yml
@@ -1,0 +1,62 @@
+name: Cross-Repo Squad Sync
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: read
+
+jobs:
+  sync:
+    if: contains(github.event.label.name, 'research:request')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create mirror issue in research repo
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CROSS_REPO_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const researchRepo = '${{ vars.RESEARCH_REPO }}';
+            const [owner, repo] = researchRepo.split('/');
+
+            // Create a mirror issue in the research repo
+            const created = await github.rest.issues.create({
+              owner,
+              repo,
+              title: `[Production Request] ${issue.title}`,
+              body: [
+                `> 🔗 Cross-posted from ${context.repo.owner}/${context.repo.repo}#${issue.number}`,
+                `> Original author: @${issue.user.login}`,
+                '',
+                issue.body || '_No description provided._',
+                '',
+                '---',
+                '**Ralph-R**: This issue was automatically mirrored from the production repo.',
+                'When research is complete, close this issue with a summary and the',
+                '`research:report-back` label to post findings back automatically.',
+              ].join('\n'),
+              labels: ['research:active', 'cross-repo']
+            });
+
+            // Comment on the original issue with a link to the research mirror
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `🔬 **Research dispatched**: Mirror issue created at [${owner}/${repo}#${created.data.number}](${created.data.html_url}).\n\nFindings will be posted back here when research completes.`
+            });
+
+            // Update label: replace 'research:request' with 'research:active'
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['research:active']
+            });
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              name: 'research:request'
+            }).catch(() => {});

--- a/templates/cross-repo/ralph-r-charter.md
+++ b/templates/cross-repo/ralph-r-charter.md
@@ -1,0 +1,41 @@
+# Ralph-R — Cross-Repo Coordinator
+
+## Identity
+
+You are **Ralph-R**, the cross-repo coordination specialist for this squad. Your job is to manage the boundary between this research repo and the production repo, ensuring work flows cleanly in both directions.
+
+You are named after Ralph Wiggum — you see connections others miss, and you faithfully report what you find, however unexpected.
+
+## Core Responsibilities
+
+1. **Monitor the production repo** for issues labeled `research:request`
+2. **Create and track mirror issues** in this research repo
+3. **Brief the research squad** on incoming requests
+4. **Collect findings** when research issues are closed or labeled `research:report-back`
+5. **Post findings back** to the corresponding production issue
+6. **Update labels** on both sides to reflect current status
+
+## Communication Style
+
+- Be brief in status updates — one paragraph max
+- Lead with the key finding, not the method
+- When reporting back, use the format: **Recommendation → Evidence → Caveats**
+- Flag blockers immediately; don't sit on them
+
+## Knowledge Sources
+
+- Production repo: `$PRODUCTION_REPO`
+- Cross-machine schema: `.squad/cross-machine/SCHEMA.md`
+- Team routing: `.squad/routing.md`
+- Active research queue: issues labeled `research:active` in this repo
+
+## Escalation
+
+If a research request is ambiguous or cannot be actioned, comment on the mirror issue and ping the production issue author by @mention. Do not leave requests silently stalled.
+
+## Tools
+
+You have access to:
+- GitHub Issues API (read/write via `CROSS_REPO_TOKEN`)
+- This repo's `.squad/` state
+- The cross-repo schema at `.squad/cross-machine/SCHEMA.md`

--- a/templates/cross-repo/research-report-back.yml
+++ b/templates/cross-repo/research-report-back.yml
@@ -1,0 +1,62 @@
+name: Research Report Back
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: read
+
+jobs:
+  report-back:
+    if: contains(github.event.label.name, 'research:report-back')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post research findings to production issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CROSS_REPO_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const productionRepo = '${{ vars.PRODUCTION_REPO }}';
+            const [prodOwner, prodRepo] = productionRepo.split('/');
+
+            // Extract production issue reference from the issue body
+            // Expected format: "> 🔗 Cross-posted from owner/repo#NUMBER"
+            const match = issue.body?.match(/Cross-posted from [^#]+#(\d+)/);
+            if (!match) {
+              core.warning('Could not find production issue reference in body — skipping report-back');
+              return;
+            }
+
+            const prodIssueNumber = parseInt(match[1], 10);
+
+            // Post findings back to the production issue
+            await github.rest.issues.createComment({
+              owner: prodOwner,
+              repo: prodRepo,
+              issue_number: prodIssueNumber,
+              body: [
+                `## 🔬 Research Complete`,
+                '',
+                `Findings from [${context.repo.owner}/${context.repo.repo}#${issue.number}](${issue.html_url}):`,
+                '',
+                issue.body || '_No summary provided._',
+                '',
+                '---',
+                `Research closed by @${context.payload.sender.login}.`,
+              ].join('\n')
+            });
+
+            // Update production issue label to 'research:complete'
+            await github.rest.issues.addLabels({
+              owner: prodOwner,
+              repo: prodRepo,
+              issue_number: prodIssueNumber,
+              labels: ['research:complete']
+            });
+            await github.rest.issues.removeLabel({
+              owner: prodOwner,
+              repo: prodRepo,
+              issue_number: prodIssueNumber,
+              name: 'research:active'
+            }).catch(() => {});


### PR DESCRIPTION
## Summary

Adds `templates/cross-repo/` — a complete template for coordinating between a **production** squad repo and a **research/staging** squad repo using the Ralph-R protocol.

## Motivation

Many teams running Squad end up needing a "try it before shipping" repo — a place where agents can experiment without touching production state. This template formalizes that pattern so any team can adopt it with minimal configuration.

## What's Added

| File | Purpose |
|------|---------|
| `cross-repo-sync.yml` | Mirrors production issues labeled `research:request` to the research repo |
| `research-report-back.yml` | Posts findings back to production when research is done |
| `SCHEMA.md` | Cross-machine message schema for the Ralph-R coordinator |
| `ralph-r-charter.md` | Agent charter template for the cross-repo coordinator agent |
| `README.md` | Setup guide with architecture diagram and label lifecycle |

## Architecture

`
Production Repo ──── research:request ──── Research Repo
(day-to-day ops)         Ralph-R          (experiments)
       └──────── research:complete ────────┘
`

## Setup (5 minutes)

1. Add `CROSS_REPO_TOKEN` secret to both repos
2. Set `RESEARCH_REPO` and `PRODUCTION_REPO` variables
3. Copy `cross-repo-sync.yml` to production, `research-report-back.yml` to research
4. Copy `SCHEMA.md` to `.squad/cross-machine/` in both repos
5. Add Ralph-R agent to your research squad team

## Origin

This template generalizes a real pattern that emerged from Squad deployments running production and research repos in parallel. The Ralph-R protocol was field-tested across multiple repositories before being extracted here.