### PR TITLE
fix: address post-merge review findings (#876, #900, #875)

### DIFF
--- a/.changeset/review-findings-fix.md
+++ b/.changeset/review-findings-fix.md
@@ -1,0 +1,6 @@
+---
+'@bradygaster/squad-cli': patch
+---
+
+fix: address post-merge review findings — YAML escaping, type safety, deprecation messages
+

--- a/.changeset/review-findings-fix.md
+++ b/.changeset/review-findings-fix.md
@@ -2,4 +2,4 @@
 '@bradygaster/squad-cli': patch
 ---
 
-fix: address post-merge review findings — YAML escaping, type safety, deprecation messages
+fix: address post-merge review findings — catch unknown narrowing and deprecation warnings for start/rc commands

--- a/.changeset/review-findings-fix.md
+++ b/.changeset/review-findings-fix.md
@@ -3,4 +3,3 @@
 ---
 
 fix: address post-merge review findings — YAML escaping, type safety, deprecation messages
-

--- a/.squad/agents/eecom/history.md
+++ b/.squad/agents/eecom/history.md
@@ -4,6 +4,12 @@
 
 ## Learnings
 
+### PR #942 rebase — cherry-pick from insider-based fork branch (2026-04-12)
+
+**Context:** PR #942 from tamirdresher's fork was retargeted from `insider` to `dev`, causing 29 files in the diff when only 3 commits (4 files relevant to dev) were the actual fix. Cherry-picked the 3 fix commits onto a clean `squad/942-rebase-type-safety` branch from dev, resolving conflicts where insider-only files (skill.ts, cross-package-exports.test.ts) didn't exist on dev. Dropped the `escapeYamlValue` import and APM YAML generation function from init.ts since skill.ts doesn't exist on dev. Opened #963 as the clean replacement, closed #942.
+
+**Key lesson:** When cherry-picking from an insider-based branch to dev, expect modify/delete conflicts for files that only exist on insider. Always verify the base assumptions of each change — imports referencing insider-only modules must be dropped or adapted.
+
 ### Loop command: second-round review fixes (#767) (2025-07-26)
 
 **Context:** Three Copilot review comments on PR #767: (1) `teamRoot` was set to `workTreeRoot` but `.squad/` may live in the main checkout when running inside a git worktree — should derive from `detectSquadDir().path`, (2) `generateLoopFile()` hardcoded the full loop.md scaffold inline, duplicating `templates/loop.md`, (3) docs said `gh` was optional but code hard-requires `gh copilot` unless `--agent-cmd` is passed.

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -753,6 +753,8 @@ async function main(): Promise<void> {
   }
 
   if (cmd === 'start') {
+    console.log(`\n${YELLOW}⚠ DEPRECATED:${RESET} "squad start" is deprecated and will be removed in a future release.`);
+    console.log(`  Use the GitHub Copilot CLI directly: ${BOLD}gh copilot${RESET}\n`);
     const { runStart } = await import('./cli/commands/start.js');
     const hasTunnel = args.includes('--tunnel');
     const portIdx = args.indexOf('--port');
@@ -834,6 +836,8 @@ async function main(): Promise<void> {
   }
 
   if (cmd === 'rc' || cmd === 'remote-control') {
+    console.log(`\n${YELLOW}⚠ DEPRECATED:${RESET} "squad rc" is deprecated and will be removed in a future release.`);
+    console.log(`  Use the GitHub Copilot CLI directly: ${BOLD}gh copilot${RESET}\n`);
     const { runRC } = await import('./cli/commands/rc.js');
     const hasTunnel = args.includes('--tunnel');
     const portIdx = args.indexOf('--port');

--- a/packages/squad-cli/src/cli/commands/plugin.ts
+++ b/packages/squad-cli/src/cli/commands/plugin.ts
@@ -156,8 +156,9 @@ export async function runPlugin(dest: string, args: string[]): Promise<void> {
         { timeout: TIMEOUTS.PLUGIN_FETCH_MS }
       );
       entries = JSON.parse(stdout.trim());
-    } catch (err: any) {
-      fatal(`Could not browse ${marketplace.source} — ${err.message}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      fatal(`Could not browse ${marketplace.source} — ${message}`);
     }
 
     if (!entries || entries.length === 0) {

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -245,9 +245,10 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
   let result;
   try {
     result = await sdkInitSquad(initOptions);
-  } catch (err: any) {
+  } catch (err: unknown) {
     process.off('SIGINT', sigintHandler);
-    fatal(`Failed to initialize squad: ${err.message}`);
+    const message = err instanceof Error ? err.message : String(err);
+    fatal(`Failed to initialize squad: ${message}`);
     return; // Unreachable but makes TS happy
   }
 


### PR DESCRIPTION
Rebased cherry-pick of tamirdresher's fix from PR #942 (originally based on insider, retargeted to dev).

Applies only the changes relevant to dev:
- Replace catch(err: any) with catch(err: unknown) + narrowing (plugin.ts, init.ts)
- Add deprecation warnings with standardized 'gh copilot' messaging (cli-entry.ts)
- Includes changeset

Dropped insider-only changes (skill.ts YAML escaping, cross-package-exports.test.ts type safety) since those files don't exist on dev.

Closes #924, #925, #926
Supersedes #942

Original author: @tamirdresher
Original commits: 35dd824, 489c73b, 4aa6c4e