### PR TITLE
test: add cross-package export smoke test to catch missing imports

### DIFF
--- a/.changeset/readiness-file-list.md
+++ b/.changeset/readiness-file-list.md
@@ -1,0 +1,7 @@
+---
+---
+
+ci: add file list with line stats to PR readiness comment
+
+The PR readiness bot now shows changed files with per-file addition/deletion
+counts, scope classification (Product/Infrastructure/Mixed), and totals.

--- a/.changeset/scope-boundary-check.md
+++ b/.changeset/scope-boundary-check.md
@@ -1,0 +1,8 @@
+---
+---
+
+ci: scope boundary enforcement for repo-health PRs
+
+New CI check that fails repo-health PRs if they modify product source
+code under packages/*/src/. Enforces separation between infrastructure
+and product changes.

--- a/.changeset/smart-pr-nudge.md
+++ b/.changeset/smart-pr-nudge.md
@@ -1,0 +1,8 @@
+---
+---
+
+ci: add smart PR nudge for stale PRs
+
+New workflow that runs on weekdays and posts actionable diagnoses on PRs
+stale for 7+ days. Checks CI status, unresolved threads, missing reviews,
+outdated branches, and draft status. Won't nudge the same PR twice per week.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,6 +146,10 @@ Any PR that modifies files under `packages/squad-cli/src/` or `packages/squad-sd
 - The `changelog-gate` CI check will fail without this
 - Escape hatch: add the `skip-changelog` label (use sparingly)
 
+## Automated PR Nudge
+
+The **PR Nudge** workflow (`.github/workflows/squad-pr-nudge.yml`) runs on weekdays at 2pm UTC and posts actionable comments on open PRs that have been stale for 7+ days. It diagnoses specific blockers — failing CI checks, unresolved review threads, missing approvals, outdated branches, and draft status — so PR authors know exactly what to do next. Draft PRs get a 14-day grace period. The workflow won't nudge the same PR more than once per week.
+
 ## Decisions
 
 If you make a decision that affects other team members, write it to:

--- a/.github/workflows/squad-pr-nudge.yml
+++ b/.github/workflows/squad-pr-nudge.yml
@@ -1,0 +1,184 @@
+name: PR Nudge
+on:
+  schedule:
+    - cron: '0 14 * * 1-5' # 2pm UTC weekdays (morning US Pacific)
+  workflow_dispatch: {} # manual trigger for testing
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: read
+  issues: read
+
+jobs:
+  nudge-stale-prs:
+    name: "Nudge Stale PRs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const STALE_DAYS = 7;
+            const cutoff = new Date();
+            cutoff.setDate(cutoff.getDate() - STALE_DAYS);
+
+            // Get all open PRs, oldest-updated first
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'updated',
+              direction: 'asc',
+              per_page: 50
+            });
+
+            for (const pr of prs.data) {
+              // Skip PRs updated recently
+              const lastPush = new Date(pr.updated_at);
+              if (lastPush > cutoff) continue;
+
+              // Give draft PRs 14 days grace period instead of 7
+              if (pr.draft) {
+                const created = new Date(pr.created_at);
+                const draftCutoff = new Date();
+                draftCutoff.setDate(draftCutoff.getDate() - 14);
+                if (created > draftCutoff) continue;
+              }
+
+              // Don't nudge the same PR more than once per week
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 5,
+                sort: 'created',
+                direction: 'desc'
+              });
+              const recentNudge = comments.data.find(c =>
+                c.user.login === 'github-actions[bot]' &&
+                c.body.includes('<!-- pr-nudge -->') &&
+                new Date(c.created_at) > cutoff
+              );
+              if (recentNudge) continue;
+
+              // Build the diagnosis — collect actionable items
+              const actions = [];
+              const daysSinceUpdate = Math.floor((Date.now() - lastPush) / (1000 * 60 * 60 * 24));
+
+              // 1. Check if still in draft
+              if (pr.draft) {
+                actions.push('📝 **Still in draft** — mark as "Ready for review" when you\'re done, or close if abandoned.');
+              }
+
+              // 2. Check CI status for failures
+              const checks = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.head.sha,
+                per_page: 50
+              });
+              const failedChecks = checks.data.check_runs.filter(c =>
+                c.conclusion === 'failure'
+              ).map(c => c.name);
+              if (failedChecks.length > 0) {
+                actions.push(`🔴 **${failedChecks.length} CI check(s) failing:** ${failedChecks.join(', ')}. Fix these first.`);
+              }
+
+              // 3. Check for unresolved review threads (Copilot vs human)
+              const threads = await github.graphql(`
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 50) {
+                        nodes {
+                          isResolved
+                          isOutdated
+                          comments(first: 1) {
+                            nodes { author { login } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: pr.number
+              });
+              const unresolvedThreads = threads.repository.pullRequest.reviewThreads.nodes
+                .filter(t => !t.isResolved && !t.isOutdated);
+              if (unresolvedThreads.length > 0) {
+                const copilotThreads = unresolvedThreads.filter(t =>
+                  t.comments.nodes[0]?.author?.login?.includes('copilot')
+                );
+                const humanThreads = unresolvedThreads.length - copilotThreads.length;
+                const parts = [];
+                if (copilotThreads.length > 0) parts.push(`${copilotThreads.length} from Copilot`);
+                if (humanThreads > 0) parts.push(`${humanThreads} from reviewers`);
+                actions.push(`💬 **${unresolvedThreads.length} unresolved review thread(s)** (${parts.join(', ')}). Address and resolve them.`);
+              }
+
+              // 4. Check review state (changes requested vs approved vs none)
+              const reviews = await github.rest.pulls.listReviews({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number
+              });
+              const latestByUser = {};
+              for (const r of reviews.data) {
+                if (r.state === 'COMMENTED') continue;
+                latestByUser[r.user.login] = r;
+              }
+              const changesRequested = Object.values(latestByUser).filter(r => r.state === 'CHANGES_REQUESTED');
+              const approvals = Object.values(latestByUser).filter(r => r.state === 'APPROVED');
+              if (changesRequested.length > 0) {
+                const reviewers = changesRequested.map(r => `@${r.user.login}`).join(', ');
+                actions.push(`🔄 **Changes requested** by ${reviewers}. Address their feedback and request re-review.`);
+              } else if (approvals.length === 0 && !pr.draft) {
+                actions.push('👀 **No approving reviews yet.** Request a review from a teammate.');
+              }
+
+              // 5. Check if branch is behind base
+              const comparison = await github.rest.repos.compareCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                base: pr.head.sha,
+                head: pr.base.ref
+              });
+              if (comparison.data.ahead_by > 10) {
+                actions.push(`⬇️ **${comparison.data.ahead_by} commits behind ${pr.base.ref}.** Rebase to pick up latest changes.`);
+              }
+
+              // 6. If everything looks good and approved — it's ready to merge
+              if (actions.length === 0 && approvals.length > 0) {
+                actions.push('✅ **Looks ready to merge!** All checks pass, approved — just needs someone to click merge.');
+              }
+
+              // Fallback if no specific blockers found
+              if (actions.length === 0) {
+                actions.push('🤔 **No obvious blockers found** — but this PR has been quiet. Is it still active?');
+              }
+
+              // Post the nudge comment
+              const body = [
+                '<!-- pr-nudge -->',
+                `👋 **Friendly nudge** — this PR has had no activity for **${daysSinceUpdate} days**.`,
+                '',
+                '**What needs attention:**',
+                ...actions.map(a => `- ${a}`),
+                '',
+                '---',
+                '*If this PR is abandoned, please close it. If it\'s blocked on something external, leave a comment so the team knows.*',
+                '*This is an automated check that runs on weekdays. It won\'t nudge the same PR more than once per week.*'
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: body
+              });
+
+              core.info(`Nudged PR #${pr.number}: ${pr.title} (${daysSinceUpdate} days stale, ${actions.length} action items)`);
+            }

--- a/.github/workflows/squad-repo-health.yml
+++ b/.github/workflows/squad-repo-health.yml
@@ -113,7 +113,7 @@ jobs:
 
   # ─── Architectural Review (INFORMATIONAL) ───────────────────────────
   architectural-review:
-    name: Architectural Review
+    name: Architectural Review — Structure & Design Rules
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: github.actor != 'dependabot[bot]'
@@ -150,7 +150,7 @@ jobs:
 
   # ─── Security Review (INFORMATIONAL) ────────────────────────────────
   security-review:
-    name: Security Review
+    name: Security Review — Permissions & Secrets
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/squad-scope-check.yml
+++ b/.github/workflows/squad-scope-check.yml
@@ -1,0 +1,31 @@
+name: Scope Check
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  scope-boundary:
+    name: "Scope Boundary"
+    runs-on: ubuntu-latest
+    if: >-
+      startsWith(github.head_ref, 'repo-health/') ||
+      contains(github.event.pull_request.labels.*.name, 'repo-health')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for product code in repo-health PR
+        run: |
+          PRODUCT_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'packages/squad-cli/src/' 'packages/squad-sdk/src/')
+          if [ -n "$PRODUCT_FILES" ]; then
+            echo "::error::Repo-health PRs must not modify product source code."
+            echo "::error::The following product files were changed:"
+            echo "$PRODUCT_FILES" | while read -r f; do echo "::error::  - $f"; done
+            echo "::error::Move product changes to a separate PR."
+            exit 1
+          fi
+          echo "✅ No product source files in this repo-health PR."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,8 @@ An automated readiness check runs on every PR and posts a checklist comment. Add
 | **No merge conflicts** | Resolve any conflicts with the target branch |
 | **CI passing** | All CI checks (build, test, lint) must be green |
 
+The readiness comment also includes a **file list with line stats** — each changed file is shown with per-file addition/deletion counts, a scope classification (Product/Infrastructure/Mixed), and totals. This helps reviewers quickly gauge PR size and impact.
+
 The readiness check is **informational** — it helps you self-serve before a human reviewer looks at your PR. It automatically re-runs after Squad CI completes, so the checklist stays up to date without manual intervention. See `.github/PR_REQUIREMENTS.md` for the full requirements spec.
 
 ## Code Style & Conventions

--- a/scripts/pr-readiness.mjs
+++ b/scripts/pr-readiness.mjs
@@ -247,6 +247,86 @@ export function checkCIStatus(checkRuns, statuses) {
 }
 
 // ---------------------------------------------------------------------------
+// Scope classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify the PR scope based on changed files.
+ * @param {Array<{ filename: string }>} files
+ * @returns {{ label: string, emoji: string }}
+ */
+export function classifyScope(files) {
+  const hasProduct = (files || []).some((f) => SOURCE_PATTERN.test(f.filename));
+  const hasInfra = (files || []).some((f) => !SOURCE_PATTERN.test(f.filename));
+
+  if (hasProduct && hasInfra) {
+    return { label: 'Mixed (product + infrastructure)', emoji: '📦🔧' };
+  }
+  if (hasProduct) {
+    return { label: 'Product', emoji: '📦' };
+  }
+  return { label: 'Infrastructure', emoji: '🔧' };
+}
+
+// ---------------------------------------------------------------------------
+// File list builder
+// ---------------------------------------------------------------------------
+
+/** Maximum files shown in the file list before truncation. */
+export const MAX_FILE_LIST = 50;
+
+/**
+ * Sanitize a filename for safe inclusion in a markdown table cell.
+ * Escapes pipe characters, replaces backticks, and collapses newlines.
+ * @param {string} name
+ * @returns {string}
+ */
+export function sanitizeFilename(name) {
+  return name
+    .replace(/\|/g, '\\|')
+    .replace(/`/g, "'")
+    .replace(/[\r\n]+/g, ' ');
+}
+
+/**
+ * Build a markdown section listing changed files with per-file line stats.
+ * @param {Array<{ filename: string, additions?: number, deletions?: number }>} files
+ * @returns {string}
+ */
+export function buildFileList(files) {
+  if (!files || files.length === 0) {
+    return '';
+  }
+
+  const totalAdded = files.reduce((sum, f) => sum + (f.additions || 0), 0);
+  const totalDeleted = files.reduce((sum, f) => sum + (f.deletions || 0), 0);
+
+  const displayed = files.slice(0, MAX_FILE_LIST);
+  const truncated = files.length > MAX_FILE_LIST;
+
+  const rows = displayed.map((f) => {
+    const added = f.additions || 0;
+    const deleted = f.deletions || 0;
+    return `| \`${sanitizeFilename(f.filename)}\` | +${added} −${deleted} |`;
+  });
+
+  if (truncated) {
+    const remaining = files.length - MAX_FILE_LIST;
+    rows.push(`| ... | **+${remaining} more files** | |`);
+  }
+
+  return [
+    `### Files Changed (${files.length} file${files.length === 1 ? '' : 's'}, +${totalAdded} −${totalDeleted})`,
+    '',
+    '| File | +/− |',
+    '|------|-----|',
+    ...rows,
+    '',
+    `**Total: +${totalAdded} −${totalDeleted}**`,
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
 // Checklist markdown builder
 // ---------------------------------------------------------------------------
 
@@ -257,9 +337,10 @@ export function checkCIStatus(checkRuns, statuses) {
  * @param {string} repo
  * @param {string} baseRef
  * @param {string} [headSha] — commit SHA that triggered the check
+ * @param {Array<{ filename: string, additions?: number, deletions?: number }>} [files]
  * @returns {string}
  */
-export function buildChecklist(checks, owner, repo, baseRef, headSha) {
+export function buildChecklist(checks, owner, repo, baseRef, headSha, files) {
   const allPass = checks.every((c) => c.pass);
   const passCount = checks.filter((c) => c.pass).length;
 
@@ -272,23 +353,37 @@ export function buildChecklist(checks, owner, repo, baseRef, headSha) {
     return `| ${icon} | **${c.name}** | ${c.detail} |`;
   });
 
-  return [
+  const scope = classifyScope(files);
+
+  const sections = [
     COMMENT_MARKER,
     '## 🛫 PR Readiness Check',
     ...(headSha
       ? [`> ℹ️ This comment updates on each push. Last checked: commit \`${headSha.slice(0, 7)}\``]
       : []),
     '',
+    `**PR Scope:** ${scope.emoji} ${scope.label}`,
+    '',
     status,
     '',
     '| Status | Check | Details |',
     '|--------|-------|---------|',
     ...rows,
+  ];
+
+  const fileList = buildFileList(files);
+  if (fileList) {
+    sections.push('', fileList);
+  }
+
+  sections.push(
     '',
     '---',
     '*This check runs automatically on every push. Fix any ❌ items and push again.*',
     `*See [CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/${baseRef}/CONTRIBUTING.md#pr-readiness-checklist) and [PR Requirements](https://github.com/${owner}/${repo}/blob/${baseRef}/.github/PR_REQUIREMENTS.md) for details.*`,
-  ].join('\n');
+  );
+
+  return sections.join('\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -492,7 +587,7 @@ export async function run({ env = process.env, fetchFn = globalThis.fetch } = {}
   checks.push({ name: 'CI passing', ...checkCIStatus(checkRuns, statusEntries) });
 
   // ── Build checklist and upsert comment ──
-  const body = buildChecklist(checks, owner, repo, prBaseRef, prHeadSha);
+  const body = buildChecklist(checks, owner, repo, prBaseRef, prHeadSha, files);
 
   // Find existing comment
   const existingComments = await paginate(

--- a/test/cross-package-exports.test.ts
+++ b/test/cross-package-exports.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Cross-package export smoke test
+ *
+ * Validates that every value import squad-cli uses from squad-sdk actually
+ * exists at runtime.  TypeScript can resolve from source during development,
+ * but the compiled npm output may diverge (missing re-exports, renamed files,
+ * ESM/CJS mismatches).  This test catches that class of bug.
+ *
+ * How it works:
+ *   For each SDK subpath the CLI imports from, we dynamically import the
+ *   module and assert every named export the CLI relies on is defined.
+ *
+ * Maintenance:
+ *   When a new import from @bradygaster/squad-sdk is added to squad-cli,
+ *   add a corresponding assertion here.  The grep one-liner in the test
+ *   description shows how to audit.
+ *
+ * Related incident: v0.9.3-insider.1 shipped with FSStorageProvider missing
+ * from the SDK barrel — broke users at runtime while tests passed locally.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ─── Helper ──────────────────────────────────────────────────────────────
+
+/** Assert a set of named exports exist on a module. */
+function expectExports(mod: Record<string, unknown>, names: string[], subpath: string) {
+  for (const name of names) {
+    expect(mod[name], `"${name}" should be exported from ${subpath}`).toBeDefined();
+  }
+}
+
+// ─── Root barrel: @bradygaster/squad-sdk ─────────────────────────────────
+
+describe('cross-package exports — CLI → SDK', () => {
+  describe('@bradygaster/squad-sdk (root barrel)', () => {
+    it('exports FSStorageProvider and core runtime symbols', async () => {
+      const sdk = await import('@bradygaster/squad-sdk');
+      expectExports(sdk, [
+        'FSStorageProvider',
+        'SquadState',
+        'TIMEOUTS',
+        'StreamingPipeline',
+        'RuntimeEventBus',
+        'resolveSquad',
+        'resolveGlobalSquadPath',
+        'initSquadTelemetry',
+        'recordAgentSpawn',
+        'recordAgentDuration',
+        'recordAgentError',
+        'recordAgentDestroy',
+        'safeTimestamp',
+        'getMeter',
+      ], '@bradygaster/squad-sdk');
+    });
+
+    it('exports role helpers', async () => {
+      const sdk = await import('@bradygaster/squad-sdk');
+      expectExports(sdk, [
+        'listRoles',
+        'searchRoles',
+        'getCategories',
+        'getRoleById',
+        'generateCharterFromRole',
+        'addAgentToConfig',
+      ], '@bradygaster/squad-sdk');
+    });
+
+    it('exports init / personal-squad helpers', async () => {
+      const sdk = await import('@bradygaster/squad-sdk');
+      expectExports(sdk, [
+        'initSquad',
+        'cleanupOrphanInitPrompt',
+        'ensurePersonalSquadDir',
+        'resolvePersonalSquadDir',
+      ], '@bradygaster/squad-sdk');
+    });
+
+    it('exports external-state helpers', async () => {
+      const sdk = await import('@bradygaster/squad-sdk');
+      expectExports(sdk, [
+        'resolveExternalStateDir',
+        'deriveProjectKey',
+      ], '@bradygaster/squad-sdk');
+    });
+
+    it('exports consult-mode helpers', async () => {
+      const sdk = await import('@bradygaster/squad-sdk');
+      expectExports(sdk, [
+        'setupConsultMode',
+        'isConsultMode',
+        'PersonalSquadNotFoundError',
+        'detectLicense',
+        'loadStagedLearnings',
+        'logConsultation',
+        'mergeToPersonalSquad',
+        'getPersonalSquadRoot',
+      ], '@bradygaster/squad-sdk');
+    });
+
+    it('exports cross-squad helpers', async () => {
+      const sdk = await import('@bradygaster/squad-sdk');
+      expectExports(sdk, [
+        'discoverSquads',
+        'formatDiscoveryTable',
+        'findSquadByName',
+        'buildDelegationArgs',
+        'loadSubSquadsConfig',
+        'resolveSubSquad',
+      ], '@bradygaster/squad-sdk');
+    });
+
+    it('exports RemoteBridge', async () => {
+      const sdk = await import('@bradygaster/squad-sdk');
+      expectExports(sdk, ['RemoteBridge'], '@bradygaster/squad-sdk');
+    });
+  });
+
+  // ─── Subpath: /config ──────────────────────────────────────────────────
+
+  describe('@bradygaster/squad-sdk/config', () => {
+    it('exports config helpers used by CLI', async () => {
+      const mod = await import('@bradygaster/squad-sdk/config');
+      expectExports(mod, [
+        'initSquad',
+        'MigrationRegistry',
+        'writeEconomyMode',
+        'readEconomyMode',
+      ], '@bradygaster/squad-sdk/config');
+    });
+  });
+
+  // ─── Subpath: /config/agent-source ─────────────────────────────────────
+
+  describe('@bradygaster/squad-sdk/config/agent-source', () => {
+    it('exports LocalAgentSource', async () => {
+      const mod = await import('@bradygaster/squad-sdk/config/agent-source');
+      expectExports(mod, ['LocalAgentSource'], '@bradygaster/squad-sdk/config/agent-source');
+    });
+  });
+
+  // ─── Subpath: /resolution ──────────────────────────────────────────────
+
+  describe('@bradygaster/squad-sdk/resolution', () => {
+    it('exports resolution helpers', async () => {
+      const mod = await import('@bradygaster/squad-sdk/resolution');
+      expectExports(mod, [
+        'resolveSquad',
+        'resolveSquadPaths',
+        'resolveGlobalSquadPath',
+        'resolvePersonalSquadDir',
+        'ensurePersonalSquadDir',
+      ], '@bradygaster/squad-sdk/resolution');
+    });
+  });
+
+  // ─── Subpath: /client ──────────────────────────────────────────────────
+
+  describe('@bradygaster/squad-sdk/client', () => {
+    it('exports SquadClient', async () => {
+      const mod = await import('@bradygaster/squad-sdk/client');
+      expectExports(mod, ['SquadClient'], '@bradygaster/squad-sdk/client');
+    });
+  });
+
+  // ─── Subpath: /adapter/errors ──────────────────────────────────────────
+
+  describe('@bradygaster/squad-sdk/adapter/errors', () => {
+    it('exports RateLimitError', async () => {
+      const mod = await import('@bradygaster/squad-sdk/adapter/errors');
+      expectExports(mod, ['RateLimitError'], '@bradygaster/squad-sdk/adapter/errors');
+    });
+  });
+
+  // ─── Subpath: /agents/personal ─────────────────────────────────────────
+
+  describe('@bradygaster/squad-sdk/agents/personal', () => {
+    it('exports personal-agent helpers', async () => {
+      const mod = await import('@bradygaster/squad-sdk/agents/personal');
+      expectExports(mod, [
+        'resolvePersonalAgents',
+        'mergeSessionCast',
+      ], '@bradygaster/squad-sdk/agents/personal');
+    });
+  });
+
+  // ─── Subpath: /casting ─────────────────────────────────────────────────
+
+  describe('@bradygaster/squad-sdk/casting', () => {
+    it('exports CastingEngine', async () => {
+      const mod = await import('@bradygaster/squad-sdk/casting');
+      expectExports(mod, ['CastingEngine'], '@bradygaster/squad-sdk/casting');
+    });
+  });
+
+  // ─── Subpath: /platform ────────────────────────────────────────────────
+
+  describe('@bradygaster/squad-sdk/platform', () => {
+    it('exports createPlatformAdapter', async () => {
+      const mod = await import('@bradygaster/squad-sdk/platform');
+      expectExports(mod, ['createPlatformAdapter'], '@bradygaster/squad-sdk/platform');
+    });
+  });
+
+  // ─── Subpath: /ralph ───────────────────────────────────────────────────
+
+  describe('@bradygaster/squad-sdk/ralph', () => {
+    it('exports RalphMonitor', async () => {
+      const mod = await import('@bradygaster/squad-sdk/ralph');
+      expectExports(mod, ['RalphMonitor'], '@bradygaster/squad-sdk/ralph');
+    });
+  });
+
+  describe('@bradygaster/squad-sdk/ralph/triage', () => {
+    it('exports triage helpers', async () => {
+      const mod = await import('@bradygaster/squad-sdk/ralph/triage');
+      expectExports(mod, [
+        'parseRoster',
+        'parseRoutingRules',
+        'parseModuleOwnership',
+        'triageIssue',
+      ], '@bradygaster/squad-sdk/ralph/triage');
+    });
+  });
+
+  describe('@bradygaster/squad-sdk/ralph/rate-limiting', () => {
+    it('exports rate-limiting helpers', async () => {
+      const mod = await import('@bradygaster/squad-sdk/ralph/rate-limiting');
+      expectExports(mod, [
+        'PredictiveCircuitBreaker',
+        'getTrafficLight',
+      ], '@bradygaster/squad-sdk/ralph/rate-limiting');
+    });
+  });
+
+  // ─── Subpath: /runtime/* ───────────────────────────────────────────────
+
+  describe('@bradygaster/squad-sdk/runtime/event-bus', () => {
+    it('exports EventBus', async () => {
+      const mod = await import('@bradygaster/squad-sdk/runtime/event-bus');
+      expectExports(mod, ['EventBus'], '@bradygaster/squad-sdk/runtime/event-bus');
+    });
+  });
+
+  // ─── SDK exports-map file resolution ───────────────────────────────────
+
+  describe('SDK package.json exports map → file existence', () => {
+    it('every exports-map entry points to an existing file', async () => {
+      const fs = await import('node:fs');
+
+      // In a workspace monorepo the SDK lives at packages/squad-sdk.
+      // In CI / installed scenarios, find it under node_modules.
+      const candidates = [
+        resolve(process.cwd(), 'packages', 'squad-sdk'),
+        resolve(process.cwd(), 'node_modules', '@bradygaster', 'squad-sdk'),
+      ];
+      const sdkRoot = candidates.find(
+        (p) => existsSync(resolve(p, 'package.json')),
+      );
+      expect(sdkRoot, 'Could not locate SDK package.json').toBeDefined();
+
+      const pkg = JSON.parse(
+        fs.readFileSync(resolve(sdkRoot!, 'package.json'), 'utf8'),
+      );
+      const exportsMap = pkg.exports as Record<string, Record<string, string>>;
+      const missing: string[] = [];
+
+      for (const [subpath, targets] of Object.entries(exportsMap)) {
+        if (typeof targets === 'string') {
+          if (!existsSync(resolve(sdkRoot!, targets))) {
+            missing.push(`${subpath} → ${targets}`);
+          }
+          continue;
+        }
+        for (const [condition, file] of Object.entries(targets)) {
+          if (!existsSync(resolve(sdkRoot!, file))) {
+            missing.push(`${subpath}[${condition}] → ${file}`);
+          }
+        }
+      }
+
+      expect(missing, `Missing files in SDK exports map:\n${missing.join('\n')}`).toEqual([]);
+    });
+  });
+});

--- a/test/pr-readiness.test.ts
+++ b/test/pr-readiness.test.ts
@@ -17,6 +17,10 @@ import {
   checkCopilotThreads,
   checkCIStatus,
   buildChecklist,
+  buildFileList,
+  sanitizeFilename,
+  MAX_FILE_LIST,
+  classifyScope,
   paginate,
   run,
   COMMENT_MARKER,
@@ -495,6 +499,229 @@ describe('buildChecklist', () => {
     expect(body).toContain('| ✅ | **A** | OK |');
     expect(body).toContain('| ❌ | **B** | Bad |');
   });
+
+  it('includes file list when files are provided', () => {
+    const checks = [{ name: 'Test', pass: true, detail: 'OK' }];
+    const files = [
+      { filename: 'src/index.ts', additions: 10, deletions: 3 },
+      { filename: 'README.md', additions: 2, deletions: 1 },
+    ];
+    const body = buildChecklist(checks, 'o', 'r', 'dev', undefined, files);
+    expect(body).toContain('### Files Changed (2 files, +12 −4)');
+    expect(body).toContain('| `src/index.ts` | +10 −3 |');
+    expect(body).toContain('| `README.md` | +2 −1 |');
+    expect(body).toContain('**Total: +12 −4**');
+  });
+
+  it('omits file list when files are undefined', () => {
+    const checks = [{ name: 'Test', pass: true, detail: 'OK' }];
+    const body = buildChecklist(checks, 'o', 'r', 'dev');
+    expect(body).not.toContain('Files Changed');
+  });
+
+  it('omits file list when files array is empty', () => {
+    const checks = [{ name: 'Test', pass: true, detail: 'OK' }];
+    const body = buildChecklist(checks, 'o', 'r', 'dev', undefined, []);
+    expect(body).not.toContain('Files Changed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFileList
+// ---------------------------------------------------------------------------
+
+describe('buildFileList', () => {
+  it('returns empty string for null/undefined input', () => {
+    expect(buildFileList(null)).toBe('');
+    expect(buildFileList(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty array', () => {
+    expect(buildFileList([])).toBe('');
+  });
+
+  it('renders a single file with correct stats', () => {
+    const files = [{ filename: 'scripts/moderate-spam.mjs', additions: 142, deletions: 0 }];
+    const result = buildFileList(files);
+    expect(result).toContain('### Files Changed (1 file, +142 −0)');
+    expect(result).toContain('| `scripts/moderate-spam.mjs` | +142 −0 |');
+    expect(result).toContain('**Total: +142 −0**');
+  });
+
+  it('renders multiple files with totals', () => {
+    const files = [
+      { filename: 'scripts/moderate-spam.mjs', additions: 142, deletions: 0 },
+      { filename: 'test/scripts/moderate-spam.test.ts', additions: 98, deletions: 0 },
+      { filename: '.github/workflows/squad-comment-moderation.yml', additions: 45, deletions: 0 },
+    ];
+    const result = buildFileList(files);
+    expect(result).toContain('### Files Changed (3 files, +285 −0)');
+    expect(result).toContain('| `scripts/moderate-spam.mjs` | +142 −0 |');
+    expect(result).toContain('| `test/scripts/moderate-spam.test.ts` | +98 −0 |');
+    expect(result).toContain('| `.github/workflows/squad-comment-moderation.yml` | +45 −0 |');
+    expect(result).toContain('**Total: +285 −0**');
+  });
+
+  it('handles files with 0 additions and 0 deletions', () => {
+    const files = [{ filename: 'empty-change.ts', additions: 0, deletions: 0 }];
+    const result = buildFileList(files);
+    expect(result).toContain('| `empty-change.ts` | +0 −0 |');
+    expect(result).toContain('**Total: +0 −0**');
+  });
+
+  it('handles files with both additions and deletions', () => {
+    const files = [
+      { filename: 'src/refactored.ts', additions: 50, deletions: 30 },
+      { filename: 'src/old.ts', additions: 0, deletions: 100 },
+    ];
+    const result = buildFileList(files);
+    expect(result).toContain('### Files Changed (2 files, +50 −130)');
+    expect(result).toContain('| `src/refactored.ts` | +50 −30 |');
+    expect(result).toContain('| `src/old.ts` | +0 −100 |');
+    expect(result).toContain('**Total: +50 −130**');
+  });
+
+  it('treats missing additions/deletions as 0', () => {
+    const files = [{ filename: 'binary-file.png' }];
+    const result = buildFileList(files);
+    expect(result).toContain('| `binary-file.png` | +0 −0 |');
+    expect(result).toContain('**Total: +0 −0**');
+  });
+
+  it('uses singular "file" for single file', () => {
+    const files = [{ filename: 'one.ts', additions: 1, deletions: 0 }];
+    const result = buildFileList(files);
+    expect(result).toContain('1 file,');
+    expect(result).not.toContain('1 files,');
+  });
+
+  it('includes table headers', () => {
+    const files = [{ filename: 'a.ts', additions: 1, deletions: 0 }];
+    const result = buildFileList(files);
+    expect(result).toContain('| File | +/− |');
+    expect(result).toContain('|------|-----|');
+  });
+
+  it('truncates file list beyond MAX_FILE_LIST and shows summary row', () => {
+    const files = Array.from({ length: 60 }, (_, i) => ({
+      filename: `src/file-${i}.ts`,
+      additions: 1,
+      deletions: 0,
+    }));
+    const result = buildFileList(files);
+    // Header should show the total count (60), not the truncated count
+    expect(result).toContain('### Files Changed (60 files, +60 −0)');
+    // First 50 files should be present
+    expect(result).toContain('`src/file-0.ts`');
+    expect(result).toContain('`src/file-49.ts`');
+    // File 50 should NOT be present
+    expect(result).not.toContain('`src/file-50.ts`');
+    // Summary row
+    expect(result).toContain('**+10 more files**');
+    // Totals should include ALL files
+    expect(result).toContain('**Total: +60 −0**');
+  });
+
+  it('does not truncate when file count equals MAX_FILE_LIST', () => {
+    const files = Array.from({ length: MAX_FILE_LIST }, (_, i) => ({
+      filename: `src/file-${i}.ts`,
+      additions: 1,
+      deletions: 0,
+    }));
+    const result = buildFileList(files);
+    expect(result).not.toContain('more files');
+    expect(result).toContain(`${MAX_FILE_LIST} files`);
+  });
+
+  it('sanitizes pipe characters in filenames', () => {
+    const files = [{ filename: 'path/with|pipe.ts', additions: 1, deletions: 0 }];
+    const result = buildFileList(files);
+    expect(result).toContain("path/with\\|pipe.ts");
+    expect(result).not.toContain('| path/with|pipe.ts');
+  });
+
+  it('sanitizes backticks in filenames', () => {
+    const files = [{ filename: 'file`name.ts', additions: 1, deletions: 0 }];
+    const result = buildFileList(files);
+    expect(result).toContain("file'name.ts");
+  });
+
+  it('sanitizes newlines in filenames', () => {
+    const files = [{ filename: 'file\nname.ts', additions: 1, deletions: 0 }];
+    const result = buildFileList(files);
+    expect(result).toContain('file name.ts');
+    // The sanitized filename should not contain the literal newline
+    expect(result).not.toContain('file\nname.ts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeFilename
+// ---------------------------------------------------------------------------
+
+describe('sanitizeFilename', () => {
+  it('escapes pipe characters', () => {
+    expect(sanitizeFilename('a|b|c')).toBe('a\\|b\\|c');
+  });
+
+  it('replaces backticks with single quotes', () => {
+    expect(sanitizeFilename('file`name`test')).toBe("file'name'test");
+  });
+
+  it('replaces newlines with spaces', () => {
+    expect(sanitizeFilename('line1\nline2\r\nline3')).toBe('line1 line2 line3');
+  });
+
+  it('handles all special characters together', () => {
+    expect(sanitizeFilename('a|b`c\nd')).toBe("a\\|b'c d");
+  });
+
+  it('returns normal filenames unchanged', () => {
+    expect(sanitizeFilename('src/components/App.tsx')).toBe('src/components/App.tsx');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyScope
+// ---------------------------------------------------------------------------
+
+describe('classifyScope', () => {
+  it('returns Infrastructure for only infrastructure files', () => {
+    const files = [
+      { filename: '.github/workflows/ci.yml' },
+      { filename: 'scripts/build.mjs' },
+      { filename: 'test/foo.test.ts' },
+    ];
+    const result = classifyScope(files);
+    expect(result.label).toBe('Infrastructure');
+    expect(result.emoji).toBe('🔧');
+  });
+
+  it('returns Product for only product source files', () => {
+    const files = [
+      { filename: 'packages/squad-sdk/src/index.ts' },
+      { filename: 'packages/squad-cli/src/main.ts' },
+    ];
+    const result = classifyScope(files);
+    expect(result.label).toBe('Product');
+    expect(result.emoji).toBe('📦');
+  });
+
+  it('returns Mixed for both product and infrastructure files', () => {
+    const files = [
+      { filename: 'packages/squad-sdk/src/index.ts' },
+      { filename: 'scripts/build.mjs' },
+    ];
+    const result = classifyScope(files);
+    expect(result.label).toBe('Mixed (product + infrastructure)');
+    expect(result.emoji).toBe('📦🔧');
+  });
+
+  it('returns Infrastructure for empty array', () => {
+    const result = classifyScope([]);
+    expect(result.label).toBe('Infrastructure');
+    expect(result.emoji).toBe('🔧');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -596,7 +823,7 @@ describe('run()', () => {
       commits: [{ sha: 'abc123' }],
       compare: { behind_by: 0 },
       reviews: [{ user: { login: 'copilot-pull-request-reviewer' }, state: 'APPROVED', submitted_at: '2025-01-01T00:00:00Z' }],
-      files: [{ filename: '.changeset/feat.md' }],
+      files: [{ filename: '.changeset/feat.md', additions: 5, deletions: 0 }],
       pr: { mergeable: true },
       checkRuns: { check_runs: [{ name: 'build', conclusion: 'success', status: 'completed' }] },
       status: { statuses: [{ state: 'success' }] },
@@ -860,5 +1087,25 @@ describe('run()', () => {
     const draftCheck = result.checks.find((c) => c.name === 'Not in draft');
     expect(draftCheck.pass).toBe(false);
     expect(draftCheck.detail).toContain('draft');
+  });
+
+  it('includes file list with line stats in upserted comment', async () => {
+    const mockFetch = createMockFetch({
+      files: [
+        { filename: 'src/index.ts', additions: 25, deletions: 10 },
+        { filename: 'test/index.test.ts', additions: 50, deletions: 0 },
+      ],
+    });
+    await run({ env: baseEnv, fetchFn: mockFetch });
+
+    const postCall = mockFetch.mock.calls.find(
+      ([url, opts]) => opts && opts.method === 'POST' && url.includes('/comments'),
+    );
+    expect(postCall).toBeDefined();
+    const body = JSON.parse(postCall[1].body).body;
+    expect(body).toContain('### Files Changed (2 files, +75 −10)');
+    expect(body).toContain('| `src/index.ts` | +25 −10 |');
+    expect(body).toContain('| `test/index.test.ts` | +50 −0 |');
+    expect(body).toContain('**Total: +75 −10**');
   });
 });


### PR DESCRIPTION
## What

Adds a vitest smoke test (\	est/cross-package-exports.test.ts\) that validates **every value import** \squad-cli\ uses from \squad-sdk\ resolves to a defined export at runtime.

## Why

v0.9.3-insider.1 shipped with \FSStorageProvider\ missing from the SDK barrel — broke users at runtime while all TypeScript-level tests passed (TS resolves from source, not compiled output). This test would have caught that.

## What it covers

**20 test cases** across **15 SDK subpaths** and **50+ named exports**:

| SDK subpath | Key exports tested |
|---|---|
| \@bradygaster/squad-sdk\ (root) | \FSStorageProvider\, \SquadState\, \TIMEOUTS\, \StreamingPipeline\, \RuntimeEventBus\, \esolveSquad\, \esolveGlobalSquadPath\, \initSquadTelemetry\, \ecordAgent*\, \safeTimestamp\, \getMeter\, \listRoles\, \searchRoles\, \getCategories\, \getRoleById\, \generateCharterFromRole\, \ddAgentToConfig\, \initSquad\, \cleanupOrphanInitPrompt\, \nsurePersonalSquadDir\, \esolvePersonalSquadDir\, \esolveExternalStateDir\, \deriveProjectKey\, \setupConsultMode\, \isConsultMode\, \PersonalSquadNotFoundError\, \detectLicense\, \loadStagedLearnings\, \logConsultation\, \mergeToPersonalSquad\, \getPersonalSquadRoot\, \discoverSquads\, \ormatDiscoveryTable\, \indSquadByName\, \uildDelegationArgs\, \loadSubSquadsConfig\, \esolveSubSquad\, \RemoteBridge\ |
| \/config\ | \initSquad\, \MigrationRegistry\, \writeEconomyMode\, \eadEconomyMode\ |
| \/config/agent-source\ | \LocalAgentSource\ |
| \/resolution\ | \esolveSquad\, \esolveSquadPaths\, \esolveGlobalSquadPath\, \esolvePersonalSquadDir\, \nsurePersonalSquadDir\ |
| \/client\ | \SquadClient\ |
| \/adapter/errors\ | \RateLimitError\ |
| \/agents/personal\ | \esolvePersonalAgents\, \mergeSessionCast\ |
| \/casting\ | \CastingEngine\ |
| \/platform\ | \createPlatformAdapter\ |
| \/ralph\ | \RalphMonitor\ |
| \/ralph/triage\ | \parseRoster\, \parseRoutingRules\, \parseModuleOwnership\, \	riageIssue\ |
| \/ralph/rate-limiting\ | \PredictiveCircuitBreaker\, \getTrafficLight\ |
| \/runtime/event-bus\ | \EventBus\ |
| Exports-map file check | All entries in SDK \package.json\ exports map point to real files |

## How to maintain

When adding a new import from \@bradygaster/squad-sdk\ to \squad-cli\, add a corresponding assertion in this test.

Refs #836