### PR TITLE
fix(test): shared Docker skip guard + template-sync timeout (#677)

### DIFF
--- a/test/aspire-integration.test.ts
+++ b/test/aspire-integration.test.ts
@@ -15,6 +15,7 @@ import { trace, metrics } from '@opentelemetry/api';
 import { NodeSDK, resources, metrics as sdkMetrics } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
+import { dockerSkipReason } from './helpers/skip-guards.js';
 
 const { Resource } = resources;
 const { PeriodicExportingMetricReader } = sdkMetrics;
@@ -23,20 +24,7 @@ const { PeriodicExportingMetricReader } = sdkMetrics;
 // Skip guard — bail early if Docker is unavailable or tests disabled
 // ============================================================================
 
-function dockerAvailable(): boolean {
-  try {
-    execSync('docker --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-const SKIP_REASON = process.env['SKIP_DOCKER_TESTS'] === '1'
-  ? 'SKIP_DOCKER_TESTS=1'
-  : !dockerAvailable()
-    ? 'Docker not available'
-    : null;
+const SKIP_REASON = dockerSkipReason();
 
 const CONTAINER_NAME = 'squad-aspire-dashboard';
 const DASHBOARD_URL = 'http://localhost:18888';

--- a/test/helpers/skip-guards.ts
+++ b/test/helpers/skip-guards.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared test helpers for skip guards and environment detection.
+ *
+ * Provides reusable functions for detecting Docker availability,
+ * shell module availability, and other environment conditions
+ * that determine whether certain test suites should run.
+ */
+
+import { execSync } from 'node:child_process';
+
+/**
+ * Check if Docker is available on this machine.
+ * Returns true if `docker --version` succeeds within 5 seconds.
+ */
+export function isDockerAvailable(): boolean {
+  try {
+    execSync('docker --version', { stdio: 'ignore', timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Determine skip reason for Docker-dependent tests.
+ * Returns null if tests should run, or a string reason to skip.
+ */
+export function dockerSkipReason(): string | null {
+  if (process.env['SKIP_DOCKER_TESTS'] === '1') {
+    return 'SKIP_DOCKER_TESTS=1';
+  }
+  if (!isDockerAvailable()) {
+    return 'Docker not available';
+  }
+  return null;
+}

--- a/test/template-sync.test.ts
+++ b/test/template-sync.test.ts
@@ -153,7 +153,7 @@ describe('sync-templates.mjs script execution', () => {
     const output = execSync('node scripts/sync-templates.mjs', {
       cwd: ROOT,
       encoding: 'utf-8',
-      timeout: 30_000,
+      timeout: 60_000,
     });
     expect(output).toContain('Synced');
   });


### PR DESCRIPTION
### What
Adds a shared Docker skip guard helper and increases the template-sync timeout to fix flaky tests under full-suite load.

### Why
Issue #582 reports ~24 intermittent test failures. This PR addresses the survivable subset (tests not being removed by #675 REPL removal):
- Docker-dependent tests (aspire-integration) had inline Docker detection duplicated across files
- template-sync script execution timed out at 30s under parallel worker contention

Note: speed-gates.test.ts, human-journeys.test.ts, and repl-ux-fixes.test.ts are also flaky but import from shell/ which is being removed by PR #675 — those are intentionally not touched here.

Closes #677, Refs #582

### How
1. New shared helper (test/helpers/skip-guards.ts): isDockerAvailable() and dockerSkipReason() — reusable across all Docker-dependent test files
2. Refactored aspire-integration.test.ts to use the shared helper instead of inline detection
3. Increased timeout in template-sync.test.ts from 30s to 60s for script execution under CI load

### Testing
- [x] No functional changes — skip guards and timeout only
- [x] Pre-existing build error on dev (TS2724 in personal.ts/init.ts) is unrelated to this PR

### Docs
N/A — test infrastructure only (exempt per PR_REQUIREMENTS.md)

### Exports
N/A

### Breaking Changes
None

### Waivers
None required — test-only changes are exempt from Documentation, Exports, and Samples requirements.
