### PR TITLE
feat(cli): deprecation warnings for tunnel, rc, and REPL commands

### DIFF
--- a/.changeset/deprecate-tunnel-rc-repl.md
+++ b/.changeset/deprecate-tunnel-rc-repl.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+Add deprecation warnings for tunnel, rc, and REPL commands. The interactive shell (no-args), `squad start`, `squad start --tunnel`, `squad rc`, and `squad rc-tunnel` now emit yellow deprecation notices pointing users to the GitHub Copilot CLI. No behavior changes — all commands still work.

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -212,7 +212,7 @@ async function main(): Promise<void> {
     console.log(`  ${BOLD}start${RESET}      Start Copilot with remote access from phone/browser ${YELLOW}[DEPRECATED]${RESET}`);
     console.log(`             Usage: start [--tunnel] [--port <n>] [--command <cmd>]`);
     console.log(`                    [copilot flags...]`);
-    console.log(`             ${DIM}⚠ Deprecated: --tunnel and remote access will be removed in a future release.${RESET}`);
+    console.log(`             ${DIM}⚠ Deprecated: will be removed in a future release.${RESET}`);
     console.log(`  ${BOLD}nap${RESET}        Context hygiene (compress, prune, archive .squad/ state)`);
     console.log(`             Usage: nap [--deep] [--dry-run]`);
     console.log(`             Flags: --deep (thorough cleanup), --dry-run (preview only)`);

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -150,7 +150,7 @@ async function main(): Promise<void> {
     console.log(`\n${BOLD}squad${RESET} v${VERSION} — Add an AI agent team to any project\n`);
     console.log(`Usage: squad [command] [options]\n`);
     console.log(`Commands:`);
-    console.log(`  ${BOLD}(default)${RESET}  Launch interactive shell (no args)`);
+    console.log(`  ${BOLD}(default)${RESET}  Launch interactive shell (no args) ${YELLOW}[DEPRECATED]${RESET}`);
     console.log(`             Flags: --global (init in personal squad directory)`);
     console.log(`  ${BOLD}init${RESET}       Initialize Squad (markdown-only, default)`);
     console.log(`             Flags: --sdk (SDK builder syntax)`);
@@ -209,12 +209,10 @@ async function main(): Promise<void> {
     console.log(`             Usage: import <file> [--force]`);
     console.log(`  ${BOLD}scrub-emails${RESET}  Remove email addresses from Squad state files`);
     console.log(`             Usage: scrub-emails [directory] (default: .ai-team/)`);
-    console.log(`  ${BOLD}start${RESET}      Start Copilot with remote access from phone/browser`);
+    console.log(`  ${BOLD}start${RESET}      Start Copilot with remote access from phone/browser ${YELLOW}[DEPRECATED]${RESET}`);
     console.log(`             Usage: start [--tunnel] [--port <n>] [--command <cmd>]`);
     console.log(`                    [copilot flags...]`);
-    console.log(`             Examples: start --tunnel --yolo`);
-    console.log(`                       start --tunnel --model claude-sonnet-4`);
-    console.log(`                       start --tunnel --command "gh copilot"`);
+    console.log(`             ${DIM}⚠ Deprecated: --tunnel and remote access will be removed in a future release.${RESET}`);
     console.log(`  ${BOLD}nap${RESET}        Context hygiene (compress, prune, archive .squad/ state)`);
     console.log(`             Usage: nap [--deep] [--dry-run]`);
     console.log(`             Flags: --deep (thorough cleanup), --dry-run (preview only)`);
@@ -239,12 +237,12 @@ async function main(): Promise<void> {
     console.log(`             Usage: personal init | list | add <name>`);
     console.log(`                    --role <role> | remove <name>`);
     console.log(`  ${BOLD}cast${RESET}       Show current session cast (project + personal agents)`);
-    console.log(`  ${BOLD}rc${RESET}         Start Remote Control bridge (phone/browser → Copilot)`);
+    console.log(`  ${BOLD}rc${RESET}         Start Remote Control bridge (phone/browser → Copilot) ${YELLOW}[DEPRECATED]${RESET}`);
     console.log(`             Usage: rc [--tunnel] [--port <n>] [--path <dir>]`);
     console.log(`  ${BOLD}copilot-bridge${RESET}  Check Copilot ACP stdio compatibility`);
     console.log(`  ${BOLD}init-remote${RESET}    Link project to remote team root (shorthand)`);
     console.log(`             Usage: init-remote <team-repo-path>`);
-    console.log(`  ${BOLD}rc-tunnel${RESET}      Check devtunnel CLI availability`);
+    console.log(`  ${BOLD}rc-tunnel${RESET}      Check devtunnel CLI availability ${YELLOW}[DEPRECATED]${RESET}`);
     console.log(`  ${BOLD}discover${RESET}   List known squads and their capabilities`);
     console.log(`  ${BOLD}delegate${RESET}   Create work in another squad`);
     console.log(`             Usage: delegate <squad-name> <description>`);
@@ -273,6 +271,8 @@ async function main(): Promise<void> {
 
   // No args → launch interactive shell; whitespace-only arg → show help
   if (rawCmd === undefined) {
+    console.log(`\n${YELLOW}⚠ DEPRECATED:${RESET} The interactive REPL shell is deprecated and will be removed in a future release.`);
+    console.log(`  Use the GitHub Copilot CLI instead: ${BOLD}gh copilot${RESET} (squad.agent.md is picked up automatically)\n`);
     // Fire-and-forget update check — non-blocking, never delays shell startup
     import('./cli/self-update.js').then(m => m.notifyIfUpdateAvailable(VERSION)).catch(() => {});
     const { runShell } = await lazyRunShell();
@@ -708,8 +708,13 @@ async function main(): Promise<void> {
   }
 
   if (cmd === 'start') {
+    console.log(`\n${YELLOW}⚠ DEPRECATED:${RESET} "squad start" is deprecated and will be removed in a future release.`);
+    console.log(`  Use the GitHub Copilot CLI directly: ${BOLD}copilot${RESET} or ${BOLD}gh copilot${RESET}\n`);
     const { runStart } = await import('./cli/commands/start.js');
     const hasTunnel = args.includes('--tunnel');
+    if (hasTunnel) {
+      console.log(`${YELLOW}⚠ DEPRECATED:${RESET} --tunnel is deprecated and will be removed in a future release.\n`);
+    }
     const portIdx = args.indexOf('--port');
     const port = (portIdx !== -1 && args[portIdx + 1]) ? parseInt(args[portIdx + 1]!, 10) : 0;
     // Collect all remaining args to pass through to copilot
@@ -789,6 +794,8 @@ async function main(): Promise<void> {
   }
 
   if (cmd === 'rc' || cmd === 'remote-control') {
+    console.log(`\n${YELLOW}⚠ DEPRECATED:${RESET} "squad rc" is deprecated and will be removed in a future release.`);
+    console.log(`  Use the GitHub Copilot CLI directly: ${BOLD}copilot${RESET} or ${BOLD}gh copilot${RESET}\n`);
     const { runRC } = await import('./cli/commands/rc.js');
     const hasTunnel = args.includes('--tunnel');
     const portIdx = args.indexOf('--port');
@@ -823,6 +830,7 @@ async function main(): Promise<void> {
   }
 
   if (cmd === 'rc-tunnel') {
+    console.log(`\n${YELLOW}⚠ DEPRECATED:${RESET} "squad rc-tunnel" is deprecated and will be removed in a future release.\n`);
     const { isDevtunnelAvailable } = await import('./cli/commands/rc-tunnel.js');
     if (isDevtunnelAvailable()) {
       console.log(`${GREEN}✓${RESET} devtunnel CLI is available`);


### PR DESCRIPTION
### What

Adds Phase 1 deprecation warnings to the tunnel, Remote Control, and REPL commands. Five commands now emit yellow warnings pointing users to the GitHub Copilot CLI as the replacement. No behavior changes - all commands still work.

### Why

The tunnel/RC/REPL features add significant complexity to the CLI without sufficient adoption. The GitHub Copilot CLI provides native interactive and remote access capabilities. Squad should be lean. Closes #899. Related: #665.

### How

Added console.log deprecation notices at the top of each affected command handler in cli-entry.ts, and [DEPRECATED] tags in the --help output. Minimal change - 1 file, 15 insertions.

| Command | Warning |
|---------|---------|
| squad (no args - REPL) | Yellow deprecation notice, points to gh copilot |
| squad start | Deprecated notice |
| squad start --tunnel | Additional tunnel-specific warning |
| squad rc / remote-control | Deprecated notice |
| squad rc-tunnel | Deprecated notice |

---

### :warning: Quick Check
- [x] If SDK/CLI source files changed: completed the applicable Changeset step below (npx changeset add / .changeset/*.md, direct CHANGELOG.md entry for maintainers, or skip-changelog label for no user-facing changes)

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from insider (targeting insider for next insider release)
- [x] Branch is up to date with insider (rebased)
- [x] Verified diff contains only intended changes (1 file: cli-entry.ts + 1 changeset)
- [x] PR is not in draft mode
- [x] Commit history is clean (2 commits: feat + changeset)

#### Build & Test
- [x] npm run build passes
- [x] npm test - pre-existing failures only (same count on bare insider), no regressions from this PR
- [x] npm run lint - pre-existing TS2578 on start.ts (exists on bare insider), no new errors from this PR
- [x] npm run lint:eslint - N/A (no new patterns introduced)

#### Changeset
- [x] Changeset added: .changeset/deprecate-tunnel-rc-repl.md (patch for @bradygaster/squad-cli)

#### Docs
- N/A - deprecation warnings are self-documenting. README/docs update will accompany the Phase 2 removal PR.

#### Exports
- N/A - no new modules or export changes.

---

### Breaking Changes
None. All commands continue to work exactly as before. Warnings are additive console output only.

### Waivers
- Item waived: (d) Documentation - README/docs feature page
- Reason: Deprecation warnings are self-documenting UX. Full docs update will accompany Phase 2 removal in a separate PR. Follow-up tracked in #665.
- Approval by: Requesting Flight/FIDO approval in PR review.