### PR TITLE
feat(ci): automated bug retro checklist on issue close [ON HOLD]

### DIFF
--- a/.github/workflows/squad-bug-retro.yml
+++ b/.github/workflows/squad-bug-retro.yml
@@ -1,0 +1,44 @@
+name: Squad Bug Retro
+
+# Posts a retro checklist comment when bug-labeled issues are closed.
+# Helps the team systematically learn from bugs by prompting structured reflection.
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  post-retro-checklist:
+    # Only run for issues that carry the "bug" label
+    if: contains(github.event.issue.labels.*.name, 'bug')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post bug retro checklist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '## 🔄 Bug Retro Checklist',
+              '',
+              '- [ ] **Why did this escape CI?** (missing test? untested code path? mock hid it?)',
+              '- [ ] **Test added that would have caught it?** (link PR)',
+              '- [ ] **Is this a class of bug?** (could the same pattern exist elsewhere?)',
+              '- [ ] **CI/review change needed?** (new lint rule? workflow gate? PR template checkbox?)',
+              '- [ ] **Retro complete** — check when all above are addressed or skipped',
+              '',
+              '_Auto-generated for closed bugs. Skip if trivial (cosmetic/typo). Uncheck "Retro complete" to reopen the retro._',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that posts a retro checklist comment when bug-labeled issues are closed.

### What it does
- Triggers on `issues.closed` events for `bug`-labeled issues
- Posts a structured retro checklist as a comment
- Helps the team systematically learn from bugs

### Workflow details
- Uses `actions/github-script@v7` with minimal `issues: write` permission
- Follows existing `squad-*` workflow naming convention
- Includes concurrency group to prevent duplicate runs
- No changeset needed — CI-only change, no product source code modified

Closes #819