### PR TITLE
fix(watch): 3 UX improvements — round timing, --log-file, immediate feedback (#2141)

### DIFF
--- a/.changeset/watch-ux-fixes-2141.md
+++ b/.changeset/watch-ux-fixes-2141.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+fix(watch): 3 UX improvements — round timing output, --log-file tee flag, immediate startup feedback (#2141)

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -177,6 +177,7 @@ async function main(): Promise<void> {
     console.log(`                    --retro           enforce retrospective checks`);
     console.log(`                    --decision-hygiene auto-merge decision inbox`);
     console.log(`             Disable: --no-<capability> overrides config.json`);
+    console.log(`             Logging: --log-file <path> tee output to file with timestamps`);
     console.log(`  ${BOLD}loop${RESET}       Prompt-driven continuous work loop`);
     console.log(`             Usage: loop [--init] [--file <path>] [--interval <min>]`);
     console.log(`             Reads loop.md and runs it each cycle (no issues needed)`);
@@ -369,6 +370,11 @@ async function main(): Promise<void> {
       ? parseInt(args[timeoutIdx + 1]!, 10)
       : undefined;
 
+    const logFileIdx = args.indexOf('--log-file');
+    const logFile = (logFileIdx !== -1 && args[logFileIdx + 1])
+      ? args[logFileIdx + 1]
+      : undefined;
+
     // Build capability overrides from CLI flags and --no-{cap} flags
     const capabilities: Record<string, boolean | Record<string, unknown>> = {};
     const registry = createDefaultRegistry();
@@ -394,6 +400,7 @@ async function main(): Promise<void> {
       timeout,
       copilotFlags,
       agentCmd,
+      logFile,
       capabilities: Object.keys(capabilities).length > 0 ? capabilities : undefined,
     });
 

--- a/packages/squad-cli/src/cli/commands/watch/config.ts
+++ b/packages/squad-cli/src/cli/commands/watch/config.ts
@@ -18,6 +18,8 @@ export interface WatchConfig {
   copilotFlags?: string;
   /** Hidden — fully override the agent command. */
   agentCmd?: string;
+  /** Optional path to a log file. When set, console output is tee'd to the file with timestamps. */
+  logFile?: string;
   /** Per-capability config: `true` / `false` / object with sub-options. */
   capabilities: Record<string, boolean | Record<string, unknown>>;
 }
@@ -63,6 +65,7 @@ export function loadWatchConfig(
     timeout: cliOverrides.timeout ?? fileConfig.timeout ?? DEFAULTS.timeout,
     copilotFlags: cliOverrides.copilotFlags ?? fileConfig.copilotFlags ?? DEFAULTS.copilotFlags,
     agentCmd: cliOverrides.agentCmd ?? fileConfig.agentCmd ?? DEFAULTS.agentCmd,
+    logFile: cliOverrides.logFile ?? fileConfig.logFile ?? DEFAULTS.logFile,
     capabilities: {
       ...DEFAULTS.capabilities,
       ...(fileConfig.capabilities ?? {}),
@@ -83,10 +86,11 @@ function normalizeFileConfig(raw: Record<string, unknown>): Partial<WatchConfig>
   if (typeof raw['timeout'] === 'number') result.timeout = raw['timeout'];
   if (typeof raw['copilotFlags'] === 'string') result.copilotFlags = raw['copilotFlags'];
   if (typeof raw['agentCmd'] === 'string') result.agentCmd = raw['agentCmd'];
+  if (typeof raw['logFile'] === 'string') result.logFile = raw['logFile'];
 
   // Everything else is a capability key
   const caps: Record<string, boolean | Record<string, unknown>> = {};
-  const reserved = new Set(['interval', 'execute', 'maxConcurrent', 'timeout', 'copilotFlags', 'agentCmd']);
+  const reserved = new Set(['interval', 'execute', 'maxConcurrent', 'timeout', 'copilotFlags', 'agentCmd', 'logFile']);
   for (const [key, value] of Object.entries(raw)) {
     if (reserved.has(key)) continue;
     if (typeof value === 'boolean' || (typeof value === 'object' && value !== null && !Array.isArray(value))) {

--- a/packages/squad-cli/src/cli/commands/watch/index.ts
+++ b/packages/squad-cli/src/cli/commands/watch/index.ts
@@ -7,6 +7,7 @@
  */
 
 import path from 'node:path';
+import fs from 'node:fs';
 import { execFile, execFileSync } from 'node:child_process';
 import { promisify } from 'node:util';
 import { FSStorageProvider } from '@bradygaster/squad-sdk';
@@ -718,6 +719,26 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
   }
   console.log();
 
+  // Fix 2: Set up log-file tee (after banner so the banner itself is captured too)
+  let logStream: fs.WriteStream | undefined;
+  if (config.logFile) {
+    const resolvedLogFile = path.resolve(config.logFile);
+    logStream = fs.createWriteStream(resolvedLogFile, { flags: 'a' });
+    const origLog = console.log.bind(console);
+    console.log = (...args: unknown[]) => {
+      origLog(...args);
+      const timestamp = new Date().toISOString().replace('T', ' ').slice(0, 19);
+      const line = args.map(a => (typeof a === 'string' ? a : String(a))).join(' ');
+      // Strip ANSI escape codes for the file
+      const plain = line.replace(/\x1b\[[0-9;]*m/g, '');
+      logStream!.write(`[${timestamp}] ${plain}\n`);
+    };
+    console.log(`${DIM}Log file: ${resolvedLogFile}${RESET}`);
+  }
+
+  // Fix 3: Immediate visual feedback after banner
+  console.log(`Running first check now...`);
+
   // Initialize circuit breaker (#515)
   const circuitBreaker = new PredictiveCircuitBreaker();
   let cbState = loadCBState(squadDirInfo.path);
@@ -769,6 +790,9 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     round++;
     const roundContext: WatchContext = { ...baseContext, round };
 
+    // Fix 1: Print round start marker
+    console.log(`\n${DIM}Starting round ${round}...${RESET}`);
+
     // Phase 1: pre-scan (self-pull, subsquad discovery)
     await runPhase('pre-scan', enabledCapabilities, roundContext, config);
 
@@ -804,6 +828,10 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     });
     await monitor.healthCheck();
     reportBoard(roundState, round);
+
+    // Fix 1: Print next poll time
+    const nextPollTime = new Date(Date.now() + interval * 60 * 1000);
+    console.log(`${DIM}Next poll at ${nextPollTime.toLocaleTimeString()}${RESET}`);
 
     // Post-round: update circuit breaker on success
     if (cbState.status === 'half-open') {
@@ -866,6 +894,7 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
       await monitor.stop();
       saveCBState(squadDirInfo.path, cbState);
       console.log(`\n${DIM}🔄 Ralph — Watch stopped${RESET}`);
+      logStream?.end();
       resolve();
     };
 


### PR DESCRIPTION
## Summary

Three UX improvements for \squad watch\ identified in E2E testing (issue tamirdresher/tamresearch1#2141).

## Changes

### Fix 1 — Round timing output (\watch/index.ts\)
- Prints \Starting round N...\ at the beginning of each round loop iteration
- Prints \Next poll at HH:MM:SS\ (local time) after each round completes, before the interval sleep

### Fix 2 — \--log-file <path>\ flag (\watch/index.ts\, \watch/config.ts\, \cli-entry.ts\)
- New \logFile?: string\ field on \WatchConfig\ interface
- When set, overrides \console.log\ to tee output to both stdout and the log file
- File output includes ISO timestamp prefix and has ANSI escape codes stripped
- Log stream is closed cleanly on shutdown
- Help text updated

### Fix 3 — Immediate visual feedback (\watch/index.ts\)
- Prints \Running first check now...\ immediately after the startup banner
- Reassures users the tool isn't stuck during the first potentially-slow check

## Testing
- \
pm run build\ passes at monorepo root
- All changes are in the watch command path; no breaking changes to existing behaviour