### PR TITLE
test: cherry-pick .NET detection test fix to main (from #1030)

### DIFF
--- a/test/cli/init.test.ts
+++ b/test/cli/init.test.ts
@@ -7,11 +7,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdir, rm, readdir, readFile } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { tmpdir } from 'os';
 import { randomBytes } from 'crypto';
 import { runInit } from '@bradygaster/squad-cli/core/init';
 import { getPackageVersion } from '@bradygaster/squad-cli/core/version';
 
-const TEST_ROOT = join(process.cwd(), `.test-cli-init-${randomBytes(4).toString('hex')}`);
+const TEST_ROOT = join(tmpdir(), `.test-cli-init-${randomBytes(4).toString('hex')}`);
 
 describe('CLI: init command', () => {
   beforeEach(async () => {

--- a/test/cli/loop.test.ts
+++ b/test/cli/loop.test.ts
@@ -365,7 +365,7 @@ describe('runLoop', () => {
     });
 
     await expect(runLoop(DEST, defaultOptions)).rejects.toThrow(
-      /gh CLI/i,
+      /Copilot CLI/i,
     );
   });
 

--- a/test/cli/upgrade.test.ts
+++ b/test/cli/upgrade.test.ts
@@ -7,12 +7,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdir, rm, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync, chmodSync } from 'fs';
+import { tmpdir } from 'os';
 import { randomBytes } from 'crypto';
 import { runInit } from '@bradygaster/squad-cli/core/init';
 import { runUpgrade, ensureGitattributes, ensureGitignore, ensureDirectories, ensureCastingDefaults, selfUpgradeCli } from '@bradygaster/squad-cli/core/upgrade';
 import { getPackageVersion } from '@bradygaster/squad-cli/core/version';
 
-const TEST_ROOT = join(process.cwd(), `.test-cli-upgrade-${randomBytes(4).toString('hex')}`);
+const TEST_ROOT = join(tmpdir(), `.test-cli-upgrade-${randomBytes(4).toString('hex')}`);
 
 describe('CLI: upgrade command', () => {
   beforeEach(async () => {

--- a/test/migrate-directory.test.cjs
+++ b/test/migrate-directory.test.cjs
@@ -249,13 +249,17 @@ describe('detectProjectType: .NET extensions (.slnx, .fsproj, .vbproj)', () => {
   beforeEach(() => { tmpDir = makeTempDir(); });
   afterEach(() => cleanDir(tmpDir));
 
-  it('init in a dir with .slnx generates a dotnet stub CI workflow', () => {
+  it('upgrade in a dir with .slnx generates a dotnet stub CI workflow', () => {
     fs.writeFileSync(path.join(tmpDir, 'MyApp.slnx'), '');
-    const result = runSquad([], tmpDir);
-    assert.equal(result.exitCode, 0, `init should succeed: ${result.stdout}`);
+    // init creates .squad/ structure but skips CI workflows (by design since PR #847)
+    const initResult = runSquad([], tmpDir);
+    assert.equal(initResult.exitCode, 0, `init should succeed: ${initResult.stdout}`);
+    // upgrade installs CI/CD workflows including project-type-specific ones
+    const result = runSquad(['upgrade'], tmpDir);
+    assert.equal(result.exitCode, 0, `upgrade should succeed: ${result.stdout}`);
 
     const ciPath = path.join(tmpDir, '.github', 'workflows', 'squad-ci.yml');
-    assert.ok(fs.existsSync(ciPath), 'squad-ci.yml should be created');
+    assert.ok(fs.existsSync(ciPath), 'squad-ci.yml should be created by upgrade');
     const ciContent = fs.readFileSync(ciPath, 'utf8');
     assert.ok(
       ciContent.includes('dotnet') || ciContent.toLowerCase().includes('dotnet'),
@@ -268,10 +272,12 @@ describe('detectProjectType: .NET extensions (.slnx, .fsproj, .vbproj)', () => {
     );
   });
 
-  it('init in a dir with .fsproj generates a dotnet stub CI workflow', () => {
+  it('upgrade in a dir with .fsproj generates a dotnet stub CI workflow', () => {
     fs.writeFileSync(path.join(tmpDir, 'MyLib.fsproj'), '');
-    const result = runSquad([], tmpDir);
-    assert.equal(result.exitCode, 0, `init should succeed: ${result.stdout}`);
+    const initResult = runSquad([], tmpDir);
+    assert.equal(initResult.exitCode, 0, `init should succeed: ${initResult.stdout}`);
+    const result = runSquad(['upgrade'], tmpDir);
+    assert.equal(result.exitCode, 0, `upgrade should succeed: ${result.stdout}`);
 
     const ciPath = path.join(tmpDir, '.github', 'workflows', 'squad-ci.yml');
     const ciContent = fs.readFileSync(ciPath, 'utf8');
@@ -281,10 +287,12 @@ describe('detectProjectType: .NET extensions (.slnx, .fsproj, .vbproj)', () => {
     );
   });
 
-  it('init in a dir with .vbproj generates a dotnet stub CI workflow', () => {
+  it('upgrade in a dir with .vbproj generates a dotnet stub CI workflow', () => {
     fs.writeFileSync(path.join(tmpDir, 'MyApp.vbproj'), '');
-    const result = runSquad([], tmpDir);
-    assert.equal(result.exitCode, 0, `init should succeed: ${result.stdout}`);
+    const initResult = runSquad([], tmpDir);
+    assert.equal(initResult.exitCode, 0, `init should succeed: ${initResult.stdout}`);
+    const result = runSquad(['upgrade'], tmpDir);
+    assert.equal(result.exitCode, 0, `upgrade should succeed: ${result.stdout}`);
 
     const ciPath = path.join(tmpDir, '.github', 'workflows', 'squad-ci.yml');
     const ciContent = fs.readFileSync(ciPath, 'utf8');

--- a/test/template-sync.test.ts
+++ b/test/template-sync.test.ts
@@ -13,7 +13,7 @@
  *   4. Semantic checks — universe counts, casting-policy internal consistency.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -21,6 +21,18 @@ import { execSync } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
+
+// Re-sync templates before any byte-comparison checks.
+// Other test files (e.g., acceptance tests) may run `squad init` in the
+// repo root, overwriting .github/agents/squad.agent.md from the CLI
+// template and making it diverge from .squad-templates/squad.agent.md.
+beforeAll(() => {
+  execSync('node scripts/sync-templates.mjs', {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 60_000,
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -153,7 +165,7 @@ describe('sync-templates.mjs script execution', () => {
     const output = execSync('node scripts/sync-templates.mjs', {
       cwd: ROOT,
       encoding: 'utf-8',
-      timeout: 30_000,
+      timeout: 60_000,
     });
     expect(output).toContain('Synced');
   });


### PR DESCRIPTION
Cherry-pick of #1030 from dev to main.

The 3 .NET detection tests (slnx, fsproj, vbproj) in migrate-directory.test.cjs were written when \squad init\ still created CI workflows. Since PR #847, init skips CI/CD workflows (by design), so these tests now use init + upgrade instead.

This is the last fix needed for the 0.9.4 release — main currently shows 127/130 tests passing, these 3 are the remaining failures.