### PR TITLE
fix(windows): Fix az CLI execution and ADO state mapping on Windows

### DIFF
--- a/.changeset/windows-ado-fixes.md
+++ b/.changeset/windows-ado-fixes.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+Fix Windows Azure CLI execution and ADO state mapping in squad watch

--- a/packages/squad-cli/src/cli/commands/watch/index.ts
+++ b/packages/squad-cli/src/cli/commands/watch/index.ts
@@ -15,6 +15,10 @@ import { FSStorageProvider } from '@bradygaster/squad-sdk';
 const storage = new FSStorageProvider();
 const execFileAsync = promisify(execFile);
 
+// On Windows, az is a .cmd batch script — execFile needs shell:true to run it.
+const azCmd = 'az';
+const azExecOpts = process.platform === 'win32' ? { shell: true } : {};
+
 import { detectSquadDir } from '../../core/detect-squad-dir.js';
 import { fatal } from '../../core/errors.js';
 import { GREEN, RED, DIM, BOLD, RESET, YELLOW } from '../../core/output.js';
@@ -145,12 +149,12 @@ async function editWorkItem(
       const assignee = options.addAssignee === '@me' ? '' : options.addAssignee;
       if (assignee) {
         try {
-          execFileSync('az', [
+          execFileSync(azCmd, [
             'boards', 'work-item', 'update',
             '--id', String(id),
             '--fields', `System.AssignedTo=${assignee}`,
             '--output', 'json',
-          ], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+          ], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], ...azExecOpts });
         } catch { /* best-effort */ }
       }
     }
@@ -727,8 +731,8 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     if (!(await ghAvailable())) fatal('gh CLI not found — install from https://cli.github.com');
     if (!(await ghAuthenticated())) fatal('gh CLI not authenticated — run: gh auth login');
   } else if (adapter.type === 'azure-devops') {
-    try { await execFileAsync('az', ['devops', '-h']); } catch { fatal('az CLI not found'); }
-    try { await execFileAsync('az', ['account', 'show']); } catch { fatal('az CLI not authenticated — run: az login'); }
+    try { await execFileAsync(azCmd, ['devops', '-h'], azExecOpts); } catch { fatal('az CLI not found'); }
+    try { await execFileAsync(azCmd, ['account', 'show'], azExecOpts); } catch { fatal('az CLI not authenticated — run: az login'); }
   }
 
   // Parse team.md

--- a/packages/squad-cli/src/cli/commands/watch/index.ts
+++ b/packages/squad-cli/src/cli/commands/watch/index.ts
@@ -11,14 +11,6 @@ import fs from 'node:fs';
 import { execFile, execFileSync } from 'node:child_process';
 import { promisify } from 'node:util';
 import { FSStorageProvider } from '@bradygaster/squad-sdk';
-
-const storage = new FSStorageProvider();
-const execFileAsync = promisify(execFile);
-
-// On Windows, az is a .cmd batch script — execFile needs shell:true to run it.
-const azCmd = 'az';
-const azExecOpts = process.platform === 'win32' ? { shell: true } : {};
-
 import { detectSquadDir } from '../../core/detect-squad-dir.js';
 import { fatal } from '../../core/errors.js';
 import { GREEN, RED, DIM, BOLD, RESET, YELLOW } from '../../core/output.js';
@@ -45,6 +37,13 @@ import type { WatchCapability, WatchContext, WatchPhase, CapabilityResult } from
 import { CapabilityRegistry } from './registry.js';
 import { createDefaultRegistry } from './capabilities/index.js';
 import { createVerboseLogger, type VerboseLogger } from './verbose.js';
+
+const storage = new FSStorageProvider();
+const execFileAsync = promisify(execFile);
+
+// On Windows, az is a .cmd batch script — execFile needs shell:true to run it.
+const azCmd = 'az';
+const azExecOpts = process.platform === 'win32' ? { shell: true } : {};
 
 // ── Re-exports for backward compatibility ────────────────────────
 

--- a/packages/squad-sdk/src/platform/azure-devops.ts
+++ b/packages/squad-sdk/src/platform/azure-devops.ts
@@ -160,13 +160,24 @@ export class AzureDevOpsAdapter implements PlatformAdapter {
   }
 
   private az(args: string[]): string {
-    return execFileSync('az', args, AZ_OPTS).trim();
+    // On Windows, shell:true joins args with spaces without quoting — quote any arg containing whitespace.
+    const safeArgs = IS_WINDOWS
+      ? args.map((a) => (/\s/.test(a) ? `"${a}"` : a))
+      : args;
+    return execFileSync('az', safeArgs, AZ_OPTS).trim();
   }
 
   async listWorkItems(options: { tags?: string[]; state?: string; limit?: number }): Promise<WorkItem[]> {
     const conditions: string[] = [];
     if (options.state) {
-      conditions.push(`[System.State] = '${escapeWiql(options.state)}'`);
+      // Map GitHub-style states to ADO WIQL equivalents
+      if (options.state === 'open') {
+        conditions.push(`[System.State] NOT IN ('Closed','Resolved','Removed','Done')`);
+      } else if (options.state === 'closed') {
+        conditions.push(`[System.State] IN ('Closed','Resolved','Done')`);
+      } else {
+        conditions.push(`[System.State] = '${escapeWiql(options.state)}'`);
+      }
     }
     if (options.tags?.length) {
       for (const tag of options.tags) {
@@ -182,7 +193,8 @@ export class AzureDevOpsAdapter implements PlatformAdapter {
     const output = this.az([
       'boards', 'query', '--wiql', wiql, ...this.workItemArgs, '--output', 'json',
     ]);
-    const items = parseJson<Array<{ id: number; fields?: Record<string, unknown> }>>(output);
+    // az boards query returns empty stdout (not "[]") when no items match
+    const items = parseJson<Array<{ id: number; fields?: Record<string, unknown> }>>(output || '[]');
 
     // Fetch full details for each work item (limited by top)
     const results: WorkItem[] = [];


### PR DESCRIPTION
### What

Two packages, four bug fixes — all related to running `squad watch` on Windows with an Azure DevOps project.

### Why

**squad-cli / watch command:**

On Windows, `az` is not a binary — it's a `.cmd` batch script. Node.js `execFile` without `{ shell: true }` fails with `ENOENT` before any ADO operation can run. The watch command fails on startup with "az CLI not found" on every Windows machine.

**squad-sdk / AzureDevOpsAdapter:**

Three additional bugs were uncovered after fixing the launch issue:

1. **WIQL arg splitting:** `AZ_OPTS` correctly sets `shell: IS_WINDOWS`, but `cmd.exe` re-parses the command line and splits args at spaces. WIQL queries contain spaces and get corrupted. Fix: quote any arg containing whitespace on Windows.

2. **Empty stdout crash:** `az boards query` returns empty string (not `[]`) when no work items match. `JSON.parse('')` throws `SyntaxError: Unexpected end of JSON input`. Fix: `output || '[]'` before parse.

3. **GitHub-style states in ADO:** The state option passes `'open'` directly into WIQL as `[System.State] = 'open'`. ADO has no `open` state — work items use `Active`, `New`, `Resolved`, etc. Every `squad watch` run with `state: 'open'` returns zero results silently. Fix: map `'open'` → `NOT IN ('Closed','Resolved','Removed','Done')` and `'closed'` → `IN ('Closed','Resolved','Done')`.

### How

**`packages/squad-cli/src/cli/commands/watch/index.ts`**
- Added `azCmd` and `azExecOpts` constants (Windows shell guard)
- Updated all three `execFile`/`execFileSync` call sites to use these constants

**`packages/squad-sdk/src/platform/azure-devops.ts`**
- `az()` method: quote args containing whitespace on Windows before passing to `execFileSync`
- `listWorkItems()`: added `output || '[]'` guard before `JSON.parse`
- `listWorkItems()`: added state mapping for GitHub-style `'open'`/`'closed'` → ADO WIQL

### Testing

On Windows with `platform: 'azure-devops'` configured in `.squad/config.json`:

1. `squad watch` — should start without "az CLI not found" error
2. Work items should appear when `state: 'open'` is used (previously returned zero)
3. Projects/orgs with spaces in their names should query correctly

### Breaking Changes

None. All fixes are additive. macOS/Linux behavior is unchanged.

---

### Relationship to #581

We're aware that [#581 (ADO-Driven Squadding PRD)](https://github.com/bradygaster/squad/issues/581) proposes a deeper architectural change — refactoring `watch.ts` to route through `PlatformAdapter` instead of calling the `gh` CLI directly. If that work lands, it will supersede the `watch/index.ts` portion of this PR.

This PR is intentionally tactical: it fixes four concrete bugs that affect every Windows user running `squad watch` against ADO **today**, without waiting on the larger platform-agnostic effort. The `azure-devops.ts` fixes (SDK layer) remain useful regardless of how `watch.ts` is eventually refactored.
