### PR TITLE
fix: squad init no longer runs git init in subdirectory; az CLI Windows shell fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- `squad init` no longer runs `git init` automatically when initialized inside a monorepo subdirectory (#939). It now shows a warning and suggests running from the git root instead.
+- Azure DevOps adapter (`az` CLI calls) now use `shell: true` on Windows so `.cmd` wrapper scripts resolve correctly (#941).
 - **Nap archival budget** (#123) — account for separator newlines in decision archival budget calculation
 
 ### Added — Full Work Monitor for squad watch (#708)
@@ -314,5 +316,6 @@ All notable changes to this project will be documented in this file.
 - New entry point: `src/cli-entry.ts` (CLI bootstrap separated from library exports)
 - Migrated to npm workspace publishing (`@bradygaster/squad-sdk`, `@bradygaster/squad-cli`)
 - Changesets infrastructure for independent package versioning
+
 
 

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -141,11 +141,7 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
       console.log();
       console.log(`${DIM}Copilot resolves .github/agents/ from the git root, not from here.${RESET}`);
       console.log(`${DIM}The Squad agent won't be visible to copilot in this folder.${RESET}`);
-      console.log();
-      // Auto-fix: run git init to create a repo boundary here
-      console.log(`${CYAN}${BOLD}→${RESET} Running ${CYAN}git init${RESET} to create a repo boundary...`);
-      execFileSync('git', ['init'], { cwd: dest, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
-      console.log(`${GREEN}${BOLD}✓${RESET} Initialized git repo at ${normalDest}`);
+      console.log(`${DIM}Consider running squad init from the git root instead.${RESET}`);
       console.log();
     }
   } catch {

--- a/packages/squad-sdk/src/platform/azure-devops.ts
+++ b/packages/squad-sdk/src/platform/azure-devops.ts
@@ -4,10 +4,12 @@
  * @module platform/azure-devops
  */
 
-import { execFileSync, execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import type { PlatformAdapter, PlatformType, WorkItem, PullRequest } from './types.js';
 
+const IS_WINDOWS = process.platform === 'win32';
 const EXEC_OPTS: { encoding: 'utf-8'; stdio: ['pipe', 'pipe', 'pipe'] } = { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] };
+const AZ_OPTS = { ...EXEC_OPTS, shell: IS_WINDOWS };
 
 /** Descriptor for a work item type returned by process template introspection. */
 export interface WorkItemTypeInfo {
@@ -22,7 +24,7 @@ export interface WorkItemTypeInfo {
 /** Check whether the az CLI with devops extension is available */
 function assertAzCliAvailable(): void {
   try {
-    execSync('az devops -h', EXEC_OPTS);
+    execFileSync('az', ['devops', '-h'], AZ_OPTS);
   } catch {
     throw new Error(
       'Azure DevOps CLI not found. Install it with:\n' +
@@ -67,7 +69,7 @@ export function getAvailableWorkItemTypes(org: string, project: string): WorkIte
       '--org', orgUrl,
       '--project', project,
       '--output', 'json',
-    ], { ...EXEC_OPTS, timeout: 3_000 }).trim();
+    ], { ...AZ_OPTS, timeout: 3_000 }).trim();
 
     const types = parseJson<Array<{
       name?: string;
@@ -158,7 +160,7 @@ export class AzureDevOpsAdapter implements PlatformAdapter {
   }
 
   private az(args: string[]): string {
-    return execFileSync('az', args, EXEC_OPTS).trim();
+    return execFileSync('az', args, AZ_OPTS).trim();
   }
 
   async listWorkItems(options: { tags?: string[]; state?: string; limit?: number }): Promise<WorkItem[]> {
@@ -433,7 +435,7 @@ export class AzureDevOpsAdapter implements PlatformAdapter {
 
       try {
         const orgUrl = `https://dev.azure.com/${targetOrg}`;
-        execFileSync('az', ['devops', 'configure', '--defaults', `organization=${orgUrl}`], EXEC_OPTS);
+        execFileSync('az', ['devops', 'configure', '--defaults', `organization=${orgUrl}`], AZ_OPTS);
       } catch {
         // az CLI might not be installed — non-fatal
       }


### PR DESCRIPTION
## What

Two targeted bug fixes:

1. **#939 — squad init no longer runs `git init` in monorepo subdirectories**
   When `squad init` detected CWD was inside a parent git repo (e.g. a monorepo subfolder), it would automatically run `git init` to create a nested repo boundary. This caused unexpected nested git repos. Now it just warns and advises the user to run from the git root.

2. **#941 — Azure DevOps adapter uses `shell: true` on Windows for `az` CLI calls**
   On Windows, `az` is a `.cmd` wrapper script. `execFileSync('az', ...)` without `shell: true` fails to resolve it. Added `IS_WINDOWS = process.platform === 'win32'` constant and `AZ_OPTS = {...EXEC_OPTS, shell: IS_WINDOWS}` applied to all `az` exec calls. Also converted `assertAzCliAvailable` from `execSync` to `execFileSync` for consistency.

## Why

- Monorepo users were getting unexpected nested git repos created during `squad init` (#939)
- Azure DevOps adapter was broken on Windows due to `.cmd` wrapper not resolving (#941)

## How

- **init.ts**: Remove the auto-fix `git init` block; replace with a clear message pointing to the git root
- **azure-devops.ts**: Add `IS_WINDOWS` + `AZ_OPTS` constants; apply to all 4 `az` exec calls

## Testing

- Build passes: `npm run build`
- Tests pass: `npx vitest run` (pre-existing failures in docs-build and cli-packaging-smoke unrelated)

Closes #939
Closes #941