### PR TITLE
fix(ci): add build step to insider publish test job

### DIFF
--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 
@@ -33,13 +33,16 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-squad-node
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Build (required for subpath export resolution)
+        run: npm run build
 
       - name: Run tests
         run: npm test
@@ -81,7 +84,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The insider publish workflow's test job runs in a fresh checkout without \dist/\ files, causing \ERR_MODULE_NOT_FOUND\ for subpath exports that resolve to \dist/\.

Adding a build step before tests fixes the resolution.

**Root cause:** The \	est\ job depends on \uild\ but does a fresh checkout without downloading build artifacts. Subpath exports like \@bradygaster/squad-cli/core/init\ and \@bradygaster/squad-sdk/ralph/rate-limiting\ point to \dist/\ files that don't exist in a source-only checkout.

**Fix:** Add \
pm run build\ before \
pm test\ in the test job.