### PR TITLE
fix: re-run PR readiness after Squad CI completes

### DIFF
--- a/.changeset/readiness-rerun.md
+++ b/.changeset/readiness-rerun.md
@@ -1,0 +1,8 @@
+---
+---
+
+ci: re-run PR readiness check after Squad CI completes
+
+Added workflow_run trigger to the readiness check so it refreshes after
+CI finishes. Uses PR API for draft status instead of env var (more reliable
+for workflow_run events). Includes 3 new draft-override tests.

--- a/.github/workflows/squad-pr-readiness.yml
+++ b/.github/workflows/squad-pr-readiness.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     branches: [dev, main, insider]
     types: [opened, synchronize, reopened, edited, ready_for_review]
+  workflow_run:
+    workflows: ["Squad CI"]
+    types: [completed]
 
 # NOTE: Using pull_request_target so we get a write token even for fork PRs.
 # This is safe because we never check out or execute PR code — all data
@@ -16,15 +19,18 @@ permissions:
   checks: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}
   cancel-in-progress: true
 
 jobs:
   readiness:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Skip if the PR is from a bot account (dependabot, renovate, etc.)
-    if: github.actor != 'dependabot[bot]'
+    # Skip bots, and skip workflow_run events with no associated PR
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && (github.event_name != 'workflow_run'
+          || github.event.workflow_run.pull_requests[0] != null)
     steps:
       - name: Checkout scripts
         uses: actions/checkout@v4
@@ -34,12 +40,12 @@ jobs:
       - name: Check PR readiness
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_DRAFT: ${{ github.event.pull_request.draft }}
-          PR_LABELS: ${{ toJson(github.event.pull_request.labels) }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.workflow_run.actor.login }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.event.workflow_run.pull_requests[0].base.ref }}
+          PR_DRAFT: ${{ github.event.pull_request.draft || 'false' }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels || '[]') }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           RUN_NAME: ${{ github.workflow }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ An automated readiness check runs on every PR and posts a checklist comment. Add
 | **No merge conflicts** | Resolve any conflicts with the target branch |
 | **CI passing** | All CI checks (build, test, lint) must be green |
 
-The readiness check is **informational** — it helps you self-serve before a human reviewer looks at your PR. See `.github/PR_REQUIREMENTS.md` for the full requirements spec.
+The readiness check is **informational** — it helps you self-serve before a human reviewer looks at your PR. It automatically re-runs after Squad CI completes, so the checklist stays up to date without manual intervention. See `.github/PR_REQUIREMENTS.md` for the full requirements spec.
 
 ## Code Style & Conventions
 

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -369,8 +369,25 @@ export async function run({ env = process.env, fetchFn = globalThis.fetch } = {}
   );
   checks.push({ name: 'Single commit', ...checkCommitCount(commits.length) });
 
-  // 2. Draft status
-  checks.push({ name: 'Not in draft', ...checkDraftStatus(prDraft) });
+  // Fetch PR data once (used for draft status + mergeability)
+  let prData = null;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const prRes = await fetchFn(`${apiBase}/pulls/${prNumber}`, {
+      headers: apiHeaders,
+    });
+    if (prRes.ok) {
+      prData = await prRes.json();
+      if (prData.mergeable === null && attempt === 0) {
+        await new Promise((r) => setTimeout(r, 3000));
+        continue;
+      }
+    }
+    break;
+  }
+
+  // 2. Draft status — prefer API truth over env var (workflow_run can't provide it)
+  const isDraft = prData?.draft ?? prDraft;
+  checks.push({ name: 'Not in draft', ...checkDraftStatus(isDraft) });
 
   // 3. Branch freshness
   let behindBy = null;
@@ -407,22 +424,8 @@ export async function run({ env = process.env, fetchFn = globalThis.fetch } = {}
   // 6. Scope cleanliness
   checks.push({ name: 'Scope clean', ...checkScopeClean(files) });
 
-  // 7. Mergeability
-  let mergeable = null;
-  for (let attempt = 0; attempt < 2; attempt++) {
-    const prRes = await fetchFn(`${apiBase}/pulls/${prNumber}`, {
-      headers: apiHeaders,
-    });
-    if (prRes.ok) {
-      const prData = await prRes.json();
-      if (prData.mergeable === null && attempt === 0) {
-        await new Promise((r) => setTimeout(r, 3000));
-        continue;
-      }
-      mergeable = prData.mergeable;
-    }
-    break;
-  }
+  // 7. Mergeability (uses PR data fetched above)
+  const mergeable = prData?.mergeable ?? null;
   checks.push({ name: 'No merge conflicts', ...checkMergeability(mergeable) });
 
   // 8. Copilot review threads resolved (via GraphQL)

--- a/test/pr-readiness.test.ts
+++ b/test/pr-readiness.test.ts
@@ -809,4 +809,56 @@ describe('run()', () => {
     const body = JSON.parse(postCall[1].body).body;
     expect(body).toContain(COMMENT_MARKER);
   });
+
+  // -------------------------------------------------------------------------
+  // API-based draft status override (line 389: prData?.draft ?? prDraft)
+  // -------------------------------------------------------------------------
+
+  it('uses API draft value (true) over env PR_DRAFT=false', async () => {
+    const mockFetch = createMockFetch({ pr: { draft: true, mergeable: true } });
+    const env = { ...baseEnv, PR_DRAFT: 'false' };
+    const result = await run({ env, fetchFn: mockFetch });
+
+    const draftCheck = result.checks.find((c) => c.name === 'Not in draft');
+    expect(draftCheck.pass).toBe(false);
+    expect(draftCheck.detail).toContain('draft');
+  });
+
+  it('uses API draft value (false) over env PR_DRAFT=true', async () => {
+    const mockFetch = createMockFetch({ pr: { draft: false, mergeable: true } });
+    const env = { ...baseEnv, PR_DRAFT: 'true' };
+    const result = await run({ env, fetchFn: mockFetch });
+
+    const draftCheck = result.checks.find((c) => c.name === 'Not in draft');
+    expect(draftCheck.pass).toBe(true);
+    expect(draftCheck.detail).toBe('Ready for review');
+  });
+
+  it('falls back to env PR_DRAFT when PR API fetch fails', async () => {
+    const mockFetch = createMockFetch();
+    mockFetch.mockImplementation(async (url, opts) => {
+      const headers = new Map([['link', '']]);
+      const ok = (json) => ({ ok: true, json: async () => json, headers });
+
+      if (url === 'https://api.github.com/graphql') return ok({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } });
+      // PR endpoint fails
+      if (url.match(/\/pulls\/\d+$/)) return { ok: false, status: 500, headers };
+      if (url.includes('/commits?')) return ok([{ sha: '1' }]);
+      if (url.includes('/compare/')) return ok({ behind_by: 0 });
+      if (url.includes('/reviews?')) return ok([]);
+      if (url.includes('/files?')) return ok([]);
+      if (url.includes('/check-runs?')) return ok({ check_runs: [] });
+      if (url.includes('/status')) return ok({ statuses: [] });
+      if (url.includes('/comments?')) return ok([]);
+      if (url.includes('/comments')) return ok({ id: 1 });
+      return ok({});
+    });
+
+    const env = { ...baseEnv, PR_DRAFT: 'true' };
+    const result = await run({ env, fetchFn: mockFetch });
+
+    const draftCheck = result.checks.find((c) => c.name === 'Not in draft');
+    expect(draftCheck.pass).toBe(false);
+    expect(draftCheck.detail).toContain('draft');
+  });
 });


### PR DESCRIPTION
## Problem

The readiness workflow (\squad-pr-readiness.yml\) runs on \pull_request_target\ which triggers on push. It snapshots CI status, Copilot review status, and thread status at that moment — but CI hasn't finished and Copilot hasn't re-reviewed yet. The readiness comment always shows stale data.

## Fix

Add a \workflow_run\ trigger so readiness also runs **after** the main CI workflow (\Squad CI\) completes. This gives a second pass that captures the final CI state.

The script (\pr-readiness.mjs\) already updates an existing comment (searches for \<!-- squad-pr-readiness -->\ marker), so a second run just updates the same comment with fresh data.

### Changes
- Added \workflow_run\ trigger for \Squad CI\ completion
- Conditional env vars to handle both \pull_request_target\ and \workflow_run\ event payloads
- Skip condition for \workflow_run\ events with no associated PR (non-PR pushes)

## Scope
Repo-health only — no product code changes.