### PR TITLE
fix: update post-init message to recommend copilot --agent squad

### DIFF
--- a/.changeset/fix-post-init-message.md
+++ b/.changeset/fix-post-init-message.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-cli': patch
+---
+
+Fix post-init message to recommend `copilot --agent squad` instead of deprecated `squad` command (closes #1034, closes #1007)

--- a/docs/src/content/docs/scenarios/multiple-squads.md
+++ b/docs/src/content/docs/scenarios/multiple-squads.md
@@ -82,7 +82,7 @@ squad init
 ✅ Squad imported
    5 agents, 23 skills, 47 decisions, histories loaded
 
-Your team is ready.
+Squad initialized. Run copilot --agent squad and tell it what you're building.
 ```
 
 This squad is now your baseline.

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -180,7 +180,7 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
       if (useShared) {
         console.log();
         console.log(`${GREEN}${BOLD}✓${RESET} Using shared .squad/ from ${mainCheckout}`);
-        console.log(`${DIM}  No changes made. Run squad commands from the main checkout.${RESET}`);
+        console.log(`${DIM}  No changes made. Run ${CYAN}${BOLD}copilot --agent squad${RESET}${DIM} commands from the main checkout.${RESET}`);
         console.log();
         return;
       }
@@ -265,7 +265,7 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
 
   // Report .init-prompt storage
   if (options.prompt) {
-    success(`.init-prompt stored — team will be cast when you start squad`);
+    success(`.init-prompt stored — team will be cast when you run ${CYAN}${BOLD}copilot --agent squad${RESET}`);
   }
 
   // Report created files
@@ -293,7 +293,7 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
 
   if (!isInitNoColor()) await sleep(80);
   console.log();
-  console.log(`${GREEN}${BOLD}Your team is ready.${RESET} Run ${CYAN}${BOLD}squad${RESET} to start.`);
+  console.log(`${GREEN}${BOLD}Squad initialized.${RESET} Run ${CYAN}${BOLD}copilot --agent squad${RESET} and tell it what you're building.`);
   console.log();
 
   // ── Personal squad bridge ───────────────────────────────────────────

--- a/test/acceptance/features/init-command.feature
+++ b/test/acceptance/features/init-command.feature
@@ -3,7 +3,7 @@ Feature: Init command
   Scenario: Init in existing project shows ready message
     Given the current directory has a ".squad" directory
     When I run "squad init"
-    Then the output contains "Your team is ready"
+    Then the output contains "Squad initialized"
     And the output contains "already exists"
     And the exit code is 0
 

--- a/test/human-journeys.test.ts
+++ b/test/human-journeys.test.ts
@@ -136,8 +136,8 @@ describe('Journey 1: I just installed this (squad init)', () => {
     await harness.close();
 
     // The human needs a clear next step — not silence
-    expect(output).toContain('Your team is ready');
-    expect(output.toLowerCase()).toContain('squad');
+    expect(output).toContain('Squad initialized');
+    expect(output).toContain('copilot --agent squad');
   });
 
   it('writes first-run marker so the REPL knows this is day one', async () => {


### PR DESCRIPTION
Fixes #1034
Fixes #1007

Both issues report the same bug: after squad init, the CLI prints "Run squad to start" but the standalone squad CLI is deprecated. Updated to recommend copilot --agent squad instead.

## Changes
- Updated init message in packages/squad-cli/src/cli/core/init.ts`n- Updated test assertions in 	est/human-journeys.test.ts`n- Updated docs example output in docs/src/content/docs/scenarios/multiple-squads.md`n- Added changeset