### PR TITLE
ci: skip prerelease version guard on insider branch [ON HOLD]

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -366,6 +366,7 @@ jobs:
           always()
           && steps.labels.outputs.skip_version != 'true'
           && vars.SQUAD_VERSION_CHECK != 'false'
+          && github.event.pull_request.base.ref != 'insider'
         run: |
           echo "## 🏷️ Prerelease Version Guard" >> $GITHUB_STEP_SUMMARY
           node -e "


### PR DESCRIPTION
## What

Skip the prerelease version guard when the PR targets the `insider` branch.

## Why

The `prerelease-version-guard` step in Squad CI blocks packages with prerelease suffixes (e.g., `0.9.4-insider.1`) from merging. This is correct for PRs targeting `dev` or `main`, but **false-positive on `insider`** where prerelease versions are expected and intentional.

This causes every PR targeting `insider` to show a CI failure, including PR #900.

## How

Added one condition to the guard's `if:` block:

`yaml
&& github.event.pull_request.base.ref != 'insider'
`

1 file, 1 line added. The guard still runs on PRs to `dev`, `main`, and `preview`.

## Testing

- CI workflow change only — no product code
- Verified the existing `if:` block syntax is valid YAML multi-line
- The `skip-version-check` label still works as an escape hatch

/cc @bradygaster @tamirdresher
