### PR TITLE
fix: lockfile integrity check excludes workspace-local packages

### DIFF
--- a/.github/workflows/squad-npm-publish.yml
+++ b/.github/workflows/squad-npm-publish.yml
@@ -79,7 +79,7 @@ jobs:
             }
             const missingIntegrity = Object.keys(pkgs).filter(k =>
               k.includes('node_modules/@bradygaster/squad-') &&
-              pkgs[k].resolved && !pkgs[k].resolved.startsWith('file:') &&
+              pkgs[k].resolved && pkgs[k].resolved.startsWith('https://') &&
               (!pkgs[k].integrity || !pkgs[k].integrity.startsWith('sha512-'))
             );
             if (missingIntegrity.length) {


### PR DESCRIPTION
The integrity hash validation in `squad-npm-publish.yml` only excluded `file:`-prefixed resolved paths, but npm workspaces use bare relative paths (e.g. `packages/squad-sdk`). Changed to only check integrity for registry-resolved (`https://`) packages.

This unblocks the v0.9.4 publish workflow.

Closes #0