### PR TITLE
fix(consult): use personal-squad dir in getPersonalSquadRoot() (#590)

### DIFF
--- a/packages/squad-sdk/src/sharing/consult.ts
+++ b/packages/squad-sdk/src/sharing/consult.ts
@@ -313,7 +313,7 @@ export interface SetupConsultModeResult {
  * Returns {globalSquadPath}/.squad/
  */
 export function getPersonalSquadRoot(): string {
-  return path.resolve(resolveGlobalSquadPath(), '.squad');
+  return path.resolve(resolveGlobalSquadPath(), 'personal-squad');
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a path resolution bug where getPersonalSquadRoot() in consult.ts returns the wrong directory, causing squad consult to enter Init Mode even when a personal squad exists.

## Root Cause

getPersonalSquadRoot() appends '.squad' to the global squad config path, resolving to an empty path instead of the personal-squad directory.

- Before (buggy): resolveGlobalSquadPath() + '.squad' -> ~/Library/Application Support/squad/.squad
- After (fixed): resolveGlobalSquadPath() + 'personal-squad' -> ~/Library/Application Support/squad/personal-squad

This is consistent with resolvePersonalSquadDir() in resolution.ts which correctly uses 'personal-squad'.

Fixes #590