### PR TITLE
fix(cli): squad doctor — add casting dir to upgrade, improve global install warnings

### DIFF
--- a/.changeset/fix-doctor-casting-upgrade.md
+++ b/.changeset/fix-doctor-casting-upgrade.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-cli': patch
+---
+
+Fix squad doctor and upgrade for insiders installs: add .squad/casting/ to ENSURE_DIRECTORIES, scaffold casting defaults from templates with permission-safe fallback, and clarify ESM warnings for global installs.

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -127,6 +127,9 @@ async function main(): Promise<void> {
   const cmd = rawCmd?.trim() || '';
 
   // --version / -v / version
+  // Investigated: routing is correct — cmd matches 'version' directly.
+  // "Unknown command: version" reports may be shell-specific (e.g. alias/wrapper
+  // prepending flags so args[0] is no longer 'version'). No intercepting router found.
   if (cmd === '--version' || cmd === '-v' || cmd === 'version') {
     console.log(VERSION);
     return;

--- a/packages/squad-cli/src/cli/commands/doctor.ts
+++ b/packages/squad-cli/src/cli/commands/doctor.ts
@@ -20,6 +20,8 @@ export interface DoctorCheck {
   name: string;
   status: 'pass' | 'fail' | 'warn';
   message: string;
+  /** Optional severity hint for display; keeps the status union stable. */
+  severity?: 'info';
 }
 
 /** Detected squad layout mode. */
@@ -327,10 +329,21 @@ function checkVscodeJsonrpcExports(cwd: string): DoctorCheck {
     };
   }
 
+  // Detect whether we're in a local dev context (node_modules exists) or global install
+  const hasNodeModules = isDirectory(path.join(cwd, 'node_modules'));
+  if (hasNodeModules) {
+    return {
+      name: 'vscode-jsonrpc exports field',
+      status: 'warn',
+      message: 'not found in node_modules — run npm install or check dependencies',
+    };
+  }
+
   return {
     name: 'vscode-jsonrpc exports field',
     status: 'warn',
-    message: 'vscode-jsonrpc not found in node_modules — expected for global CLI installs. For local development, run: npm install',
+    severity: 'info',
+    message: 'not found in node_modules (expected for global installs)',
   };
 }
 
@@ -372,10 +385,21 @@ function checkCopilotSdkSessionPatch(cwd: string): DoctorCheck {
     }
   }
 
+  // Detect whether we're in a local dev context (node_modules exists) or global install
+  const hasNodeModules = isDirectory(path.join(cwd, 'node_modules'));
+  if (hasNodeModules) {
+    return {
+      name: 'copilot-sdk session.js ESM patch',
+      status: 'warn',
+      message: 'not found in node_modules — run npm install or check dependencies',
+    };
+  }
+
   return {
     name: 'copilot-sdk session.js ESM patch',
     status: 'warn',
-    message: '@github/copilot-sdk not found in node_modules — expected for global CLI installs. For local development, run: npm install',
+    severity: 'info',
+    message: 'not found in node_modules (expected for global installs)',
   };
 }
 
@@ -487,14 +511,16 @@ export function printDoctorReport(checks: DoctorCheck[], mode: DoctorMode): void
   console.log(`Mode: ${mode}\n`);
 
   for (const c of checks) {
-    console.log(`${STATUS_ICON[c.status]}  ${c.name} — ${c.message}`);
+    const icon = c.severity === 'info' ? 'ℹ️' : STATUS_ICON[c.status];
+    console.log(`${icon}  ${c.name} — ${c.message}`);
   }
 
   const passed = checks.filter(c => c.status === 'pass').length;
   const failed = checks.filter(c => c.status === 'fail').length;
-  const warned = checks.filter(c => c.status === 'warn').length;
+  const warned = checks.filter(c => c.status === 'warn' && c.severity !== 'info').length;
+  const infos = checks.filter(c => c.severity === 'info').length;
 
-  console.log(`\nSummary: ${passed} passed, ${failed} failed, ${warned} warnings\n`);
+  console.log(`\nSummary: ${passed} passed, ${failed} failed, ${warned} warnings, ${infos} info\n`);
 }
 
 /**

--- a/packages/squad-cli/src/cli/core/upgrade.ts
+++ b/packages/squad-cli/src/cli/core/upgrade.ts
@@ -284,6 +284,8 @@ const ENSURE_DIRECTORIES = [
   '.squad/log',
   '.squad/sessions',
   '.squad/decisions/inbox',
+  '.squad/casting',
+  '.squad/agents',
   '.copilot/skills',
 ];
 
@@ -373,6 +375,60 @@ export function ensureDirectories(dest: string): string[] {
 }
 
 /**
+ * Scaffold default casting files (registry.json, policy.json, history.json)
+ * if they don't already exist. Sources content from shipped templates when
+ * available, falling back to inline JSON defaults.
+ */
+export function ensureCastingDefaults(dest: string, templatesDir?: string): string[] {
+  const castingDir = path.join(dest, '.squad', 'casting');
+
+  // Map destination file → template file name
+  const templateMap: Array<{ name: string; templateName: string; fallback: string }> = [
+    { name: 'registry.json', templateName: 'casting-registry.json', fallback: JSON.stringify({ agents: {} }, null, 2) + '\n' },
+    { name: 'policy.json', templateName: 'casting-policy.json', fallback: JSON.stringify({ casting_policy_version: '1.1', allowlist_universes: [], universe_capacity: {} }, null, 2) + '\n' },
+    { name: 'history.json', templateName: 'casting-history.json', fallback: JSON.stringify({ universe_usage_history: [], assignment_cast_snapshots: {} }, null, 2) + '\n' },
+  ];
+
+  // Use caller-provided templatesDir when available; resolve once otherwise
+  let tDir = templatesDir;
+  if (!tDir) {
+    try {
+      tDir = getTemplatesDir();
+    } catch {
+      // templates dir not found — will use inline fallbacks
+    }
+  }
+
+  const created: string[] = [];
+  for (const file of templateMap) {
+    const filePath = path.join(castingDir, file.name);
+    if (!storage.existsSync(filePath)) {
+      // Prefer shipped template content; fall back to inline JSON
+      let content = file.fallback;
+      if (tDir) {
+        const tplPath = path.join(tDir, file.templateName);
+        if (storage.existsSync(tplPath)) {
+          const tplContent = storage.readSync(tplPath);
+          if (tplContent) content = tplContent;
+        }
+      }
+      try {
+        storage.mkdirSync(castingDir, { recursive: true });
+        storage.writeSync(filePath, content);
+        created.push(`.squad/casting/${file.name}`);
+      } catch (err: unknown) {
+        if (err instanceof Error && 'code' in err && ['EPERM', 'EACCES'].includes((err as NodeJS.ErrnoException).code ?? '')) {
+          warn(`Could not write ${file.name} to .squad/casting/ (read-only). Create it manually.`);
+          return created;
+        }
+        throw err;
+      }
+    }
+  }
+  return created;
+}
+
+/**
  * Copy all skills from package templates to .copilot/skills/ (force: false)
  */
 function syncAllSkills(dest: string, templatesDir: string): number {
@@ -429,6 +485,12 @@ function runEnsureChecks(dest: string, templatesDir: string, filesUpdated: strin
   if (dirsCreated.length > 0) {
     success(`created ${dirsCreated.length} missing directories`);
     filesUpdated.push(...dirsCreated);
+  }
+
+  const castingFiles = ensureCastingDefaults(dest, templatesDir);
+  if (castingFiles.length > 0) {
+    success(`scaffolded ${castingFiles.length} default casting files`);
+    filesUpdated.push(...castingFiles);
   }
 
   const skillCount = syncAllSkills(dest, templatesDir);

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -210,24 +210,26 @@ describe('squad doctor', () => {
 
   // ── #565 — Actionable resolution hints in warnings ────────────────
 
-  it('vscode-jsonrpc warn says "expected for global CLI installs" when not in node_modules', async () => {
+  it('vscode-jsonrpc info says "expected for global installs" when not in node_modules', async () => {
     await scaffold(TEST_ROOT);
 
     const checks = await runDoctor(TEST_ROOT);
     const jsonrpcCheck = checks.find((c: DoctorCheck) => c.name === 'vscode-jsonrpc exports field');
     expect(jsonrpcCheck).toBeDefined();
     expect(jsonrpcCheck?.status).toBe('warn');
-    expect(jsonrpcCheck?.message).toContain('expected for global CLI installs');
+    expect(jsonrpcCheck?.severity).toBe('info');
+    expect(jsonrpcCheck?.message).toContain('expected for global installs');
   });
 
-  it('copilot-sdk warn says "expected for global CLI installs" when not in node_modules', async () => {
+  it('copilot-sdk info says "expected for global installs" when not in node_modules', async () => {
     await scaffold(TEST_ROOT);
 
     const checks = await runDoctor(TEST_ROOT);
     const sdkCheck = checks.find((c: DoctorCheck) => c.name === 'copilot-sdk session.js ESM patch');
     expect(sdkCheck).toBeDefined();
     expect(sdkCheck?.status).toBe('warn');
-    expect(sdkCheck?.message).toContain('expected for global CLI installs');
+    expect(sdkCheck?.severity).toBe('info');
+    expect(sdkCheck?.message).toContain('expected for global installs');
   });
 
   it('absolute teamRoot warning includes "Edit .squad/config.json"', async () => {

--- a/test/cli/upgrade.test.ts
+++ b/test/cli/upgrade.test.ts
@@ -9,7 +9,7 @@ import { join } from 'path';
 import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync, chmodSync } from 'fs';
 import { randomBytes } from 'crypto';
 import { runInit } from '@bradygaster/squad-cli/core/init';
-import { runUpgrade, ensureGitattributes, ensureGitignore, ensureDirectories } from '@bradygaster/squad-cli/core/upgrade';
+import { runUpgrade, ensureGitattributes, ensureGitignore, ensureDirectories, ensureCastingDefaults } from '@bradygaster/squad-cli/core/upgrade';
 import { getPackageVersion } from '@bradygaster/squad-cli/core/version';
 
 const TEST_ROOT = join(process.cwd(), `.test-cli-upgrade-${randomBytes(4).toString('hex')}`);
@@ -352,5 +352,65 @@ describe('CLI: upgrade command', () => {
     // or it processes the full manifest)
     expect(forceResult.filesUpdated.length).toBeGreaterThan(0);
     expect(forceResult.filesUpdated).toContain('squad.agent.md');
+  });
+
+  /* ── ensureDirectories includes .squad/casting ──────────────── */
+
+  it('ensureDirectories creates .squad/casting/', () => {
+    const dir = join(TEST_ROOT, 'dirs-test-casting');
+    mkdirSync(dir, { recursive: true });
+    const created = ensureDirectories(dir);
+    expect(created).toContain('.squad/casting');
+    expect(existsSync(join(dir, '.squad', 'casting'))).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /* ── ensureCastingDefaults ──────────────────────────────────── */
+
+  it('ensureCastingDefaults scaffolds registry.json, policy.json, history.json', () => {
+    const dir = join(TEST_ROOT, 'casting-defaults-test');
+    mkdirSync(join(dir, '.squad', 'casting'), { recursive: true });
+    const created = ensureCastingDefaults(dir);
+    expect(created).toContain('.squad/casting/registry.json');
+    expect(created).toContain('.squad/casting/policy.json');
+    expect(created).toContain('.squad/casting/history.json');
+    // Verify valid JSON
+    const registry = JSON.parse(readFileSync(join(dir, '.squad', 'casting', 'registry.json'), 'utf8'));
+    expect(registry).toHaveProperty('agents');
+    const policy = JSON.parse(readFileSync(join(dir, '.squad', 'casting', 'policy.json'), 'utf8'));
+    expect(policy).toHaveProperty('casting_policy_version', '1.1');
+    const history = JSON.parse(readFileSync(join(dir, '.squad', 'casting', 'history.json'), 'utf8'));
+    expect(history).toHaveProperty('universe_usage_history');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('ensureCastingDefaults does not overwrite existing files', () => {
+    const dir = join(TEST_ROOT, 'casting-defaults-existing');
+    const castingDir = join(dir, '.squad', 'casting');
+    mkdirSync(castingDir, { recursive: true });
+    writeFileSync(join(castingDir, 'registry.json'), '{"agents":{"custom":true}}');
+    const created = ensureCastingDefaults(dir);
+    // registry.json should NOT be in created (already exists)
+    expect(created).not.toContain('.squad/casting/registry.json');
+    // policy.json and history.json should be created
+    expect(created).toContain('.squad/casting/policy.json');
+    expect(created).toContain('.squad/casting/history.json');
+    // Existing file should be preserved
+    const registry = JSON.parse(readFileSync(join(castingDir, 'registry.json'), 'utf8'));
+    expect(registry.agents.custom).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('upgrade scaffolds casting defaults for repos init before casting existed', async () => {
+    // Remove casting directory to simulate pre-casting init
+    const castingDir = join(TEST_ROOT, '.squad', 'casting');
+    if (existsSync(castingDir)) {
+      await rm(castingDir, { recursive: true, force: true });
+    }
+    const result = await runUpgrade(TEST_ROOT);
+    // Casting dir and defaults should be recreated
+    expect(existsSync(join(castingDir, 'registry.json'))).toBe(true);
+    expect(existsSync(join(castingDir, 'policy.json'))).toBe(true);
+    expect(existsSync(join(castingDir, 'history.json'))).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes 3 issues found during v0.9.1 insiders testing:

1. **Bug:** \squad upgrade\ doesn't create \.squad/casting/\ directory — added to ENSURE_DIRECTORIES and scaffold defaults
2. **UX:** Doctor warns about missing vscode-jsonrpc and copilot-sdk in global installs — clarified messaging
3. **Investigated:** \squad version\ command routing — confirmed correct, may be shell-specific

## Related Issues
- Closes #820 — Add .squad/casting to ENSURE_DIRECTORIES
- Closes #821 — Doctor ESM checks clarify global install context
- Relates to #822 — Init→upgrade→doctor parity test suite (deeper prevention work)

## Related PRDs
- #817 — Init/Upgrade Parity & SDK Compatibility Testing PRD
- #818 — @github/copilot-sdk Compatibility Testing & Breaking Change Detection PRD
- #819 — Automated Bug Retro Checklist on Issue Close PRD

## Root Cause
\squad init\ and \squad upgrade\ are two code paths that should produce the same scaffolding but are maintained independently with no shared contract. When casting was added to init (Mar 23), the upgrade path was never updated. See retro analysis in #817.

Found by Brady during insiders install.