### PR TITLE
docs: add cross-links between related documentation pages (#936)

### DIFF
--- a/docs/src/content/docs/concepts/architecture.md
+++ b/docs/src/content/docs/concepts/architecture.md
@@ -65,6 +65,7 @@ Ralph is the work monitor. He watches your GitHub or GitLab issues, tracks work 
 
 ## Learn more
 
-- [**Work routing**](../features/routing) — How the coordinator decides which agents to spawn
-- [**Memory and knowledge**](memory-and-knowledge) — How decisions, skills, and history persist
-- [**Parallel work**](parallel-work) — How agents work simultaneously without conflicts
+- [**Your Team**](./your-team.md) — How agents form, specialize, and work together
+- [**Work routing**](../features/routing.md) — How the coordinator decides which agents to spawn
+- [**Memory and knowledge**](memory-and-knowledge.md) — How decisions, skills, and history persist
+- [**Parallel work**](parallel-work.md) — How agents work simultaneously without conflicts

--- a/docs/src/content/docs/concepts/github-workflow.md
+++ b/docs/src/content/docs/concepts/github-workflow.md
@@ -264,3 +264,11 @@ squad watch --interval 5
 ```
 
 Starts persistent local polling — checks GitHub every 5 minutes for new work and triages automatically.
+
+---
+
+## See Also
+
+- [Your Team](./your-team.md) — How work routes to the right agent
+- [Work Routing](../features/routing.md) — Domain routing and agent assignment
+- [Parallel Work](./parallel-work.md) — Multi-agent parallel execution on batched issues

--- a/docs/src/content/docs/concepts/memory-and-knowledge.md
+++ b/docs/src/content/docs/concepts/memory-and-knowledge.md
@@ -290,3 +290,11 @@ Search past decisions for database choices
 ```
 
 Finds historical decisions related to a specific topic or keyword.
+
+---
+
+## See Also
+
+- [Your Team](./your-team.md) — How agents use shared memory to coordinate
+- [Architecture](./architecture.md) — How the coordinator and agents share state
+- [Parallel Work](./parallel-work.md) — How agents maintain consistency while working in parallel

--- a/docs/src/content/docs/concepts/parallel-work.md
+++ b/docs/src/content/docs/concepts/parallel-work.md
@@ -361,3 +361,11 @@ Use the main worktree's Squad team
 ```
 
 Creates a symlink so this worktree shares the main checkout's `.squad/` state.
+
+---
+
+## See Also
+
+- [Your Team](./your-team.md) — How agents form and specialize for different roles
+- [Architecture](./architecture.md) — How the coordinator orchestrates parallel execution
+- [Memory & Knowledge](./memory-and-knowledge.md) — How agents share context across parallel work

--- a/docs/src/content/docs/concepts/your-team.md
+++ b/docs/src/content/docs/concepts/your-team.md
@@ -345,3 +345,12 @@ Who handles authentication work?
 ```
 
 Coordinator checks routing and skills, reports the responsible agent(s).
+
+---
+
+## See Also
+
+- [Architecture](./architecture.md) — How the coordinator, agents, and shared memory work together
+- [Work Routing](../features/routing.md) — How work gets assigned to the right agent
+- [Parallel Work & Models](./parallel-work.md) — Agents working simultaneously without conflicts
+- [Memory & Knowledge](./memory-and-knowledge.md) — How decisions and agent history persist

--- a/docs/src/content/docs/features/built-in-roles.md
+++ b/docs/src/content/docs/features/built-in-roles.md
@@ -94,3 +94,11 @@ $ squad roles --search "security"      # search by keyword
 ## Attribution
 
 Built-in role content is adapted from [agency-agents](https://github.com/msitarzewski/agency-agents) by AgentLand Contributors, released under the MIT License.
+
+---
+
+## See Also
+
+- [Your Team](../concepts/your-team.md) — Team setup, roster, and role composition
+- [Architecture](../concepts/architecture.md) — How agents with specific roles are orchestrated
+- [Work Routing](./routing.md) — How work routes to agents based on their roles

--- a/docs/src/content/docs/features/routing.md
+++ b/docs/src/content/docs/features/routing.md
@@ -169,3 +169,11 @@ Coordinator explains the routing decision based on pattern match or skill fit.
 Fenster, implement the new search API. Hockney, write integration tests for it.
 ```
 Named routing to two agents. Both spawn in parallel.
+
+---
+
+## See Also
+
+- [Your Team](../concepts/your-team.md) — How team members and roles are defined
+- [Architecture](../concepts/architecture.md) — How the coordinator uses routing to dispatch work
+- [Parallel Work](../concepts/parallel-work.md) — Multi-agent parallel execution

--- a/docs/src/content/docs/guide/build-autonomous-agent.md
+++ b/docs/src/content/docs/guide/build-autonomous-agent.md
@@ -535,3 +535,11 @@ streaming.clear();
 - Read the [SDK reference](/reference/sdk/) for the complete API surface
 - See the [extensibility guide](/guide/extensibility/) for where your agent fits in the Squad ecosystem
 - Check the [Aspire dashboard scenario](/scenarios/aspire-dashboard/) for observability setup
+
+---
+
+## See Also
+
+- [Your Team](../concepts/your-team.md) — Agent roles, charters, and team composition
+- [Architecture](../concepts/architecture.md) — How the coordinator orchestrates work
+- [SDK Reference](../reference/sdk.md) — SDK API for autonomous agents


### PR DESCRIPTION
Closes #936

Adds cross-references between related docs pages for improved navigation:

- Added 'See Also' sections linking foundational concepts (Your Team, Architecture, Parallel Work, Memory & Knowledge)
- Connected feature pages to their related concept and guide pages (Work Routing, Built-in Roles)
- Linked guide pages to foundational concepts and SDK references
- Linked GitHub integration to routing and team concepts

All links follow the issue's Priority 1 mapping for high-impact navigation improvements.