### PR TITLE
fix(test): Docker skip guards + flaky test stabilization (#677)

### DIFF
--- a/test/aspire-integration.test.ts
+++ b/test/aspire-integration.test.ts
@@ -15,6 +15,7 @@ import { trace, metrics } from '@opentelemetry/api';
 import { NodeSDK, resources, metrics as sdkMetrics } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
+import { dockerSkipReason } from './helpers/skip-guards.js';
 
 const { Resource } = resources;
 const { PeriodicExportingMetricReader } = sdkMetrics;
@@ -23,20 +24,7 @@ const { PeriodicExportingMetricReader } = sdkMetrics;
 // Skip guard — bail early if Docker is unavailable or tests disabled
 // ============================================================================
 
-function dockerAvailable(): boolean {
-  try {
-    execSync('docker --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-const SKIP_REASON = process.env['SKIP_DOCKER_TESTS'] === '1'
-  ? 'SKIP_DOCKER_TESTS=1'
-  : !dockerAvailable()
-    ? 'Docker not available'
-    : null;
+const SKIP_REASON = dockerSkipReason();
 
 const CONTAINER_NAME = 'squad-aspire-dashboard';
 const DASHBOARD_URL = 'http://localhost:18888';
@@ -71,14 +59,17 @@ function removeContainer(): void {
 }
 
 // Best-effort cleanup on unexpected exit (Ctrl+C, uncaught exception, etc.)
-// This prevents orphaned containers when the test runner is interrupted.
-for (const signal of ['SIGINT', 'SIGTERM'] as const) {
-  process.once(signal, () => {
-    removeContainer();
-    process.exit(128 + (signal === 'SIGINT' ? 2 : 15));
-  });
+// Only register handlers when Docker tests will actually run — avoids
+// Docker side effects (and stale removeContainer calls) in skip mode.
+if (SKIP_REASON === null) {
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.once(signal, () => {
+      removeContainer();
+      process.exit(128 + (signal === 'SIGINT' ? 2 : 15));
+    });
+  }
+  process.once('exit', () => removeContainer());
 }
-process.once('exit', () => removeContainer());
 
 // ============================================================================
 // OTel setup — NodeSDK with gRPC exporters targeting the Aspire dashboard

--- a/test/cli/aspire.test.ts
+++ b/test/cli/aspire.test.ts
@@ -18,6 +18,13 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { dockerSkipReason } from '../helpers/skip-guards.js';
+
+// ===========================================================================
+// Skip guard — bail early if Docker is unavailable or tests disabled
+// ===========================================================================
+
+const SKIP_REASON = dockerSkipReason();
 
 // ===========================================================================
 // Docker availability helpers (mockable)
@@ -63,29 +70,39 @@ function buildAspireStopCommands(name = 'squad-aspire-dashboard'): string[][] {
 }
 
 // ===========================================================================
-// Docker availability
+// Docker availability — requires real Docker
 // ===========================================================================
 
-describe('CLI: squad aspire — Docker availability', { timeout: 30_000 }, () => {
+describe.skipIf(SKIP_REASON !== null)(
+  `CLI: squad aspire — Docker availability (${SKIP_REASON ?? 'enabled'})`,
+  { timeout: 30_000 },
+  () => {
   it('checkDockerAvailability returns version string when Docker is present', () => {
     const result = checkDockerAvailability();
-    if (result === null) {
-      console.warn('[ENV] Docker not available — skipping Docker detection test');
-      return;
-    }
+    expect(result).not.toBeNull();
     expect(result).toMatch(/docker/i);
   });
+});
 
-  it('checkDockerAvailability returns null when Docker is absent', () => {
+// ===========================================================================
+// Docker availability — mocked (always runs, no Docker required)
+// ===========================================================================
+
+describe('CLI: squad aspire — Docker detection (mocked)', () => {
+  it('checkDockerAvailability returns null when Docker CLI is absent', () => {
     const mockExecSync = vi.fn(() => { throw new Error('docker not found'); });
     let result: string | null;
     try {
-      mockExecSync();
+      mockExecSync('docker --version', { encoding: 'utf-8', timeout: 5000 });
       result = 'unexpected';
     } catch {
       result = null;
     }
     expect(result).toBeNull();
+    expect(mockExecSync).toHaveBeenCalledWith(
+      'docker --version',
+      expect.objectContaining({ encoding: 'utf-8' }),
+    );
   });
 });
 

--- a/test/helpers/skip-guards.ts
+++ b/test/helpers/skip-guards.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared test helpers for Docker-related skip guards and environment detection.
+ *
+ * Provides reusable functions for detecting Docker availability
+ * and determining whether Docker-dependent test suites should run.
+ */
+
+import { execSync } from 'node:child_process';
+
+/**
+ * Check if Docker is usable on this machine.
+ * Returns true if `docker info` succeeds within 5 seconds.
+ */
+export function isDockerAvailable(): boolean {
+  try {
+    execSync('docker info', { stdio: 'ignore', timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Determine skip reason for Docker-dependent tests.
+ * Returns null if tests should run, or a string reason to skip.
+ */
+export function dockerSkipReason(): string | null {
+  if (process.env['SKIP_DOCKER_TESTS'] === '1') {
+    return 'SKIP_DOCKER_TESTS=1';
+  }
+  if (!isDockerAvailable()) {
+    return 'Docker not available';
+  }
+  return null;
+}

--- a/test/template-sync.test.ts
+++ b/test/template-sync.test.ts
@@ -153,7 +153,7 @@ describe('sync-templates.mjs script execution', () => {
     const output = execSync('node scripts/sync-templates.mjs', {
       cwd: ROOT,
       encoding: 'utf-8',
-      timeout: 30_000,
+      timeout: 60_000,
     });
     expect(output).toContain('Synced');
   });


### PR DESCRIPTION
Cherry-picks the fix from #723. Adds shared Docker skip guard helper and stabilizes flaky tests.

## Changes
- **New:** \	est/helpers/skip-guards.ts\ — shared \dockerSkipReason()\ helper
- **Refactored:** \	est/aspire-integration.test.ts\ — uses shared helper instead of inline Docker check
- **Added:** \	est/cli/aspire.test.ts\ — \describe.skipIf\ guard so Docker tests skip gracefully
- **Fixed:** \	est/template-sync.test.ts\ — timeout 30s → 60s for flaky stability

## Testing
- ✅ 162 tests pass (Docker tests skip gracefully without Docker)
- ✅ 5 aspire-integration tests correctly skipped

Original author: @tamirdresher
Closes #677, fixes #582

Part of stale PR triage (diberry/squad#137)