### PR TITLE
fix(ci): impact workflow permission — issues:write → pull-requests:write

### DIFF
--- a/.github/workflows/squad-impact.yml
+++ b/.github/workflows/squad-impact.yml
@@ -10,8 +10,7 @@ on:
 # PR data is fetched read-only via gh CLI — no untrusted code is executed.
 permissions:
   contents: read
-  pull-requests: read
-  issues: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
One-line fix: the impact analysis workflow needs \pull-requests: write\ (not \issues: write\) to post PR comments. This was missed when #786 was decontaminated.

Unblocks CI for #813, #800, #768.