### PR TITLE
test: fix .NET detection tests to use upgrade instead of init

### DIFF
--- a/test/migrate-directory.test.cjs
+++ b/test/migrate-directory.test.cjs
@@ -249,13 +249,17 @@ describe('detectProjectType: .NET extensions (.slnx, .fsproj, .vbproj)', () => {
   beforeEach(() => { tmpDir = makeTempDir(); });
   afterEach(() => cleanDir(tmpDir));
 
-  it('init in a dir with .slnx generates a dotnet stub CI workflow', () => {
+  it('upgrade in a dir with .slnx generates a dotnet stub CI workflow', () => {
     fs.writeFileSync(path.join(tmpDir, 'MyApp.slnx'), '');
-    const result = runSquad([], tmpDir);
-    assert.equal(result.exitCode, 0, `init should succeed: ${result.stdout}`);
+    // init creates .squad/ structure but skips CI workflows (by design since PR #847)
+    const initResult = runSquad([], tmpDir);
+    assert.equal(initResult.exitCode, 0, `init should succeed: ${initResult.stdout}`);
+    // upgrade installs CI/CD workflows including project-type-specific ones
+    const result = runSquad(['upgrade'], tmpDir);
+    assert.equal(result.exitCode, 0, `upgrade should succeed: ${result.stdout}`);
 
     const ciPath = path.join(tmpDir, '.github', 'workflows', 'squad-ci.yml');
-    assert.ok(fs.existsSync(ciPath), 'squad-ci.yml should be created');
+    assert.ok(fs.existsSync(ciPath), 'squad-ci.yml should be created by upgrade');
     const ciContent = fs.readFileSync(ciPath, 'utf8');
     assert.ok(
       ciContent.includes('dotnet') || ciContent.toLowerCase().includes('dotnet'),
@@ -268,10 +272,12 @@ describe('detectProjectType: .NET extensions (.slnx, .fsproj, .vbproj)', () => {
     );
   });
 
-  it('init in a dir with .fsproj generates a dotnet stub CI workflow', () => {
+  it('upgrade in a dir with .fsproj generates a dotnet stub CI workflow', () => {
     fs.writeFileSync(path.join(tmpDir, 'MyLib.fsproj'), '');
-    const result = runSquad([], tmpDir);
-    assert.equal(result.exitCode, 0, `init should succeed: ${result.stdout}`);
+    const initResult = runSquad([], tmpDir);
+    assert.equal(initResult.exitCode, 0, `init should succeed: ${initResult.stdout}`);
+    const result = runSquad(['upgrade'], tmpDir);
+    assert.equal(result.exitCode, 0, `upgrade should succeed: ${result.stdout}`);
 
     const ciPath = path.join(tmpDir, '.github', 'workflows', 'squad-ci.yml');
     const ciContent = fs.readFileSync(ciPath, 'utf8');
@@ -281,10 +287,12 @@ describe('detectProjectType: .NET extensions (.slnx, .fsproj, .vbproj)', () => {
     );
   });
 
-  it('init in a dir with .vbproj generates a dotnet stub CI workflow', () => {
+  it('upgrade in a dir with .vbproj generates a dotnet stub CI workflow', () => {
     fs.writeFileSync(path.join(tmpDir, 'MyApp.vbproj'), '');
-    const result = runSquad([], tmpDir);
-    assert.equal(result.exitCode, 0, `init should succeed: ${result.stdout}`);
+    const initResult = runSquad([], tmpDir);
+    assert.equal(initResult.exitCode, 0, `init should succeed: ${initResult.stdout}`);
+    const result = runSquad(['upgrade'], tmpDir);
+    assert.equal(result.exitCode, 0, `upgrade should succeed: ${result.stdout}`);
 
     const ciPath = path.join(tmpDir, '.github', 'workflows', 'squad-ci.yml');
     const ciContent = fs.readFileSync(ciPath, 'utf8');


### PR DESCRIPTION
## Summary

The 3 dotnet project type tests (.slnx, .fsproj, .vbproj) in migrate-directory.test.cjs expected squad-ci.yml to be created during squad init. Since PR #847 (commit f522840f), init intentionally skips CI/CD workflows — they are installed by squad upgrade.

## Changes

Changed the 3 tests to:
1. Run init first (creates .squad/ structure, no CI workflows)
2. Run upgrade (installs CI/CD workflows including project-type-specific ones)

This matches the existing pattern in Group 7 (the migrate+upgrade test at line 302).

## Context

These are the last 3 test failures blocking the 0.9.4 release. Brady confirmed option (b) — change tests to use upgrade. See discussion in contributors chat.

Fixes the 3 remaining test failures after PR #1005.
