### PR TITLE
Persist sidebar scroll position across navigation

### DIFF
--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -77,11 +77,24 @@ const base = import.meta.env.BASE_URL;
     overlay?.classList.add('hidden');
   }
 
-  function saveSidebarScroll() {
+  let lastScrollTop = 0;
+  let rafPending = false;
+
+  function trackSidebarScroll() {
     const { sidebar } = getSidebarElements();
     if (!sidebar) return;
 
-    sessionStorage.setItem(SIDEBAR_SCROLL_KEY, String(sidebar.scrollTop));
+    if (!rafPending) {
+      rafPending = true;
+      requestAnimationFrame(() => {
+        lastScrollTop = sidebar.scrollTop;
+        rafPending = false;
+      });
+    }
+  }
+
+  function flushSidebarScroll() {
+    sessionStorage.setItem(SIDEBAR_SCROLL_KEY, String(lastScrollTop));
   }
 
   function restoreSidebarScroll() {
@@ -95,6 +108,7 @@ const base = import.meta.env.BASE_URL;
     if (Number.isNaN(scrollTop)) return false;
 
     sidebar.scrollTop = scrollTop;
+    lastScrollTop = scrollTop;
     return true;
   }
 
@@ -103,7 +117,7 @@ const base = import.meta.env.BASE_URL;
     if (!sidebar) return;
 
     if (!sidebar.dataset.scrollPersistenceBound) {
-      sidebar.addEventListener('scroll', saveSidebarScroll, { passive: true });
+      sidebar.addEventListener('scroll', trackSidebarScroll, { passive: true });
       sidebar.dataset.scrollPersistenceBound = 'true';
     }
 
@@ -122,9 +136,10 @@ const base = import.meta.env.BASE_URL;
   }
 
   if (!window.__squadDocsSidebarStateSetup) {
+    document.addEventListener('astro:before-swap', flushSidebarScroll);
     document.addEventListener('astro:after-swap', initSidebar);
     document.addEventListener('astro:page-load', initSidebar);
-    window.addEventListener('pagehide', saveSidebarScroll);
+    window.addEventListener('pagehide', flushSidebarScroll);
     window.__squadDocsSidebarStateSetup = true;
   }
 

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -62,19 +62,71 @@ const base = import.meta.env.BASE_URL;
 <div id="sidebar-overlay" class="fixed inset-0 z-40 bg-black/50 hidden lg:hidden"></div>
 
 <script>
-  const sidebar = document.getElementById('sidebar');
-  const overlay = document.getElementById('sidebar-overlay');
+  const SIDEBAR_SCROLL_KEY = 'squad-docs-sidebar-scroll';
+
+  function getSidebarElements() {
+    return {
+      sidebar: document.getElementById('sidebar'),
+      overlay: document.getElementById('sidebar-overlay'),
+    };
+  }
 
   function closeSidebar() {
+    const { sidebar, overlay } = getSidebarElements();
     sidebar?.classList.add('-translate-x-full');
     overlay?.classList.add('hidden');
   }
 
-  overlay?.addEventListener('click', closeSidebar);
+  function saveSidebarScroll() {
+    const { sidebar } = getSidebarElements();
+    if (!sidebar) return;
 
-  // Scroll the active TOC link into view on page load
-  const activeLink = sidebar?.querySelector('.sidebar-link.active');
-  if (activeLink && sidebar) {
-    activeLink.scrollIntoView({ block: 'center', behavior: 'instant' });
+    sessionStorage.setItem(SIDEBAR_SCROLL_KEY, String(sidebar.scrollTop));
   }
+
+  function restoreSidebarScroll() {
+    const { sidebar } = getSidebarElements();
+    if (!sidebar) return false;
+
+    const savedScrollTop = sessionStorage.getItem(SIDEBAR_SCROLL_KEY);
+    if (savedScrollTop === null) return false;
+
+    const scrollTop = Number(savedScrollTop);
+    if (Number.isNaN(scrollTop)) return false;
+
+    sidebar.scrollTop = scrollTop;
+    return true;
+  }
+
+  function initSidebar() {
+    const { sidebar, overlay } = getSidebarElements();
+    if (!sidebar) return;
+
+    if (!sidebar.dataset.scrollPersistenceBound) {
+      sidebar.addEventListener('scroll', saveSidebarScroll, { passive: true });
+      sidebar.dataset.scrollPersistenceBound = 'true';
+    }
+
+    if (overlay && !overlay.dataset.closeHandlerBound) {
+      overlay.addEventListener('click', closeSidebar);
+      overlay.dataset.closeHandlerBound = 'true';
+    }
+
+    requestAnimationFrame(() => {
+      const restoredScroll = restoreSidebarScroll();
+      if (restoredScroll) return;
+
+      const activeLink = sidebar.querySelector('.sidebar-link.active');
+      activeLink?.scrollIntoView({ block: 'center', behavior: 'instant' });
+    });
+  }
+
+  if (!window.__squadDocsSidebarStateSetup) {
+    document.addEventListener('astro:after-swap', initSidebar);
+    document.addEventListener('astro:page-load', initSidebar);
+    window.addEventListener('pagehide', saveSidebarScroll);
+    window.__squadDocsSidebarStateSetup = true;
+  }
+
+  initSidebar();
 </script>

--- a/docs/tests/sidebar.spec.mjs
+++ b/docs/tests/sidebar.spec.mjs
@@ -49,14 +49,16 @@ test.describe('Docs sidebar navigation', () => {
     }, TARGET);
 
     await page.waitForURL(new RegExp(TARGET.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
-    await page.waitForTimeout(100);
+
+    await expect.poll(async () => page.evaluate(() => {
+      const sidebar = document.getElementById('sidebar');
+      if (!sidebar) throw new Error('Sidebar not found');
+      return sidebar.scrollTop;
+    }), { timeout: 5000 }).toBeGreaterThan(initialSidebarScroll - 10);
 
     const restoredSidebarScroll = await page.evaluate(() => {
       const sidebar = document.getElementById('sidebar');
-      if (!sidebar) {
-        throw new Error('Sidebar not found');
-      }
-
+      if (!sidebar) throw new Error('Sidebar not found');
       return sidebar.scrollTop;
     });
 

--- a/docs/tests/sidebar.spec.mjs
+++ b/docs/tests/sidebar.spec.mjs
@@ -1,0 +1,68 @@
+/**
+ * Playwright e2e tests for docs sidebar behavior.
+ */
+import { test, expect } from '@playwright/test';
+
+const START = '/squad/docs/get-started/five-minute-start/';
+const TARGET = '/squad/docs/scenarios/ci-cd-integration/';
+
+test.describe('Docs sidebar navigation', () => {
+  test('keeps the sidebar scroll position when opening another article', async ({ page }) => {
+    await page.goto(START);
+
+    await page.evaluate(() => sessionStorage.removeItem('squad-docs-sidebar-scroll'));
+
+    const sidebar = page.locator('#sidebar');
+    await expect(sidebar).toBeVisible();
+
+    await page.evaluate(() => {
+      const sidebar = document.getElementById('sidebar');
+      if (!sidebar) {
+        throw new Error('Sidebar not found');
+      }
+
+      sidebar.scrollTop = 900;
+      sidebar.dispatchEvent(new Event('scroll'));
+      window.scrollTo(0, 1000);
+    });
+
+    const initialSidebarScroll = await page.evaluate(() => {
+      const sidebar = document.getElementById('sidebar');
+      if (!sidebar) {
+        throw new Error('Sidebar not found');
+      }
+
+      return sidebar.scrollTop;
+    });
+
+    expect(initialSidebarScroll).toBeGreaterThan(0);
+
+    await page.evaluate((targetHref) => {
+      const link = document.querySelector(`#sidebar a[href="${targetHref}"]`)
+        ?? document.querySelector('#sidebar a[href*="docs/scenarios/ci-cd-integration/"]');
+
+      if (!(link instanceof HTMLAnchorElement)) {
+        throw new Error('Target sidebar link not found');
+      }
+
+      link.click();
+    }, TARGET);
+
+    await page.waitForURL(new RegExp(TARGET.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    await page.waitForTimeout(100);
+
+    const restoredSidebarScroll = await page.evaluate(() => {
+      const sidebar = document.getElementById('sidebar');
+      if (!sidebar) {
+        throw new Error('Sidebar not found');
+      }
+
+      return sidebar.scrollTop;
+    });
+
+    const pageScroll = await page.evaluate(() => window.scrollY);
+
+    expect(pageScroll).toBeLessThan(20);
+    expect(Math.abs(restoredSidebarScroll - initialSidebarScroll)).toBeLessThan(10);
+  });
+});


### PR DESCRIPTION
### What
Implements sessionStorage-based persistence for the docs sidebar scroll position, so users retain their scroll state when navigating between articles. Refactors sidebar event binding for idempotency and adds Playwright E2E tests to verify scroll restoration works as intended.

### Why
Its very hard to navigate the logs when always being sent to the top of the menu. This way the user can click the next menu item easily. 

### How
Adds sidebar scroll-state persistence using sessionStorage, saving the current sidebar scrollTop during navigation and restoring it after the next docs page loads. Updates sidebar initialization so event handlers are only registered once across Astro page swaps, preventing duplicate bindings. Falls back to scrolling the active menu item into view only when no saved sidebar position exists. Includes a Playwright test that confirms the article resets to the top while the left navigation keeps its previous scroll position after selecting another docs page.

---

### ⚠️ Quick Check
- [ ] If SDK/CLI source files changed: completed the applicable Changeset step below (`npx changeset add` / `.changeset/*.md`, direct `CHANGELOG.md` entry for maintainers, or `skip-changelog` label for no user-facing changes)

### PR Readiness Checklist

> The PR readiness bot will validate these automatically after push.
> Check each item before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for full details.

#### Branch & Commit
- [x] Branch created from `dev` (not `main`)
- [x] Branch is up to date with `dev` (`git fetch upstream && git rebase upstream/dev`)
- [x] Verified diff contains only intended changes (`git diff --cached --stat`)
- [x] PR is **not** in draft mode (mark ready when checks pass)
- [ ] Commit history is clean (squash fixups before review)

#### Build & Test
- [x] `npm run build` passes
- [x] `npm test` passes (all tests green)! There are currently lot of failing tests locally but not in pipelines..
- [x] `npm run lint` passes (type check clean)
- [x] `npm run lint:eslint` passes
- [ ] For migration PRs (>20 files): include test output summary in PR description

#### Changeset
- [ ] Changeset added via `npx changeset add` (if `packages/squad-sdk/src/` or `packages/squad-cli/src/` changed)
- [ ] Or direct `CHANGELOG.md` entry (maintainers only — write-protected for external contributors)
- [ ] Or `skip-changelog` label applied (if no user-facing changes)

#### Docs
<!-- "N/A" only if truly no user-facing change. -->
- [ ] README section updated (if new feature/module)
- [ ] Docs feature page (if new user-facing capability)

#### Exports
<!-- For SDK changes only. "N/A" if no new modules. -->
- [ ] package.json subpath exports updated (if new module)

---

### Breaking Changes
<!-- Any backward-incompatible changes. "None" if clean. -->

### Waivers
<!-- If skipping any REQUIRED item: 1) Request waiver in this section, 2) Named reviewer must approve in PR comments BEFORE merge. Format: "Waived: {item}, reason: {why}, approved by: {Flight|FIDO}" -->
