### PR TITLE
fix(ci): skip Playwright tests in insider publish (covered by Squad CI)

### DIFF
--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 
@@ -33,13 +33,16 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-squad-node
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Build
+        run: npm run build
 
       - name: Run tests
         run: npm test
@@ -81,7 +84,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Run tests
-        run: npm test
+      - name: Run tests (skip Playwright — covered by Squad CI)
+        run: npx vitest run --exclude 'test/aspire-integration.test.ts'
 
   # CI Hardening: npm registry health check (item 10)
   # Fail early if registry is unreachable instead of failing mid-publish.


### PR DESCRIPTION
The insider publish workflow was running all tests including \spire-integration.test.ts\ which requires Playwright/Docker — unnecessary since Squad CI already covers these.

**Change:** In \squad-insider-publish.yml\, changed \
pm test\ to \
px vitest run --exclude 'test/aspire-integration.test.ts'\.

**Why:** The Playwright-dependent test (\spire-integration.test.ts\) needs Docker + Chromium. The publish workflow only needs to verify core functionality before publishing. Full integration coverage is handled by Squad CI.

**Release workflow:** \squad-insider-release.yml\ uses \
ode --test test/*.test.cjs\ (different runner, no Playwright dependency) — no change needed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>