### PR TITLE
fix(ci): 5 quick-win CI hardening improvements (#121)

### DIFF
--- a/.github/workflows/ci-rerun.yml
+++ b/.github/workflows/ci-rerun.yml
@@ -88,19 +88,35 @@ jobs:
 
       - name: Install dependencies
         run: |
+          success=false
           for i in 1 2 3; do
-            npm install && break
+            if npm install; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm install failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm install failed after 3 attempts"
+            exit 1
+          fi
 
       - name: Install docs dependencies
         run: |
+          success=false
           for i in 1 2 3; do
-            npm ci && break
+            if npm ci; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm ci failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm ci failed after 3 attempts"
+            exit 1
+          fi
         working-directory: docs
 
       - name: Install Playwright browsers

--- a/.github/workflows/ci-rerun.yml
+++ b/.github/workflows/ci-rerun.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Fetch PR metadata
         id: pr
@@ -65,6 +66,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Fix stale lockfile entries
         run: |
@@ -85,10 +87,20 @@ jobs:
           "
 
       - name: Install dependencies
-        run: npm install
+        run: |
+          for i in 1 2 3; do
+            npm install && break
+            echo "Retry $i/3 — npm install failed, retrying in 5s..."
+            sleep 5
+          done
 
       - name: Install docs dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && break
+            echo "Retry $i/3 — npm ci failed, retrying in 5s..."
+            sleep 5
+          done
         working-directory: docs
 
       - name: Install Playwright browsers

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -11,8 +11,36 @@ permissions:
   contents: read
 
 jobs:
-  docs-quality:
+  # ── Path filter for conditional job execution ──────────────────────────
+  # Detects which areas of the repo changed so downstream jobs can skip
+  # when their inputs haven't changed (e.g., skip docs-quality on code-only PRs).
+  changes:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect changed paths
+        id: filter
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
+          if echo "$CHANGED" | grep -qE '^(docs/|README\.md|\.markdownlint|\.cspell)'; then
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  docs-quality:
+    needs: changes
+    if: "!cancelled() && (github.event_name == 'push' || needs.changes.outputs.docs == 'true')"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
@@ -21,7 +49,12 @@ jobs:
           node-version: 22
 
       - name: Install docs tools
-        run: npm install --no-save markdownlint-cli2 cspell
+        run: |
+          for i in 1 2 3; do
+            npm install --no-save markdownlint-cli2 cspell && break
+            echo "Retry $i/3 — npm install failed, retrying in 5s..."
+            sleep 5
+          done
 
       - name: Lint docs markdown
         run: npx markdownlint-cli2
@@ -31,12 +64,14 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Fix stale lockfile entries
         run: |
@@ -57,10 +92,20 @@ jobs:
           "
 
       - name: Install dependencies
-        run: npm install
+        run: |
+          for i in 1 2 3; do
+            npm install && break
+            echo "Retry $i/3 — npm install failed, retrying in 5s..."
+            sleep 5
+          done
 
       - name: Install docs dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && break
+            echo "Retry $i/3 — npm ci failed, retrying in 5s..."
+            sleep 5
+          done
         working-directory: docs
 
       - name: Install Playwright browsers
@@ -138,6 +183,7 @@ jobs:
     # ──────────────────────────────────────────────────────────────────────
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
@@ -218,6 +264,7 @@ jobs:
     # ──────────────────────────────────────────────────────────────────────
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
@@ -424,6 +471,7 @@ jobs:
 
   publish-policy:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
@@ -470,6 +518,7 @@ jobs:
     # ──────────────────────────────────────────────────────────────────────
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
@@ -554,6 +603,7 @@ jobs:
     # ──────────────────────────────────────────────────────────────────────
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
@@ -659,6 +709,7 @@ jobs:
     # ──────────────────────────────────────────────────────────────────────
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -15,7 +15,6 @@ jobs:
   # Detects which areas of the repo changed so downstream jobs can skip
   # when their inputs haven't changed (e.g., skip docs-quality on code-only PRs).
   changes:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     outputs:
@@ -27,10 +26,15 @@ jobs:
       - name: Detect changed paths
         id: filter
         run: |
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
-          CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
-          if echo "$CHANGED" | grep -qE '^(docs/|README\.md|\.markdownlint|\.cspell)'; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+            CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
+          else
+            # On push, compare against parent commit
+            CHANGED=$(git diff --name-only HEAD~1...HEAD 2>/dev/null || echo "docs/")
+          fi
+          if echo "$CHANGED" | grep -qE '^(docs/|README\.md|\.markdownlint|\.cspell|cspell\.json)'; then
             echo "docs=true" >> "$GITHUB_OUTPUT"
           else
             echo "docs=false" >> "$GITHUB_OUTPUT"
@@ -50,11 +54,19 @@ jobs:
 
       - name: Install docs tools
         run: |
+          success=false
           for i in 1 2 3; do
-            npm install --no-save markdownlint-cli2 cspell && break
+            if npm install --no-save markdownlint-cli2 cspell; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm install failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm install failed after 3 attempts"
+            exit 1
+          fi
 
       - name: Lint docs markdown
         run: npx markdownlint-cli2
@@ -93,19 +105,35 @@ jobs:
 
       - name: Install dependencies
         run: |
+          success=false
           for i in 1 2 3; do
-            npm install && break
+            if npm install; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm install failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm install failed after 3 attempts"
+            exit 1
+          fi
 
       - name: Install docs dependencies
         run: |
+          success=false
           for i in 1 2 3; do
-            npm ci && break
+            if npm ci; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm ci failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm ci failed after 3 attempts"
+            exit 1
+          fi
         working-directory: docs
 
       - name: Install Playwright browsers

--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [20]
@@ -20,9 +21,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && break
+            echo "Retry $i/3 — npm ci failed, retrying in 5s..."
+            sleep 5
+          done
 
       - name: Build
         run: npm run build
@@ -30,6 +37,7 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20]
@@ -39,9 +47,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && break
+            echo "Retry $i/3 — npm ci failed, retrying in 5s..."
+            sleep 5
+          done
 
       - name: Run tests
         run: npm test
@@ -49,6 +63,7 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [20]
@@ -59,9 +74,25 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Validate npm token
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is not configured — publish will fail"
+            exit 1
+          fi
+          echo "✅ NPM_TOKEN is set"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && break
+            echo "Retry $i/3 — npm ci failed, retrying in 5s..."
+            sleep 5
+          done
 
       - name: Build packages
         run: npm -w packages/squad-sdk run build && npm -w packages/squad-cli run build

--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -25,11 +25,19 @@ jobs:
 
       - name: Install dependencies
         run: |
+          success=false
           for i in 1 2 3; do
-            npm ci && break
+            if npm ci; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm ci failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm ci failed after 3 attempts"
+            exit 1
+          fi
 
       - name: Build
         run: npm run build
@@ -51,11 +59,19 @@ jobs:
 
       - name: Install dependencies
         run: |
+          success=false
           for i in 1 2 3; do
-            npm ci && break
+            if npm ci; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm ci failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm ci failed after 3 attempts"
+            exit 1
+          fi
 
       - name: Run tests
         run: npm test
@@ -88,11 +104,19 @@ jobs:
 
       - name: Install dependencies
         run: |
+          success=false
           for i in 1 2 3; do
-            npm ci && break
+            if npm ci; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm ci failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm ci failed after 3 attempts"
+            exit 1
+          fi
 
       - name: Build packages
         run: npm -w packages/squad-sdk run build && npm -w packages/squad-cli run build

--- a/.github/workflows/squad-npm-publish.yml
+++ b/.github/workflows/squad-npm-publish.yml
@@ -89,11 +89,19 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: |
+          success=false
           for i in 1 2 3; do
-            npm ci && break
+            if npm ci; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm ci failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm ci failed after 3 attempts"
+            exit 1
+          fi
       - name: Build
         run: npm run build
         env:
@@ -119,6 +127,7 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
       - name: Validate npm token
         run: |
           if [ -z "$NODE_AUTH_TOKEN" ]; then
@@ -141,11 +150,19 @@ jobs:
           echo "Publishing version: ${VERSION}"
       - name: Install dependencies
         run: |
+          success=false
           for i in 1 2 3; do
-            npm ci && break
+            if npm ci; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm ci failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm ci failed after 3 attempts"
+            exit 1
+          fi
       - name: Build squad-sdk
         run: npm -w packages/squad-sdk run build
       - name: Verify package version matches target
@@ -184,6 +201,7 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
       - name: Validate npm token
         run: |
           if [ -z "$NODE_AUTH_TOKEN" ]; then
@@ -206,11 +224,19 @@ jobs:
           echo "Publishing version: ${VERSION}"
       - name: Install dependencies
         run: |
+          success=false
           for i in 1 2 3; do
-            npm ci && break
+            if npm ci; then
+              success=true
+              break
+            fi
             echo "Retry $i/3 — npm ci failed, retrying in 5s..."
             sleep 5
           done
+          if [ "$success" = false ]; then
+            echo "::error::npm ci failed after 3 attempts"
+            exit 1
+          fi
       - name: "Guard against file: dependencies"
         run: |
           SDK_DEP=$(node -p "require('./packages/squad-cli/package.json').dependencies['@bradygaster/squad-sdk']")

--- a/.github/workflows/squad-npm-publish.yml
+++ b/.github/workflows/squad-npm-publish.yml
@@ -15,6 +15,7 @@ jobs:
   preflight:
     name: Pre-publish dependency validation
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,6 +78,7 @@ jobs:
     name: CLI packaging smoke test
     needs: preflight
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -84,8 +86,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
       - name: Install dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && break
+            echo "Retry $i/3 — npm ci failed, retrying in 5s..."
+            sleep 5
+          done
       - name: Build
         run: npm run build
         env:
@@ -102,6 +110,7 @@ jobs:
     name: Publish @bradygaster/squad-sdk
     needs: [preflight, smoke-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -110,6 +119,15 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
+      - name: Validate npm token
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is not configured — publish will fail"
+            exit 1
+          fi
+          echo "✅ NPM_TOKEN is set"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Determine version
         id: version
         run: |
@@ -122,7 +140,12 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Publishing version: ${VERSION}"
       - name: Install dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && break
+            echo "Retry $i/3 — npm ci failed, retrying in 5s..."
+            sleep 5
+          done
       - name: Build squad-sdk
         run: npm -w packages/squad-sdk run build
       - name: Verify package version matches target
@@ -152,6 +175,7 @@ jobs:
     name: Publish @bradygaster/squad-cli
     needs: [preflight, smoke-test, publish-sdk]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -160,6 +184,15 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
+      - name: Validate npm token
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is not configured — publish will fail"
+            exit 1
+          fi
+          echo "✅ NPM_TOKEN is set"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Determine version
         id: version
         run: |
@@ -172,7 +205,12 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Publishing version: ${VERSION}"
       - name: Install dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && break
+            echo "Retry $i/3 — npm ci failed, retrying in 5s..."
+            sleep 5
+          done
       - name: "Guard against file: dependencies"
         run: |
           SDK_DEP=$(node -p "require('./packages/squad-cli/package.json').dependencies['@bradygaster/squad-sdk']")


### PR DESCRIPTION
## CI Hardening Quick Wins

**Issue:** [diberry/squad#121](https://github.com/diberry/squad/issues/121) — CI Hardening: 19 opportunities identified (5 quick wins)

**Analysis:** [docs/proposals/ci-hardening-opportunities.md](docs/proposals/ci-hardening-opportunities.md)

---

### Quick Wins Implemented

| # | Improvement | Files | Expected Impact |
|---|------------|-------|----------------|
| 1 | **Retry logic on npm install** — 3-attempt retry wrapper on all npm install/ci calls | All 4 files | 20-30% reduction in transient CI failures |
| 2 | **Job timeout tuning** — timeout-minutes on every job (3-15 min based on expected duration) | All 4 files | Prevents 6-hour hangs from stuck jobs |
| 3 | **npm cache optimization** — cache npm on setup-node where missing | squad-ci, ci-rerun, insider-publish | 30-40% speedup on npm install steps |
| 4 | **Conditional docs quality checks** — path filter job skips docs-quality on code-only PRs | squad-ci | 10-15% faster on code-only PRs |
| 5 | **Publish secret validation** — fail-fast check for NPM_TOKEN before publish steps | npm-publish, insider-publish | Immediate failure on misconfigured secrets |

### Files Changed

- `.github/workflows/squad-ci.yml` — retry, cache, timeouts, conditional docs-quality via path filter
- `.github/workflows/squad-npm-publish.yml` — retry, cache, timeouts, secret validation on both publish jobs
- `.github/workflows/squad-insider-publish.yml` — retry, cache, timeouts, secret validation
- `.github/workflows/ci-rerun.yml` — retry, cache, timeout

### Implementation Details

**Retry pattern** (consistent across all files): 3 attempts with 5-second delay between retries. Silent on success, logs retry count on failure.

**Path filter** (docs-quality conditional): New `changes` job detects if docs/ files changed. `docs-quality` skips on code-only PRs, always runs on push to dev/insider. Uses `!cancelled()` to handle skipped dependency on push events.

**Secret validation** (publish workflows): Early validation step checks NPM_TOKEN exists before any install/build work. Fails with a clear error annotation if secret is missing.

### Verification

- [x] All 4 YAML files parse without errors
- [x] No .squad/ files in diff
- [x] Changes limited to .github/workflows/ only

Closes diberry/squad#121
