### PR TITLE
feat(ci): waza-based skill quality checks (Phase 1) — PRD #812

### DIFF
--- a/.github/workflows/squad-skill-quality.yml
+++ b/.github/workflows/squad-skill-quality.yml
@@ -1,0 +1,209 @@
+name: Skill Quality (waza)
+
+on:
+  pull_request:
+    paths:
+      - '.copilot/skills/**'
+      - '.squad/skills/**'
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6 AM UTC
+  workflow_dispatch:
+    inputs:
+      skills:
+        description: 'Comma-separated skill names (blank = all)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  WAZA_VERSION: '0.23.0'
+
+jobs:
+  skill-check:
+    name: 'Skill Quality Check'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Phase 1: informational only — don't block merges
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install waza
+        run: |
+          ASSET="waza_${WAZA_VERSION}_linux_amd64.tar.gz"
+          URL="https://github.com/microsoft/waza/releases/download/v${WAZA_VERSION}/${ASSET}"
+          echo "Downloading waza v${WAZA_VERSION} from ${URL}"
+          curl -fsSL -o waza.tar.gz "${URL}"
+          tar -xzf waza.tar.gz
+          chmod +x waza
+          sudo mv waza /usr/local/bin/waza
+          rm -f waza.tar.gz
+          waza --version
+
+      - name: Detect changed skills
+        id: detect
+        if: github.event_name == 'pull_request'
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          CHANGED=$(git diff --name-only "$BASE"..."$HEAD" -- \
+            '.copilot/skills/' \
+            '.squad/skills/' \
+          )
+
+          # Extract unique skill directories that contain SKILL.md changes
+          SKILL_DIRS=""
+          for file in $CHANGED; do
+            dir=$(dirname "$file")
+            if [ -f "${dir}/SKILL.md" ]; then
+              SKILL_DIRS=$(printf '%s\n%s' "$SKILL_DIRS" "$dir")
+            fi
+          done
+
+          # Deduplicate
+          SKILL_DIRS=$(echo "$SKILL_DIRS" | sort -u | grep -v '^$' || true)
+
+          if [ -z "$SKILL_DIRS" ]; then
+            echo "No skill directories changed."
+            echo "has_skills=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changed skill directories:"
+            echo "$SKILL_DIRS"
+            # Store as newline-separated list
+            echo "has_skills=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "skill_dirs<<EOF"
+              echo "$SKILL_DIRS"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Collect all skills (scheduled/dispatch)
+        id: collect
+        if: github.event_name != 'pull_request'
+        run: |
+          SKILL_DIRS=""
+
+          # Explicit input skills
+          if [ -n "${{ inputs.skills }}" ]; then
+            IFS=',' read -ra NAMES <<< "${{ inputs.skills }}"
+            for name in "${NAMES[@]}"; do
+              name=$(echo "$name" | xargs)  # trim whitespace
+              for root in .copilot/skills .squad/skills; do
+                if [ -f "${root}/${name}/SKILL.md" ]; then
+                  SKILL_DIRS=$(printf '%s\n%s' "$SKILL_DIRS" "${root}/${name}")
+                fi
+              done
+            done
+          else
+            # Discover all skills in governed roots
+            for root in .copilot/skills .squad/skills; do
+              if [ -d "$root" ]; then
+                for skill_dir in "$root"/*/; do
+                  if [ -f "${skill_dir}SKILL.md" ]; then
+                    SKILL_DIRS=$(printf '%s\n%s' "$SKILL_DIRS" "${skill_dir%/}")
+                  fi
+                done
+              fi
+            done
+          fi
+
+          SKILL_DIRS=$(echo "$SKILL_DIRS" | sort -u | grep -v '^$' || true)
+
+          if [ -z "$SKILL_DIRS" ]; then
+            echo "No skills found."
+            echo "has_skills=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skills to check:"
+            echo "$SKILL_DIRS"
+            echo "has_skills=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "skill_dirs<<EOF"
+              echo "$SKILL_DIRS"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run waza check
+        id: check
+        run: |
+          # Determine which skills to check
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            HAS_SKILLS="${{ steps.detect.outputs.has_skills }}"
+            SKILL_DIRS="${{ steps.detect.outputs.skill_dirs }}"
+          else
+            HAS_SKILLS="${{ steps.collect.outputs.has_skills }}"
+            SKILL_DIRS="${{ steps.collect.outputs.skill_dirs }}"
+          fi
+
+          if [ "$HAS_SKILLS" != "true" ]; then
+            echo "No skills to check — skipping."
+            echo "## Skill Quality Check" >> "$GITHUB_STEP_SUMMARY"
+            echo "No skill files changed in this PR." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          TOTAL=0
+          PASSED=0
+          FAILED=0
+          ERRORS=0
+          RESULTS=""
+
+          while IFS= read -r skill_dir; do
+            [ -z "$skill_dir" ] && continue
+            TOTAL=$((TOTAL + 1))
+            skill_name=$(basename "$skill_dir")
+            echo "──────────────────────────────────────────"
+            echo "Checking: ${skill_dir}/SKILL.md"
+
+            set +e
+            OUTPUT=$(waza check "${skill_dir}" 2>&1)
+            EXIT_CODE=$?
+            set -e
+
+            case $EXIT_CODE in
+              0)
+                PASSED=$((PASSED + 1))
+                STATUS="✅ Pass"
+                ;;
+              2)
+                ERRORS=$((ERRORS + 1))
+                STATUS="⚠️ Config error"
+                ;;
+              *)
+                FAILED=$((FAILED + 1))
+                STATUS="❌ Fail"
+                ;;
+            esac
+
+            echo "  Result: ${STATUS} (exit ${EXIT_CODE})"
+            RESULTS="${RESULTS}| \`${skill_name}\` | ${STATUS} | ${EXIT_CODE} |\n"
+          done <<< "$SKILL_DIRS"
+
+          echo "──────────────────────────────────────────"
+          echo "Total: ${TOTAL}, Passed: ${PASSED}, Failed: ${FAILED}, Errors: ${ERRORS}"
+
+          # Write job summary
+          {
+            echo "## 🥋 Skill Quality Check (waza v${WAZA_VERSION})"
+            echo ""
+            echo "| Skill | Status | Exit Code |"
+            echo "|-------|--------|-----------|"
+            echo -e "$RESULTS"
+            echo ""
+            echo "**Summary:** ${PASSED}/${TOTAL} passed"
+            if [ $FAILED -gt 0 ] || [ $ERRORS -gt 0 ]; then
+              echo ""
+              echo "> ⚠️ **Phase 1 (informational):** Failures do not block merge."
+              echo "> See [waza docs](https://github.com/microsoft/waza) for skill authoring guidance."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/proposals/waza-skill-quality-checks.md
+++ b/docs/proposals/waza-skill-quality-checks.md
@@ -1,0 +1,97 @@
+# Proposal: Waza-Based PR Quality Checks for Squad Skills
+
+**Issue:** bradygaster/squad#812
+**Author:** Flight (Lead)
+**Date:** 2026-04-08
+**Status:** Phase 1 — Informational
+
+---
+
+## Problem Statement
+
+Squad skills are authored, reviewed, and promoted without automated quality checks.
+A skill can be merged with broken patterns, mismatched trigger rules, or confidence
+levels set by gut feel. With 20+ skills across `.copilot/skills/`, there is no CI gate
+to catch regressions before merge.
+
+---
+
+## Viability Assessment
+
+**Tool:** [microsoft/waza](https://github.com/microsoft/waza) — Go CLI for AI agent skill evaluation.
+
+| Criterion          | Status |
+|--------------------|--------|
+| Public repo?       | ✅ Yes — MIT licensed |
+| Active?            | ✅ Updated 2026-04-07, 76 open issues |
+| Has releases?      | ✅ v0.23.0 (latest), binary install for linux/darwin/windows |
+| Fits Squad needs?  | ✅ `waza check` validates skill structure and readiness |
+| CI integration?    | ✅ JSON output, JUnit reporter, GitHub Actions compatible |
+| Install in CI?     | ✅ Pre-built binaries via release assets |
+
+**Key limitation:** `go install` does not work (LFS-dependent embedded binaries).
+Must use pre-built release binaries.
+
+---
+
+## Approach: Phased Rollout
+
+### Phase 1 (This PR) — Informational Only
+
+- GitHub Actions workflow at `.github/workflows/squad-skill-quality.yml`
+- Triggers on PRs modifying `.copilot/skills/**` or `.squad/skills/**`
+- Installs waza v0.23.0 from pinned release binary
+- Runs `waza check` on changed skill files
+- Reports results via GitHub Actions job summary (read-only permissions)
+- **Does NOT block merges** — `continue-on-error: true`
+- Nightly and manual dispatch modes check all skills
+
+### Phase 2 (Future) — Eval Suites + Gating
+
+- Bootstrap eval suites for high-confidence skills
+- Run `waza run` with mock engine on PRs
+- Graduate to hard merge gate once baselines established
+- Add confidence promotion thresholds (≥80% → medium, ≥95% → high)
+
+### Phase 3 (Future) — Full Evaluation
+
+- Nightly runs with `copilot-sdk` engine (requires API keys)
+- Cross-model comparison matrix
+- Dashboard integration
+
+---
+
+## Design Decisions
+
+1. **Pinned version, not latest.** CI installs waza v0.23.0 from release assets.
+   Prevents drift and ensures reproducible results.
+
+2. **Explicit path allowlist, not `**/SKILL.md`.** Squad has 90+ SKILL.md files
+   across templates, test fixtures, and active skills. Only `.copilot/skills/` and
+   `.squad/skills/` are governed.
+
+3. **Job summary, not PR comments.** The workflow uses `pull_request` trigger with
+   `contents: read` only. No write permissions needed — results appear in the
+   Actions job summary tab.
+
+4. **Informational-only in Phase 1.** Squad's SKILL.md frontmatter (domain,
+   confidence, source) may not align with waza's spec checker expectations.
+   Phase 1 establishes a baseline without blocking PRs.
+
+5. **No `.waza.yaml` in repo root.** Waza's config only supports single-path
+   `paths.skills`. Squad's skills live in multiple roots. We pass explicit paths
+   instead.
+
+6. **Skip `waza run` in Phase 1.** Zero eval suites exist today. Running
+   `waza run` would always be a no-op.
+
+---
+
+## Open Questions
+
+| # | Question | Resolution |
+|---|----------|------------|
+| 1 | Will Squad's YAML frontmatter pass `waza check`? | Phase 1 will answer this empirically |
+| 2 | When to bootstrap eval suites? | After Phase 1 baseline shows which skills need evals |
+| 3 | Hard gate timing? | After Phase 1 runs for 2+ weeks with stable results |
+| 4 | Token budget enforcement? | Deferred to Phase 3 |


### PR DESCRIPTION
Closes bradygaster/squad#812

## What

Adds a GitHub Actions workflow (.github/workflows/squad-skill-quality.yml) that runs [microsoft/waza](https://github.com/microsoft/waza) check against Squad skill files on every PR that modifies .copilot/skills/ or .squad/skills/.

## Viability Assessment

| Criterion | Status |
|-----------|--------|
| Public repo? | ✅ MIT licensed |
| Active? | ✅ v0.23.0, updated 2026-04-07 |
| Binary releases? | ✅ linux/darwin/windows |
| CI integration? | ✅ JSON output, JUnit, exit codes |

## Phase 1 (This PR) — Informational Only

- **Does NOT block merges** — \continue-on-error: true\
- Installs waza v0.23.0 from pinned release binary
- Runs \waza check\ on changed skill files
- Reports results via GitHub Actions job summary (read-only permissions)
- Nightly + manual dispatch modes check all skills
- Explicit path allowlist (only governed skill roots, not \**/SKILL.md\)

## Phase 2 (Future)
- Bootstrap eval suites, add \waza run\ with mock engine
- Graduate to hard merge gate after 2+ weeks of stable results

## Files Changed
- \.github/workflows/squad-skill-quality.yml\ — the workflow
- \docs/proposals/waza-skill-quality-checks.md\ — proposal doc
- \.squad/decisions/inbox/flight-waza-assessment.md\ — decision record
- \.squad/agents/flight/history.md\ — learning update

Working as Flight (Lead)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>