### PR TITLE
feat(template): back-port Ralph reviewer orchestration

### DIFF
--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -1063,6 +1063,19 @@ When an artifact is **rejected** by a Reviewer:
 6. **Lockout duration:** The lockout persists for that revision cycle. If the revision is also rejected, the same rule applies again — the revision author is now also locked out, and a third agent must revise.
 7. **Deadlock handling:** If all eligible agents have been locked out of an artifact, the Coordinator MUST escalate to the user rather than re-admitting a locked-out author.
 
+### Reviewer attestation gate (for projects with CI disabled)
+
+> **When to apply:** Enable this gate when a project has CI disabled (repo-wide or on a branch) and needs a behavioural correctness check before approval. Skip entirely when CI is green-on-head and the CI gate is sufficient.
+
+**Before approving any PR**, a squad reviewer agent MUST:
+
+1. Verify the PR body contains the **local-test attestation** section with the checkbox ticked (`- [x]`).
+2. Verify the **attested SHA** in the PR body exactly matches the PR's current `headRefOid` (latest commit SHA).
+3. If either check fails, the reviewer MUST leave a `REQUEST_CHANGES` review citing "missing or stale local-test attestation — please run the full test suite locally, tick the attestation checkbox in the PR body, and update the attested SHA to the current HEAD." Do NOT approve.
+4. **Re-verify on every new push.** Any approval is implicitly invalidated by a new commit; the reviewer must re-check the attestation SHA against the new `headRefOid` and re-approve (or request changes) accordingly.
+
+This gate replaces CI as the behavioural correctness check while CI is disabled. When CI is re-enabled, restore the normal CI-green requirement in addition to (not in place of) this gate.
+
 ---
 
 ## Multi-Agent Artifact Format
@@ -1164,14 +1177,16 @@ gh pr list --state open --draft --json number,title,author,labels,checks --limit
 |----------|--------|--------|
 | **Untriaged issues** | `squad` label, no `squad:{member}` label | Lead triages: reads issue, assigns `squad:{member}` label |
 | **Assigned but unstarted** | `squad:{member}` label, no assignee or no PR | Spawn the assigned agent to pick it up |
-| **Draft PRs** | PR in draft from squad member | Check if agent needs to continue; if stalled, nudge |
+| **Draft PRs** | PR in draft from squad member | Check if agent needs to continue; if stalled, nudge; when PR leaves draft, next round will classify it as Awaiting review |
+| **Awaiting review** | PR non-draft, `reviewDecision` is null/`REVIEW_REQUIRED`, no squad reviewer assigned | Route to appropriate squad reviewer(s) based on changed paths + labels; request review via `gh pr edit --add-reviewer` and spawn reviewer agent(s) to perform the review |
 | **Review feedback** | PR has `CHANGES_REQUESTED` review | Route feedback to PR author agent to address |
-| **CI failures** | PR checks failing | Notify assigned agent to fix, or create a fix issue |
-| **Approved PRs** | PR approved, CI green, ready to merge | Merge and close related issue |
+| **CI failures** | PR checks failing (when CI is enabled) | Notify assigned agent to fix, or create a fix issue. *If the project has CI disabled and uses the attestation gate instead, Ralph verifies the local-test attestation (checkbox + SHA matching `headRefOid`) and treats stale/missing attestation as the "Missing attestation" category.* |
+| **Missing attestation** | (Attestation-gate projects only) Local-test attestation checkbox is unticked, or the attested SHA does not match the current `headRefOid` | Comment on the PR asking the author agent to run the full test suite locally, tick the attestation checkbox, and update the SHA to the latest commit. Do NOT advance to merge. |
+| **Approved PRs** | PR approved, automated reviewer (e.g. Copilot) clean, **CI green on head SHA (or local-test attestation present and SHA matches head, for attestation-gate projects)**, ready to merge | Merge and close related issue |
 | **No work found** | All clear | Report: "📋 Board is clear. Ralph is idling." Suggest `npx @bradygaster/squad-cli watch` for persistent polling. |
 
 **Step 3 — Act on highest-priority item:**
-- Process one category at a time, highest priority first (untriaged > assigned > CI failures > review feedback > approved PRs)
+- Process one category at a time, highest priority first (untriaged > assigned > missing attestation > awaiting review > CI failures > review feedback > approved PRs). *Attestation-gate projects substitute "missing attestation" for CI failures as the behavioural correctness check.*
 - Spawn agents as needed, collect results
 - **⚡ CRITICAL: After results are collected, DO NOT stop. DO NOT wait for user input. IMMEDIATELY go back to Step 1 and scan again.** This is a loop — Ralph keeps cycling until the board is clear or the user says "idle". Each cycle is one "round".
 - If multiple items exist in the same category, process them in parallel (spawn multiple agents)
@@ -1188,6 +1203,51 @@ After every 3-5 rounds, pause and report before continuing:
 ```
 
 **Do NOT ask for permission to continue.** Just report and keep going. The user must explicitly say "idle" or "stop" to break the loop. If the user provides other input during a round, process it and then resume the loop.
+
+### Reviewer routing (Step 2: Awaiting review)
+
+When a PR leaves draft and has no squad reviewer assigned, Ralph routes it to one or more squad reviewers based on the changed paths and labels.
+
+**Approval gate — Ralph only advances a PR to "Approved / mergeable" when ALL of:**
+
+1. Any automated reviewer (e.g. GitHub Copilot's automatic PR review, if enabled by the project's branch protection) has **zero unaddressed comments**, AND
+2. **≥1 squad reviewer** has approved. If branch protection requires a second reviewer and the automated reviewer counts, ≥1 squad reviewer is sufficient; otherwise require ≥2 human/squad reviewers. If the PR touches **≥2 domains**, route to **≥2 squad reviewers** in parallel regardless, AND
+3. Either **CI is green on the head SHA**, OR (for projects using the attestation gate) **the PR body contains the local-test attestation checkbox ticked AND the attested SHA matches the PR's current `headRefOid`**.
+
+Only then does the PR graduate to the **Approved PRs** category for merge.
+
+**Path / label → reviewer mapping (example — each squad defines its own in `routing.md`):**
+
+| Changed paths / labels | Reviewer role | Domain |
+|------------------------|---------------|--------|
+| `.github/**`, `.squad/**`, governance, agent charters | **Lead** | Governance, code review |
+| `tests/**`, `*.test.*`, `*.spec.*`, `src/**` touching behavior | **Tester / QA** | Test gate |
+| `auth/**`, secrets, IAM, RBAC, any security-tagged label | **Security reviewer** | Security |
+| `infra/**`, IaC files, networking, WAF | **Infra reviewer** | WAF / infra |
+| Multiple domains hit | Route to multiple reviewers **in parallel** | — |
+
+Squads customise this table via their `.squad/routing.md`. The principle is: map changed-file patterns and labels to the roles on the roster who own that domain. When a PR hits ≥2 domains, route to ≥2 reviewers in parallel.
+
+**Dispatch rules:**
+
+- **Reviewers are spawned as background agents** (via the `task` tool with `mode: "background"`) so multiple reviewers run **in parallel**, not sequentially. When a PR hits ≥2 domains, dispatch all required reviewers in a single response — Ralph waits on completion notifications, not on each reviewer in turn.
+- Reviewer agents run in **their own worktrees or feature branches**, never on `main`. Ralph must never dispatch a reviewer (or any agent) that works directly on `main`.
+- Reviewer gates are "bump UP to premium" work per §Model Selection — use the premium tier for reviewer spawns.
+- Request review on the PR with `gh pr edit {N} --add-reviewer {handle}` (or the squad equivalent) before spawning the reviewer agent, so the GitHub-side reviewer state matches.
+
+**Commit → re-review loop:**
+
+- Any new commit to the PR triggers a fresh automated review (if enabled). The approval gate **re-opens** on every new commit and only closes again when the latest automated review has zero unaddressed comments.
+- After a new commit, Ralph waits for the new automated review, re-inspects `reviewDecision`, and **re-dispatches any squad reviewer whose previous verdict is now outdated** (e.g., they approved an earlier SHA that has since been force-pushed or had new commits added).
+
+**On `CHANGES_REQUESTED`:**
+
+- Hand off to the existing **Review feedback** step. The **Reviewer Rejection Protocol** applies. The original author is **locked out** of self-revision; a different agent (or a newly spawned specialist) must perform the fix. Ralph and the Coordinator enforce this lockout.
+
+**Re-verification on every new commit:** After any new commit is pushed to a PR, Ralph MUST:
+1. Re-check CI status on the new head SHA. For attestation-gate projects, re-check the attestation checkbox is still ticked AND the attested SHA equals the new `headRefOid`. A stale SHA invalidates the attestation; Ralph demotes the PR back to **Missing attestation** and asks the author agent to re-run tests locally and update the SHA.
+2. Wait for and re-inspect any new automated review.
+3. Re-dispatch any squad reviewer whose previous approval is now outdated.
 
 ### Watch Mode (`squad watch`)
 


### PR DESCRIPTION
## Summary

Back-ports Ralph reviewer-orchestration patterns that were developed in a downstream project using the Squad framework ([garylumsden/azure-ai-pii-redaction#258](https://github.com/garylumsden/azure-ai-pii-redaction/issues/258)) into the upstream template so future `squad init` users get them out of the box.

All additions are generic — no downstream-specific cast names, issue numbers, or model names are hard-coded. Each squad continues to customise its own routing.md.

## What changed

**`templates/squad.agent.md.template`** (+64 / -4):

1. **Reviewer attestation gate** (new sub-section under Reviewer Rejection Protocol).
   - Opt-in pattern for projects that have CI disabled. Requires a local-test attestation checkbox + SHA match in the PR body before a reviewer may approve. Re-invalidated by any new commit.

2. **Ralph work-check table** — two new rows + minor rewrites:
   - **Awaiting review** — PR leaves draft, no squad reviewer assigned → route to appropriate squad reviewer(s) by changed paths + labels.
   - **Missing attestation** — attestation checkbox unticked or SHA stale → comment asking author agent to re-run tests locally and update.
   - **CI failures** — rewritten to cover both CI-enabled projects *and* attestation-gate projects.
   - **Approved PRs** / **Draft PRs** — updated phrasing to match the new flow.

3. **Step 3 priority order** updated to include the new categories.

4. **New section: `### Reviewer routing (Step 2: Awaiting review)`** — inserted before `### Watch Mode`. Covers:
   - **3-condition approval gate:** (1) automated reviewer clean, (2) ≥1 squad reviewer (≥2 if PR hits ≥2 domains) approved, (3) CI green on head SHA **OR** (for attestation-gate projects) local-test attestation valid for current `headRefOid`.
   - Generic path/label → reviewer role mapping table (Lead / Tester / Security / Infra) — explicitly flagged as an example each squad customises in `routing.md`.
   - Dispatch rules: parallel background spawn, dedicated worktrees/branches, premium-tier model per §Model Selection.
   - Commit → re-review loop: every new commit re-opens the gate; squad reviewers with stale approvals are re-dispatched.
   - `CHANGES_REQUESTED` handoff into existing Reviewer Rejection Protocol lockout (original author cannot self-revise).
   - Re-verification on every new commit: CI status re-checked, attestation SHA re-checked, automated review re-inspected.

## Why

Projects that adopt Squad end up independently reinventing most of this. Promoting it upstream gives new squads sensible defaults while leaving every project-specific choice (cast names, domain-to-reviewer mapping, whether CI is enabled, which reviewers are squad agents vs humans vs Copilot) to local `routing.md` / `team.md`.

## Genericization notes

- No hard-coded cast names — the mapping table uses generic roles (Lead, Tester, Security reviewer, Infra reviewer) and is explicitly described as a template.
- No hard-coded issue numbers — the attestation gate is introduced by purpose ("when a project has CI disabled"), not by reference to any specific issue.
- Uses the current upstream model catalog — premium-tier selection is described in prose rather than pinned to specific model IDs, so it continues to work as §Model Selection evolves.
- "Automated reviewer" language is used generically (e.g. "GitHub Copilot's automatic PR review, if enabled by the project's branch protection") so squads on different review stacks aren't left out.

## Testing

- `git diff --stat upstream/dev` → `templates/squad.agent.md.template | 68 ++++++++++++++++++++++++++++++++++++--- 1 file changed, 64 insertions(+), 4 deletions(-)`
- Diff is purely additive to existing Ralph + Reviewer Rejection Protocol sections; no cross-file changes, no template/runtime file schema changes, no backwards-incompatible behaviour changes for squads that don't adopt the new rows (existing categories retained).

## Out of scope / not changed

- Version stamp, model catalog, CURRENT_DATETIME, worktree-root resolution, refusal-rules wording, and MCP section wording are left as-is — those are upstream-owned and my downstream has its own drift there that I am not back-porting.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
