### PR TITLE
feat(ci): add pull request template with contributor checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,21 +7,41 @@
 ### How
 <!-- Approach taken. Key design decisions and trade-offs. -->
 
-### Testing
-<!-- What was tested and how. "npm run preflight" output or CI green. -->
+---
+
+### PR Readiness Checklist
+
+> The PR readiness bot will validate these automatically after push.
+> Check each item before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for full details.
+
+#### Branch & Commit
+- [ ] Branch created from `dev` (not `main`)
+- [ ] Branch is up to date with `dev` (`git fetch upstream && git rebase upstream/dev`)
+- [ ] PR is **not** in draft mode (mark ready when checks pass)
+- [ ] Commit history is clean (squash fixups before review)
+
+#### Build & Test
 - [ ] `npm run build` passes
 - [ ] `npm test` passes (all tests green)
-- [ ] For migration PRs (>20 files): test output summary included below
+- [ ] `npm run lint` passes (type check clean)
+- [ ] `npm run lint:eslint` passes
+- [ ] For migration PRs (>20 files): include test output summary in PR description
 
-### Docs
-<!-- What documentation was updated. "N/A" only if truly no user-facing change. -->
-- [ ] CHANGELOG.md entry (if packages/squad-sdk/src/ or packages/squad-cli/src/ changed)
+#### Changeset
+- [ ] Changeset added via `npx changeset add` (if `packages/squad-sdk/src/` or `packages/squad-cli/src/` changed)
+- [ ] Or direct `CHANGELOG.md` entry (maintainers only — write-protected for external contributors)
+- [ ] Or `skip-changelog` label applied (if no user-facing changes)
+
+#### Docs
+<!-- "N/A" only if truly no user-facing change. -->
 - [ ] README section updated (if new feature/module)
 - [ ] Docs feature page (if new user-facing capability)
 
-### Exports
+#### Exports
 <!-- For SDK changes only. "N/A" if no new modules. -->
 - [ ] package.json subpath exports updated (if new module)
+
+---
 
 ### Breaking Changes
 <!-- Any backward-incompatible changes. "None" if clean. -->


### PR DESCRIPTION
### What
Enhances the PR template with a structured readiness checklist that contributors see at PR creation time.

### Why
Suggested by @tamirdresher in [PR #752 review](https://github.com/bradygaster/squad/pull/752). Having static checkboxes upfront complements any future dynamic PR readiness bot — template gives the checklist before push, bot validates after push.

### How
Updated \.github/PULL_REQUEST_TEMPLATE.md\ to include:
- **Branch & Commit** checks (branch from dev, up to date, not draft, clean history)
- **Build & Test** checks (build, test, lint)
- **Changeset** checks (changeset or CHANGELOG or skip-changelog label)
- **Docs** and **Exports** sections (carried forward)
- Bot validation note and CONTRIBUTING.md reference

Closes #778

Working as EECOM (Core Dev)