### PR TITLE
fix: resolve 404 on API docs navigation link

### DIFF
--- a/docs/src/content/docs/reference/sdk.md
+++ b/docs/src/content/docs/reference/sdk.md
@@ -4,7 +4,7 @@
 
 Complete reference for `@bradygaster/squad-sdk` — the programmatic API for Squad.
 
-> **See also:** [API Reference (TypeDoc)](/reference/api/) — Complete auto-generated reference with full type signatures for all exports.
+> **See also:** [API Reference](api-reference.md) — Complete auto-generated reference with full type signatures for all exports.
 
 ```bash
 npm install @bradygaster/squad-sdk

--- a/docs/src/navigation.ts
+++ b/docs/src/navigation.ts
@@ -84,7 +84,7 @@ export const NAV_SECTIONS: NavSection[] = [
     items: [
       { title: 'CLI', slug: 'reference/cli' },
       { title: 'SDK', slug: 'reference/sdk' },
-      { title: 'SDK API Reference', slug: 'reference/api' },
+      { title: 'SDK API Reference', slug: 'reference/api-reference' },
       { title: 'SDK Integration', slug: 'reference/integration' },
       { title: 'Tools & Hooks', slug: 'reference/tools-and-hooks' },
       { title: 'Config', slug: 'reference/config' },


### PR DESCRIPTION
## Summary

Fixes the 404 at https://bradygaster.github.io/squad/docs/reference/api/ reported in #990.

## Root Cause

The navigation slug in `docs/src/navigation.ts` was `reference/api`, but the actual content file is `api-reference.md` which generates the slug `reference/api-reference`. Additionally, `sdk.md` had a broken absolute link to `/reference/api/`.

## Changes

- **`docs/src/navigation.ts`** — Fixed slug from `reference/api` → `reference/api-reference`
- **`docs/src/content/docs/reference/sdk.md`** — Changed broken absolute link to a relative markdown link (`api-reference.md`)

Closes #990