### PR TITLE
fix: sync root package.json version to 0.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.9.1",
+  "version": "0.9.4",
   "private": true,
   "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",


### PR DESCRIPTION
## Fix: Sync Root Version to 0.9.4

The release/0.9.4 merge (PR #1023) bumped `packages/squad-cli` and `packages/squad-sdk` to v0.9.4, but the root `package.json` remained at v0.9.1. 

### Problem
The `squad-release.yml` workflow reads the version from root `package.json`, and `CHANGELOG.md` already documents [0.9.4]. This mismatch caused the release workflow to fail on every push to main.

### Solution
Updated root `package.json` version to 0.9.4 to match the packages and CHANGELOG.

### Impact
✅ Merging this PR will trigger the full release chain:
- squad-release.yml creates v0.9.4 tag
- GitHub Release published automatically
- squad-npm-publish.yml publishes @latest to npm

---
Ready for review. Brady will merge.