### PR TITLE
fix: sync issues:opened trigger to all heartbeat template copies

### DIFF
--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -18,7 +18,7 @@ name: Squad Heartbeat (Ralph)
 on:
   # React to completed work or new squad work
   issues:
-    types: [closed, labeled]
+    types: [opened, closed, labeled]
   pull_request:
     types: [closed]
 

--- a/.squad-templates/workflows/squad-heartbeat.yml
+++ b/.squad-templates/workflows/squad-heartbeat.yml
@@ -9,7 +9,7 @@ name: Squad Heartbeat (Ralph)
 on:
   # React to completed work or new squad work
   issues:
-    types: [closed, labeled]
+    types: [opened, closed, labeled]
   pull_request:
     types: [closed]
 

--- a/packages/squad-cli/templates/workflows/squad-heartbeat.yml
+++ b/packages/squad-cli/templates/workflows/squad-heartbeat.yml
@@ -9,7 +9,7 @@ name: Squad Heartbeat (Ralph)
 on:
   # React to completed work or new squad work
   issues:
-    types: [closed, labeled]
+    types: [opened, closed, labeled]
   pull_request:
     types: [closed]
 

--- a/packages/squad-sdk/templates/workflows/squad-heartbeat.yml
+++ b/packages/squad-sdk/templates/workflows/squad-heartbeat.yml
@@ -9,7 +9,7 @@ name: Squad Heartbeat (Ralph)
 on:
   # React to completed work or new squad work
   issues:
-    types: [closed, labeled]
+    types: [opened, closed, labeled]
   pull_request:
     types: [closed]
 

--- a/templates/workflows/squad-heartbeat.yml
+++ b/templates/workflows/squad-heartbeat.yml
@@ -9,7 +9,7 @@ name: Squad Heartbeat (Ralph)
 on:
   # React to completed work or new squad work
   issues:
-    types: [closed, labeled]
+    types: [opened, closed, labeled]
   pull_request:
     types: [closed]
 


### PR DESCRIPTION
## What

Addresses #815 — high Actions usage from Squad Heartbeat (Ralph).

## Changes

- **Schedule trigger**: Already removed in a previous CI hardening pass (no cron existed in current code)
- **Added \issues: opened\** to the event types so Ralph auto-triages new issues when created
- **All 5 synced copies updated**: canonical source (\.squad-templates/\), 3 mirrors (\	emplates/\, \packages/squad-cli/templates/\, \packages/squad-sdk/templates/\), and the active workflow (\.github/workflows/\)
- Template sync test (146 tests) passes ✅

## Trigger block (after)

\\\yaml
on:
  issues:
    types: [opened, closed, labeled]
  pull_request:
    types: [closed]
  workflow_dispatch:
\\\

Closes #815