### PR TITLE
fix(ci): insider publish - Node 22, build step, and Playwright install

### DIFF
--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 
@@ -41,8 +41,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Run tests
-        run: npm test
+      - name: Build
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run tests (skip docs-build — needs Docker unavailable on publish runner)
+        run: npx vitest run --exclude 'test/docs-build.test.ts'
 
   # CI Hardening: npm registry health check (item 10)
   # Fail early if registry is unreachable instead of failing mid-publish.
@@ -81,7 +87,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What

Proper fix for the insider publish workflow CI failures.

### Changes
- **Node 20 → 22** across all jobs (build, test, publish) for actions/setup-node v4 compatibility
- **Build step in test job** — tests require compiled output from \
pm run build\
- **Install Playwright Chromium** via \
px playwright install chromium --with-deps\ so aspire-integration tests actually run
- **Exclude only docs-build test** — it needs Docker which isn't available on the publish runner; all other tests (including Playwright) now run properly

### Why
The insider publish workflow runs on a clean GitHub Actions runner. Without building first and installing Playwright, the test job fails. Previous PRs (#851, #852) worked around this by skipping Playwright tests entirely — this PR fixes the root cause so the tests validate properly.

Supersedes: #851, #852