### PR TITLE
fix(ci): combined CI workarounds (#697 + #698)

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -351,6 +351,7 @@ jobs:
         if: steps.flag.outputs.skip == 'false' && steps.label.outputs.skip != 'true' && steps.changes.outputs.skip != 'true'
         run: |
           npm ci --ignore-scripts
+          node packages/squad-cli/scripts/patch-esm-imports.mjs
           npm run build -w packages/squad-sdk
 
       - name: Build and test samples
@@ -721,6 +722,7 @@ jobs:
         if: steps.flag.outputs.skip == 'false' && steps.label.outputs.skip != 'true' && steps.changes.outputs.skip != 'true'
         run: |
           npm ci --ignore-scripts
+          node packages/squad-cli/scripts/patch-esm-imports.mjs
           npm run build -w packages/squad-sdk
 
       - name: Smoke test all subpath exports


### PR DESCRIPTION
## Summary

Consolidates PRs #697 and #698, which both modify `.github/workflows/squad-ci.yml` to fix the same root cause: `@github/copilot-sdk`'s ESM import of `vscode-jsonrpc/node` (missing `.js` extension) breaking CI on Linux runners.

## What each PR did

| PR | Approach | Effect |
|----|----------|--------|
| #697 | **Skip workaround** — added `SKIP_SAMPLES` (streaming-chat) and `SKIP_EXPORTS` (./client) lists to bypass the failing tests | Tests skipped entirely |
| #698 | **Proper fix** — run the existing `patch-esm-imports.mjs` script after `npm ci --ignore-scripts` | Root cause patched, all tests run |

## Resolution

**#698's approach wins.** The repo already has `packages/squad-cli/scripts/patch-esm-imports.mjs` (added for issue #449) that patches the missing ESM extension. It runs as a `postinstall` hook, but CI uses `npm ci --ignore-scripts` which skips lifecycle hooks. Adding an explicit `node packages/squad-cli/scripts/patch-esm-imports.mjs` step after `npm ci` in both affected jobs fixes the actual problem — making #697's skip-based workaround unnecessary.

## What changed

**`.github/workflows/squad-ci.yml`** — 2 lines added:

1. **samples-build job** (line ~354): `node packages/squad-cli/scripts/patch-esm-imports.mjs` after `npm ci --ignore-scripts`
2. **export-smoke-test job** (line ~725): Same patch step after `npm ci --ignore-scripts`

## Root cause

`@github/copilot-sdk@0.1.32`'s `dist/session.js` imports `vscode-jsonrpc/node` without a `.js` extension. Since `vscode-jsonrpc@8.2.1` has no `exports` field, Node.js 22+ strict ESM resolution fails. The existing patch script injects the missing `exports` field into `vscode-jsonrpc/package.json`.

## Re-enable conditions

Remove the patch steps when `@github/copilot-sdk` ships ESM-compliant imports (i.e., `vscode-jsonrpc/node.js` instead of `vscode-jsonrpc/node`). Upstream: https://github.com/github/copilot-sdk/issues/707

## Why consolidate

Both PRs touch the same file with overlapping intent. Shipping them separately would create a confusing git history and the skip workaround from #697 would immediately become dead code once #698's fix lands.

Refs: #697, #698