### PR TITLE
fix(ci): remove all cron schedules from GitHub Actions workflows (#694)

### DIFF
--- a/.github/workflows/squad-docs-links.yml
+++ b/.github/workflows/squad-docs-links.yml
@@ -1,8 +1,6 @@
 name: Docs — Weekly Link Check
 
 on:
-  schedule:
-    - cron: '0 9 * * 1'  # Monday 9am UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -7,10 +7,6 @@ name: Squad Heartbeat (Ralph)
 # Run 'squad upgrade' to sync installed copies from source templates.
 
 on:
-  schedule:
-    # Every 30 minutes — adjust via cron expression as needed
-    - cron: '*/30 * * * *'
-
   # React to completed work or new squad work
   issues:
     types: [closed, labeled]

--- a/.squad-templates/workflows/squad-heartbeat.yml
+++ b/.squad-templates/workflows/squad-heartbeat.yml
@@ -7,10 +7,6 @@ name: Squad Heartbeat (Ralph)
 # Run 'squad upgrade' to sync installed copies from source templates.
 
 on:
-  schedule:
-    # Every 30 minutes — adjust via cron expression as needed
-    - cron: '*/30 * * * *'
-
   # React to completed work or new squad work
   issues:
     types: [closed, labeled]

--- a/packages/squad-cli/templates/workflows/squad-heartbeat.yml
+++ b/packages/squad-cli/templates/workflows/squad-heartbeat.yml
@@ -7,10 +7,6 @@ name: Squad Heartbeat (Ralph)
 # Run 'squad upgrade' to sync installed copies from source templates.
 
 on:
-  schedule:
-    # Every 30 minutes — adjust via cron expression as needed
-    - cron: '*/30 * * * *'
-
   # React to completed work or new squad work
   issues:
     types: [closed, labeled]

--- a/packages/squad-sdk/templates/workflows/squad-heartbeat.yml
+++ b/packages/squad-sdk/templates/workflows/squad-heartbeat.yml
@@ -7,10 +7,6 @@ name: Squad Heartbeat (Ralph)
 # Run 'squad upgrade' to sync installed copies from source templates.
 
 on:
-  schedule:
-    # Every 30 minutes — adjust via cron expression as needed
-    - cron: '*/30 * * * *'
-
   # React to completed work or new squad work
   issues:
     types: [closed, labeled]

--- a/templates/workflows/squad-heartbeat.yml
+++ b/templates/workflows/squad-heartbeat.yml
@@ -7,10 +7,6 @@ name: Squad Heartbeat (Ralph)
 # Run 'squad upgrade' to sync installed copies from source templates.
 
 on:
-  schedule:
-    # Every 30 minutes — adjust via cron expression as needed
-    - cron: '*/30 * * * *'
-
   # React to completed work or new squad work
   issues:
     types: [closed, labeled]


### PR DESCRIPTION
## What
Removes every `schedule:` / `cron:` trigger from all 6 workflow files and their template copies.

## Why
Cron-triggered workflows cause unwanted CI runs, quota burn, and noise. This is the final removal — cron schedules must never be re-added.

## Files changed (6 files, 22 deletions, 0 additions)
- `.github/workflows/squad-docs-links.yml` — removed weekly Monday cron
- `.github/workflows/squad-heartbeat.yml` — removed 30-minute heartbeat cron
- `templates/workflows/squad-heartbeat.yml` — template copy
- `.squad-templates/workflows/squad-heartbeat.yml` — template copy
- `packages/squad-cli/templates/workflows/squad-heartbeat.yml` — CLI package template
- `packages/squad-sdk/templates/workflows/squad-heartbeat.yml` — SDK package template

## What stays
- All event-driven triggers (issues, pull_request, workflow_dispatch)
- `squad watch` for local polling
- SDK scheduler APIs (library feature, not repo workflows)

Closes #694