### PR TITLE
docs: add contributor-to-core-team PR handoff process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ External contributors don't have write access, so the review-to-merge flow has a
 
 **Your side (contributor):**
 
-1. ✅ All CI checks are green (build, test, lint, changeset)
+1. ✅ All required CI checks are green (build, test, lint; changeset/CHANGELOG gate only applies when `packages/squad-cli/src/` or `packages/squad-sdk/src/` files change)
 2. ✅ PR is no longer a draft — mark as **"Ready for review"**
 3. ✅ Copilot reviewer bot posts its review automatically
 4. ✅ Accept any Copilot suggestions you agree with (you have permission to accept suggestions)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,10 +151,32 @@ The Co-authored-by trailer is **required** for all commits (added by Copilot CLI
 
 1. Add a changeset: `npx changeset add` (required before PR — see Changesets section)
 2. Push your branch: `git push origin {yourusername}/217-readme-help-update`
-3. Create a PR with explicit base and head: `gh pr create --base dev --repo bradygaster/squad --head {yourusername}:your-branch`
+3. Create a PR **as a draft**: `gh pr create --draft --base dev --repo bradygaster/squad --head {yourusername}:your-branch`
 4. Link the issue: Add `Closes #217` to PR description
-5. Wait for CI checks to pass
-6. Request review from the team (agents will respond via comments)
+5. Work on your changes until CI passes and you're satisfied
+6. **Mark as "Ready for review"** — this is the handoff signal to the core team (see below)
+
+### Handoff: Contributor → Core Team
+
+External contributors don't have write access, so the review-to-merge flow has a handoff point. Here's exactly what happens:
+
+**Your side (contributor):**
+
+1. ✅ All CI checks are green (build, test, lint, changeset)
+2. ✅ PR is no longer a draft — mark as **"Ready for review"**
+3. ✅ Copilot reviewer bot posts its review automatically
+4. ✅ Accept any Copilot suggestions you agree with (you have permission to accept suggestions)
+5. ✅ If Copilot flags issues you can't resolve via suggestions, note them in a PR comment
+
+> **Note:** You may see a "Fix with Copilot" button on review comments — this requires repo write access and won't work for external contributors. Use "Accept suggestion" instead, or leave a comment explaining why you disagree.
+
+**Core team side (after you undraft):**
+
+1. Look for CI-green, undrafted PRs from contributors
+2. Address any remaining Copilot review issues (using "Fix with Copilot" or manual fixes)
+3. Human review, resolve threads, and merge
+
+**TL;DR:** Your job is done when the PR is undrafted, CI is green, and you've responded to Copilot suggestions. The core team takes it from there.
 
 ### PR Readiness Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,10 +165,11 @@ External contributors don't have write access, so the review-to-merge flow has a
 1. ✅ All required CI checks are green (build, test, lint; changeset/CHANGELOG gate only applies when `packages/squad-cli/src/` or `packages/squad-sdk/src/` files change)
 2. ✅ PR is no longer a draft — mark as **"Ready for review"**
 3. ✅ Copilot reviewer bot posts its review automatically
-4. ✅ Accept any Copilot suggestions you agree with (you have permission to accept suggestions)
-5. ✅ If Copilot flags issues you can't resolve via suggestions, note them in a PR comment
+4. ✅ Review Copilot's suggestions and manually apply any you agree with in your fork
+5. ✅ Push updates to your branch to address Copilot's feedback
+6. ✅ If Copilot flags issues you can't resolve, note them in a PR comment
 
-> **Note:** You may see a "Fix with Copilot" button on review comments — this requires repo write access and won't work for external contributors. Use "Accept suggestion" instead, or leave a comment explaining why you disagree.
+> **Note:** Copilot review suggestions appear as comments, but the "Commit suggestion" and "Fix with Copilot" buttons require repo write access and won't work for external contributors. Review the suggestions, apply them manually in your fork, and push your changes.
 
 **Core team side (after you undraft):**
 


### PR DESCRIPTION
- [x] Updated "Handoff: Contributor → Core Team" section in CONTRIBUTING.md
- [x] Rewrote checklist item to say "all required CI checks are green" with a note that the changeset/CHANGELOG gate only applies when SDK/CLI source files change