### PR TITLE
fix(ci): prevent template literal injection in repo-health workflow

### DIFF
--- a/.github/workflows/squad-repo-health.yml
+++ b/.github/workflows/squad-repo-health.yml
@@ -41,9 +41,10 @@ jobs:
           OUTPUT=$(node scripts/check-bootstrap-deps.mjs --ref ${{ github.event.pull_request.head.sha }} 2>&1)
           EXIT_CODE=$?
           echo "$OUTPUT"
-          echo "result<<EOF" >> $GITHUB_OUTPUT
+          DELIM="EOF_$(uuidgen)"
+          echo "result<<${DELIM}" >> $GITHUB_OUTPUT
           echo "$OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${DELIM}" >> $GITHUB_OUTPUT
           echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
           exit $EXIT_CODE
 
@@ -95,19 +96,22 @@ jobs:
           git fetch origin dev --quiet
           OUTPUT=$(node scripts/check-squad-leakage.mjs origin/dev ${{ github.event.pull_request.head.sha }} 2>&1)
           echo "$OUTPUT"
-          echo "result<<EOF" >> $GITHUB_OUTPUT
+          DELIM="EOF_$(uuidgen)"
+          echo "result<<${DELIM}" >> $GITHUB_OUTPUT
           echo "$OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${DELIM}" >> $GITHUB_OUTPUT
       - name: Comment on leakage
         if: always()
         uses: actions/github-script@v7
+        env:
+          STEP_RESULT: ${{ steps.leakage.outputs.result }}
         with:
           script: |
             const { run } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/repo-health-comment.mjs`);
             await run({
               github,
               context,
-              output: `${{ steps.leakage.outputs.result }}`,
+              output: process.env.STEP_RESULT ?? '',
               job: 'leakage',
             });
 
@@ -132,19 +136,22 @@ jobs:
           git fetch origin dev --quiet
           OUTPUT=$(node scripts/architectural-review.mjs origin/dev ${{ github.event.pull_request.head.sha }} 2>&1)
           echo "$OUTPUT"
-          echo "result<<EOF" >> $GITHUB_OUTPUT
+          DELIM="EOF_$(uuidgen)"
+          echo "result<<${DELIM}" >> $GITHUB_OUTPUT
           echo "$OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${DELIM}" >> $GITHUB_OUTPUT
       - name: Comment on findings
         if: always()
         uses: actions/github-script@v7
+        env:
+          STEP_RESULT: ${{ steps.arch.outputs.result }}
         with:
           script: |
             const { run } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/repo-health-comment.mjs`);
             await run({
               github,
               context,
-              output: `${{ steps.arch.outputs.result }}`,
+              output: process.env.STEP_RESULT ?? '',
               job: 'architectural',
             });
 
@@ -169,18 +176,21 @@ jobs:
           git fetch origin dev --quiet
           OUTPUT=$(node scripts/security-review.mjs origin/dev ${{ github.event.pull_request.head.sha }} 2>&1)
           echo "$OUTPUT"
-          echo "result<<EOF" >> $GITHUB_OUTPUT
+          DELIM="EOF_$(uuidgen)"
+          echo "result<<${DELIM}" >> $GITHUB_OUTPUT
           echo "$OUTPUT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${DELIM}" >> $GITHUB_OUTPUT
       - name: Comment on findings
         if: always()
         uses: actions/github-script@v7
+        env:
+          STEP_RESULT: ${{ steps.security.outputs.result }}
         with:
           script: |
             const { run } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/repo-health-comment.mjs`);
             await run({
               github,
               context,
-              output: `${{ steps.security.outputs.result }}`,
+              output: process.env.STEP_RESULT ?? '',
               job: 'security',
             });


### PR DESCRIPTION
Closes #769 - fixes P2 security finding from RETRO audit.

## Problem
squad-repo-health.yml injects step outputs directly into actions/github-script script: blocks via JS template literals. If output contains backticks or template expressions, they get interpreted as code.

## Fix
- **Template literal injection (primary):** Moved all 3 step output references to env: blocks. Scripts now read process.env.STEP_RESULT (with ?? '' fallback) - treated as data, not code.
- **Heredoc delimiter injection (secondary):** Replaced all 4 static EOF delimiters with unique uuidgen-based delimiters to prevent early termination.

## Changes
- .github/workflows/squad-repo-health.yml (1 file, 21 insertions, 11 deletions)
- No changes to scripts/repo-health-comment.mjs (contract unchanged)