### PR TITLE
fix(ci): strip trailing slash from sample_dir path variable

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -361,6 +361,7 @@ jobs:
           SKIPPED=0
 
           for sample_dir in samples/*/; do
+            sample_dir="${sample_dir%/}"
             sample=$(basename "$sample_dir")
 
             if [ ! -f "$sample_dir/package.json" ]; then


### PR DESCRIPTION
## What
Strips trailing slash from sample_dir in samples-build CI job.

## Why
Copilot code review found that the glob pattern samples/*/ produces paths with trailing slash. When interpolated into require('.//package.json'), this creates ./samples/name//package.json (double slash). While Unix tolerates this, it's incorrect and could fail on some systems.

## How
Adds \ to strip trailing slash after the for loop iterator.

## Copilot Review Finding
This was identified by automated Copilot code review on the merged upstream dev branch after PRs #690, #691, #692 were squash-merged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>