### PR TITLE
feat(ci): @github/copilot-sdk compatibility testing & breaking change detection [ON HOLD]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot — SDK compatibility monitoring
+# Tracks @github/copilot-sdk and vscode-jsonrpc for breaking changes.
+# Pre-release versions are tested separately via the nightly canary workflow.
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: "@github/copilot-sdk"
+      - dependency-name: "vscode-jsonrpc"
+    ignore:
+      # Pre-releases are tested by squad-canary-sdk.yml — don't open PRs for them
+      - dependency-name: "*"
+        update-types: ["version-update:semver-pre-release"]
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5

--- a/.github/workflows/squad-canary-sdk.yml
+++ b/.github/workflows/squad-canary-sdk.yml
@@ -1,0 +1,143 @@
+name: "Squad Canary — SDK Compatibility"
+
+# Nightly smoke test against @github/copilot-sdk@next.
+# Catches breaking changes before they land in a stable release.
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # Daily at 4 AM UTC
+  workflow_dispatch: # Manual trigger for on-demand testing
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check if @next tag exists
+        id: check-next
+        run: |
+          if npm view @github/copilot-sdk@next version 2>/dev/null; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "version=$(npm view @github/copilot-sdk@next version)" >> "$GITHUB_OUTPUT"
+          else
+            # Distinguish "no tag" from registry errors
+            if npm view @github/copilot-sdk versions --json >/dev/null 2>&1; then
+              echo "::notice::@github/copilot-sdk@next tag does not exist — skipping canary"
+              echo "available=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::Failed to query npm registry — possible outage"
+              exit 1
+            fi
+          fi
+
+      - name: Install copilot-sdk@next
+        if: steps.check-next.outputs.available == 'true'
+        run: |
+          echo "Installing @github/copilot-sdk@${{ steps.check-next.outputs.version }}"
+          npm install -w packages/squad-sdk @github/copilot-sdk@next --save-exact
+
+      - name: Rerun ESM patches
+        if: steps.check-next.outputs.available == 'true'
+        run: |
+          # The SDK override may replace patched files — reapply patches
+          node packages/squad-cli/scripts/patch-esm-imports.mjs
+
+      - name: Build
+        if: steps.check-next.outputs.available == 'true'
+        run: npm run build
+
+      - name: Run tests
+        if: steps.check-next.outputs.available == 'true'
+        run: npm test
+
+      - name: Report failure
+        if: failure() && steps.check-next.outputs.available == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `SDK Canary: @github/copilot-sdk@${process.env.CANARY_VERSION} breaks on Node ${{ matrix.node-version }}`;
+            const labels = ['bug', 'sdk-canary'];
+            const body = [
+              `## 🐤 SDK Canary Failure`,
+              ``,
+              `**SDK version:** \`@github/copilot-sdk@${process.env.CANARY_VERSION}\``,
+              `**Node version:** ${{ matrix.node-version }}`,
+              `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ``,
+              `The nightly canary detected a compatibility issue with the next version of the Copilot SDK.`,
+              `Review the workflow run logs for details.`,
+            ].join('\n');
+
+            // Check for existing open canary issue
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'sdk-canary',
+              state: 'open',
+              per_page: 1,
+            });
+
+            if (existing.length > 0) {
+              // Comment on existing issue
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body: `### 🔄 Canary still failing\n\n${body}`,
+              });
+              core.info(`Commented on existing issue #${existing[0].number}`);
+            } else {
+              // Ensure labels exist before creating issue
+              for (const label of labels) {
+                try {
+                  await github.rest.issues.getLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label,
+                  });
+                } catch {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label,
+                    color: label === 'bug' ? 'd73a4a' : 'fbca04',
+                    description: label === 'sdk-canary' ? 'Nightly SDK compatibility canary failure' : undefined,
+                  });
+                }
+              }
+
+              const { data: issue } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels,
+              });
+              core.info(`Created issue #${issue.number}`);
+            }
+        env:
+          CANARY_VERSION: ${{ steps.check-next.outputs.version }}

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -172,7 +172,7 @@
     "README.md"
   ],
   "scripts": {
-    "postinstall": "node scripts/patch-esm-imports.mjs && node scripts/patch-ink-rendering.mjs",
+    "postinstall": "node scripts/patch-esm-imports.mjs && node scripts/verify-patches.mjs && node scripts/patch-ink-rendering.mjs",
     "prepublishOnly": "npm run build",
     "build": "tsc -p tsconfig.json && npm run postbuild",
     "postbuild": "node -e \"require('fs').cpSync('src/remote-ui', 'dist/remote-ui', {recursive: true})\""

--- a/packages/squad-cli/scripts/verify-patches.mjs
+++ b/packages/squad-cli/scripts/verify-patches.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * Postinstall Patch Verification
+ *
+ * Runs after patch-esm-imports.mjs to verify patches applied correctly.
+ * Fails loudly at install time (not at runtime) if something is wrong.
+ *
+ * Checks:
+ * 1. vscode-jsonrpc/package.json has exports["./node"] (Layer 1 patch)
+ * 2. copilot-sdk session.js has no bare 'vscode-jsonrpc/node' imports (Layer 2 patch)
+ *
+ * See also: packages/squad-cli/src/cli/commands/doctor.ts (runtime equivalent)
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const SEARCH_ROOTS = [
+  join(__dirname, '..', 'node_modules'),
+  join(__dirname, '..', '..', '..', 'node_modules'),
+  join(__dirname, '..', '..'),
+];
+
+let errors = 0;
+
+// ── Layer 1: vscode-jsonrpc exports ──────────────────────────────────
+function verifyJsonrpcExports() {
+  for (const root of SEARCH_ROOTS) {
+    const pkgPath = join(root, 'vscode-jsonrpc', 'package.json');
+    if (!existsSync(pkgPath)) continue;
+
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+
+      if (!pkg.exports || !pkg.exports['./node']) {
+        console.error(
+          '❌ PATCH VERIFICATION FAILED: vscode-jsonrpc/package.json is missing exports["./node"].\n' +
+            '   The ESM patch did not apply. Run: node packages/squad-cli/scripts/patch-esm-imports.mjs\n' +
+            `   Checked: ${pkgPath}`,
+        );
+        errors++;
+        return;
+      }
+
+      console.log('✅ vscode-jsonrpc exports["./node"] verified');
+      return;
+    } catch (err) {
+      console.error(`❌ Failed to read ${pkgPath}: ${err.message}`);
+      errors++;
+      return;
+    }
+  }
+
+  // Package not found — may be a minimal install or CI step that doesn't need it
+  console.log('⏭️  vscode-jsonrpc not found — skipping exports verification');
+}
+
+// ── Layer 2: copilot-sdk session.js imports ──────────────────────────
+function verifySdkSessionImports() {
+  for (const root of SEARCH_ROOTS) {
+    const sessionPath = join(root, '@github', 'copilot-sdk', 'dist', 'session.js');
+    if (!existsSync(sessionPath)) continue;
+
+    try {
+      const content = readFileSync(sessionPath, 'utf8');
+      const bareImports = content.match(/from\s+["']vscode-jsonrpc\/node["']/g);
+
+      if (bareImports && bareImports.length > 0) {
+        console.error(
+          '❌ PATCH VERIFICATION FAILED: @github/copilot-sdk/dist/session.js still has bare\n' +
+            "   'vscode-jsonrpc/node' imports (missing .js extension).\n" +
+            '   The ESM patch did not apply. Run: node packages/squad-cli/scripts/patch-esm-imports.mjs\n' +
+            `   Checked: ${sessionPath}`,
+        );
+        errors++;
+        return;
+      }
+
+      console.log('✅ copilot-sdk session.js imports verified');
+      return;
+    } catch (err) {
+      console.error(`❌ Failed to read ${sessionPath}: ${err.message}`);
+      errors++;
+      return;
+    }
+  }
+
+  // File not found — SDK may have restructured internals, which is fine
+  // The smoke test (test/sdk-compatibility-smoke.test.ts) catches real breakage
+  console.log('⏭️  copilot-sdk/dist/session.js not found — skipping import verification');
+}
+
+// ── Run ──────────────────────────────────────────────────────────────
+verifyJsonrpcExports();
+verifySdkSessionImports();
+
+if (errors > 0) {
+  console.error(`\n💥 ${errors} patch verification(s) failed — install cannot continue.`);
+  console.error('   Fix: run "node packages/squad-cli/scripts/patch-esm-imports.mjs" then retry.\n');
+  process.exit(1);
+}

--- a/test/sdk-compatibility-smoke.test.ts
+++ b/test/sdk-compatibility-smoke.test.ts
@@ -1,0 +1,55 @@
+/**
+ * SDK Compatibility Smoke Test
+ *
+ * Validates that @github/copilot-sdk exports the interface Squad depends on.
+ * Uses REAL imports (no vi.mock) so breakage is caught before runtime.
+ *
+ * If this test fails, it means a copilot-sdk update removed or renamed
+ * something Squad uses in packages/squad-sdk/src/adapter/client.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Methods that CopilotClientAdapter (client.ts) calls on CopilotClient instances.
+// Keep in sync with packages/squad-sdk/src/adapter/client.ts usage.
+const EXPECTED_CLIENT_METHODS = [
+  'start',
+  'stop',
+  'forceStop',
+  'createSession',
+  'resumeSession',
+  'listSessions',
+  'deleteSession',
+  'getLastSessionId',
+  'ping',
+  'getStatus',
+] as const;
+
+describe('SDK compatibility smoke test', () => {
+  it('CopilotClient is exported and is a constructor', async () => {
+    const sdk = await import('@github/copilot-sdk');
+    expect(sdk.CopilotClient).toBeDefined();
+    expect(typeof sdk.CopilotClient).toBe('function');
+  });
+
+  for (const method of EXPECTED_CLIENT_METHODS) {
+    it(`CopilotClient.prototype.${method} exists`, async () => {
+      const sdk = await import('@github/copilot-sdk');
+      const proto = sdk.CopilotClient.prototype;
+      expect(
+        typeof proto[method],
+        `Missing method: CopilotClient.prototype.${method} — ` +
+          `Squad's adapter depends on this. Check if copilot-sdk renamed or removed it.`,
+      ).toBe('function');
+    });
+  }
+
+  it('vscode-jsonrpc/node subpath is importable', async () => {
+    // This subpath import depends on the ESM patch (postinstall).
+    // If this fails, the patch-esm-imports.mjs postinstall didn't run.
+    const jsonrpc = await import('vscode-jsonrpc/node');
+    expect(jsonrpc).toBeDefined();
+    // createMessageConnection is the main API surface used by copilot-sdk
+    expect(typeof jsonrpc.createMessageConnection).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Adds automated SDK compatibility testing infrastructure:

### What's included
- **Dependabot config** — daily npm update checks for copilot-sdk and vscode-jsonrpc
- **Nightly canary workflow** — tests against copilot-sdk@next on Node 22/24 matrix, alerts on breakage
- **Unmocked SDK smoke test** — validates real SDK interface (CopilotClient + 10 methods) in CI
- **Postinstall patch verification** — fails loudly if ESM patches don't apply

### What's deferred (medium priority)
- FR-5: SDK version matrix (depends on FR-3)
- FR-6: Patch deprecation tracking

Closes #818