### PR TITLE
fix(cli): runtime commands resolve externalized state paths (#949)

### DIFF
--- a/.changeset/fix-externalized-state-paths.md
+++ b/.changeset/fix-externalized-state-paths.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-cli': patch
+---
+
+Fix runtime commands to correctly resolve externalized state paths

--- a/packages/squad-cli/src/cli/commands/doctor.ts
+++ b/packages/squad-cli/src/cli/commands/doctor.ts
@@ -12,6 +12,7 @@
 
 import path from 'node:path';
 import { FSStorageProvider } from '@bradygaster/squad-sdk';
+import { resolveStateDir } from '../core/effective-squad-dir.js';
 
 const storage = new FSStorageProvider();
 
@@ -464,11 +465,13 @@ export async function runDoctor(cwd?: string): Promise<DoctorCheck[]> {
 
   // 5–9 standard files (only if .squad/ exists)
   if (isDirectory(squadDir)) {
-    checks.push(checkTeamMd(squadDir));
-    checks.push(checkRoutingMd(squadDir));
-    checks.push(checkAgentsDir(squadDir));
-    checks.push(checkCastingRegistry(squadDir));
-    checks.push(checkDecisionsMd(squadDir));
+    // Resolve effective state dir for externalized files
+    const stateDir = resolveStateDir(squadDir);
+    checks.push(checkTeamMd(stateDir));
+    checks.push(checkRoutingMd(stateDir));
+    checks.push(checkAgentsDir(stateDir));
+    checks.push(checkCastingRegistry(stateDir));
+    checks.push(checkDecisionsMd(stateDir));
     const rateLimitCheck = checkRateLimitStatus(squadDir);
     if (rateLimitCheck) checks.push(rateLimitCheck);
   }

--- a/packages/squad-cli/src/cli/commands/loop.ts
+++ b/packages/squad-cli/src/cli/commands/loop.ts
@@ -11,7 +11,7 @@ import { execFile, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-import { detectSquadDir } from '../core/detect-squad-dir.js';
+import { effectiveSquadDir } from '../core/effective-squad-dir.js';
 import { fatal } from '../core/errors.js';
 import { GREEN, RED, DIM, BOLD, RESET, YELLOW } from '../core/output.js';
 import {
@@ -265,9 +265,9 @@ async function checkGhCopilot(): Promise<void> {
 export async function runLoop(dest: string, options: LoopConfig): Promise<void> {
   const workTreeRoot = path.resolve(dest);
 
-  // Detect squad directory (must exist)
-  const squadDirInfo = detectSquadDir(workTreeRoot);
-  const teamMd = path.join(squadDirInfo.path, 'team.md');
+  // Detect squad directory (must exist) — follows external state if configured
+  const { local: squadDirInfo, stateDir } = effectiveSquadDir(workTreeRoot);
+  const teamMd = path.join(stateDir, 'team.md');
   const teamRoot = path.dirname(squadDirInfo.path);
 
   if (!existsSync(teamMd)) {

--- a/packages/squad-cli/src/cli/commands/plugin.ts
+++ b/packages/squad-cli/src/cli/commands/plugin.ts
@@ -9,7 +9,7 @@ import { promisify } from 'node:util';
 import { TIMEOUTS, FSStorageProvider } from '@bradygaster/squad-sdk';
 import { success, warn, info, dim, bold, DIM, BOLD, RESET } from '../core/output.js';
 import { fatal } from '../core/errors.js';
-import { detectSquadDir } from '../core/detect-squad-dir.js';
+import { effectiveSquadDir } from '../core/effective-squad-dir.js';
 import { ghAvailable, ghAuthenticated } from '../core/gh-cli.js';
 
 const execFileAsync = promisify(execFile);
@@ -36,9 +36,9 @@ export async function runPlugin(dest: string, args: string[]): Promise<void> {
     fatal('Usage: squad plugin marketplace add|remove|list|browse');
   }
 
-  const squadDirInfo = detectSquadDir(dest);
+  const { stateDir } = effectiveSquadDir(dest);
   const storage = new FSStorageProvider();
-  const pluginsDir = join(squadDirInfo.path, 'plugins');
+  const pluginsDir = join(stateDir, 'plugins');
   const marketplacesFile = join(pluginsDir, 'marketplaces.json');
 
   async function readMarketplaces(): Promise<MarketplacesRegistry> {

--- a/packages/squad-cli/src/cli/commands/watch/index.ts
+++ b/packages/squad-cli/src/cli/commands/watch/index.ts
@@ -15,7 +15,7 @@ import { FSStorageProvider } from '@bradygaster/squad-sdk';
 const storage = new FSStorageProvider();
 const execFileAsync = promisify(execFile);
 
-import { detectSquadDir } from '../../core/detect-squad-dir.js';
+import { effectiveSquadDir } from '../../core/effective-squad-dir.js';
 import { fatal } from '../../core/errors.js';
 import { GREEN, RED, DIM, BOLD, RESET, YELLOW } from '../../core/output.js';
 import {
@@ -647,10 +647,10 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     fatal('--interval must be a positive number of minutes');
   }
 
-  // Detect squad directory
-  const squadDirInfo = detectSquadDir(dest);
-  const teamMd = path.join(squadDirInfo.path, 'team.md');
-  const routingMdPath = path.join(squadDirInfo.path, 'routing.md');
+  // Detect squad directory — follows external state if configured
+  const { local: squadDirInfo, stateDir } = effectiveSquadDir(dest);
+  const teamMd = path.join(stateDir, 'team.md');
+  const routingMdPath = path.join(stateDir, 'routing.md');
   const teamRoot = path.dirname(squadDirInfo.path);
 
   if (!storage.existsSync(teamMd)) {

--- a/packages/squad-cli/src/cli/core/effective-squad-dir.ts
+++ b/packages/squad-cli/src/cli/core/effective-squad-dir.ts
@@ -1,0 +1,46 @@
+/**
+ * Effective squad directory resolution — external state aware.
+ *
+ * Wraps detectSquadDir() to follow the config.json stateLocation marker
+ * when state has been externalized via `squad externalize`.
+ *
+ * @module cli/core/effective-squad-dir
+ */
+
+import { detectSquadDir, type SquadDirInfo } from './detect-squad-dir.js';
+import { loadDirConfig, resolveExternalStateDir } from '@bradygaster/squad-sdk';
+
+/**
+ * Resolve the effective state directory from a local .squad/ path.
+ *
+ * If `.squad/config.json` has `stateLocation: 'external'` and a valid
+ * `projectKey`, returns the external state directory. Otherwise returns
+ * the original `squadDirPath` unchanged.
+ */
+export function resolveStateDir(squadDirPath: string): string {
+  const config = loadDirConfig(squadDirPath);
+  if (config?.stateLocation === 'external' && config.projectKey) {
+    return resolveExternalStateDir(config.projectKey, false);
+  }
+  return squadDirPath;
+}
+
+export interface EffectiveSquadDirs {
+  /** The local .squad/ directory info (for config.json and non-state files) */
+  local: SquadDirInfo;
+  /** The effective state directory (external dir when externalized, otherwise local .squad/) */
+  stateDir: string;
+}
+
+/**
+ * Detect the squad directory and resolve the effective state dir.
+ *
+ * Combines detectSquadDir() (zero-dependency bootstrap) with external
+ * state resolution from config.json. Use `stateDir` for reading state
+ * files (team.md, routing.md, agents/, plugins/, etc.) and `local.path`
+ * for non-state files that remain in the working tree.
+ */
+export function effectiveSquadDir(dest: string): EffectiveSquadDirs {
+  const local = detectSquadDir(dest);
+  return { local, stateDir: resolveStateDir(local.path) };
+}

--- a/packages/squad-cli/src/cli/shell/coordinator.ts
+++ b/packages/squad-cli/src/cli/shell/coordinator.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { listRoles, searchRoles, FSStorageProvider } from '@bradygaster/squad-sdk';
+import { listRoles, searchRoles, FSStorageProvider, loadDirConfig, resolveExternalStateDir } from '@bradygaster/squad-sdk';
 
 import type { ShellMessage } from './types.js';
 
@@ -233,8 +233,15 @@ export async function buildCoordinatorPrompt(config: CoordinatorConfig): Promise
   const squadRoot = config.teamRoot;
   const storage = new FSStorageProvider();
 
+  // Resolve effective state dir (external when externalized)
+  const localSquadDir = join(squadRoot, '.squad');
+  const dirConfig = loadDirConfig(localSquadDir);
+  const stateDir = (dirConfig?.stateLocation === 'external' && dirConfig.projectKey)
+    ? resolveExternalStateDir(dirConfig.projectKey, false)
+    : localSquadDir;
+
   // Load team.md for roster
-  const teamPath = config.teamPath ?? join(squadRoot, '.squad', 'team.md');
+  const teamPath = config.teamPath ?? join(stateDir, 'team.md');
   let teamContent = '';
   try {
     const raw = await storage.read(teamPath);
@@ -252,7 +259,7 @@ export async function buildCoordinatorPrompt(config: CoordinatorConfig): Promise
   }
 
   // Load routing.md for routing rules
-  const routingPath = config.routingPath ?? join(squadRoot, '.squad', 'routing.md');
+  const routingPath = config.routingPath ?? join(stateDir, 'routing.md');
   let routingContent = '';
   try {
     const raw = await storage.read(routingPath);

--- a/packages/squad-cli/src/cli/shell/index.ts
+++ b/packages/squad-cli/src/cli/shell/index.ts
@@ -21,7 +21,7 @@ import type { SquadSession } from '@bradygaster/squad-sdk/client';
 import type { SquadPermissionHandler } from '@bradygaster/squad-sdk/client';
 import { RateLimitError } from '@bradygaster/squad-sdk/adapter/errors';
 import type { ShellMessage } from './types.js';
-import { FSStorageProvider, initSquadTelemetry, TIMEOUTS, StreamingPipeline, recordAgentSpawn, recordAgentDuration, recordAgentError, recordAgentDestroy, RuntimeEventBus, resolveSquad, resolveGlobalSquadPath } from '@bradygaster/squad-sdk';
+import { FSStorageProvider, initSquadTelemetry, TIMEOUTS, StreamingPipeline, recordAgentSpawn, recordAgentDuration, recordAgentError, recordAgentDestroy, RuntimeEventBus, resolveSquad, resolveGlobalSquadPath, loadDirConfig, resolveExternalStateDir } from '@bradygaster/squad-sdk';
 import type { UsageEvent } from '@bradygaster/squad-sdk';
 import { enableShellMetrics, recordShellSessionDuration, recordAgentResponseLatency, recordShellError } from './shell-metrics.js';
 import { parseAgentFromDescription } from './agent-name-parser.js';
@@ -208,8 +208,14 @@ export async function runShell(): Promise<void> {
 
   // Session persistence — create or resume a previous session
   // Skip resume on first run (no team.md or .first-run marker present)
-  const hasTeam = storage.existsSync(join(teamRoot, '.squad', 'team.md'));
-  const isFirstRun = storage.existsSync(join(teamRoot, '.squad', '.first-run'));
+  // Resolve effective state dir for externalized state
+  const localSquadDir = join(teamRoot, '.squad');
+  const dirConfig = loadDirConfig(localSquadDir);
+  const stateDir = (dirConfig?.stateLocation === 'external' && dirConfig.projectKey)
+    ? resolveExternalStateDir(dirConfig.projectKey, false)
+    : localSquadDir;
+  const hasTeam = storage.existsSync(join(stateDir, 'team.md'));
+  const isFirstRun = storage.existsSync(join(stateDir, '.first-run'));
   let persistedSession: SessionData = createSession();
   const recentSession = (hasTeam && !isFirstRun) ? loadLatestSession(teamRoot) : null;
   if (recentSession) {

--- a/packages/squad-cli/src/cli/shell/lifecycle.ts
+++ b/packages/squad-cli/src/cli/shell/lifecycle.ts
@@ -9,6 +9,7 @@
 
 import path from 'node:path';
 import { FSStorageProvider } from '@bradygaster/squad-sdk';
+import { resolveStateDir } from '../core/effective-squad-dir.js';
 import { SessionRegistry } from './sessions.js';
 import { ShellRenderer } from './render.js';
 import type { ShellState, ShellMessage } from './types.js';
@@ -64,15 +65,18 @@ export class ShellLifecycle {
     this.state.status = 'initializing';
     const storage = new FSStorageProvider();
 
-    const squadDir = path.resolve(this.options.teamRoot, '.squad');
-    if (!await storage.exists(squadDir) || !await storage.isDirectory(squadDir)) {
+    const localSquadDir = path.resolve(this.options.teamRoot, '.squad');
+    if (!await storage.exists(localSquadDir) || !await storage.isDirectory(localSquadDir)) {
       this.state.status = 'error';
       const err = new Error(
         `No team found. Run \`squad init\` to create one.`
       );
-      debugLog('initialize: .squad/ directory not found at', squadDir);
+      debugLog('initialize: .squad/ directory not found at', localSquadDir);
       throw err;
     }
+
+    // Resolve effective state dir (external when externalized)
+    const squadDir = resolveStateDir(localSquadDir);
 
     const teamPath = path.join(squadDir, 'team.md');
     const teamContent = await storage.read(teamPath);
@@ -88,7 +92,7 @@ export class ShellLifecycle {
     this.discoveredAgents = parseTeamManifest(teamContent);
 
     if (this.discoveredAgents.length === 0) {
-      const initPromptPath = path.join(squadDir, '.init-prompt');
+      const initPromptPath = path.join(localSquadDir, '.init-prompt');
       if (!await storage.exists(initPromptPath)) {
         console.warn('⚠ No agents found in team.md. Run `squad init "describe your project"` to cast a team.');
       }
@@ -295,7 +299,9 @@ export interface WelcomeData {
 export function loadWelcomeData(teamRoot: string): WelcomeData | null {
   try {
     const storage = new FSStorageProvider();
-    const teamPath = path.join(teamRoot, '.squad', 'team.md');
+    const localSquadDir = path.join(teamRoot, '.squad');
+    const stateDir = resolveStateDir(localSquadDir);
+    const teamPath = path.join(stateDir, 'team.md');
     const content = storage.readSync(teamPath);
     if (content === undefined) return null;
 
@@ -309,7 +315,7 @@ export function loadWelcomeData(teamRoot: string): WelcomeData | null {
       .map(a => ({ name: a.name, role: a.role, emoji: getRoleEmoji(a.role) }));
 
     let focus: string | null = null;
-    const nowPath = path.join(teamRoot, '.squad', 'identity', 'now.md');
+    const nowPath = path.join(stateDir, 'identity', 'now.md');
     const nowContent = storage.readSync(nowPath);
     if (nowContent !== undefined) {
       const focusMatch = nowContent.match(/focus_area:\s*(.+)/);
@@ -317,7 +323,7 @@ export function loadWelcomeData(teamRoot: string): WelcomeData | null {
     }
 
     // Detect and consume first-run marker from `squad init`
-    const firstRunPath = path.join(teamRoot, '.squad', '.first-run');
+    const firstRunPath = path.join(stateDir, '.first-run');
     let isFirstRun = false;
     if (storage.existsSync(firstRunPath)) {
       isFirstRun = true;

--- a/test/effective-squad-dir.test.ts
+++ b/test/effective-squad-dir.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for effective-squad-dir: resolveStateDir() and effectiveSquadDir()
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { resolveStateDir, effectiveSquadDir } from '../packages/squad-cli/src/cli/core/effective-squad-dir.js';
+import { resolveGlobalSquadPath } from '@bradygaster/squad-sdk/resolution';
+
+const TMP = join(process.cwd(), `.test-effective-squad-dir-${randomBytes(4).toString('hex')}`);
+
+function scaffold(...dirs: string[]): void {
+  for (const d of dirs) {
+    mkdirSync(join(TMP, d), { recursive: true });
+  }
+}
+
+function writeConfig(squadDir: string, config: Record<string, unknown>): void {
+  writeFileSync(join(squadDir, 'config.json'), JSON.stringify(config, null, 2));
+}
+
+describe('resolveStateDir()', () => {
+  beforeEach(() => {
+    if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
+    mkdirSync(TMP, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('returns local path when no config.json exists', () => {
+    scaffold('.squad');
+    const squadDir = join(TMP, '.squad');
+    expect(resolveStateDir(squadDir)).toBe(squadDir);
+  });
+
+  it('returns local path when stateLocation is not external', () => {
+    scaffold('.squad');
+    const squadDir = join(TMP, '.squad');
+    writeConfig(squadDir, { version: 1, teamRoot: '.' });
+    expect(resolveStateDir(squadDir)).toBe(squadDir);
+  });
+
+  it('returns external path when stateLocation is external', () => {
+    scaffold('.squad');
+    const squadDir = join(TMP, '.squad');
+    const projectKey = `test-external-${randomBytes(4).toString('hex')}`;
+    writeConfig(squadDir, {
+      version: 1,
+      teamRoot: '.',
+      projectKey,
+      stateLocation: 'external',
+    });
+
+    const result = resolveStateDir(squadDir);
+    const globalDir = resolveGlobalSquadPath();
+    const expected = join(globalDir, 'projects', projectKey);
+    expect(result).toBe(expected);
+
+    // Cleanup external dir
+    if (existsSync(expected)) rmSync(expected, { recursive: true, force: true });
+  });
+
+  it('returns local path when stateLocation is external but projectKey is missing', () => {
+    scaffold('.squad');
+    const squadDir = join(TMP, '.squad');
+    writeConfig(squadDir, {
+      version: 1,
+      teamRoot: '.',
+      stateLocation: 'external',
+    });
+    expect(resolveStateDir(squadDir)).toBe(squadDir);
+  });
+});
+
+describe('effectiveSquadDir()', () => {
+  beforeEach(() => {
+    if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
+    mkdirSync(TMP, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('returns local for both when state is not externalized', () => {
+    scaffold('.squad');
+    const { local, stateDir } = effectiveSquadDir(TMP);
+    expect(local.path).toBe(join(TMP, '.squad'));
+    expect(stateDir).toBe(join(TMP, '.squad'));
+  });
+
+  it('returns external stateDir when state is externalized', () => {
+    scaffold('.squad');
+    const squadDir = join(TMP, '.squad');
+    const projectKey = `test-effective-${randomBytes(4).toString('hex')}`;
+    writeConfig(squadDir, {
+      version: 1,
+      teamRoot: '.',
+      projectKey,
+      stateLocation: 'external',
+    });
+
+    const { local, stateDir } = effectiveSquadDir(TMP);
+    expect(local.path).toBe(squadDir);
+
+    const globalDir = resolveGlobalSquadPath();
+    expect(stateDir).toBe(join(globalDir, 'projects', projectKey));
+
+    // Cleanup
+    const extDir = join(globalDir, 'projects', projectKey);
+    if (existsSync(extDir)) rmSync(extDir, { recursive: true, force: true });
+  });
+
+  it('preserves SquadDirInfo metadata in local field', () => {
+    scaffold('.squad');
+    const { local } = effectiveSquadDir(TMP);
+    expect(local.name).toBe('.squad');
+    expect(local.isLegacy).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #949

## Problem
After running \squad externalize\, runtime CLI commands (loop, watch, plugin, doctor, start/shell) still read state files from local \.squad/\ instead of the external state directory. This makes externalized state invisible to those commands.

## Fix
Adds \esolveStateDir()\ and \ffectiveSquadDir()\ helpers in \packages/squad-cli/src/cli/core/effective-squad-dir.ts\ that:
1. Read \config.json\ from local \.squad/\
2. If \stateLocation === 'external'\, resolve the external path via \esolveExternalStateDir(projectKey)\
3. Return the external path for state reads, local path for non-state files

Updated commands: loop, watch, plugin, doctor, shell/lifecycle, shell/coordinator, shell/index.

Non-state files (.ralph-state.json, schedule.json, config.json, rate-limit-status.json) correctly remain on the local path.

Includes 7 unit tests for the new resolver.