### PR TITLE
chore: prep CHANGELOG for v0.9.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-04-25
+
 ### Fixed
 - `squad init` no longer runs `git init` automatically when initialized inside a monorepo subdirectory (#939). It now shows a warning and suggests running from the git root instead.
 - Azure DevOps adapter (`az` CLI calls) now use `shell: true` on Windows so `.cmd` wrapper scripts resolve correctly (#941).


### PR DESCRIPTION
This PR converts the `[Unreleased]` section in CHANGELOG.md to `[0.9.4]` with today's date (2026-04-25).

## Why This Matters
PR #1023 bumped the version to 0.9.4 across all package.json files, but the CHANGELOG wasn't updated. The release automation workflow (`squad-release.yml`) requires a CHANGELOG entry matching the version before it will proceed.

## What Happens Next
Once this PR is merged to `main`, the `squad-release.yml` workflow will:
1. Validate the `## [0.9.4]` CHANGELOG entry
2. Create a git tag `v0.9.4`
3. Create a GitHub Release
4. Trigger `squad-npm-publish.yml` to publish to npm @latest

**Ready for Brady to review and merge.**