### PR TITLE
fix: insider publish workflow - add build step and use Node 22

### DIFF
--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 
@@ -33,13 +33,16 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-squad-node
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Build
+        run: npm run build
 
       - name: Run tests
         run: npm test
@@ -81,7 +84,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

The insider publish workflow (squad-insider-publish.yml) had 80+ test failures every run, blocking insider publishes.

### Root Cause

1. **Missing build step in test job**: The build and test jobs run on separate VMs. Since dist/ is gitignored, the test job starts with a fresh checkout that has no compiled output. Vitest fails to resolve workspace package exports.

2. **Wrong Node version**: All jobs used node-version [20], but both packages declare engines.node >= 22.5.0. The CLI version gate rejects Node 20 at runtime.

### Fix

- Added npm run build step to the test job (matching what the main CI does)
- Changed all jobs from node-version [20] to [22] (matching engines requirement and main CI)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
