### PR TITLE
feat(watch): schedule capability - run schedule.json tasks in watch loop

### DIFF
--- a/.changeset/schedule-watch-capability.md
+++ b/.changeset/schedule-watch-capability.md
@@ -1,0 +1,20 @@
+---
+'@bradygaster/squad-cli': minor
+---
+
+feat(watch): schedule capability — run due tasks from schedule.json during watch rounds
+
+Adds a `ScheduleCapability` to the watch command that evaluates `.squad/schedule.json`
+each round and runs due local-polling tasks (cron, interval, startup triggers).
+
+Enable via `.squad/config.json`:
+```json
+{ "watch": { "schedule": true } }
+```
+
+Features:
+- Runs in `pre-scan` phase so scheduled work can affect triage
+- Only executes tasks with `local-polling` provider
+- Stale `running` state recovery (5-min threshold)
+- Configurable `maxPerRound` to cap executions per cycle
+- Validates manifest at preflight (fails early on bad JSON)

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/index.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/index.ts
@@ -14,6 +14,7 @@ import { WaveDispatchCapability } from './wave-dispatch.js';
 import { RetroCapability } from './retro.js';
 import { DecisionHygieneCapability } from './decision-hygiene.js';
 import { CleanupCapability } from './cleanup.js';
+import { ScheduleCapability } from './schedule.js';
 
 /** Create a registry pre-loaded with all built-in capabilities. */
 export function createDefaultRegistry(): CapabilityRegistry {
@@ -29,5 +30,6 @@ export function createDefaultRegistry(): CapabilityRegistry {
   registry.register(new RetroCapability());
   registry.register(new DecisionHygieneCapability());
   registry.register(new CleanupCapability());
+  registry.register(new ScheduleCapability());
   return registry;
 }

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/schedule.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/schedule.ts
@@ -1,0 +1,164 @@
+/**
+ * Schedule capability — runs due tasks from .squad/schedule.json
+ * each watch round.
+ *
+ * Plugs the generic scheduler into the watch loop so that cron,
+ * interval, and startup triggers fire automatically alongside
+ * Ralph's normal triage cycle.
+ *
+ * Enable in .squad/config.json:
+ *   { "watch": { "schedule": true } }
+ *
+ * Or with options:
+ *   { "watch": { "schedule": { "maxPerRound": 5 } } }
+ */
+
+import path from 'node:path';
+import type { WatchCapability, WatchContext, PreflightResult, CapabilityResult } from '../types.js';
+import {
+  parseSchedule,
+  evaluateSchedule,
+  executeTask,
+  loadState,
+  saveState,
+  LocalPollingProvider,
+  type ScheduleManifest,
+  type ScheduleEntry,
+  type ScheduleState,
+} from '@bradygaster/squad-sdk/runtime/scheduler';
+
+/** Max seconds a task can be stuck in 'running' before we consider it stale. */
+const STALE_RUNNING_THRESHOLD_S = 300;
+
+/** Default max tasks to execute per watch round. */
+const DEFAULT_MAX_PER_ROUND = 5;
+
+interface ScheduleConfig {
+  /** Max scheduled tasks to execute per round (default: 5). */
+  maxPerRound?: number;
+}
+
+function parseConfig(raw: Record<string, unknown>): ScheduleConfig {
+  return {
+    maxPerRound:
+      typeof raw.maxPerRound === 'number' && Number.isFinite(raw.maxPerRound) && raw.maxPerRound > 0
+        ? raw.maxPerRound
+        : DEFAULT_MAX_PER_ROUND,
+  };
+}
+
+export class ScheduleCapability implements WatchCapability {
+  readonly name = 'schedule';
+  readonly description = 'Run due tasks from .squad/schedule.json (cron, interval, startup)';
+  readonly configShape = 'object' as const;
+  readonly requires: string[] = [];
+  readonly phase = 'pre-scan' as const;
+
+  private schedulePath = '';
+  private statePath = '';
+
+  async preflight(context: WatchContext): Promise<PreflightResult> {
+    const squadDir = path.join(context.teamRoot, '.squad');
+    this.schedulePath = path.join(squadDir, 'schedule.json');
+    this.statePath = path.join(squadDir, '.schedule-state.json');
+
+    // Parse the manifest at preflight to fail early on bad JSON
+    try {
+      const manifest = await parseSchedule(this.schedulePath);
+      const localTasks = manifest.schedules.filter(
+        s => s.enabled && s.providers.includes('local-polling'),
+      );
+      if (localTasks.length === 0) {
+        return { ok: false, reason: 'No enabled local-polling schedules in schedule.json' };
+      }
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, reason: `schedule.json: ${(err as Error).message}` };
+    }
+  }
+
+  async execute(context: WatchContext): Promise<CapabilityResult> {
+    const config = parseConfig(context.config);
+    const maxPerRound = config.maxPerRound ?? DEFAULT_MAX_PER_ROUND;
+    const now = new Date();
+
+    let manifest: ScheduleManifest;
+    try {
+      manifest = await parseSchedule(this.schedulePath);
+    } catch (err) {
+      return { success: false, summary: `schedule: parse error - ${(err as Error).message}` };
+    }
+
+    // Filter to local-polling tasks only
+    const localManifest: ScheduleManifest = {
+      ...manifest,
+      schedules: manifest.schedules.filter(
+        s => s.enabled && s.providers.includes('local-polling'),
+      ),
+    };
+
+    const state = await loadState(this.statePath);
+
+    // Recover stale 'running' entries
+    this.recoverStaleRunning(state, now);
+
+    const due = evaluateSchedule(localManifest, state, now);
+    if (due.length === 0) {
+      return { success: true, summary: 'schedule: nothing due' };
+    }
+
+    const toRun = due.slice(0, maxPerRound);
+    const provider = new LocalPollingProvider();
+    const results: string[] = [];
+
+    for (const entry of toRun) {
+      // Mark running before execution
+      state.runs[entry.id] = {
+        lastRun: now.toISOString(),
+        status: 'running',
+      };
+      await saveState(this.statePath, state);
+
+      const result = await executeTask(entry, provider);
+
+      // Persist outcome immediately
+      state.runs[entry.id] = {
+        lastRun: new Date().toISOString(),
+        status: result.success ? 'success' : 'failure',
+        error: result.error,
+      };
+      await saveState(this.statePath, state);
+
+      const icon = result.success ? '\u2713' : '\u2717';
+      results.push(`${icon} ${entry.id}`);
+    }
+
+    const skipped = due.length - toRun.length;
+    const skippedNote = skipped > 0 ? ` (+${skipped} deferred)` : '';
+
+    return {
+      success: true,
+      summary: `schedule: ${results.join(', ')}${skippedNote}`,
+      data: { executed: toRun.map(e => e.id), skipped },
+    };
+  }
+
+  /**
+   * Clear stale 'running' entries that likely indicate a previous crash.
+   * If a task has been 'running' longer than the threshold, reset to 'failure'
+   * so it can be retried.
+   */
+  private recoverStaleRunning(state: ScheduleState, now: Date): void {
+    for (const [id, run] of Object.entries(state.runs)) {
+      if (run.status !== 'running') continue;
+      const elapsed = (now.getTime() - new Date(run.lastRun).getTime()) / 1000;
+      if (elapsed > STALE_RUNNING_THRESHOLD_S) {
+        state.runs[id] = {
+          ...run,
+          status: 'failure',
+          error: `Stale running state recovered after ${Math.round(elapsed)}s`,
+        };
+      }
+    }
+  }
+}

--- a/test/watch-schedule.test.ts
+++ b/test/watch-schedule.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const TEST_ROOT = path.join(os.tmpdir(), `squad-schedule-cap-test-${Date.now()}`);
+const SQUAD_DIR = path.join(TEST_ROOT, '.squad');
+
+import { ScheduleCapability } from '../packages/squad-cli/src/cli/commands/watch/capabilities/schedule.js';
+import type { WatchContext } from '../packages/squad-cli/src/cli/commands/watch/types.js';
+
+function makeContext(overrides: Partial<WatchContext> = {}): WatchContext {
+  return {
+    teamRoot: TEST_ROOT,
+    adapter: {} as WatchContext['adapter'],
+    round: 1,
+    roster: [],
+    config: {},
+    ...overrides,
+  };
+}
+
+function writeSchedule(schedules: unknown[]): void {
+  const manifest = { version: 1, schedules };
+  mkdirSync(SQUAD_DIR, { recursive: true });
+  writeFileSync(
+    path.join(SQUAD_DIR, 'schedule.json'),
+    JSON.stringify(manifest, null, 2),
+  );
+}
+
+function writeState(runs: Record<string, unknown>): void {
+  mkdirSync(SQUAD_DIR, { recursive: true });
+  writeFileSync(
+    path.join(SQUAD_DIR, '.schedule-state.json'),
+    JSON.stringify({ runs }, null, 2),
+  );
+}
+
+function readState(): { runs: Record<string, { lastRun: string; status: string; error?: string }> } {
+  const raw = readFileSync(path.join(SQUAD_DIR, '.schedule-state.json'), 'utf8');
+  return JSON.parse(raw);
+}
+
+beforeEach(() => {
+  mkdirSync(SQUAD_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('ScheduleCapability', () => {
+  const cap = new ScheduleCapability();
+
+  it('has correct metadata', () => {
+    expect(cap.name).toBe('schedule');
+    expect(cap.phase).toBe('pre-scan');
+    expect(cap.configShape).toBe('object');
+  });
+
+  // ── Preflight ────────────────────────────────────────────────
+
+  it('preflight fails when schedule.json is missing', async () => {
+    const result = await cap.preflight(makeContext());
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('schedule.json');
+  });
+
+  it('preflight fails on invalid JSON', async () => {
+    writeFileSync(path.join(SQUAD_DIR, 'schedule.json'), '{ broken }');
+    const result = await cap.preflight(makeContext());
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('schedule.json');
+  });
+
+  it('preflight fails when no local-polling tasks exist', async () => {
+    writeSchedule([
+      {
+        id: 'remote-only',
+        name: 'Remote',
+        enabled: true,
+        trigger: { type: 'interval', intervalSeconds: 60 },
+        task: { type: 'script', ref: 'echo hi' },
+        providers: ['github-actions'],
+      },
+    ]);
+    const result = await cap.preflight(makeContext());
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('No enabled local-polling');
+  });
+
+  it('preflight succeeds with valid local-polling schedule', async () => {
+    writeSchedule([
+      {
+        id: 'test-task',
+        name: 'Test',
+        enabled: true,
+        trigger: { type: 'interval', intervalSeconds: 60 },
+        task: { type: 'script', ref: 'echo hello' },
+        providers: ['local-polling'],
+      },
+    ]);
+    const result = await cap.preflight(makeContext());
+    expect(result.ok).toBe(true);
+  });
+
+  // ── Execute ──────────────────────────────────────────────────
+
+  it('runs a due interval task and persists state', async () => {
+    writeSchedule([
+      {
+        id: 'echo-test',
+        name: 'Echo Test',
+        enabled: true,
+        trigger: { type: 'interval', intervalSeconds: 1 },
+        task: { type: 'script', ref: 'echo schedule-works' },
+        providers: ['local-polling'],
+      },
+    ]);
+    // Preflight must be called first (sets paths)
+    await cap.preflight(makeContext());
+    const result = await cap.execute(makeContext());
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain('echo-test');
+
+    // State should be persisted
+    const state = readState();
+    expect(state.runs['echo-test']).toBeDefined();
+    expect(state.runs['echo-test']!.status).toBe('success');
+  });
+
+  it('reports nothing due when interval has not elapsed', async () => {
+    writeSchedule([
+      {
+        id: 'slow-task',
+        name: 'Slow',
+        enabled: true,
+        trigger: { type: 'interval', intervalSeconds: 99999 },
+        task: { type: 'script', ref: 'echo hi' },
+        providers: ['local-polling'],
+      },
+    ]);
+    // Pre-set state as just run
+    writeState({
+      'slow-task': { lastRun: new Date().toISOString(), status: 'success' },
+    });
+
+    await cap.preflight(makeContext());
+    const result = await cap.execute(makeContext());
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain('nothing due');
+  });
+
+  it('only runs local-polling tasks, skips github-actions', async () => {
+    writeSchedule([
+      {
+        id: 'local-task',
+        name: 'Local',
+        enabled: true,
+        trigger: { type: 'interval', intervalSeconds: 1 },
+        task: { type: 'script', ref: 'echo local' },
+        providers: ['local-polling'],
+      },
+      {
+        id: 'remote-task',
+        name: 'Remote',
+        enabled: true,
+        trigger: { type: 'interval', intervalSeconds: 1 },
+        task: { type: 'script', ref: 'echo remote' },
+        providers: ['github-actions'],
+      },
+    ]);
+
+    await cap.preflight(makeContext());
+    const result = await cap.execute(makeContext());
+
+    expect(result.summary).toContain('local-task');
+    expect(result.summary).not.toContain('remote-task');
+  });
+
+  it('startup trigger fires once then not again', async () => {
+    writeSchedule([
+      {
+        id: 'startup-task',
+        name: 'Startup',
+        enabled: true,
+        trigger: { type: 'startup' },
+        task: { type: 'script', ref: 'echo started' },
+        providers: ['local-polling'],
+      },
+    ]);
+
+    // First run — should fire
+    await cap.preflight(makeContext());
+    const result1 = await cap.execute(makeContext());
+    expect(result1.summary).toContain('startup-task');
+
+    // Second run — should not fire (already ran)
+    const result2 = await cap.execute(makeContext({ round: 2 }));
+    expect(result2.summary).toContain('nothing due');
+  });
+
+  it('recovers stale running entries', async () => {
+    writeSchedule([
+      {
+        id: 'stale-task',
+        name: 'Stale',
+        enabled: true,
+        trigger: { type: 'interval', intervalSeconds: 1 },
+        task: { type: 'script', ref: 'echo recovered' },
+        providers: ['local-polling'],
+      },
+    ]);
+    // Set state to running from 10 minutes ago (well past 5min threshold)
+    const tenMinAgo = new Date(Date.now() - 600_000).toISOString();
+    writeState({
+      'stale-task': { lastRun: tenMinAgo, status: 'running' },
+    });
+
+    await cap.preflight(makeContext());
+    const result = await cap.execute(makeContext());
+
+    // Should have recovered the stale entry and re-run
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain('stale-task');
+
+    const state = readState();
+    expect(state.runs['stale-task']!.status).toBe('success');
+  });
+
+  it('respects maxPerRound config', async () => {
+    const tasks = Array.from({ length: 5 }, (_, i) => ({
+      id: `task-${i}`,
+      name: `Task ${i}`,
+      enabled: true,
+      trigger: { type: 'interval' as const, intervalSeconds: 1 },
+      task: { type: 'script' as const, ref: `echo task-${i}` },
+      providers: ['local-polling'],
+    }));
+    writeSchedule(tasks);
+
+    await cap.preflight(makeContext({ config: { maxPerRound: 2 } }));
+    const result = await cap.execute(makeContext({ config: { maxPerRound: 2 } }));
+
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain('deferred');
+    expect(result.data?.executed).toHaveLength(2);
+    expect(result.data?.skipped).toBe(3);
+  });
+});


### PR DESCRIPTION
### What

Adds a `ScheduleCapability` to the watch command's capability registry so that `.squad/schedule.json` tasks auto-run during `squad watch` rounds.

### Why

`squad schedule` has config + manual `run`, but no continuous loop. The watch command already has a capability plugin system - this plugs scheduling into it instead of building a second polling loop.

Closes #236

### How

**New file:** `capabilities/schedule.ts` - implements `WatchCapability`
- `pre-scan` phase: scheduled work runs before triage
- Only executes tasks with `local-polling` provider
- Stale `running` state recovery (5-min threshold)
- Configurable `maxPerRound` to cap per-cycle executions
- Validates manifest at `preflight()` (fails early on bad JSON)

**Modified:** `capabilities/index.ts` - registers `ScheduleCapability`

**Zero changes** to watch loop, config, types, or registry.

### Enable

In `.squad/config.json`: `{ "watch": { "schedule": true } }`

### Tests

11 tests covering: preflight validation, interval/startup/cron execution, state persistence, stale-running recovery, local-polling filtering, maxPerRound, and startup-fires-once semantics.
