### PR TITLE
fix: add "mktree" to cspell dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -35,7 +35,7 @@
     "MSMQ", "permadeath", "Permadeath", "CRDT", "httpx",
     "Pydantic", "sdkgen", "ttft", "Strausz", "mycompany",
     "slugified", "simplejwt", "pytest", "Luca", "Clemenza",
-    "Tessio", "Triaging", "Futurama", "mklink", "slnx", "jqlang",
+    "Tessio", "Triaging", "Futurama", "mklink", "mktree", "slnx", "jqlang",
     "benleane", "TELMU", "Automator", "kedacore",
     "DEVBOX", "myaccount"
   ],


### PR DESCRIPTION
The `docs-quality` CI job fails because cspell flags `mktree` as an unknown word in `docs/src/content/docs/features/state-backends.md` (line 272).

`mktree` is a legitimate git plumbing command (`git mktree`) referenced in the security section of the state-backends doc. This adds it to the `words` array in `cspell.json`, right after the existing `mklink` entry.