### PR TITLE
fix: remove duplicate permissions key in squad-ci.yml

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -10,7 +10,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  pull-requests: read
 
 # Prevent parallel runs from competing for resources
 concurrency:


### PR DESCRIPTION
Fixes ghost CI failures (0 jobs executed) on dev since commit 7b4ba796.

## Problem
The CI cleanup PR introduced a duplicate `pull-requests: read` key in the workflow permissions block. Duplicate YAML keys cause GitHub Actions to silently skip all jobs, producing runs that complete instantly with 0 jobs and a `failure` conclusion.

## Fix
Remove the duplicate `pull-requests: read` line (line 13).

## Verification
All dev CI runs since Apr 18 show 0 jobs. The last successful run (Apr 8) used the pre-cleanup workflow. This fix restores the valid YAML structure.