### PR TITLE
Emphasize human-led productivity in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [English](README.md) | [中文](README.zh.md)
 
-**AI agent teams for any project.** One command. A team that grows with your code.
+**Human-led AI agent teams for any project.** One command. A team that helps you move faster with your code.
 
 [![Status](https://img.shields.io/badge/status-alpha-blueviolet)](#status)
 [![Platform](https://img.shields.io/badge/platform-GitHub%20Copilot-blue)](#what-is-squad)
@@ -13,9 +13,13 @@
 
 ## What is Squad?
 
-Squad gives you an AI development team through GitHub Copilot. Describe what you're building. Get a team of specialists — frontend, backend, tester, lead — that live in your repo as files. They persist across sessions, learn your codebase, share decisions, and get better the more you use them.
+Squad gives you a human-directed AI development team through GitHub Copilot. Describe what you're building. Get a team of specialists — frontend, backend, tester, lead — that live in your repo as files. They persist across sessions, learn your codebase, share decisions, and help you move faster without giving up oversight.
 
-It's not a chatbot wearing hats. Each team member runs in its own context, reads only its own knowledge, and writes back what it learned.
+Squad is a productivity tool for humans, not a replacement for engineers, reviewers, or decision-makers. People stay accountable for priorities, approvals, and final changes; Squad helps with coordination, repetition, and parallel execution.
+
+It's not a chatbot wearing hats. Each team member runs in its own context, reads only its own knowledge, and writes back what it learned so the work stays inspectable.
+
+> **Responsible AI stance** — Squad is built to amplify a human operator with GitHub Copilot, not to remove humans from the loop. Use it to delegate faster, review better, and keep governance close to the code.
 
 ---
 
@@ -117,9 +121,9 @@ Use `--force` to re-apply updates even when your installed version already match
 
 ---
 
-## Watch Mode — Ralph's Autonomous Polling
+## Watch Mode — Ralph's Automated Polling
 
-Ralph continuously polls for work and dispatches agents to handle it. Watch mode is perfect for unmanned squad operations — let agents work while you're away.
+Ralph continuously polls for work and dispatches agents to handle it. Watch mode helps a human team stay responsive — Ralph automates triage, execution handoffs, and monitoring, then escalates back to people when judgment or approval is needed.
 
 ### Quick Start
 
@@ -171,7 +175,7 @@ Ralph uses an **agent-delegated selection pattern**:
 5. The agent **decides which issue to work on** and **how**
 6. Ralph monitors execution, logs results, updates issue status
 
-This design gives **agents full autonomy** over issue selection while keeping the polling loop lean.
+This design keeps the polling loop lean while letting agents handle issue selection automatically under the team's rules, review gates, and escalation policy.
 
 ### Issue Selection & Escalation
 
@@ -339,9 +343,9 @@ Eight working examples from beginner to advanced — casting, governance, stream
 
 ---
 
-## Agents Work in Parallel— You Catch Up When You're Ready
+## Agents Work in Parallel — You Stay in Control
 
-Squad doesn't work on a human schedule. When you give a task, the coordinator launches every agent that can usefully start — simultaneously.
+Squad helps one human coordinate more work at once. When you give a task, the coordinator launches every agent that can usefully start — simultaneously — while you keep priorities, review, and final decisions.
 
 ```
 You: "Team, build the login page"
@@ -353,7 +357,7 @@ You: "Team, build the login page"
   📋 Scribe — logging everything...             ⎦
 ```
 
-When agents finish, the coordinator immediately chains follow-up work. If you step away, a breadcrumb trail is waiting when you get back:
+When agents finish, the coordinator records follow-up work and leaves a breadcrumb trail so you can review what happened with full context:
 
 - **`decisions.md`** — every decision any agent made
 - **`orchestration-log/`** — what was spawned, why, and what happened

--- a/docs/src/components/Search.astro
+++ b/docs/src/components/Search.astro
@@ -11,9 +11,9 @@ const base = import.meta.env.BASE_URL;
     <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
     </svg>
-    <span class="hidden sm:inline">Search docsΓÇª</span>
+    <span class="hidden sm:inline">Search docs...</span>
     <kbd class="hidden sm:inline-flex ml-auto text-xs border border-surface-300 dark:border-surface-600 rounded px-1.5 py-0.5 text-surface-400" id="search-shortcut-kbd">
-      <span class="text-xs" id="search-modifier">Γîÿ</span>K
+      <span class="text-xs" id="search-modifier">Ctrl+</span>K
     </kbd>
   </button>
 </div>
@@ -30,7 +30,7 @@ const base = import.meta.env.BASE_URL;
         <input
           id="search-input"
           type="text"
-          placeholder="Search documentationΓÇª"
+          placeholder="Search documentation..."
           class="flex-1 py-3 bg-transparent text-surface-900 dark:text-white placeholder-surface-400 outline-none text-base"
           autocomplete="off"
         />
@@ -39,7 +39,7 @@ const base = import.meta.env.BASE_URL;
       <div id="search-status" class="hidden px-4 py-2 text-xs text-surface-500 dark:text-surface-400 border-b border-surface-100 dark:border-surface-800"></div>
       <div id="search-results" class="max-h-[60vh] overflow-y-auto p-2">
         <div class="p-8 text-center text-surface-400 text-sm" id="search-empty">
-          Start typing to searchΓÇª
+          Start typing to search...
         </div>
       </div>
 
@@ -48,7 +48,7 @@ const base = import.meta.env.BASE_URL;
 </div>
 
 <script define:vars={{ base }}>
-  // Pagefind instance persists across View Transitions ΓÇö no need to re-import
+  // Pagefind instance persists across View Transitions - no need to re-import
   let pagefind = null;
 
   async function loadPagefind() {
@@ -96,7 +96,7 @@ const base = import.meta.env.BASE_URL;
     if (searchResults) searchResults.innerHTML = '';
     if (searchEmpty) {
       searchResults?.appendChild(searchEmpty);
-      searchEmpty.textContent = 'Start typing to searchΓÇª';
+      searchEmpty.textContent = 'Start typing to search...';
     }
     searchStatus?.classList.add('hidden');
     document.body.style.overflow = '';
@@ -107,7 +107,7 @@ const base = import.meta.env.BASE_URL;
     if (!query) {
       if (searchResults && searchEmpty) {
         searchResults.innerHTML = '';
-        searchEmpty.textContent = 'Start typing to searchΓÇª';
+        searchEmpty.textContent = 'Start typing to search...';
         searchResults.appendChild(searchEmpty);
       }
       searchStatus?.classList.add('hidden');
@@ -148,18 +148,18 @@ const base = import.meta.env.BASE_URL;
           </div>
           <div class="text-sm text-surface-500 dark:text-surface-400 mt-0.5 line-clamp-2">${result.excerpt || ''}</div>
         `;
-        // Close modal on click ΓÇö navigation proceeds via View Transitions
+        // Close modal on click - navigation proceeds via View Transitions
         a.addEventListener('click', closeSearch);
         searchResults.appendChild(a);
       });
     } catch {
       if (searchResults) {
-        searchResults.innerHTML = '<div class="p-8 text-center text-surface-400 text-sm">Search index loadingΓÇª</div>';
+        searchResults.innerHTML = '<div class="p-8 text-center text-surface-400 text-sm">Search index loading...</div>';
       }
     }
   }
 
-  // Global keydown ΓÇö register exactly once, never duplicated
+  // Global keydown - register exactly once, never duplicated
   let _globalKeydownRegistered = false;
   function handleGlobalKeydown(e) {
     if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
@@ -197,7 +197,7 @@ const base = import.meta.env.BASE_URL;
     const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
     const modifierEl = document.getElementById('search-modifier');
     if (modifierEl) {
-      modifierEl.textContent = isMac ? 'Γîÿ' : 'Ctrl+';
+      modifierEl.textContent = isMac ? 'Cmd+' : 'Ctrl+';
     }
 
     // Create fresh bound handlers

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -158,21 +158,21 @@ const base = import.meta.env.BASE_URL;
   <!-- Trust strip -->
   <section class="relative border-y border-surface-200/60 dark:border-surface-800/60 bg-surface-50/80 dark:bg-surface-900/30 backdrop-blur-sm">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5">
-        <div class="flex flex-wrap items-center justify-center gap-x-8 gap-y-2 text-lg">
-          <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
-            <span class="w-1.5 h-1.5 rounded-full bg-squad-500"></span>
-            <span>Humans stay in charge</span>
-          </div>
-          <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
-            <span class="w-1.5 h-1.5 rounded-full bg-accent-500"></span>
-            <span>Built-in governance</span>
-          </div>
-          <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
-            <span class="w-1.5 h-1.5 rounded-full bg-navy-500"></span>
-            <span>Persistent team memory</span>
-          </div>
-          <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
-            <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+      <div class="flex flex-wrap items-center justify-center gap-x-8 gap-y-2 text-lg">
+        <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-squad-500"></span>
+          <span>Humans stay in charge</span>
+        </div>
+        <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-accent-500"></span>
+          <span>Built-in governance</span>
+        </div>
+        <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-navy-500"></span>
+          <span>Persistent team memory</span>
+        </div>
+        <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
           <span>MIT open source</span>
         </div>
       </div>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -32,12 +32,11 @@ const base = import.meta.env.BASE_URL;
           </div>
 
           <h1 class="animate-fade-up-scale delay-100 text-5xl sm:text-6xl lg:text-7xl font-extrabold tracking-tight text-surface-900 dark:text-white mb-6 leading-[1.1]">
-            Your <span class="text-squad-700 dark:text-squad-300">Human-led</span><br />
-            <span class="bg-gradient-to-r from-squad-600 via-squad-500 to-squad-400 bg-clip-text text-transparent">AI Development Team</span>
+            Your agents <span class="bg-gradient-to-r from-squad-600 via-squad-500 to-squad-400 bg-clip-text text-transparent">bring your ideas to life</span>
           </h1>
 
           <p class="animate-fade-up delay-300 text-lg sm:text-xl text-surface-600 dark:text-surface-300 mb-10 leading-relaxed max-w-xl mx-auto lg:mx-0">
-            Describe what you're building. Squad coordinates specialists that live in your repo so an individual human can delegate more, review faster, and keep the final call.
+            Describe what you're building. Squad coordinates agents that live in your repo and grow with your code. You spend less time prompting, more time deciding, and convert ideas into product more efficiently than ever before.
           </p>
 
           <div class="animate-fade-up delay-500 flex flex-col sm:flex-row items-center justify-center lg:justify-start gap-4 mb-12">

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -6,7 +6,7 @@ import Footer from '../components/Footer.astro';
 const base = import.meta.env.BASE_URL;
 ---
 
-<BaseLayout title="Your AI Development Team">
+<BaseLayout title="Human-Led AI Development Team">
   <Header />
 
   <!-- Hero -->
@@ -32,13 +32,12 @@ const base = import.meta.env.BASE_URL;
           </div>
 
           <h1 class="animate-fade-up-scale delay-100 text-5xl sm:text-6xl lg:text-7xl font-extrabold tracking-tight text-surface-900 dark:text-white mb-6 leading-[1.1]">
-            Your AI<br />
-            <span class="bg-gradient-to-r from-squad-600 via-squad-500 to-squad-400 bg-clip-text text-transparent">Development Team</span>
+            Your <span class="text-squad-700 dark:text-squad-300">Human-led</span><br />
+            <span class="bg-gradient-to-r from-squad-600 via-squad-500 to-squad-400 bg-clip-text text-transparent">AI Development Team</span>
           </h1>
 
           <p class="animate-fade-up delay-300 text-lg sm:text-xl text-surface-600 dark:text-surface-300 mb-10 leading-relaxed max-w-xl mx-auto lg:mx-0">
-            Describe what you're building. Get a team of specialists that live in your repo.
-            Agents fan out, build in parallel, and land pull requests in minutes.
+            Describe what you're building. Squad coordinates specialists that live in your repo so an individual human can delegate more, review faster, and keep the final call.
           </p>
 
           <div class="animate-fade-up delay-500 flex flex-col sm:flex-row items-center justify-center lg:justify-start gap-4 mb-12">
@@ -76,72 +75,80 @@ const base = import.meta.env.BASE_URL;
         </div>
 
         <!-- Right: Terminal demo -->
-        <div class="animate-fade-up delay-400 relative">
-          <!-- Glow behind terminal -->
-          <div class="absolute -inset-4 bg-gradient-to-r from-squad-500/20 via-accent-400/15 to-navy-500/20 dark:from-squad-500/10 dark:via-accent-400/8 dark:to-navy-500/10 rounded-2xl blur-2xl"></div>
-          <div class="relative bg-surface-900 dark:bg-surface-800 rounded-2xl overflow-hidden shadow-2xl border border-surface-700/50">
-            <div class="flex items-center gap-2 px-4 py-3 bg-surface-800/80 dark:bg-surface-700/80 border-b border-surface-700/50">
-              <div class="flex gap-1.5">
-                <div class="w-3 h-3 rounded-full bg-red-500/80"></div>
-                <div class="w-3 h-3 rounded-full bg-yellow-500/80"></div>
-                <div class="w-3 h-3 rounded-full bg-green-500/80"></div>
+        <div class="animate-fade-up delay-400 space-y-6">
+          <div class="relative">
+            <!-- Glow behind terminal -->
+            <div class="absolute -inset-4 bg-gradient-to-r from-squad-500/20 via-accent-400/15 to-navy-500/20 dark:from-squad-500/10 dark:via-accent-400/8 dark:to-navy-500/10 rounded-2xl blur-2xl"></div>
+            <div class="relative bg-surface-900 dark:bg-surface-800 rounded-2xl overflow-hidden shadow-2xl border border-surface-700/50">
+              <div class="flex items-center gap-2 px-4 py-3 bg-surface-800/80 dark:bg-surface-700/80 border-b border-surface-700/50">
+                <div class="flex gap-1.5">
+                  <div class="w-3 h-3 rounded-full bg-red-500/80"></div>
+                  <div class="w-3 h-3 rounded-full bg-yellow-500/80"></div>
+                  <div class="w-3 h-3 rounded-full bg-green-500/80"></div>
+                </div>
+                <span class="text-xs text-surface-400 ml-2 font-mono">Copilot Chat</span>
               </div>
-              <span class="text-xs text-surface-400 ml-2 font-mono">Copilot Chat</span>
-            </div>
-            <div class="p-5 sm:p-6 font-mono text-xs sm:text-sm space-y-4">
-              <div>
-                <p class="text-surface-500 text-xs mb-1.5">YOU</p>
-                <p class="text-surface-200 leading-relaxed">Team, build the recipe listing page. We need an API endpoint that returns recipes and a React component that displays them.</p>
-              </div>
-              <div class="border-t border-surface-700/50 pt-4">
-                <p class="text-surface-500 text-xs mb-3">SQUAD RESPONSE</p>
-                <div class="space-y-2.5">
-                  <div class="flex items-start gap-3 agent-line" style="--delay: 0">
-                    <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-yellow-500/15 text-yellow-400 text-xs shrink-0">🏗️</span>
-                    <div>
-                      <span class="text-yellow-400 font-medium">Flight</span>
-                      <span class="text-surface-400"> — reviewing requirements, defining API contract</span>
+              <div class="p-5 sm:p-6 font-mono text-xs sm:text-sm space-y-4">
+                <div>
+                  <p class="text-surface-500 text-xs mb-1.5">YOU</p>
+                  <p class="text-surface-200 leading-relaxed">Team, build the recipe listing page. We need an API endpoint that returns recipes and a React component that displays them.</p>
+                </div>
+                <div class="border-t border-surface-700/50 pt-4">
+                  <p class="text-surface-500 text-xs mb-3">SQUAD RESPONSE</p>
+                  <div class="space-y-2.5">
+                    <div class="flex items-start gap-3 agent-line" style="--delay: 0">
+                      <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-yellow-500/15 text-yellow-400 text-xs shrink-0">🏗️</span>
+                      <div>
+                        <span class="text-yellow-400 font-medium">Flight</span>
+                        <span class="text-surface-400"> — reviewing requirements, defining API contract</span>
+                      </div>
                     </div>
-                  </div>
-                  <div class="flex items-start gap-3 agent-line" style="--delay: 1">
-                    <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-blue-500/15 text-blue-400 text-xs shrink-0">⚛️</span>
-                    <div>
-                      <span class="text-blue-400 font-medium">EECOM</span>
-                      <span class="text-surface-400"> — building RecipeList component</span>
+                    <div class="flex items-start gap-3 agent-line" style="--delay: 1">
+                      <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-blue-500/15 text-blue-400 text-xs shrink-0">⚛️</span>
+                      <div>
+                        <span class="text-blue-400 font-medium">EECOM</span>
+                        <span class="text-surface-400"> — building RecipeList component</span>
+                      </div>
                     </div>
-                  </div>
-                  <div class="flex items-start gap-3 agent-line" style="--delay: 2">
-                    <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-green-500/15 text-green-400 text-xs shrink-0">🔧</span>
-                    <div>
-                      <span class="text-green-400 font-medium">CAPCOM</span>
-                      <span class="text-surface-400"> — creating GET /api/recipes endpoint</span>
+                    <div class="flex items-start gap-3 agent-line" style="--delay: 2">
+                      <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-green-500/15 text-green-400 text-xs shrink-0">🔧</span>
+                      <div>
+                        <span class="text-green-400 font-medium">CAPCOM</span>
+                        <span class="text-surface-400"> — creating GET /api/recipes endpoint</span>
+                      </div>
                     </div>
-                  </div>
-                  <div class="flex items-start gap-3 agent-line" style="--delay: 3">
-                    <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-purple-500/15 text-purple-400 text-xs shrink-0">🧪</span>
-                    <div>
-                      <span class="text-purple-400 font-medium">FIDO</span>
-                      <span class="text-surface-400"> — writing test cases from requirements</span>
+                    <div class="flex items-start gap-3 agent-line" style="--delay: 3">
+                      <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-purple-500/15 text-purple-400 text-xs shrink-0">🧪</span>
+                      <div>
+                        <span class="text-purple-400 font-medium">FIDO</span>
+                        <span class="text-surface-400"> — writing test cases from requirements</span>
+                      </div>
                     </div>
-                  </div>
-                  <div class="flex items-start gap-3 agent-line" style="--delay: 4">
-                    <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-surface-500/15 text-surface-400 text-xs shrink-0">📋</span>
-                    <div>
-                      <span class="text-surface-400 font-medium">Scribe</span>
-                      <span class="text-surface-500"> — logging decisions</span>
+                    <div class="flex items-start gap-3 agent-line" style="--delay: 4">
+                      <span class="inline-flex items-center justify-center w-6 h-6 rounded-md bg-surface-500/15 text-surface-400 text-xs shrink-0">📋</span>
+                      <div>
+                        <span class="text-surface-400 font-medium">Scribe</span>
+                        <span class="text-surface-500"> — logging decisions</span>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div class="flex items-center gap-2 pt-2 border-t border-surface-700/50">
-                <div class="flex -space-x-1">
-                  <div class="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse"></div>
-                  <div class="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" style="animation-delay: 150ms"></div>
-                  <div class="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" style="animation-delay: 300ms"></div>
+                <div class="flex items-center gap-2 pt-2 border-t border-surface-700/50">
+                  <div class="flex -space-x-1">
+                    <div class="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse"></div>
+                    <div class="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" style="animation-delay: 150ms"></div>
+                    <div class="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" style="animation-delay: 300ms"></div>
+                  </div>
+                  <span class="text-sm sm:text-base font-medium text-surface-500 animate-pulse">5 agents working in parallel…</span>
                 </div>
-                <span class="text-surface-500 text-xs">5 agents working in parallel…</span>
               </div>
             </div>
+          </div>
+
+          <div class="rounded-2xl border border-squad-300/80 dark:border-squad-400/30 bg-gradient-to-br from-squad-50 via-accent-50/80 to-white dark:from-squad-500/12 dark:via-accent-500/10 dark:to-white/5 backdrop-blur-sm px-5 py-4 text-left shadow-lg shadow-squad-500/10">
+            <p class="text-sm sm:text-base text-surface-700 dark:text-surface-300 leading-relaxed">
+              <strong class="text-squad-700 dark:text-squad-300">Responsible AI, explicitly:</strong> Squad does not replace humans, and it is not intended to. Its goal is to make an individual more productive while keeping oversight, approvals, and accountability in human hands.
+            </p>
           </div>
         </div>
       </div>
@@ -151,21 +158,21 @@ const base = import.meta.env.BASE_URL;
   <!-- Trust strip -->
   <section class="relative border-y border-surface-200/60 dark:border-surface-800/60 bg-surface-50/80 dark:bg-surface-900/30 backdrop-blur-sm">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5">
-      <div class="flex flex-wrap items-center justify-center gap-x-8 gap-y-2 text-lg">
-        <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
-          <span class="w-1.5 h-1.5 rounded-full bg-squad-500"></span>
-          <span>Persistent team memory</span>
-        </div>
-        <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
-          <span class="w-1.5 h-1.5 rounded-full bg-accent-500"></span>
-          <span>Parallel execution</span>
-        </div>
-        <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
-          <span class="w-1.5 h-1.5 rounded-full bg-navy-500"></span>
-          <span>Setup in seconds</span>
-        </div>
-        <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
-          <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+        <div class="flex flex-wrap items-center justify-center gap-x-8 gap-y-2 text-lg">
+          <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
+            <span class="w-1.5 h-1.5 rounded-full bg-squad-500"></span>
+            <span>Humans stay in charge</span>
+          </div>
+          <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
+            <span class="w-1.5 h-1.5 rounded-full bg-accent-500"></span>
+            <span>Built-in governance</span>
+          </div>
+          <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
+            <span class="w-1.5 h-1.5 rounded-full bg-navy-500"></span>
+            <span>Persistent team memory</span>
+          </div>
+          <div class="flex items-center gap-2 text-surface-600 dark:text-surface-300">
+            <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
           <span>MIT open source</span>
         </div>
       </div>
@@ -177,9 +184,9 @@ const base = import.meta.env.BASE_URL;
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-16">
         <p class="text-squad-600 dark:text-squad-400 font-semibold text-sm tracking-wide uppercase mb-3">Why Squad?</p>
-        <h2 class="text-3xl sm:text-4xl font-bold text-surface-900 dark:text-white mb-5">Multi-agent orchestration,<br class="hidden sm:block" /> moved from prompts into code</h2>
+        <h2 class="text-3xl sm:text-4xl font-bold text-surface-900 dark:text-white mb-5">Multi-agent orchestration,<br class="hidden sm:block" /> with humans in charge</h2>
         <p class="text-lg text-surface-600 dark:text-surface-400 max-w-2xl mx-auto">
-          Enforced rules, persistent teams, parallel execution — everything you need for AI that actually ships.
+          Enforced rules, persistent teams, and accountable workflows — everything you need for AI that helps people ship responsibly.
         </p>
       </div>
 
@@ -188,8 +195,8 @@ const base = import.meta.env.BASE_URL;
           <div class="md:flex md:items-start md:gap-5">
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-squad-500 to-squad-600 flex items-center justify-center mb-4 md:mb-0 text-white text-lg shadow-lg shadow-squad-500/20 shrink-0">🚀</div>
             <div>
-              <h3 class="text-lg font-semibold text-surface-900 dark:text-white mb-2">Parallel AI Teamwork</h3>
-              <p class="text-surface-600 dark:text-surface-400 text-sm leading-relaxed">Give a task to the team and multiple agents fan out simultaneously. No waiting in line — results land in minutes.</p>
+              <h3 class="text-lg font-semibold text-surface-900 dark:text-white mb-2">Human-Directed Parallel Work</h3>
+              <p class="text-surface-600 dark:text-surface-400 text-sm leading-relaxed">Give a task to the team and specialists fan out together. You set the direction, review the results, and keep the final decision. Squad uses AI-emulated specialist roles to make a real human more productive, not to replace real humans.</p>
             </div>
           </div>
         </div>
@@ -197,13 +204,13 @@ const base = import.meta.env.BASE_URL;
         <div class="group relative p-6 rounded-2xl bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-800 hover:border-accent-300/50 dark:hover:border-accent-600/30 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-accent-500/5">
           <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-accent-500 to-accent-600 flex items-center justify-center mb-5 text-white text-lg shadow-lg shadow-accent-500/20">🧠</div>
           <h3 class="text-lg font-semibold text-surface-900 dark:text-white mb-2">Persistent Memory</h3>
-          <p class="text-surface-600 dark:text-surface-400 text-sm leading-relaxed">Agents remember decisions and conventions across sessions. Your team gets smarter every time you work together.</p>
+          <p class="text-surface-600 dark:text-surface-400 text-sm leading-relaxed">Agents remember decisions and conventions across sessions so people spend less time repeating context and more time reviewing the work that matters.</p>
         </div>
 
         <div class="group relative p-6 rounded-2xl bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-800 hover:border-navy-300/50 dark:hover:border-navy-600/30 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-navy-500/5">
           <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-navy-600 to-navy-700 flex items-center justify-center mb-5 text-white text-lg shadow-lg shadow-navy-500/20">🐙</div>
           <h3 class="text-lg font-semibold text-surface-900 dark:text-white mb-2">GitHub-Native</h3>
-          <p class="text-surface-600 dark:text-surface-400 text-sm leading-relaxed">Squad lives in your repo as <code class="bg-surface-100 dark:bg-surface-800 px-1.5 py-0.5 rounded text-xs font-mono">.squad/</code>. Commit it, share it, clone it. Your team travels with your code.</p>
+          <p class="text-surface-600 dark:text-surface-400 text-sm leading-relaxed">Squad lives in your repo as <code class="bg-surface-100 dark:bg-surface-800 px-1.5 py-0.5 rounded text-xs font-mono">.squad/</code>. Commit it, share it, clone it. Team state, decisions, and context stay inspectable with your code.</p>
         </div>
 
         <div class="group relative p-6 rounded-2xl bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-800 hover:border-navy-300/50 dark:hover:border-navy-600/30 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl hover:shadow-navy-500/5 md:col-span-2 lg:col-span-2">
@@ -211,7 +218,7 @@ const base = import.meta.env.BASE_URL;
             <div class="w-11 h-11 rounded-xl bg-gradient-to-br from-navy-600 to-navy-700 flex items-center justify-center mb-4 md:mb-0 text-white text-lg shadow-lg shadow-navy-500/20 shrink-0">🛡️</div>
             <div>
               <h3 class="text-lg font-semibold text-surface-900 dark:text-white mb-2">Built-in Governance</h3>
-              <p class="text-surface-600 dark:text-surface-400 text-sm leading-relaxed">File-write guards, PII scrubbing, reviewer lockout — rules enforced in code, not suggestions in prompts.</p>
+              <p class="text-surface-600 dark:text-surface-400 text-sm leading-relaxed">File-write guards, PII scrubbing, reviewer lockout, and clear escalation points — rules enforced in code, not suggestions in prompts.</p>
             </div>
           </div>
         </div>
@@ -256,7 +263,7 @@ const base = import.meta.env.BASE_URL;
         <div class="flex-1 relative text-center flex flex-col items-center">
           <div class="inline-flex items-center justify-center w-12 h-12 rounded-2xl bg-squad-600 text-white font-bold text-lg mb-5 shadow-lg shadow-squad-600/25">2</div>
           <h3 class="font-semibold text-surface-900 dark:text-white mb-2">Initialize</h3>
-          <p class="text-sm text-surface-600 dark:text-surface-400 mb-4 flex-1">Describe your project and Squad generates your team.</p>
+          <p class="text-sm text-surface-600 dark:text-surface-400 mb-4 flex-1">Describe your project and Squad generates a team you direct.</p>
           <code class="text-sm font-mono bg-surface-100 dark:bg-surface-800 text-surface-700 dark:text-green-400 px-3 py-1.5 rounded-lg border border-surface-200 dark:border-transparent">squad init</code>
         </div>
         <div class="hidden sm:flex items-start pt-4 shrink-0">
@@ -265,7 +272,7 @@ const base = import.meta.env.BASE_URL;
         <div class="flex-1 relative text-center flex flex-col items-center">
           <div class="inline-flex items-center justify-center w-12 h-12 rounded-2xl bg-squad-600 text-white font-bold text-lg mb-5 shadow-lg shadow-squad-600/25">3</div>
           <h3 class="font-semibold text-surface-900 dark:text-white mb-2">Build</h3>
-          <p class="text-sm text-surface-600 dark:text-surface-400 mb-4 flex-1">Talk to your team — they build, test, and land PRs.</p>
+          <p class="text-sm text-surface-600 dark:text-surface-400 mb-4 flex-1">Talk to your team — they help you build, test, and prepare changes for review.</p>
           <code class="text-sm font-mono bg-surface-100 dark:bg-surface-800 text-surface-700 dark:text-green-400 px-3 py-1.5 rounded-lg border border-surface-200 dark:border-transparent">copilot --agent squad</code>
         </div>
       </div>
@@ -322,8 +329,8 @@ const base = import.meta.env.BASE_URL;
     <div class="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(240,79,127,0.15),transparent_70%)]"></div>
     <div class="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.04)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.04)_1px,transparent_1px)] bg-[size:40px_40px]"></div>
     <div class="relative max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-6">Ship faster with<br />your AI team</h2>
-      <p class="text-lg text-navy-200/80 mb-10 max-w-xl mx-auto">One install. One command. Your full team, ready to build.</p>
+      <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-6">Ship faster with<br />a human-led AI team</h2>
+      <p class="text-lg text-navy-200/80 mb-10 max-w-xl mx-auto">One install. One command. Keep people accountable while Squad handles the repetitive coordination.</p>
       <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
         <a
           href={`${base}docs/get-started/installation/`}

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -146,7 +146,7 @@ const base = import.meta.env.BASE_URL;
 
           <div class="rounded-2xl border border-squad-300/80 dark:border-squad-400/30 bg-gradient-to-br from-squad-50 via-accent-50/80 to-white dark:from-squad-500/12 dark:via-accent-500/10 dark:to-white/5 backdrop-blur-sm px-5 py-4 text-left shadow-lg shadow-squad-500/10">
             <p class="text-sm sm:text-base text-surface-700 dark:text-surface-300 leading-relaxed">
-              <strong class="text-squad-700 dark:text-squad-300">Responsible AI, explicitly:</strong> Squad does not replace humans, and it is not intended to. Its goal is to make an individual more productive while keeping oversight, approvals, and accountability in human hands.
+              <strong class="text-squad-700 dark:text-squad-300">Responsible AI, explicitly:</strong> Squad democratizes multi-agentic work and extends human development teams' capabilities. Its goal is to make an individual more productive while enabling human oversight, review, and accountability at agentic speed.
             </p>
           </div>
         </div>

--- a/test/docs-build.test.ts
+++ b/test/docs-build.test.ts
@@ -302,6 +302,7 @@ describe('Docs Build Script (Astro)', () => {
     const html = readFile(indexPath);
     expect(html).toMatch(/<!doctype html>/i);
     expect(html).toContain('Development Team');
+    expect(html).toContain('Humans stay in charge');
   });
 
   // --- 5. Blog index ---


### PR DESCRIPTION
## Summary
- reframe the homepage and README around human-led productivity and responsible AI
- refine the landing page hero, callout, parallel-work copy, and visual emphasis
- fix garbled search UI text and keep the docs build regression aligned

<img width="2548" height="1275" alt="image" src="https://github.com/user-attachments/assets/262dc872-044e-4598-a595-4a18a63bcd51" />

## Validation
- `npx vitest run test\docs-build.test.ts`

## Notes
- `npm run build` currently fails on the base branch with an unrelated TypeScript error in `packages/squad-sdk/src/platform/comms-teams.ts` (`TOKEN_PATH` vs `tokenPath`); this PR does not touch that area.

Closes #986

cc @diberry @bradygaster @tamirdresher