### PR TITLE
feat(ci): add samples build validation gate

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -276,6 +276,27 @@ jobs:
           npm ci --ignore-scripts
           npm run build -w packages/squad-sdk
 
+      - name: Patch npm-registry samples to use local SDK
+        if: steps.flag.outputs.skip == 'false' && steps.label.outputs.skip != 'true' && steps.changes.outputs.skip != 'true'
+        shell: bash
+        run: |
+          for pkg in samples/*/package.json; do
+            if grep -q '"@bradygaster/squad-sdk"' "$pkg" && ! grep -q 'file:' "$pkg"; then
+              node -e "
+                const fs = require('fs');
+                const p = JSON.parse(fs.readFileSync('$pkg', 'utf8'));
+                if (p.dependencies?.['@bradygaster/squad-sdk']) {
+                  p.dependencies['@bradygaster/squad-sdk'] = 'file:../../packages/squad-sdk';
+                }
+                if (p.devDependencies?.['@bradygaster/squad-sdk']) {
+                  p.devDependencies['@bradygaster/squad-sdk'] = 'file:../../packages/squad-sdk';
+                }
+                fs.writeFileSync('$pkg', JSON.stringify(p, null, 2) + '\n');
+              "
+              echo "Patched $pkg to use local SDK"
+            fi
+          done
+
       - name: Build and test samples
         if: steps.flag.outputs.skip == 'false' && steps.label.outputs.skip != 'true' && steps.changes.outputs.skip != 'true'
         run: |

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -213,6 +213,136 @@ jobs:
         if: steps.flag.outputs.skip == 'false' && !contains(github.event.pull_request.labels.*.name, 'skip-exports-check') && steps.changes.outputs.skip != 'true'
         run: node scripts/check-exports-map.mjs
 
+  samples-build:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            samples/**/package-lock.json
+
+      - name: Check feature flag
+        id: flag
+        # Default: gate is ENABLED. Set vars.SQUAD_SAMPLES_CI to "false"
+        # to explicitly disable.
+        run: |
+          if [ "${{ vars.SQUAD_SAMPLES_CI }}" = "false" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Samples build gate disabled via vars.SQUAD_SAMPLES_CI"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check skip label
+        if: steps.flag.outputs.skip == 'false'
+        id: label
+        run: |
+          SKIP="false"
+          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q "skip-samples-ci"; then
+            SKIP="true"
+            echo "Skipping samples build gate (skip-samples-ci label present)"
+          fi
+          echo "skip=$SKIP" >> "$GITHUB_OUTPUT"
+
+      - name: Check for SDK source changes
+        if: steps.flag.outputs.skip == 'false' && steps.label.outputs.skip != 'true'
+        id: changes
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          SDK_CHANGED=$(git diff --name-only "$BASE"..."$HEAD" | grep -E '^packages/squad-sdk/src/' || true)
+          if [ -z "$SDK_CHANGED" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No SDK source changes detected -- samples build not applicable"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "SDK source files changed:"
+            echo "$SDK_CHANGED"
+          fi
+
+      - name: Install root dependencies and build SDK
+        if: steps.flag.outputs.skip == 'false' && steps.label.outputs.skip != 'true' && steps.changes.outputs.skip != 'true'
+        run: |
+          npm ci --ignore-scripts
+          npm run build -w packages/squad-sdk
+
+      - name: Build and test samples
+        if: steps.flag.outputs.skip == 'false' && steps.label.outputs.skip != 'true' && steps.changes.outputs.skip != 'true'
+        run: |
+          FAILED=0
+          PASSED=0
+          SKIPPED=0
+
+          for sample_dir in samples/*/; do
+            sample=$(basename "$sample_dir")
+
+            if [ ! -f "$sample_dir/package.json" ]; then
+              echo "::notice::[$sample] No package.json -- skipping"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            HAS_BUILD=$(node -e "const p=require('./$sample_dir/package.json'); process.exit(p.scripts?.build ? 0 : 1)" 2>/dev/null && echo "true" || echo "false")
+            HAS_TEST=$(node -e "const p=require('./$sample_dir/package.json'); process.exit(p.scripts?.test ? 0 : 1)" 2>/dev/null && echo "true" || echo "false")
+
+            if [ "$HAS_BUILD" = "false" ] && [ "$HAS_TEST" = "false" ]; then
+              echo "::notice::[$sample] No build or test scripts -- skipping"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            echo ""
+            echo "========================================="
+            echo "[$sample] Installing dependencies..."
+            echo "========================================="
+            if ! (cd "$sample_dir" && npm install --ignore-scripts 2>&1); then
+              echo "::error::[$sample] npm install failed"
+              FAILED=$((FAILED + 1))
+              continue
+            fi
+
+            if [ "$HAS_BUILD" = "true" ]; then
+              echo "[$sample] Running build..."
+              if ! (cd "$sample_dir" && npm run build 2>&1); then
+                echo "::error::[$sample] npm run build failed"
+                FAILED=$((FAILED + 1))
+                continue
+              fi
+            fi
+
+            if [ "$HAS_TEST" = "true" ]; then
+              echo "[$sample] Running tests..."
+              if ! (cd "$sample_dir" && npm test 2>&1); then
+                echo "::error::[$sample] npm test failed"
+                FAILED=$((FAILED + 1))
+                continue
+              fi
+            fi
+
+            echo "::notice::[$sample] Passed"
+            PASSED=$((PASSED + 1))
+          done
+
+          echo ""
+          echo "========================================="
+          echo "Samples build summary: $PASSED passed, $FAILED failed, $SKIPPED skipped"
+          echo "========================================="
+
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::$FAILED sample(s) failed build/test validation"
+            exit 1
+          fi
+
   publish-policy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -190,6 +190,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+
       - name: Check for SDK source changes
         if: steps.flag.outputs.skip == 'false' && !contains(github.event.pull_request.labels.*.name, 'skip-exports-check')
         id: changes

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -190,7 +190,6 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-
       - name: Check for SDK source changes
         if: steps.flag.outputs.skip == 'false' && !contains(github.event.pull_request.labels.*.name, 'skip-exports-check')
         id: changes

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -305,7 +305,7 @@ jobs:
             echo "========================================="
             echo "[$sample] Installing dependencies..."
             echo "========================================="
-            if ! (cd "$sample_dir" && npm install --ignore-scripts 2>&1); then
+            if ! (cd "$sample_dir" && if [ -f package-lock.json ]; then npm ci; else npm install; fi 2>&1); then
               echo "::error::[$sample] npm install failed"
               FAILED=$((FAILED + 1))
               continue


### PR DESCRIPTION
## Part 3: Repo Health -- Samples Build CI Gate

### What
Adds a samples-build job to squad-ci.yml that validates all sample projects still compile and pass tests when SDK source files change.

### Why
The 11 sample projects in samples/ ship with zero CI coverage. SDK changes can silently break samples, which users discover only when they try to follow a tutorial. This gate catches breakage at PR time, not after release.

Issue: #103
Gate 3 tracking: #104

### How
- New samples-build job in .github/workflows/squad-ci.yml
- Only triggers on pull requests (same as changelog-gate and exports-map-check)
- Only runs when files in packages/squad-sdk/src/ are changed (three-dot diff)
- Feature-flagged: gate is ENABLED by default; set vars.SQUAD_SAMPLES_CI to false to disable
- Skip label: skip-samples-ci (uses github.event.pull_request.labels per Copilot review lesson)
- Installs root dependencies and builds the SDK first (samples reference SDK via file: links)
- Loops through each samples/*/ directory:
  - Skips samples without package.json
  - Skips samples with no build or test scripts
  - Runs npm install, then npm run build and/or npm run test as applicable
- Reports a summary with pass/fail/skip counts per sample
- Uses GitHub Actions annotations (::error::, ::notice::) for clear CI output

### Samples Inventory
| Sample | Build | Test | SDK Dep |
|--------|-------|------|---------|
| autonomous-pipeline | tsc | vitest | npm |
| azure-function-squad | tsc | tsx dry-run | file: |
| cost-aware-router | tsc | vitest | npm |
| hello-squad | -- | vitest | file: |
| hook-governance | -- | vitest | file: |
| knock-knock | -- | -- | file: |
| rock-paper-scissors | -- | -- | file: |
| skill-discovery | -- | vitest | file: |
| storage-provider-azure | N/A | N/A | N/A |
| storage-provider-sqlite | N/A | N/A | N/A |
| streaming-chat | tsc --noEmit | vitest | file: |

### Related Issues
- Closes #103
- Part of Gate 3: #104

### Testing
- npm run build -- passes
- npm test -- 173 suites pass; 11 failures are pre-existing vitest worker timeouts unrelated to this YAML-only change
- YAML change reviewed for correct indentation and step conditional logic
- Feature flag and skip label patterns match existing changelog-gate and exports-map-check gates

### Breaking Changes
None. This is an additive CI gate. It does not block existing jobs and can be disabled via feature flag or skip label.

### Waivers
None requested.

### Preflight
- [x] npm run build -- passes
- [x] npm test -- 173 suites pass, 11 pre-existing timeout failures (vitest worker resource exhaustion on Windows)
