### PR TITLE
Add Copilot plugin manifest

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "squad",
+  "description": "Human-led AI agent teams for any project.",
+  "version": "0.9.1",
+  "author": {
+    "name": "Brady Gaster"
+  },
+  "repository": "https://github.com/bradygaster/squad",
+  "homepage": "https://github.com/bradygaster/squad#readme",
+  "license": "MIT",
+  "keywords": ["copilot", "multi-agent", "squad"],
+  "agents": ".github/agents",
+  "skills": ".copilot/skills"
+}
+


### PR DESCRIPTION
## Summary

Adds a Copilot CLI `plugin.json` manifest so Squad can be installed as a GitHub Copilot plugin.

## Changes

- Adds root-level `plugin.json` with Squad metadata.
- Points plugin agents to `.github/agents`.
- Points plugin skills to `.copilot/skills`.

## Validation

- Confirmed the current upstream repo cannot be installed with `copilot plugin install bradygaster/squad` because no plugin manifest exists.
- Confirmed the Copilot CLI looks for `plugin.json`, `.github/plugin/plugin.json`, `.plugin/plugin.json`, or `.claude-plugin/plugin.json`.
- Confirmed the manifest is available on this PR branch. Full `copilot plugin install bradygaster/squad` validation requires the manifest to be on the default branch because the CLI does not accept a branch ref in the plugin install spec.
- Confirmed `copilot plugin install sbroenne/squad` works from the fork default branch after adding this manifest there for testing.
