### PR TITLE
feat(watch): --verbose flag for debugging empty boards

### DIFF
--- a/.changeset/watch-verbose-mode.md
+++ b/.changeset/watch-verbose-mode.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": minor
+---
+
+Add --verbose flag to squad watch for debugging empty boards and silent failures (#781)

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -400,9 +400,20 @@ async function main(): Promise<void> {
       capabilities: Object.keys(capabilities).length > 0 ? capabilities : undefined,
     });
 
-    // After parsing all flags, check for positional args that look like prompts
+    // After parsing all flags, check for positional args that look like prompts.
+    // Skip values that follow known value-flags (e.g. "--interval 5" → "5" is not positional).
+    const knownValueFlags = new Set([
+      '--interval', '--copilot-flags', '--agent-cmd', '--max-concurrent', '--timeout', '--board-project',
+    ]);
     const watchArgStart = args.indexOf(cmd) + 1;
-    const positionalArgs = args.slice(watchArgStart).filter(a => !a.startsWith('--') && !a.startsWith('-'));
+    const watchArgs = args.slice(watchArgStart);
+    const positionalArgs: string[] = [];
+    for (let i = 0; i < watchArgs.length; i++) {
+      const arg = watchArgs[i]!;
+      if (knownValueFlags.has(arg)) { i++; continue; }
+      if (arg.startsWith('-')) continue;
+      positionalArgs.push(arg);
+    }
     if (positionalArgs.length > 0 && config.verbose) {
       console.log(`[verbose] ⚠️ Positional args ignored by watch: "${positionalArgs.join(' ')}". Use --execute to process issues.`);
     }

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -349,6 +349,8 @@ async function main(): Promise<void> {
 
     const execute = args.includes('--execute') ? true : undefined;
 
+    const verbose = args.includes('--verbose') || args.includes('-v');
+
     const copilotFlagsIdx = args.indexOf('--copilot-flags');
     const copilotFlags = (copilotFlagsIdx !== -1 && args[copilotFlagsIdx + 1])
       ? args[copilotFlagsIdx + 1]
@@ -394,8 +396,16 @@ async function main(): Promise<void> {
       timeout,
       copilotFlags,
       agentCmd,
+      verbose,
       capabilities: Object.keys(capabilities).length > 0 ? capabilities : undefined,
     });
+
+    // After parsing all flags, check for positional args that look like prompts
+    const watchArgStart = args.indexOf(cmd) + 1;
+    const positionalArgs = args.slice(watchArgStart).filter(a => !a.startsWith('--') && !a.startsWith('-'));
+    if (positionalArgs.length > 0 && config.verbose) {
+      console.log(`[verbose] ⚠️ Positional args ignored by watch: "${positionalArgs.join(' ')}". Use --execute to process issues.`);
+    }
 
     await runWatch(process.cwd(), config);
     return;

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/execute.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/execute.ts
@@ -190,7 +190,7 @@ export class ExecuteCapability implements WatchCapability {
     try {
       const timeout = ((context.config['timeout'] as number) ?? 30) * 60_000;
 
-      vlog.log(`Execute: agentCmd=${context.agentCmd ?? 'gh copilot'}, maxConcurrent=${maxConcurrent}, timeout=${timeout / 60_000}m`);
+      vlog.log(`Execute: agentCmd=${context.agentCmd ?? 'gh copilot'}, timeout=${timeout / 60_000}m`);
 
       // Fetch open issues with squad label
       const sdkItems = await context.adapter.listWorkItems({ tags: ['squad'], state: 'open', limit: 50 });

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/execute.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/execute.ts
@@ -5,6 +5,7 @@
 import { execFile, type ChildProcess } from 'node:child_process';
 import type { WatchCapability, WatchContext, PreflightResult, CapabilityResult } from '../types.js';
 import type { MachineCapabilities } from '@bradygaster/squad-sdk/ralph/capabilities';
+import { createVerboseLogger } from '../verbose.js';
 
 /** Normalized work item for execution. */
 export interface ExecutableWorkItem {
@@ -114,9 +115,13 @@ export class ExecuteCapability implements WatchCapability {
   }
 
   async execute(context: WatchContext): Promise<CapabilityResult> {
+    const vlog = createVerboseLogger(context.verbose ?? false);
+
     try {
       const maxConcurrent = (context.config['maxConcurrent'] as number) ?? 1;
       const timeout = ((context.config['timeout'] as number) ?? 30) * 60_000;
+
+      vlog.log(`Execute: agentCmd=${context.agentCmd ?? 'gh copilot'}, maxConcurrent=${maxConcurrent}, timeout=${timeout / 60_000}m`);
 
       // Fetch open issues with squad label
       const sdkItems = await context.adapter.listWorkItems({ tags: ['squad'], state: 'open', limit: 50 });
@@ -134,6 +139,12 @@ export class ExecuteCapability implements WatchCapability {
 
       const executable = findExecutableIssues(context.roster, capabilities, handled);
       const batch = executable.slice(0, maxConcurrent);
+
+      vlog.log(`Execute: ${issues.length} total issues, ${handled.length} capable, ${executable.length} executable, ${batch.length} in batch`);
+      for (const issue of batch) {
+        const labels = issue.labels.map(l => l.name).join(', ');
+        vlog.log(`  → #${issue.number}: "${issue.title}" [${labels}]`);
+      }
 
       if (batch.length === 0) {
         return { success: true, summary: 'no executable issues' };

--- a/packages/squad-cli/src/cli/commands/watch/config.ts
+++ b/packages/squad-cli/src/cli/commands/watch/config.ts
@@ -20,6 +20,8 @@ export interface WatchConfig {
   agentCmd?: string;
   /** Per-capability config: `true` / `false` / object with sub-options. */
   capabilities: Record<string, boolean | Record<string, unknown>>;
+  /** Enable verbose diagnostic output for debugging. */
+  verbose?: boolean;
 }
 
 const DEFAULTS: WatchConfig = {
@@ -68,6 +70,7 @@ export function loadWatchConfig(
       ...(fileConfig.capabilities ?? {}),
       ...(cliOverrides.capabilities ?? {}),
     },
+    verbose: cliOverrides.verbose ?? fileConfig.verbose ?? false,
   };
 
   return merged;
@@ -83,10 +86,11 @@ function normalizeFileConfig(raw: Record<string, unknown>): Partial<WatchConfig>
   if (typeof raw['timeout'] === 'number') result.timeout = raw['timeout'];
   if (typeof raw['copilotFlags'] === 'string') result.copilotFlags = raw['copilotFlags'];
   if (typeof raw['agentCmd'] === 'string') result.agentCmd = raw['agentCmd'];
+  if (typeof raw['verbose'] === 'boolean') result.verbose = raw['verbose'];
 
   // Everything else is a capability key
   const caps: Record<string, boolean | Record<string, unknown>> = {};
-  const reserved = new Set(['interval', 'execute', 'maxConcurrent', 'timeout', 'copilotFlags', 'agentCmd']);
+  const reserved = new Set(['interval', 'execute', 'maxConcurrent', 'timeout', 'copilotFlags', 'agentCmd', 'verbose']);
   for (const [key, value] of Object.entries(raw)) {
     if (reserved.has(key)) continue;
     if (typeof value === 'boolean' || (typeof value === 'object' && value !== null && !Array.isArray(value))) {

--- a/packages/squad-cli/src/cli/commands/watch/index.ts
+++ b/packages/squad-cli/src/cli/commands/watch/index.ts
@@ -39,6 +39,7 @@ import type { WatchConfig } from './config.js';
 import type { WatchCapability, WatchContext, WatchPhase, CapabilityResult } from './types.js';
 import { CapabilityRegistry } from './registry.js';
 import { createDefaultRegistry } from './capabilities/index.js';
+import { createVerboseLogger, type VerboseLogger } from './verbose.js';
 
 // ── Re-exports for backward compatibility ────────────────────────
 
@@ -47,6 +48,7 @@ export { loadWatchConfig } from './config.js';
 export type { WatchCapability, WatchContext, WatchPhase, PreflightResult, CapabilityResult } from './types.js';
 export { CapabilityRegistry } from './registry.js';
 export { createDefaultRegistry } from './capabilities/index.js';
+export { createVerboseLogger, type VerboseLogger } from './verbose.js';
 
 // ── Watch Platform Abstraction ───────────────────────────────────
 
@@ -193,12 +195,17 @@ type PRBoardState = Pick<BoardState, 'drafts' | 'needsReview' | 'changesRequeste
   totalOpen: number;
 };
 
-async function checkPRs(roster: ReturnType<typeof parseRoster>, adapter: PlatformAdapter): Promise<PRBoardState> {
+async function checkPRs(roster: ReturnType<typeof parseRoster>, adapter: PlatformAdapter, vlog?: VerboseLogger): Promise<PRBoardState> {
   const timestamp = new Date().toLocaleTimeString();
   const prs = await listWatchPullRequests(adapter, { state: 'open', limit: 20 });
   const squadPRs = prs.filter(pr =>
     pr.labels.some(l => l.name.startsWith('squad')) || pr.headRefName.startsWith('squad/'),
   );
+
+  vlog?.log(`PRs found: ${prs.length} total`);
+  for (const pr of squadPRs) {
+    vlog?.log(`  PR #${pr.number}: "${pr.title}" draft=${pr.isDraft} review=${pr.reviewDecision ?? 'none'}`);
+  }
 
   if (squadPRs.length === 0) {
     return { drafts: 0, needsReview: 0, changesRequested: 0, ciFailures: 0, readyToMerge: 0, totalOpen: 0 };
@@ -272,10 +279,18 @@ async function runCheck(
   autoAssign: boolean,
   capabilities: MachineCapabilities | null,
   adapter: PlatformAdapter,
+  vlog?: VerboseLogger,
 ): Promise<BoardState> {
   const timestamp = new Date().toLocaleTimeString();
   try {
     const issues = await listWatchWorkItems(adapter, { label: 'squad', state: 'open', limit: 20 });
+
+    vlog?.log(`Issues found: ${issues.length} total`);
+    for (const issue of issues) {
+      const labels = issue.labels?.map((l: { name: string }) => l.name).join(', ') ?? 'none';
+      const assignees = issue.assignees?.map((a: { login: string }) => a.login).join(', ') ?? 'none';
+      vlog?.log(`  #${issue.number}: "${issue.title}" [${labels}] assignees=[${assignees}]`);
+    }
 
     const { filterByCapabilities } = await import('@bradygaster/squad-sdk/ralph/capabilities');
     const { handled: capableIssues, skipped: incapableIssues } = filterByCapabilities(issues, capabilities);
@@ -329,7 +344,7 @@ async function runCheck(
       }
     }
 
-    const prState = await checkPRs(roster, adapter);
+    const prState = await checkPRs(roster, adapter, vlog);
     return { untriaged: untriaged.length, assigned: assignedIssues.length, executed: 0, ...prState };
   } catch (e) {
     console.error(`${RED}✗${RESET} [${timestamp}] Check failed: ${(e as Error).message}`);
@@ -635,6 +650,32 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     return fatal(`Could not detect platform: ${(err as Error).message}`);
   }
 
+  // Verbose logger
+  const vlog = createVerboseLogger(config.verbose ?? false);
+
+  vlog.section('Startup');
+  vlog.table({
+    repo: teamRoot,
+    platform: adapter.type,
+    verbose: true,
+    interval: `${config.interval}m`,
+    execute: config.execute ?? false,
+    agentCmd: config.agentCmd ?? '(default: gh copilot)',
+    dispatchMode: config.capabilities['wave-dispatch'] ? 'wave' : 'task',
+    maxConcurrent: config.maxConcurrent ?? 1,
+  });
+
+  // Auth check (verbose)
+  if (adapter.type === 'github') {
+    try {
+      const authOut = execFileSync('gh', ['auth', 'status'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+      const activeAccount = authOut.match(/Logged in to .* account (\S+)/)?.[1];
+      vlog.log(`Auth: ${activeAccount ?? 'unknown'}`);
+    } catch {
+      vlog.warn('gh auth status failed — API calls may fail silently');
+    }
+  }
+
   // Verify platform CLI availability
   if (adapter.type === 'github') {
     if (!(await ghAvailable())) fatal('gh CLI not found — install from https://cli.github.com');
@@ -688,6 +729,7 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     config: {},
     agentCmd: config.agentCmd,
     copilotFlags: config.copilotFlags,
+    verbose: config.verbose,
   };
 
   const enabledCapabilities = await preflightCapabilities(registry, config, baseContext);
@@ -713,6 +755,7 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
 
   async function executeRound(): Promise<void> {
     const ts = new Date().toLocaleTimeString();
+    const roundStart = Date.now();
 
     // Circuit breaker gate
     if (cbState.status === 'open') {
@@ -756,6 +799,8 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     round++;
     const roundContext: WatchContext = { ...baseContext, round };
 
+    vlog.section(`Round ${round}`);
+
     // Phase 1: pre-scan (self-pull, subsquad discovery)
     await runPhase('pre-scan', enabledCapabilities, roundContext, config);
 
@@ -766,7 +811,7 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     }
 
     // Core: triage (always runs — not a capability)
-    const roundState = await runCheck(rules, modules, roster, hasCopilot, autoAssign, capabilities, adapter);
+    const roundState = await runCheck(rules, modules, roster, hasCopilot, autoAssign, capabilities, adapter, vlog);
 
     // Phase 2: post-triage (two-pass hydration)
     await runPhase('post-triage', enabledCapabilities, roundContext, config);
@@ -790,6 +835,19 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
       timestamp: new Date(),
     });
     await monitor.healthCheck();
+
+    // Verbose board counters
+    vlog.table({
+      untriaged: roundState.untriaged,
+      assigned: roundState.assigned,
+      drafts: roundState.drafts,
+      needsReview: roundState.needsReview,
+      changesRequested: roundState.changesRequested,
+      ciFailures: roundState.ciFailures,
+      readyToMerge: roundState.readyToMerge,
+      executed: roundState.executed,
+    });
+
     reportBoard(roundState, round);
 
     // Post-round: update circuit breaker on success
@@ -806,6 +864,10 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
       cbState.consecutiveFailures = 0;
     }
     saveCBState(squadDirInfo.path, cbState);
+
+    const roundEnd = Date.now();
+    const elapsed = ((roundEnd - roundStart) / 1000).toFixed(1);
+    vlog.log(`Round ${round} complete (${elapsed}s)`);
   }
 
   // Run immediately, then on interval

--- a/packages/squad-cli/src/cli/commands/watch/index.ts
+++ b/packages/squad-cli/src/cli/commands/watch/index.ts
@@ -657,6 +657,7 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
   vlog.table({
     repo: teamRoot,
     platform: adapter.type,
+    // This table only prints when verbose mode is active, so verbose is always true here.
     verbose: config.verbose ?? false,
     interval: `${config.interval}m`,
     execute: config.execute ?? false,

--- a/packages/squad-cli/src/cli/commands/watch/index.ts
+++ b/packages/squad-cli/src/cli/commands/watch/index.ts
@@ -657,7 +657,7 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
   vlog.table({
     repo: teamRoot,
     platform: adapter.type,
-    verbose: true,
+    verbose: config.verbose ?? false,
     interval: `${config.interval}m`,
     execute: config.execute ?? false,
     agentCmd: config.agentCmd ?? '(default: gh copilot)',
@@ -665,8 +665,8 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     maxConcurrent: config.maxConcurrent ?? 1,
   });
 
-  // Auth check (verbose)
-  if (adapter.type === 'github') {
+  // Auth check (verbose only — avoid unnecessary process spawn on every startup)
+  if (config.verbose && adapter.type === 'github') {
     try {
       const authOut = execFileSync('gh', ['auth', 'status'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
       const activeAccount = authOut.match(/Logged in to .* account (\S+)/)?.[1];

--- a/packages/squad-cli/src/cli/commands/watch/types.ts
+++ b/packages/squad-cli/src/cli/commands/watch/types.ts
@@ -37,6 +37,8 @@ export interface WatchContext {
   /** Hidden --agent-cmd override. */
   agentCmd?: string;
   copilotFlags?: string;
+  /** Verbose diagnostic output enabled. */
+  verbose?: boolean;
 }
 
 /** Contract that every watch capability must implement. */

--- a/packages/squad-cli/src/cli/commands/watch/verbose.ts
+++ b/packages/squad-cli/src/cli/commands/watch/verbose.ts
@@ -1,0 +1,26 @@
+/**
+ * Verbose logger for squad watch debugging.
+ * Only outputs when --verbose is enabled.
+ */
+export function createVerboseLogger(enabled: boolean) {
+  return {
+    log: (...args: unknown[]) => {
+      if (enabled) console.log('[verbose]', ...args);
+    },
+    warn: (...args: unknown[]) => {
+      if (enabled) console.log('[verbose] ⚠️', ...args);
+    },
+    section: (title: string) => {
+      if (enabled) console.log(`[verbose] ── ${title} ──`);
+    },
+    table: (data: Record<string, unknown>) => {
+      if (enabled) {
+        for (const [k, v] of Object.entries(data)) {
+          console.log(`[verbose]   ${k}: ${v}`);
+        }
+      }
+    },
+  };
+}
+
+export type VerboseLogger = ReturnType<typeof createVerboseLogger>;


### PR DESCRIPTION
## Add `--verbose` flag for debugging `squad watch`

When watch says "Board is clear — Ralph is idling", users have **zero visibility** into why. This PR adds `--verbose` / `-v` that outputs diagnostic info at every step.

### Usage

```bash
squad watch --execute --verbose
squad watch --execute -v --interval 5
```

### What verbose shows

| Phase | Output |
|-------|--------|
| **Startup** | Repo, platform (github/ado), auth account, agent-cmd, dispatch mode, interval |
| **Per-round** | Issues found with labels/assignees, why each was included/excluded |
| **PRs** | Open PRs with draft/review status |
| **Execute** | Agent command being used, batch size, dispatch classification |
| **Board** | Counter breakdown (untriaged, assigned, drafts, review, CI, merge-ready) |
| **Timing** | Round duration in seconds |
| **Warnings** | Unused positional args, auth failures |

### Example output

```
[verbose] ── Startup ──
[verbose]   repo: C:\src\my-project
[verbose]   platform: github
[verbose]   auth: tamirdresher
[verbose]   execute: true
[verbose]   agentCmd: agency copilot --agent squad
[verbose]   interval: 10m
[verbose] ── Round 1 ──
[verbose] Issues found: 3
[verbose]   #42: "Fix auth bug" [squad, squad:data] assignees=[tamirdresher]
[verbose]   #43: "Research new lib" [squad] assignees=[]
[verbose]   #44: "Update docs" [squad, squad:seven] assignees=[]
[verbose] PRs found: 1
[verbose]   PR #100: "Fix auth" draft=false review=APPROVED
[verbose]   untriaged: 1
[verbose]   assigned: 2
[verbose]   readyToMerge: 1
[verbose] Round 1 complete (2.8s)
```

### Also fixes
- **Warns on unused positional args**: `squad watch "Run scheduled tasks"` now shows `⚠️ Positional args ignored by watch` in verbose mode (the prompt is NOT used by watch)

### Files changed

| File | Change |
|------|--------|
| `verbose.ts` | **New** — `createVerboseLogger()` (log, warn, section, table) |
| `config.ts` | `verbose` field in WatchConfig |
| `types.ts` | `verbose` in WatchContext |
| `cli-entry.ts` | `--verbose` / `-v` parsing + positional arg warning |
| `index.ts` | Verbose logging in startup, round loop, issue/PR scan, board report |
| `execute.ts` | Verbose logging for agent command, batch, dispatch |

Closes #781