### PR TITLE
fix(cast): pass repo root to LocalAgentSource instead of .squad/ dir

### DIFF
--- a/.changeset/fix-cast-base-path.md
+++ b/.changeset/fix-cast-base-path.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-cli': patch
+---
+
+Fix cast command passing wrong base path to LocalAgentSource — used repo root (cwd) instead of .squad/ dir to prevent double-nested .squad/.squad/agents/ lookup

--- a/.changeset/fix-cast-base-path.md
+++ b/.changeset/fix-cast-base-path.md
@@ -2,4 +2,4 @@
 '@bradygaster/squad-cli': patch
 ---
 
-Fix cast command passing wrong base path to LocalAgentSource — used repo root (cwd) instead of .squad/ dir to prevent double-nested .squad/.squad/agents/ lookup
+Passes repo root to LocalAgentSource instead of .squad/ dir, preventing a double-nested .squad/.squad/agents/ lookup. In remote mode, passes paths.teamDir (team repo root) so agents are discovered from the correct location.

--- a/packages/squad-cli/src/cli/commands/cast.ts
+++ b/packages/squad-cli/src/cli/commands/cast.ts
@@ -7,6 +7,7 @@
  * @module cli/commands/cast
  */
 
+import * as path from 'node:path';
 import { LocalAgentSource } from '@bradygaster/squad-sdk/config/agent-source';
 import { resolvePersonalAgents, mergeSessionCast } from '@bradygaster/squad-sdk/agents/personal';
 import { resolveSquadPaths } from '@bradygaster/squad-sdk/resolution';
@@ -23,8 +24,15 @@ export async function runCast(cwd: string): Promise<void> {
     fatal('No squad found. Run "squad init" first.');
   }
   
-  // Discover project agents
-  const projectSource = new LocalAgentSource(cwd);
+  // Discover project agents.
+  // LocalAgentSource appends .squad/agents to its base path, so we must supply:
+  //   - local mode: parent of paths.projectDir (the repo root)
+  //   - remote mode: paths.teamDir (the team repo root, which itself contains .squad/agents)
+  const agentBase =
+    paths.mode === 'remote'
+      ? paths.teamDir
+      : path.resolve(paths.projectDir, '..');
+  const projectSource = new LocalAgentSource(agentBase);
   const projectAgents = await projectSource.listAgents();
   
   // Discover personal agents

--- a/packages/squad-cli/src/cli/commands/cast.ts
+++ b/packages/squad-cli/src/cli/commands/cast.ts
@@ -24,7 +24,7 @@ export async function runCast(cwd: string): Promise<void> {
   }
   
   // Discover project agents
-  const projectSource = new LocalAgentSource(paths.teamDir);
+  const projectSource = new LocalAgentSource(cwd);
   const projectAgents = await projectSource.listAgents();
   
   // Discover personal agents

--- a/test/cli/cast.test.ts
+++ b/test/cli/cast.test.ts
@@ -2,8 +2,10 @@
  * squad cast — session cast display tests
  *
  * Verifies the cast command correctly discovers project agents
- * by passing repo root (not .squad/ dir) to LocalAgentSource.
- * Regression test for #871 (double-nested .squad/.squad/agents path).
+ * by deriving the correct base path from resolveSquadPaths():
+ *   - local mode:  parent of paths.projectDir (repo root)
+ *   - remote mode: paths.teamDir (team repo root)
+ * Regression tests for #871 (double-nested .squad/.squad/agents path).
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -14,11 +16,15 @@ import { randomBytes } from 'crypto';
 
 const TEST_ROOT = join(process.cwd(), `.test-cast-${randomBytes(4).toString('hex')}`);
 
-const SAMPLE_CHARTER = `---
-name: TestAgent
-role: Core Dev
----
-# TestAgent
+/**
+ * Charter using ## Identity sections, as expected by parseCharterMetadata().
+ * The agent name and role are read from these sections; fallback is the
+ * directory name when the section is absent.
+ */
+const SAMPLE_CHARTER = `## Identity
+
+**Name:** TestAgent
+**Role:** Core Dev
 
 Test agent for cast command tests.
 `;
@@ -71,8 +77,7 @@ describe('squad cast', () => {
     // it would look in .squad/.squad/agents/ — which doesn't exist — and find 0 agents.
     // With the fix, it looks in TEST_ROOT/.squad/agents/ and finds our test agent.
     const output = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
-    // Agent discovered from .squad/agents/test-agent/ (name derived from directory)
-    expect(output).toContain('test-agent');
+    expect(output).toContain('TestAgent');
     expect(output).toContain('Session Cast');
   });
 
@@ -82,7 +87,7 @@ describe('squad cast', () => {
     // Create a decoy agent at the WRONG double-nested path
     const wrongPath = join(TEST_ROOT, '.squad', '.squad', 'agents', 'decoy');
     await mkdir(wrongPath, { recursive: true });
-    await writeFile(join(wrongPath, 'charter.md'), `---\nname: Decoy\nrole: Wrong\n---\n# Decoy\n`);
+    await writeFile(join(wrongPath, 'charter.md'), `## Identity\n\n**Name:** Decoy\n**Role:** Wrong\n`);
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -90,8 +95,59 @@ describe('squad cast', () => {
     await runCast(TEST_ROOT);
 
     const output = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
-    // Should find test-agent from correct path, not decoy from wrong path
-    expect(output).toContain('test-agent');
-    expect(output).not.toContain('decoy');
+    // Should find TestAgent from correct path, not decoy from wrong path
+    expect(output).toContain('TestAgent');
+    expect(output).not.toContain('Decoy');
+  });
+
+  it('discovers agents when runCast is called from a nested subdirectory', async () => {
+    await scaffold(TEST_ROOT);
+
+    // Simulate invoking from a deep nested working directory — resolveSquadPaths
+    // walks up the tree until it finds .squad/, then the fix computes the repo root
+    // as path.resolve(projectDir, '..') so LocalAgentSource scans the right path.
+    const nestedDir = join(TEST_ROOT, 'src', 'feature', 'deep');
+    await mkdir(nestedDir, { recursive: true });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { runCast } = await import('@bradygaster/squad-cli/commands/cast');
+    await runCast(nestedDir);
+
+    const output = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(output).toContain('TestAgent');
+    expect(output).toContain('Session Cast');
+  });
+
+  it('discovers agents from team repository in remote mode', async () => {
+    // Remote mode: project has .squad/config.json with teamRoot pointing to a
+    // separate team repo.  Agents live in <teamRoot>/.squad/agents/, not in the
+    // project's own .squad/.
+    const projectRoot = join(TEST_ROOT, 'project');
+    const teamRoot = join(TEST_ROOT, 'team');
+
+    // Bootstrap project's .squad with a config.json that enables remote mode
+    const projectSq = join(projectRoot, '.squad');
+    await mkdir(projectSq, { recursive: true });
+    await writeFile(
+      join(projectSq, 'config.json'),
+      JSON.stringify({ version: 1, teamRoot: '../team' }),
+    );
+
+    // Team repo holds the agents
+    await mkdir(join(teamRoot, '.squad', 'agents', 'remote-agent'), { recursive: true });
+    await writeFile(
+      join(teamRoot, '.squad', 'agents', 'remote-agent', 'charter.md'),
+      `## Identity\n\n**Name:** RemoteAgent\n**Role:** Remote Engineer\n`,
+    );
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { runCast } = await import('@bradygaster/squad-cli/commands/cast');
+    await runCast(projectRoot);
+
+    const output = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    expect(output).toContain('RemoteAgent');
+    expect(output).toContain('Session Cast');
   });
 });

--- a/test/cli/cast.test.ts
+++ b/test/cli/cast.test.ts
@@ -1,0 +1,97 @@
+/**
+ * squad cast — session cast display tests
+ *
+ * Verifies the cast command correctly discovers project agents
+ * by passing repo root (not .squad/ dir) to LocalAgentSource.
+ * Regression test for #871 (double-nested .squad/.squad/agents path).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import { randomBytes } from 'crypto';
+
+const TEST_ROOT = join(process.cwd(), `.test-cast-${randomBytes(4).toString('hex')}`);
+
+const SAMPLE_CHARTER = `---
+name: TestAgent
+role: Core Dev
+---
+# TestAgent
+
+Test agent for cast command tests.
+`;
+
+async function scaffold(root: string): Promise<void> {
+  const sq = join(root, '.squad');
+  await mkdir(join(sq, 'agents', 'test-agent'), { recursive: true });
+  await writeFile(join(sq, 'agents', 'test-agent', 'charter.md'), SAMPLE_CHARTER);
+  await mkdir(join(sq, 'casting'), { recursive: true });
+  await writeFile(join(sq, 'team.md'), '# Team\n\n## Members\n\n- TestAgent\n');
+  await writeFile(join(sq, 'routing.md'), '# Routing\n');
+  await writeFile(join(sq, 'decisions.md'), '# Decisions\n');
+  await writeFile(
+    join(sq, 'casting', 'registry.json'),
+    JSON.stringify({ agents: [] }, null, 2),
+  );
+}
+
+// Mock personal agents to isolate project agent discovery
+vi.mock('@bradygaster/squad-sdk/agents/personal', () => ({
+  resolvePersonalAgents: vi.fn(async () => [] as unknown[]),
+  mergeSessionCast: vi.fn((project: unknown[], personal: unknown[]) => [...(project as unknown[]), ...(personal as unknown[])]),
+}));
+
+describe('squad cast', () => {
+  beforeEach(async () => {
+    if (existsSync(TEST_ROOT)) {
+      await rm(TEST_ROOT, { recursive: true, force: true });
+    }
+    await mkdir(TEST_ROOT, { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (existsSync(TEST_ROOT)) {
+      await rm(TEST_ROOT, { recursive: true, force: true });
+    }
+  });
+
+  it('discovers project agents using repo root, not .squad/ dir (#871)', async () => {
+    await scaffold(TEST_ROOT);
+
+    // Suppress console output during test
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { runCast } = await import('@bradygaster/squad-cli/commands/cast');
+    await runCast(TEST_ROOT);
+
+    // If the bug were present (passing paths.teamDir = .squad/ to LocalAgentSource),
+    // it would look in .squad/.squad/agents/ — which doesn't exist — and find 0 agents.
+    // With the fix, it looks in TEST_ROOT/.squad/agents/ and finds our test agent.
+    const output = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    // Agent discovered from .squad/agents/test-agent/ (name derived from directory)
+    expect(output).toContain('test-agent');
+    expect(output).toContain('Session Cast');
+  });
+
+  it('does not look in double-nested .squad/.squad/agents/ path', async () => {
+    await scaffold(TEST_ROOT);
+
+    // Create a decoy agent at the WRONG double-nested path
+    const wrongPath = join(TEST_ROOT, '.squad', '.squad', 'agents', 'decoy');
+    await mkdir(wrongPath, { recursive: true });
+    await writeFile(join(wrongPath, 'charter.md'), `---\nname: Decoy\nrole: Wrong\n---\n# Decoy\n`);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { runCast } = await import('@bradygaster/squad-cli/commands/cast');
+    await runCast(TEST_ROOT);
+
+    const output = logSpy.mock.calls.map(c => c.join(' ')).join('\n');
+    // Should find test-agent from correct path, not decoy from wrong path
+    expect(output).toContain('test-agent');
+    expect(output).not.toContain('decoy');
+  });
+});


### PR DESCRIPTION
## What

\cast\ command passed \paths.teamDir\ (which is \.squad/\) to \LocalAgentSource\, but \LocalAgentSource\ internally appends \.squad/agents\ — resulting in \.squad/.squad/agents\ (double-nested, wrong path). Agents were never discovered in local mode.

## Fix

Changed \
ew LocalAgentSource(paths.teamDir)\ to \
ew LocalAgentSource(cwd)\ in \packages/squad-cli/src/cli/commands/cast.ts\.

## Tests

Added \	est/cli/cast.test.ts\ with two regression tests:
1. Agents discovered from correct path (\<repo>/.squad/agents/\)
2. Decoy agent at wrong double-nested path (\.squad/.squad/agents/\) is NOT discovered

## Verification

- Grepped all \LocalAgentSource\ usages — no other callers have the same bug
- Both tests pass

Closes #871