### PR TITLE
Draft: fix #714 packaged SDK export validation

### DIFF
--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -169,6 +169,7 @@
   ],
   "scripts": {
     "postinstall": "node scripts/patch-esm-imports.mjs && node scripts/patch-ink-rendering.mjs",
+    "prepack": "npm run build",
     "prepublishOnly": "npm run build",
     "build": "tsc -p tsconfig.json && npm run postbuild",
     "postbuild": "node -e \"require('fs').cpSync('src/remote-ui', 'dist/remote-ui', {recursive: true})\""

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -221,6 +221,7 @@
     "README.md"
   ],
   "scripts": {
+    "prepack": "npm run build",
     "prepublishOnly": "npm run build",
     "build": "tsc -p tsconfig.json"
   },

--- a/test/cli-packaging-smoke.test.ts
+++ b/test/cli-packaging-smoke.test.ts
@@ -27,30 +27,17 @@ describe('CLI packaging smoke test', { timeout: 120_000 }, () => {
     const sdkDir = join(cwd, 'packages', 'squad-sdk');
     const cliDir = join(cwd, 'packages', 'squad-cli');
 
-    // Build first if dist/ doesn't exist
-    const sdkDist = join(sdkDir, 'dist');
-    const cliDist = join(cliDir, 'dist');
-
     // SKIP_BUILD_BUMP prevents bump-build.mjs from mutating versions to
     // invalid 4-part semver (e.g. 0.8.25.4) which npm install rejects.
     const buildEnv = { ...process.env, SKIP_BUILD_BUMP: '1' };
 
-    if (!existsSync(sdkDist)) {
-      console.log('Building squad-sdk...');
-      execSync('npm run build', { cwd: sdkDir, stdio: 'inherit', env: buildEnv });
-    }
-
-    if (!existsSync(cliDist)) {
-      console.log('Building squad-cli...');
-      execSync('npm run build', { cwd: cliDir, stdio: 'inherit', env: buildEnv });
-    }
-
-    // Pack both packages
+    // Pack both packages. npm pack must exercise package-local prepack hooks
+    // so the tarballs always contain fresh dist/ artifacts.
     console.log('Packing squad-sdk...');
     const sdkPackOutput = execSync('npm pack --quiet', {
       cwd: sdkDir,
       encoding: 'utf8',
-      env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+      env: { ...buildEnv, NO_COLOR: '1', FORCE_COLOR: '0' },
     }).trim();
     sdkTarball = join(sdkDir, sdkPackOutput.split('\n').pop()!.trim());
 
@@ -58,7 +45,7 @@ describe('CLI packaging smoke test', { timeout: 120_000 }, () => {
     const cliPackOutput = execSync('npm pack --quiet', {
       cwd: cliDir,
       encoding: 'utf8',
-      env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+      env: { ...buildEnv, NO_COLOR: '1', FORCE_COLOR: '0' },
     }).trim();
     cliTarball = join(cliDir, cliPackOutput.split('\n').pop()!.trim());
 
@@ -208,6 +195,34 @@ describe('CLI packaging smoke test', { timeout: 120_000 }, () => {
     expect(existsSync(sdkPkg), 'squad-sdk not installed as dependency of squad-cli').toBe(true);
     const pkg = JSON.parse(require('fs').readFileSync(sdkPkg, 'utf8'));
     expect(pkg.name).toBe('@bradygaster/squad-sdk');
+  });
+
+  it('packaged squad-sdk exports FSStorageProvider from root', () => {
+    const script = [
+      "import('@bradygaster/squad-sdk')",
+      "  .then((sdk) => console.log(typeof sdk.FSStorageProvider))",
+      "  .catch((error) => { console.error(error); process.exit(1); });",
+    ].join('');
+    const stdout = execSync(`node --input-type=module -e ${JSON.stringify(script)}`, {
+      cwd: tempDir,
+      encoding: 'utf8',
+      env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+    }).trim();
+    expect(stdout).toBe('function');
+  });
+
+  it('packaged squad-sdk exports FSStorageProvider from /storage subpath', () => {
+    const script = [
+      "import('@bradygaster/squad-sdk/storage')",
+      "  .then((storage) => console.log(typeof storage.FSStorageProvider))",
+      "  .catch((error) => { console.error(error); process.exit(1); });",
+    ].join('');
+    const stdout = execSync(`node --input-type=module -e ${JSON.stringify(script)}`, {
+      cwd: tempDir,
+      encoding: 'utf8',
+      env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+    }).trim();
+    expect(stdout).toBe('function');
   });
 
   // ============================================================================

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -7,6 +7,12 @@ describe('SDK package exports', () => {
     expect(typeof sdk.VERSION).toBe('string');
   });
 
+  it('exports FSStorageProvider from root', async () => {
+    const sdk = await import('@bradygaster/squad-sdk');
+    expect(sdk.FSStorageProvider).toBeDefined();
+    expect(typeof sdk.FSStorageProvider).toBe('function');
+  });
+
   it('exports from /config subpath', async () => {
     const config = await import('@bradygaster/squad-sdk/config');
     expect(config).toBeDefined();
@@ -45,5 +51,11 @@ describe('SDK package exports', () => {
   it('exports from /tools subpath', async () => {
     const tools = await import('@bradygaster/squad-sdk/tools');
     expect(tools).toBeDefined();
+  });
+
+  it('exports FSStorageProvider from /storage subpath', async () => {
+    const storage = await import('@bradygaster/squad-sdk/storage');
+    expect(storage.FSStorageProvider).toBeDefined();
+    expect(typeof storage.FSStorageProvider).toBe('function');
   });
 });


### PR DESCRIPTION
Closes #714

## Summary
This fixes the packaged CLI/SDK `FSStorageProvider` mismatch by making tarball creation rebuild fresh artifacts and by tightening packaging/export coverage.

## Root cause
`FSStorageProvider` is exported in source, but `npm pack` could reuse stale `dist/` output when package tarballs were created from package directories. That allowed a tarball to carry outdated SDK build artifacts even though the current TypeScript source exported `FSStorageProvider` correctly.

## What changed
- added `prepack` scripts to `packages/squad-sdk` and `packages/squad-cli` so `npm pack` rebuilds fresh package artifacts
- updated `test/cli-packaging-smoke.test.ts` to rely on `npm pack` rebuilding the tarballs instead of conditionally reusing existing `dist/`
- extended `test/package-exports.test.ts` to assert `FSStorageProvider` is exported from both `@bradygaster/squad-sdk` and `@bradygaster/squad-sdk/storage`
- extended the packaging smoke test to verify those packaged exports inside the installed tarball

## Validation
- `npm run build -w packages/squad-sdk`
- `npm run build -w packages/squad-cli`
- `npx vitest run test\\package-exports.test.ts test\\cli-packaging-smoke.test.ts`

## Status
Implementation is complete, but I am leaving this PR in draft state for now.