### PR TITLE
fix: rename duplicate hasForce declaration blocking all releases

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1189,10 +1189,10 @@ if (cmd === 'import') {
       : `skill-${index}`;
     return { skillContent, skillName };
   });
-  const hasForce = typeof force !== 'undefined' && force;
+  const shouldForce = typeof force !== 'undefined' && force;
 
   if (fs.existsSync(copilotSkillsImportDir)) {
-    if (hasForce) {
+    if (shouldForce) {
       const archivedSkillsDir = path.join(dest, '.copilot', `skills.backup.${Date.now()}`);
       fs.renameSync(copilotSkillsImportDir, archivedSkillsDir);
     } else {


### PR DESCRIPTION
## Problem

Every release run on main fails with a SyntaxError: duplicate const hasForce declaration in index.cjs (lines 1130 and 1192). The esbuild bundler flattened two separate function scopes into one, creating the conflict. 90/130 tests fail because index.cjs can't load at all.

This has been blocking every single release - v0.9.4 hasn't made it to npm latest.

## Fix

Renamed the second hasForce (line 1192) to shouldForce. They serve different purposes:
- Line 1130: CLI arg check (process.argv.includes('--force'))
- Line 1192: parameter check in skills import function

## Impact

Once merged, the release pipeline should pass and publish v0.9.4 to npm.
