### PR TITLE
feat(sdk): runtime-extensible role catalog for marketplace plugins (#975)

### DIFF
--- a/docs/src/content/docs/features/built-in-roles.md
+++ b/docs/src/content/docs/features/built-in-roles.md
@@ -91,6 +91,51 @@ $ squad roles --search "security"      # search by keyword
 - Add extra ownership or approach items with `extraOwnership`/`extraApproach`.
 - Base roles are starting points — the coordinator refines them for your project context during casting.
 
+## Plugin-contributed roles
+
+Marketplace plugins can extend the catalog with their own roles. A plugin ships a `roles/` directory containing JSON role definitions; Squad loads `.squad/plugins/<plugin>/roles/*.json` automatically when you run `squad`, `squad roles`, or `squad init`.
+
+Plugin roles are **additive** — they cannot override a built-in role id. Use a namespaced id (for example `@acme/react-frontend`) so there's no collision:
+
+```json
+// .squad/plugins/@acme-frontend/roles/react.json
+{
+  "id": "@acme/react-frontend",
+  "title": "Acme React Frontend",
+  "category": "engineering",
+  "emoji": "⚛️",
+  "vibe": "Acme-flavored React specialist.",
+  "expertise": ["React", "Testing Library", "State management"],
+  "style": "Direct. Tested.",
+  "ownership": ["Acme UI layer"],
+  "approach": ["Measure-first"],
+  "boundaries": { "handles": "React UI", "doesNotHandle": "Backend APIs" },
+  "voice": "Crisp and opinionated.",
+  "routingPatterns": ["react", "frontend", "acme"],
+  "attribution": "Contributed by the @acme marketplace plugin."
+}
+```
+
+Once the plugin is installed, the role resolves identically to a built-in:
+
+```typescript
+useRole('@acme/react-frontend', { name: 'ada' });
+```
+
+It also appears in `squad roles` under a **🔌 Plugin Roles** section grouped by plugin, and in `searchRoles()` / `listRoles()` / `getCategories()`.
+
+For programmatic registration (tests, hot-reload, or a custom loader), import:
+
+```typescript
+import {
+  registerPluginRoles,
+  getPluginRoleRegistrations,
+  loadPluginRolesFromDir,
+} from '@bradygaster/squad-sdk';
+```
+
+`registerPluginRoles(plugin, roles)` throws if any `role.id` collides with a built-in and skips ids already registered by another plugin (reported via the `skipped` list).
+
 ## Attribution
 
 Built-in role content is adapted from [agency-agents](https://github.com/msitarzewski/agency-agents) by AgentLand Contributors, released under the MIT License.

--- a/docs/src/content/docs/features/plugins.md
+++ b/docs/src/content/docs/features/plugins.md
@@ -285,6 +285,8 @@ my-team-plugins/
 │   ├── charter.md          # Agent template
 │   ├── skills/
 │   │   └── awesome-skill.md
+│   ├── roles/              # Optional: additional base roles
+│   │   └── react.json      # Resolves via useRole('@your-plugin/react')
 │   └── decisions.md        # Conventions
 ├── microservices-template/
 │   ├── charter.md
@@ -293,6 +295,8 @@ my-team-plugins/
 │       └── fault-tolerance.md
 └── README.md               # Plugin descriptions
 ```
+
+Role files in `roles/` are loaded into the SDK role catalog. See [Built-in Roles → Plugin-contributed roles](./built-in-roles.md#plugin-contributed-roles) for the file format and collision rules.
 
 ### Step 1: Create the repository
 

--- a/docs/src/content/docs/guide/building-extensions.md
+++ b/docs/src/content/docs/guide/building-extensions.md
@@ -23,6 +23,8 @@ my-extension/
 │   └── CEREMONY.md
 ├── directives/
 │   └── DIRECTIVE.md
+├── roles/
+│   └── ROLE.json       # Optional: additional base roles (see built-in-roles doc)
 └── README.md
 ```
 

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -275,6 +275,8 @@ async function main(): Promise<void> {
   if (rawCmd === undefined) {
     // Fire-and-forget update check — non-blocking, never delays shell startup
     import('./cli/self-update.js').then(m => m.notifyIfUpdateAvailable(VERSION)).catch(() => {});
+    const { loadPluginRolesForDest } = await import('./cli/core/plugin-roles.js');
+    loadPluginRolesForDest(getSquadStartDir());
     const { runShell } = await lazyRunShell();
     await runShell();
     return;
@@ -309,6 +311,9 @@ async function main(): Promise<void> {
     const noWorkflows = args.includes('--no-workflows');
     const sdk = args.includes('--sdk');
     const roles = args.includes('--roles');
+    // Load plugin-contributed roles so init scaffolding can discover them.
+    const { loadPluginRolesForDest } = await import('./cli/core/plugin-roles.js');
+    loadPluginRolesForDest(dest);
     // Global init: suppress workflows (no GitHub CI in ~/.config/squad/) and bootstrap personal squad
     runInit(dest, { includeWorkflows: !noWorkflows && !hasGlobal, sdk, roles, isGlobal: hasGlobal }).catch(err => {
       fatal(err.message);
@@ -714,6 +719,8 @@ async function main(): Promise<void> {
   }
 
   if (cmd === 'roles') {
+    const { loadPluginRolesForDest } = await import('./cli/core/plugin-roles.js');
+    loadPluginRolesForDest(getSquadStartDir());
     const { runRoles } = await import('./cli/commands/roles.js');
     await runRoles(args.slice(1));
     return;

--- a/packages/squad-cli/src/cli/commands/roles.ts
+++ b/packages/squad-cli/src/cli/commands/roles.ts
@@ -1,4 +1,10 @@
-import { listRoles, searchRoles, getCategories } from '@bradygaster/squad-sdk';
+import {
+  listRoles,
+  searchRoles,
+  getCategories,
+  getPluginRoleRegistrations,
+  BASE_ROLES,
+} from '@bradygaster/squad-sdk';
 
 type RoleRecord = ReturnType<typeof listRoles>[number];
 
@@ -51,10 +57,14 @@ export async function runRoles(args: string[]): Promise<void> {
     return;
   }
 
-  const softwareRoles = roles.filter(r => SOFTWARE_DEVELOPMENT_CATEGORIES.has(r.category));
-  const businessRoles = roles.filter(r => !SOFTWARE_DEVELOPMENT_CATEGORIES.has(r.category));
+  const builtinIds = new Set(BASE_ROLES.map(r => r.id));
+  const builtinRoles = roles.filter(r => builtinIds.has(r.id));
+  const pluginRoles = roles.filter(r => !builtinIds.has(r.id));
 
-  console.log(`\n📦 Built-in Roles (${listRoles().length} base roles)`);
+  const softwareRoles = builtinRoles.filter(r => SOFTWARE_DEVELOPMENT_CATEGORIES.has(r.category));
+  const businessRoles = builtinRoles.filter(r => !SOFTWARE_DEVELOPMENT_CATEGORIES.has(r.category));
+
+  console.log(`\n📦 Built-in Roles (${BASE_ROLES.length} base roles)`);
   console.log('   Adapted from agency-agents by AgentLand Contributors (MIT)\n');
 
   if (softwareRoles.length > 0) {
@@ -67,5 +77,23 @@ export async function runRoles(args: string[]): Promise<void> {
     console.log('  Business & Operations:');
     printRoleRows(businessRoles);
     console.log();
+  }
+
+  if (pluginRoles.length > 0) {
+    const registrations = getPluginRoleRegistrations();
+    const byPlugin = new Map<string, typeof pluginRoles>();
+    for (const reg of registrations) {
+      if (!pluginRoles.some(r => r.id === reg.role.id)) continue;
+      const bucket = byPlugin.get(reg.plugin) ?? [];
+      bucket.push(reg.role);
+      byPlugin.set(reg.plugin, bucket);
+    }
+
+    console.log(`🔌 Plugin Roles (${pluginRoles.length} from ${byPlugin.size} plugin${byPlugin.size === 1 ? '' : 's'})\n`);
+    for (const [plugin, pluginRoleList] of byPlugin) {
+      console.log(`  ${plugin}:`);
+      printRoleRows(pluginRoleList);
+      console.log();
+    }
   }
 }

--- a/packages/squad-cli/src/cli/core/plugin-roles.ts
+++ b/packages/squad-cli/src/cli/core/plugin-roles.ts
@@ -1,0 +1,29 @@
+/**
+ * Plugin role discovery for the CLI — loads `<squadDir>/plugins/*\/roles/*.json`
+ * into the SDK role registry so `squad roles`, `squad hire`, and `squad init`
+ * see plugin-contributed roles alongside the built-ins.
+ */
+
+import { loadPluginRolesFromDir, type PluginRoleLoadSummary } from '@bradygaster/squad-sdk';
+import { join } from 'node:path';
+import { detectSquadDir } from './detect-squad-dir.js';
+
+let loadedForDir: string | null = null;
+
+/**
+ * Load plugin roles for the squad directory derived from `dest`.
+ *
+ * Idempotent per-process: once a directory has been scanned, subsequent
+ * calls for the same directory are no-ops. Pass `{ force: true }` to
+ * reload (e.g. after installing a new plugin in the same shell session).
+ */
+export function loadPluginRolesForDest(
+  dest: string,
+  opts: { force?: boolean } = {},
+): PluginRoleLoadSummary[] {
+  const info = detectSquadDir(dest);
+  const pluginsDir = join(info.path, 'plugins');
+  if (!opts.force && loadedForDir === pluginsDir) return [];
+  loadedForDir = pluginsDir;
+  return loadPluginRolesFromDir(pluginsDir);
+}

--- a/packages/squad-sdk/src/roles/index.ts
+++ b/packages/squad-sdk/src/roles/index.ts
@@ -12,38 +12,55 @@
 
 export type { BaseRole, RoleCategory, UseRoleOptions } from './types.js';
 export { BASE_ROLES, ENGINEERING_ROLE_IDS, CATEGORY_ROLE_IDS } from './catalog.js';
+export {
+  registerPluginRoles,
+  unregisterPluginRole,
+  clearPluginRoles,
+  getPluginRoles,
+  getPluginRoleRegistrations,
+  getAllRoles,
+} from './registry.js';
+export type { PluginRoleRegistration, RegisterPluginRolesResult } from './registry.js';
+export { loadPluginRolesFromDir } from './loader.js';
+export type { PluginRoleLoadSummary } from './loader.js';
 
 import type { BaseRole, RoleCategory, UseRoleOptions } from './types.js';
 import type { AgentDefinition } from '../builders/types.js';
-import { BASE_ROLES } from './catalog.js';
+import { getAllRoles } from './registry.js';
 
 /**
- * Get all available base roles, optionally filtered by category.
+ * Get all available roles (built-in + plugin), optionally filtered by category.
+ *
+ * Plugin roles registered via {@link registerPluginRoles} are included
+ * after the built-in base roles.
  */
 export function listRoles(category?: RoleCategory): readonly BaseRole[] {
-  if (!category) return BASE_ROLES;
-  return BASE_ROLES.filter(r => r.category === category);
+  const all = getAllRoles();
+  if (!category) return all;
+  return all.filter(r => r.category === category);
 }
 
 /**
- * Look up a base role by ID.
+ * Look up a role by ID. Searches built-in base roles and plugin-registered
+ * roles. Built-ins are checked first; plugin roles cannot override a built-in.
  *
- * @param id - Role ID (e.g., 'backend', 'marketing')
+ * @param id - Role ID (e.g., 'backend', '@acme/frontend')
  * @returns The role definition, or undefined if not found
  */
 export function getRoleById(id: string): BaseRole | undefined {
-  return BASE_ROLES.find(r => r.id === id);
+  return getAllRoles().find(r => r.id === id);
 }
 
 /**
  * Search roles by keyword across title, vibe, expertise, and routing patterns.
+ * Includes plugin-registered roles.
  *
  * @param query - Search query (case-insensitive)
  * @returns Matching roles sorted by relevance
  */
 export function searchRoles(query: string): readonly BaseRole[] {
   const q = query.toLowerCase();
-  return BASE_ROLES.filter(r => {
+  return getAllRoles().filter(r => {
     return (
       r.title.toLowerCase().includes(q) ||
       r.vibe.toLowerCase().includes(q) ||
@@ -55,11 +72,12 @@ export function searchRoles(query: string): readonly BaseRole[] {
 }
 
 /**
- * Get all unique categories in the catalog.
+ * Get all unique categories in the catalog, including categories
+ * contributed by plugin roles.
  */
 export function getCategories(): readonly RoleCategory[] {
   const cats = new Set<RoleCategory>();
-  for (const r of BASE_ROLES) cats.add(r.category);
+  for (const r of getAllRoles()) cats.add(r.category);
   return [...cats];
 }
 
@@ -87,7 +105,7 @@ export function getCategories(): readonly RoleCategory[] {
 export function useRole(roleId: string, options: UseRoleOptions): AgentDefinition {
   const role = getRoleById(roleId);
   if (!role) {
-    const available = BASE_ROLES.map(r => r.id).join(', ');
+    const available = getAllRoles().map(r => r.id).join(', ');
     throw new Error(
       `Unknown base role '${roleId}'. Available roles: ${available}`
     );

--- a/packages/squad-sdk/src/roles/loader.ts
+++ b/packages/squad-sdk/src/roles/loader.ts
@@ -1,0 +1,107 @@
+/**
+ * Plugin Role Loader — discovers role definitions in a plugins directory
+ * and registers them with the {@link registerPluginRoles} registry.
+ *
+ * Convention:
+ *   `<pluginsDir>/<plugin-name>/roles/*.json`
+ *
+ * Each JSON file may contain either a single {@link BaseRole} object or
+ * an array of `BaseRole` objects. The plugin directory name is used as
+ * the `plugin` attribution in the registry.
+ *
+ * @module roles/loader
+ */
+
+import { join } from 'node:path';
+import type { BaseRole } from './types.js';
+import type { StorageProvider } from '../storage/index.js';
+import { FSStorageProvider } from '../storage/index.js';
+import { registerPluginRoles, type RegisterPluginRolesResult } from './registry.js';
+
+/** Per-file load summary. */
+export interface PluginRoleLoadSummary {
+  /** Plugin directory name. */
+  readonly plugin: string;
+  /** Absolute path of the JSON file loaded. */
+  readonly source: string;
+  /** Registration result for the roles in this file. */
+  readonly result: RegisterPluginRolesResult;
+  /** Error message, if the file was malformed or registration failed. */
+  readonly error?: string;
+}
+
+/**
+ * Scan `pluginsDir` for plugin role definitions and register them.
+ *
+ * Safe to call even when `pluginsDir` does not exist — returns an empty
+ * summary list.
+ *
+ * @param pluginsDir - Absolute path to the plugins directory
+ *   (typically `<squadDir>/plugins`).
+ * @param storage - Optional storage provider (defaults to filesystem).
+ */
+export function loadPluginRolesFromDir(
+  pluginsDir: string,
+  storage: StorageProvider = new FSStorageProvider(),
+): PluginRoleLoadSummary[] {
+  const summaries: PluginRoleLoadSummary[] = [];
+
+  if (!storage.existsSync(pluginsDir) || !storage.isDirectorySync(pluginsDir)) {
+    return summaries;
+  }
+
+  for (const plugin of storage.listSync(pluginsDir)) {
+    const pluginPath = join(pluginsDir, plugin);
+    if (!storage.isDirectorySync(pluginPath)) continue;
+
+    const rolesDir = join(pluginPath, 'roles');
+    if (!storage.existsSync(rolesDir) || !storage.isDirectorySync(rolesDir)) continue;
+
+    for (const entry of storage.listSync(rolesDir)) {
+      if (!entry.endsWith('.json')) continue;
+      const source = join(rolesDir, entry);
+
+      let raw: string | undefined;
+      try {
+        raw = storage.readSync(source);
+      } catch (err) {
+        summaries.push({
+          plugin,
+          source,
+          result: { registered: [], skipped: [] },
+          error: err instanceof Error ? err.message : String(err),
+        });
+        continue;
+      }
+      if (!raw) continue;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (err) {
+        summaries.push({
+          plugin,
+          source,
+          result: { registered: [], skipped: [] },
+          error: `invalid JSON: ${err instanceof Error ? err.message : String(err)}`,
+        });
+        continue;
+      }
+
+      const roles = (Array.isArray(parsed) ? parsed : [parsed]) as BaseRole[];
+      try {
+        const result = registerPluginRoles(plugin, roles);
+        summaries.push({ plugin, source, result });
+      } catch (err) {
+        summaries.push({
+          plugin,
+          source,
+          result: { registered: [], skipped: [] },
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  return summaries;
+}

--- a/packages/squad-sdk/src/roles/registry.ts
+++ b/packages/squad-sdk/src/roles/registry.ts
@@ -1,0 +1,121 @@
+/**
+ * Plugin Role Registry — runtime-extensible role catalog.
+ *
+ * Lets marketplace plugins contribute additional role definitions
+ * that `useRole()`, `listRoles()`, `searchRoles()`, and `getCategories()`
+ * will discover alongside the built-in {@link BASE_ROLES}.
+ *
+ * Plugin roles are **additive only** — a plugin may not register a role
+ * whose `id` matches a built-in base role. Registering a duplicate id
+ * throws so that misconfiguration surfaces loudly at install time rather
+ * than silently replacing a built-in charter.
+ *
+ * @module roles/registry
+ */
+
+import type { BaseRole } from './types.js';
+import { BASE_ROLES } from './catalog.js';
+
+/**
+ * A plugin role registration record — the role plus the plugin that
+ * registered it. Useful for diagnostics (`squad roles --debug`) and for
+ * surfacing the source of a role in tooling.
+ */
+export interface PluginRoleRegistration {
+  /** Plugin name (e.g., `@acme/frontend-roles`). */
+  readonly plugin: string;
+  /** The role definition contributed by the plugin. */
+  readonly role: BaseRole;
+}
+
+/** Outcome of a `registerPluginRoles` call. */
+export interface RegisterPluginRolesResult {
+  /** Roles that were successfully registered on this call. */
+  readonly registered: readonly BaseRole[];
+  /** Roles that were skipped, with a human-readable reason. */
+  readonly skipped: readonly { readonly id: string; readonly reason: string }[];
+}
+
+const pluginRoles = new Map<string, PluginRoleRegistration>();
+
+function baseRoleIds(): Set<string> {
+  return new Set(BASE_ROLES.map(r => r.id));
+}
+
+/**
+ * Register a batch of plugin-contributed roles.
+ *
+ * Collision rules:
+ * - If `role.id` matches a built-in `BASE_ROLES` id, the call throws.
+ *   Built-in roles are load-bearing for existing configs and must never
+ *   be shadowed; surface the problem to the plugin author.
+ * - If `role.id` is already registered by another plugin, the role is
+ *   skipped and reported via the `skipped` list (no throw, so one bad
+ *   role in a plugin bundle does not block the rest).
+ *
+ * @param plugin - Name of the plugin registering the roles (for diagnostics).
+ * @param roles - Role definitions to register.
+ * @throws If any role id collides with a built-in base role.
+ */
+export function registerPluginRoles(
+  plugin: string,
+  roles: readonly BaseRole[],
+): RegisterPluginRolesResult {
+  const builtins = baseRoleIds();
+  const registered: BaseRole[] = [];
+  const skipped: { id: string; reason: string }[] = [];
+
+  for (const role of roles) {
+    if (!role || typeof role.id !== 'string' || role.id.length === 0) {
+      skipped.push({ id: String((role as BaseRole | undefined)?.id ?? 'unknown'), reason: 'missing id' });
+      continue;
+    }
+    if (builtins.has(role.id)) {
+      throw new Error(
+        `Plugin '${plugin}' cannot register role '${role.id}' — it collides with a built-in base role. ` +
+          `Use a namespaced id such as '@${plugin}/${role.id}'.`,
+      );
+    }
+    const existing = pluginRoles.get(role.id);
+    if (existing) {
+      skipped.push({
+        id: role.id,
+        reason: `already registered by plugin '${existing.plugin}'`,
+      });
+      continue;
+    }
+    pluginRoles.set(role.id, { plugin, role });
+    registered.push(role);
+  }
+
+  return { registered, skipped };
+}
+
+/** Remove a single plugin role. Returns true if the id was registered. */
+export function unregisterPluginRole(id: string): boolean {
+  return pluginRoles.delete(id);
+}
+
+/** Remove every plugin role. Intended for tests and hot-reload paths. */
+export function clearPluginRoles(): void {
+  pluginRoles.clear();
+}
+
+/** All plugin-registered roles, in registration order. */
+export function getPluginRoles(): readonly BaseRole[] {
+  return [...pluginRoles.values()].map(r => r.role);
+}
+
+/** Full registration records (plugin + role), in registration order. */
+export function getPluginRoleRegistrations(): readonly PluginRoleRegistration[] {
+  return [...pluginRoles.values()];
+}
+
+/**
+ * Merged view: built-in roles first, then plugin roles in registration
+ * order. Built-ins always precede plugin roles so that lookups and
+ * iteration remain deterministic.
+ */
+export function getAllRoles(): readonly BaseRole[] {
+  return [...BASE_ROLES, ...getPluginRoles()];
+}

--- a/test/plugin-roles.test.ts
+++ b/test/plugin-roles.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  listRoles,
+  getRoleById,
+  searchRoles,
+  getCategories,
+  useRole,
+  registerPluginRoles,
+  clearPluginRoles,
+  getPluginRoles,
+  getPluginRoleRegistrations,
+  getAllRoles,
+  loadPluginRolesFromDir,
+} from '../packages/squad-sdk/src/roles/index.js';
+import { BASE_ROLES } from '../packages/squad-sdk/src/roles/catalog.js';
+import type { BaseRole } from '../packages/squad-sdk/src/roles/types.js';
+
+function sampleRole(overrides: Partial<BaseRole> = {}): BaseRole {
+  return {
+    id: '@acme/react-frontend',
+    title: 'React Frontend (Acme)',
+    category: 'engineering',
+    emoji: '⚛️',
+    vibe: 'Acme-flavored React specialist.',
+    expertise: ['React', 'Testing Library', 'State management'],
+    style: 'Direct. Tested.',
+    ownership: ['Acme UI layer'],
+    approach: ['Measure-first'],
+    boundaries: { handles: 'React UI', doesNotHandle: 'Backend APIs' },
+    voice: 'Crisp and opinionated.',
+    routingPatterns: ['react', 'frontend', 'acme'],
+    attribution: 'Contributed by the @acme marketplace plugin.',
+    ...overrides,
+  };
+}
+
+describe('plugin role registry', () => {
+  beforeEach(() => {
+    clearPluginRoles();
+  });
+  afterEach(() => {
+    clearPluginRoles();
+  });
+
+  it('registerPluginRoles adds roles that getRoleById/listRoles/searchRoles can find', () => {
+    const role = sampleRole();
+    const result = registerPluginRoles('@acme/frontend-roles', [role]);
+    expect(result.registered).toHaveLength(1);
+    expect(result.skipped).toHaveLength(0);
+
+    expect(getRoleById(role.id)).toEqual(role);
+    expect(listRoles().some(r => r.id === role.id)).toBe(true);
+    expect(listRoles('engineering').some(r => r.id === role.id)).toBe(true);
+    expect(searchRoles('acme').some(r => r.id === role.id)).toBe(true);
+  });
+
+  it('throws when a plugin role id collides with a built-in base role', () => {
+    expect(() =>
+      registerPluginRoles('@evil/overrider', [sampleRole({ id: 'backend' })]),
+    ).toThrowError(/cannot register role 'backend'/);
+    // Built-in backend is untouched.
+    expect(getRoleById('backend')?.id).toBe('backend');
+    expect(getPluginRoles()).toHaveLength(0);
+  });
+
+  it('skips (does not throw) when two plugins try the same id', () => {
+    registerPluginRoles('@acme/one', [sampleRole()]);
+    const result = registerPluginRoles('@acme/two', [sampleRole()]);
+    expect(result.registered).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.id).toBe('@acme/react-frontend');
+    expect(result.skipped[0]?.reason).toMatch(/already registered/);
+  });
+
+  it('getPluginRoleRegistrations records the plugin source', () => {
+    registerPluginRoles('@acme/frontend-roles', [sampleRole()]);
+    const regs = getPluginRoleRegistrations();
+    expect(regs).toHaveLength(1);
+    expect(regs[0]?.plugin).toBe('@acme/frontend-roles');
+    expect(regs[0]?.role.id).toBe('@acme/react-frontend');
+  });
+
+  it('getCategories includes categories contributed by plugin roles', () => {
+    registerPluginRoles('@acme/compliance', [
+      sampleRole({ id: '@acme/auditor', category: 'compliance' }),
+    ]);
+    expect(getCategories()).toContain('compliance');
+  });
+
+  it('useRole resolves plugin role ids identically to built-ins', () => {
+    registerPluginRoles('@acme/frontend-roles', [sampleRole()]);
+    const agent = useRole('@acme/react-frontend', { name: 'ada' });
+    expect(agent.role).toBe('React Frontend (Acme)');
+    expect(agent.charter).toContain('Contributed by the @acme marketplace plugin');
+    expect(agent.charter).toContain('## Identity');
+  });
+
+  it('useRole error lists plugin roles among available ids', () => {
+    registerPluginRoles('@acme/frontend-roles', [sampleRole()]);
+    try {
+      useRole('nonexistent', { name: 'ghost' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).toContain('@acme/react-frontend');
+      expect(msg).toContain('backend');
+    }
+  });
+
+  it('getAllRoles returns BASE_ROLES first then plugin roles', () => {
+    registerPluginRoles('@acme/frontend-roles', [sampleRole()]);
+    const all = getAllRoles();
+    expect(all.slice(0, BASE_ROLES.length)).toEqual(BASE_ROLES);
+    expect(all[all.length - 1]?.id).toBe('@acme/react-frontend');
+  });
+
+  it('clearPluginRoles removes all registrations', () => {
+    registerPluginRoles('@acme/frontend-roles', [sampleRole()]);
+    clearPluginRoles();
+    expect(getPluginRoles()).toHaveLength(0);
+    expect(getRoleById('@acme/react-frontend')).toBeUndefined();
+  });
+});
+
+describe('loadPluginRolesFromDir', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    clearPluginRoles();
+    tmp = mkdtempSync(join(tmpdir(), 'squad-plugin-roles-'));
+  });
+  afterEach(() => {
+    clearPluginRoles();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns an empty summary when the pluginsDir does not exist', () => {
+    const summaries = loadPluginRolesFromDir(join(tmp, 'does-not-exist'));
+    expect(summaries).toEqual([]);
+  });
+
+  it('loads JSON role files and registers them', () => {
+    const pluginDir = join(tmp, 'plugins', '@acme-plugin', 'roles');
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(join(pluginDir, 'frontend.json'), JSON.stringify(sampleRole()), 'utf-8');
+
+    const summaries = loadPluginRolesFromDir(join(tmp, 'plugins'));
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.plugin).toBe('@acme-plugin');
+    expect(summaries[0]?.result.registered).toHaveLength(1);
+    expect(getRoleById('@acme/react-frontend')).toBeDefined();
+  });
+
+  it('accepts a JSON array of roles in a single file', () => {
+    const pluginDir = join(tmp, 'plugins', 'multi', 'roles');
+    mkdirSync(pluginDir, { recursive: true });
+    const roles = [
+      sampleRole({ id: '@multi/a', title: 'A' }),
+      sampleRole({ id: '@multi/b', title: 'B' }),
+    ];
+    writeFileSync(join(pluginDir, 'bundle.json'), JSON.stringify(roles), 'utf-8');
+
+    const summaries = loadPluginRolesFromDir(join(tmp, 'plugins'));
+    expect(summaries[0]?.result.registered).toHaveLength(2);
+    expect(getRoleById('@multi/a')).toBeDefined();
+    expect(getRoleById('@multi/b')).toBeDefined();
+  });
+
+  it('reports invalid JSON without throwing', () => {
+    const pluginDir = join(tmp, 'plugins', 'bad', 'roles');
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(join(pluginDir, 'broken.json'), '{ not valid', 'utf-8');
+
+    const summaries = loadPluginRolesFromDir(join(tmp, 'plugins'));
+    expect(summaries[0]?.error).toMatch(/invalid JSON/);
+    expect(summaries[0]?.result.registered).toHaveLength(0);
+  });
+
+  it('reports collisions with built-in role ids without aborting the scan', () => {
+    const pluginDir = join(tmp, 'plugins', 'shadow', 'roles');
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(
+      join(pluginDir, 'override.json'),
+      JSON.stringify(sampleRole({ id: 'backend' })),
+      'utf-8',
+    );
+    writeFileSync(
+      join(pluginDir, 'ok.json'),
+      JSON.stringify(sampleRole({ id: '@shadow/fine' })),
+      'utf-8',
+    );
+
+    const summaries = loadPluginRolesFromDir(join(tmp, 'plugins'));
+    const override = summaries.find(s => s.source.endsWith('override.json'));
+    const ok = summaries.find(s => s.source.endsWith('ok.json'));
+    expect(override?.error).toMatch(/cannot register role 'backend'/);
+    expect(ok?.result.registered).toHaveLength(1);
+    expect(getRoleById('@shadow/fine')).toBeDefined();
+    // Built-in backend is unchanged.
+    expect(getRoleById('backend')?.title).toBe('Backend Developer');
+  });
+
+  it('ignores non-directory entries and non-JSON files', () => {
+    const pluginsDir = join(tmp, 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    writeFileSync(join(pluginsDir, 'README.md'), '# not a plugin', 'utf-8');
+    const pluginDir = join(pluginsDir, 'real', 'roles');
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(join(pluginDir, 'note.txt'), 'ignored', 'utf-8');
+    writeFileSync(join(pluginDir, 'role.json'), JSON.stringify(sampleRole()), 'utf-8');
+
+    const summaries = loadPluginRolesFromDir(pluginsDir);
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.plugin).toBe('real');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #975. Lets marketplace plugins ship a `roles/` directory whose definitions resolve through `useRole()` / `listRoles()` / `searchRoles()` / `getCategories()` identically to built-in roles.

- **New module:** `packages/squad-sdk/src/roles/registry.ts` — runtime role registry. `registerPluginRoles(plugin, roles)` throws on collision with a built-in (additive-only guarantee) and skips duplicate-plugin ids with a structured `skipped` result.
- **New module:** `packages/squad-sdk/src/roles/loader.ts` — `loadPluginRolesFromDir(<squadDir>/plugins)` scans `<plugin>/roles/*.json` (single role or array) and registers each.
- **SDK re-exports:** `registerPluginRoles`, `unregisterPluginRole`, `clearPluginRoles`, `getPluginRoles`, `getPluginRoleRegistrations`, `getAllRoles`, `loadPluginRolesFromDir`, plus types.
- **CLI:** new `loadPluginRolesForDest()` helper is invoked from `squad` (interactive), `squad roles`, and `squad init`, so plugin roles appear in the catalog, hire wizard, and `--sdk --roles` scaffolding.
- **CLI UX:** `squad roles` gains a "🔌 Plugin Roles" section grouped by plugin name.
- **Tests:** `test/plugin-roles.test.ts` (15 new cases) covers collision, duplicate-skip, category contribution, `useRole()` resolution, loader edge cases (missing dir, invalid JSON, non-JSON entries, built-in shadow attempt). Existing role tests unchanged and passing.

## Design notes
- Plugin roles are **appended** after `BASE_ROLES` in `getAllRoles()` so iteration order stays deterministic. Collision with a built-in id is a hard error — an organization that wants a tweaked `backend` must use a namespaced id like `@acme/backend`.
- The registry is process-global module state. `loadPluginRolesForDest()` is idempotent per-directory for a single process (pass `{ force: true }` to reload after `squad plugin marketplace add …`).

## Risks / call-outs
1. **Process-global registry state.** Tests that register plugin roles and don't clean up can leak into later files. New tests use `clearPluginRoles()` in `beforeEach`/`afterEach`, but future contributors need the same discipline.
2. **Unvalidated plugin role shape.** The loader `JSON.parse`s whatever is on disk and hands it to `registerPluginRoles()`. Missing fields will blow up later in `useRole()` (TypeScript types aren't enforced at runtime). A follow-up could add a Zod-style schema check; issue scope didn't require it.
3. **Supply-chain trust boundary.** A plugin with write access to `.squad/plugins/` can register any non-built-in role id. We cannot shadow a built-in (guard), but a plugin could register `@malicious/lead` and socially engineer users into casting it. Same trust model as the existing plugin marketplace; worth naming.
4. **Init defaults are unchanged.** `SDK_ROLES_STARTER_TEAM` in `config/init.ts` still points at built-in ids only. `squad init --sdk --roles` won't auto-select a plugin role; users opt in explicitly by passing the plugin role id (e.g. via the hire wizard or `useRole('@acme/x', …)` in `squad.config.ts`). Intentional — we don't want init to pick up arbitrary plugin-provided roles as the default team composition.
5. **CLI startup cost.** Loader runs on every `squad` / `squad roles` / `squad init` invocation. If `.squad/plugins` is missing the cost is a single `statSync`. If populated, it reads every `roles/*.json`. Negligible for reasonable plugin counts but worth watching if a plugin ships hundreds of roles.
6. **Pre-existing build-state oddity.** `npm run lint` / `npm run build` fails on `dev` today with `TOKEN_PATH` in `platform/comms-teams.ts` — unrelated to this PR but flagging so reviewers don't attribute it.

## Test plan
- [x] `npx vitest run test/roles.test.ts test/plugin-roles.test.ts test/init-base-roles.test.ts test/fact-checker-role.test.ts test/casting.test.ts test/casting-engine-integration.test.ts test/cast-parser.test.ts test/init-sdk.test.ts test/init-scaffolding.test.ts test/builders.test.ts test/consumer-imports.test.ts test/package-exports.test.ts test/shell.test.ts` — 375/375 pass locally
- [x] `tsc --noEmit` clean on both `packages/squad-sdk` and `packages/squad-cli` for the changed files
- [ ] Manual: drop a sample role JSON in `.squad/plugins/demo/roles/x.json`, run `squad roles` — plugin section appears
- [ ] Manual: `useRole('@demo/x', { name: 'foo' })` in `squad.config.ts` resolves without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)