### PR TITLE
fix(coordinator): add routing enforcement refusal rule

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -19,6 +19,7 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT generate domain artifacts (code, designs, analyses) — spawn an agent
   - You may NOT bypass reviewer approval on rejected work
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
+  - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
 Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
 - **No** → Init Mode

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -19,6 +19,7 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT generate domain artifacts (code, designs, analyses) — spawn an agent
   - You may NOT bypass reviewer approval on rejected work
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
+  - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
 Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
 - **No** → Init Mode

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -19,6 +19,7 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT generate domain artifacts (code, designs, analyses) — spawn an agent
   - You may NOT bypass reviewer approval on rejected work
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
+  - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
 Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
 - **No** → Init Mode

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -19,6 +19,7 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT generate domain artifacts (code, designs, analyses) — spawn an agent
   - You may NOT bypass reviewer approval on rejected work
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
+  - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
 Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
 - **No** → Init Mode

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -19,6 +19,7 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT generate domain artifacts (code, designs, analyses) — spawn an agent
   - You may NOT bypass reviewer approval on rejected work
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
+  - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
 Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
 - **No** → Init Mode


### PR DESCRIPTION
Closes #853

## Problem
The coordinator sometimes does domain work itself instead of dispatching to team members. Some models interpret existing refusal rules loosely.

## Fix
Added explicit refusal rule:
> You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (answering factual questions already in context).

Also confirmed the Init Mode 3-state check (zero roster entries) was already present in all copies — no change needed.

## Files Changed
- `.github/agents/squad.agent.md` — added 4th refusal rule (canonical)
- `templates/squad.agent.md.template` — synced
- `packages/squad-cli/templates/squad.agent.md.template` — synced
- `packages/squad-sdk/templates/squad.agent.md.template` — synced
- `.squad-templates/squad.agent.md` — synced (5th tracked copy)
- `.squad/agents/procedures/history.md` — session learnings

Working as Procedures (Prompt Engineer)