### PR TITLE
feat: add runtime driver abstraction for platform-agnostic AI coding agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Human-led AI agent teams for any project.** One command. A team that helps you move faster with your code.
 
 [![Status](https://img.shields.io/badge/status-alpha-blueviolet)](#status)
-[![Platform](https://img.shields.io/badge/platform-GitHub%20Copilot-blue)](#what-is-squad)
+[![Platform](https://img.shields.io/badge/platform-Multi--runtime-blue)](#what-is-squad)
 
 > ⚠️ **Alpha Software** — Squad is experimental. APIs and CLI commands may change between releases. We'll document breaking changes in [CHANGELOG.md](CHANGELOG.md).
 
@@ -13,7 +13,7 @@
 
 ## What is Squad?
 
-Squad gives you a human-directed AI development team through GitHub Copilot. Describe what you're building. Get a team of specialists — frontend, backend, tester, lead — that live in your repo as files. They persist across sessions, learn your codebase, share decisions, and help you move faster without giving up oversight.
+Squad gives you a human-directed AI development team through pluggable agent runtimes. Currently supports GitHub Copilot; OpenCode, Claude Code, and Cursor are in development. Describe what you're building. Get a team of specialists — frontend, backend, tester, lead — that live in your repo as files. They persist across sessions, learn your codebase, share decisions, and help you move faster without giving up oversight.
 
 Squad is a productivity tool for humans, not a replacement for engineers, reviewers, or decision-makers. People stay accountable for priorities, approvals, and final changes; Squad helps with coordination, repetition, and parallel execution.
 

--- a/RUNTIME_REFRACTOR_PLAN.md
+++ b/RUNTIME_REFRACTOR_PLAN.md
@@ -1,0 +1,206 @@
+# Squad Runtime Agnostic Refactoring Plan
+
+## Overview
+
+Refactor Squad to support alternative AI coding agent runtimes beyond GitHub Copilot (e.g., OpenCode CLI), enabling platform-agnostic multi-agent orchestration.
+
+## Current Architecture Analysis
+
+### Hard Coupling Points
+1. **`CopilotClient` instantiation** — directly imports `@github/copilot-sdk`
+2. **CLI commands** (`start`, `aspire`) — hardcoded to launch GitHub Copilot
+3. **Platform detection** — GitHub-specific file/issue APIs
+4. **Session pool** — tied to Copilot session lifecycle
+
+### Existing Abstraction Points
+- `adapter/types.ts` — Squad-stable interfaces decoupling from Copilot SDK types
+- `adapter/client.ts` — `CopilotSessionAdapter` wrapping SDK sessions to `SquadSession` interface
+- `SquadProviderConfig` — BYOK support for API endpoints (but not runtime agnostic)
+
+---
+
+## Implementation Phases
+
+### Phase 1: Driver Interface Definition
+**Effort:** Medium
+
+Create `AgentRuntimeDriver` interface that abstracts runtime-specific implementations.
+
+```typescript
+// packages/squad-sdk/src/runtime/driver.ts
+
+export interface AgentRuntimeDriver {
+  readonly name: string;  // "copilot" | "opencode" | "claude-code" | "cursor"
+
+  // Connection lifecycle
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  isConnected(): boolean;
+
+  // Session management
+  createSession(config: SessionConfig): Promise<AgentSession>;
+  resumeSession(sessionId: string, config?: SessionConfig): Promise<AgentSession>;
+  listSessions(): Promise<SessionMetadata[]>;
+  deleteSession(sessionId: string): Promise<void>;
+
+  // Auth
+  getAuthStatus(): Promise<AuthStatus>;
+  getStatus(): Promise<RuntimeStatus>;
+
+  // Models
+  listModels(): Promise<ModelInfo[]>;
+}
+
+export interface AgentSession {
+  readonly sessionId: string;
+  sendMessage(options: MessageOptions): Promise<void>;
+  sendAndWait(options: MessageOptions, timeout?: number): Promise<unknown>;
+  abort(): Promise<void>;
+  getMessages(): Promise<unknown[]>;
+  on(eventType: string, handler: EventHandler): void;
+  off(eventType: string, handler: EventHandler): void;
+  close(): Promise<void>;
+}
+```
+
+### Phase 2: Copilot Driver Extraction
+**Effort:** Medium
+
+Move current `CopilotClient` wrapper logic into a dedicated driver under `drivers/copilot/`.
+
+```
+packages/squad-sdk/src/drivers/
+├── copilot/
+│   └── driver.ts        # Current CopilotClient wrapper (refactored)
+├── opencode/
+│   └── driver.ts        # New: OpenCode CLI driver (future)
+└── index.ts             # Driver registry and factory
+```
+
+### Phase 3: OpenCode Driver Implementation
+**Effort:** Medium-High
+
+Implement `OpenCodeDriver` for OpenCode CLI using stdio communication.
+
+Key considerations:
+- Discover OpenCode's JSON-RPC/stlio interface
+- Implement session lifecycle management
+- Handle tool schema mapping
+
+### Phase 4: Config Schema Update
+**Effort:** Low
+
+Add `runtime` field to `squad.config.ts`:
+
+```typescript
+export default defineSquad({
+  runtime: {
+    name: "opencode",  // or "copilot", "claude-code", etc.
+    config: {
+      // runtime-specific configuration
+    }
+  },
+  // ... existing config
+});
+```
+
+### Phase 5: CLI Command Routing
+**Effort:** Medium
+
+Make `start`, `doctor`, and other runtime-aware commands use the active driver instead of hardcoding Copilot.
+
+```typescript
+// Abstract command interface
+export interface RuntimeCommand {
+  start(options: StartOptions): Promise<void>;
+  stop(): Promise<void>;
+  status(): Promise<RuntimeStatus>;
+}
+```
+
+### Phase 6: Session Pool Abstraction
+**Effort:** Medium
+
+Update `SessionPool` to use `AgentRuntimeDriver` interface instead of `CopilotClient` directly.
+
+---
+
+## Directory Structure
+
+```
+packages/squad-sdk/src/
+├── runtime/
+│   ├── driver.ts           # AgentRuntimeDriver interface
+│   ├── registry.ts         # RuntimeRegistry for driver management
+│   └── index.ts
+├── drivers/
+│   ├── copilot/
+│   │   └── driver.ts       # Copilot runtime driver
+│   ├── opencode/
+│   │   └── driver.ts       # OpenCode runtime driver (future)
+│   └── index.ts
+├── adapter/
+│   ├── client.ts          # SquadClient (updated to use driver)
+│   ├── types.ts            # Squad stable types
+│   └── errors.ts
+└── ... existing modules ...
+```
+
+---
+
+## Key Challenges
+
+| Challenge | Mitigation |
+|----------|------------|
+| OpenCode Protocol Discovery | Implement wrapper that spawns opencode and communicates via stdin/stdout. May need to discover or define JSON-RPC interface. |
+| Session Persistence | Each runtime may have its own storage format. Abstract to common interface. |
+| Tool Schema Differences | Create tool mapping layer between runtime tools and Squad's tool interface. |
+| Model Selection | Abstract `listModels()` to a common model interface. |
+
+---
+
+## Minimal Viable Change (MVP)
+
+For quick OpenCode support:
+
+1. Create `AgentRuntimeDriver` interface
+2. Create `OpenCodeDriver` with `connect()`, `createSession()`, `sendMessage()`, `close()`
+3. Make `SquadClient` accept a driver instead of hardcoding `CopilotClient`
+4. Add `runtime` option to `squad.config.ts`
+5. Keep tooling, routing, casting, hooks unchanged
+
+This gives working OpenCode integration without rewriting the entire platform.
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `packages/squad-sdk/src/runtime/driver.ts` | Driver interface definitions |
+| `packages/squad-sdk/src/runtime/registry.ts` | RuntimeRegistry for driver management |
+| `packages/squad-sdk/src/runtime/index.ts` | Runtime module exports |
+| `packages/squad-sdk/src/drivers/copilot/driver.ts` | Copilot driver (refactored) |
+| `packages/squad-sdk/src/drivers/opencode/driver.ts` | OpenCode driver (new) |
+| `packages/squad-sdk/src/drivers/index.ts` | Driver exports |
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `packages/squad-sdk/src/adapter/client.ts` | Make SquadClient use RuntimeRegistry |
+| `packages/squad-sdk/src/builders/types.ts` | Add runtime config to squad builder |
+| `packages/squad-sdk/src/config/schema.ts` | Add runtime field validation |
+| `packages/squad-cli/src/cli-entry.ts` | Runtime-aware command routing |
+| `squad.config.ts` | Add runtime configuration option |
+
+---
+
+## Success Criteria
+
+1. Squad can be configured to use "opencode" as the runtime
+2. Agent sessions can be created via OpenCode CLI (stdio)
+3. Messages can be sent to agents and responses received
+4. Sessions can be closed cleanly
+5. Existing Copilot-based workflows continue to work unchanged
+6. New runtimes can be added by implementing `AgentRuntimeDriver` interface

--- a/docs/src/content/docs/reference/runtime.md
+++ b/docs/src/content/docs/reference/runtime.md
@@ -1,0 +1,143 @@
+# Runtime Configuration
+
+> ⚠️ **Experimental** — Runtime abstraction is in active development. OpenCode, Claude Code, and Cursor drivers are planned but not yet implemented.
+
+Squad supports multiple AI coding agent runtimes through a driver abstraction layer. This allows teams to use whichever runtime fits their workflow.
+
+---
+
+## Supported Runtimes
+
+| Runtime | Status | Notes |
+|---------|--------|-------|
+| `copilot` | Stable | GitHub Copilot (default) |
+| `opencode` | Planned | OpenCode CLI — protocol not yet documented |
+| `claude-code` | Planned | Anthropic Claude Code — not yet started |
+| `cursor` | Planned | Cursor AI — not yet started |
+
+---
+
+## Configuring a Runtime
+
+### SDK-First (Recommended)
+
+In `squad.config.ts`, use the `runtime` option:
+
+```typescript
+import { defineSquad, defineTeam, defineAgent, defineRuntime } from '@bradygaster/squad-sdk';
+
+export default defineSquad({
+  team: defineTeam({
+    name: 'Platform Squad',
+    members: ['@edie'],
+  }),
+  agents: [
+    defineAgent({ name: 'edie', role: 'TypeScript Engineer' }),
+  ],
+  runtime: defineRuntime({
+    name: 'copilot',
+    config: {
+      // copilot-specific config
+    },
+  }),
+});
+```
+
+### Runtime Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `name` | `string` | ✅ | Runtime identifier: `'copilot'` (default), `'opencode'`, `'claude-code'`, `'cursor'` |
+| `config` | `object` | ❌ | Runtime-specific configuration passed to the driver |
+| `cliPath` | `string` | ❌ | Path to runtime CLI executable (useful for custom installations) |
+| `cliUrl` | `string` | ❌ | URL for external server connection (mutually exclusive with `cliPath`) |
+
+---
+
+## Runtime-Specific Configuration
+
+### GitHub Copilot
+
+Copilot is the default runtime. No configuration needed for standard setup.
+
+```typescript
+runtime: defineRuntime({
+  name: 'copilot',
+  config: {
+    // Optional: override defaults
+  },
+}),
+```
+
+**Authentication:** Uses `gh auth` credentials. Run `gh auth login` before using Squad.
+
+### OpenCode (Planned)
+
+OpenCode is a CLI-based agent runtime. Configuration details will be added once the protocol is documented.
+
+```typescript
+runtime: defineRuntime({
+  name: 'opencode',
+  cliPath: '/usr/local/bin/opencode',  // optional
+}),
+```
+
+### Claude Code (Planned)
+
+Anthropic's Claude Code agent. Not yet implemented.
+
+### Cursor (Planned)
+
+Cursor AI's agent mode. Not yet implemented.
+
+---
+
+## Changing the Runtime
+
+To switch from the default Copilot to another runtime:
+
+1. **Update `squad.config.ts`:**
+
+```typescript
+runtime: defineRuntime({
+  name: 'opencode',
+}),
+```
+
+2. **Run `squad build`** to regenerate config:
+
+```bash
+squad build
+```
+
+3. **Verify with `squad doctor`**:
+
+```bash
+squad doctor
+```
+
+---
+
+## Driver Interface
+
+Advanced users can implement custom drivers by implementing `AgentRuntimeDriver`:
+
+```typescript
+interface AgentRuntimeDriver {
+  readonly name: string;
+  initialize(config: RuntimeConfig): Promise<void>;
+  createSession(options: SessionOptions): Promise<AgentSession>;
+  listSessions(): Promise<SessionInfo[]>;
+  dispose(): Promise<void>;
+}
+```
+
+See [`packages/squad-sdk/src/runtime/driver.ts`](https://github.com/bradygaster/squad/blob/dev/packages/squad-sdk/src/runtime/driver.ts) for the full interface.
+
+---
+
+## See Also
+
+- [SDK-First Mode](./sdk-first-mode.md) — define your team in TypeScript
+- [Architecture](./concepts/architecture.md) — how Squad components work together
+- [GitHub Workflow](./concepts/github-workflow.md) — current Copilot integration details

--- a/docs/src/content/docs/reference/runtime.md
+++ b/docs/src/content/docs/reference/runtime.md
@@ -1,7 +1,5 @@
 # Runtime Configuration
 
-> ⚠️ **Experimental** — Runtime abstraction is in active development. OpenCode, Claude Code, and Cursor drivers are planned but not yet implemented.
-
 Squad supports multiple AI coding agent runtimes through a driver abstraction layer. This allows teams to use whichever runtime fits their workflow.
 
 ---
@@ -11,7 +9,7 @@ Squad supports multiple AI coding agent runtimes through a driver abstraction la
 | Runtime | Status | Notes |
 |---------|--------|-------|
 | `copilot` | Stable | GitHub Copilot (default) |
-| `opencode` | Planned | OpenCode CLI — protocol not yet documented |
+| `opencode` | Experimental | OpenCode CLI — uses subprocess mode with JSON event streaming |
 | `claude-code` | Planned | Anthropic Claude Code — not yet started |
 | `cursor` | Planned | Cursor AI — not yet started |
 
@@ -47,10 +45,10 @@ export default defineSquad({
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `name` | `string` | ✅ | Runtime identifier: `'copilot'` (default), `'opencode'`, `'claude-code'`, `'cursor'` |
-| `config` | `object` | ❌ | Runtime-specific configuration passed to the driver |
-| `cliPath` | `string` | ❌ | Path to runtime CLI executable (useful for custom installations) |
-| `cliUrl` | `string` | ❌ | URL for external server connection (mutually exclusive with `cliPath`) |
+| `name` | `string` | Yes | Runtime identifier: `'copilot'` (default), `'opencode'`, `'claude-code'`, `'cursor'` |
+| `config` | `object` | No | Runtime-specific configuration passed to the driver |
+| `cliPath` | `string` | No | Path to runtime CLI executable (useful for custom installations) |
+| `cliUrl` | `string` | No | URL for external server connection (mutually exclusive with `cliPath`) |
 
 ---
 
@@ -71,16 +69,26 @@ runtime: defineRuntime({
 
 **Authentication:** Uses `gh auth` credentials. Run `gh auth login` before using Squad.
 
-### OpenCode (Planned)
+### OpenCode
 
-OpenCode is a CLI-based agent runtime. Configuration details will be added once the protocol is documented.
+OpenCode is a CLI-based agent runtime that uses the `opencode run` command with JSON output for subprocess communication.
 
 ```typescript
 runtime: defineRuntime({
   name: 'opencode',
-  cliPath: '/usr/local/bin/opencode',  // optional
+  cliPath: '/usr/local/bin/opencode',  // optional, defaults to 'opencode'
+  config: {
+    requestTimeout: 120000,  // ms, default 120s
+    sessionTimeout: 300000, // ms, default 300s
+  },
 }),
 ```
+
+**How it works:** Each session spawns a new `opencode run --format json` subprocess. The driver parses JSON events (`step_start`, `text`, `step_finish`) for streaming output and error handling.
+
+**Session continuation:** The `--continue` flag is automatically used when resuming a session.
+
+**Authentication:** Uses OpenCode CLI authentication (no additional config needed).
 
 ### Claude Code (Planned)
 
@@ -125,10 +133,20 @@ Advanced users can implement custom drivers by implementing `AgentRuntimeDriver`
 ```typescript
 interface AgentRuntimeDriver {
   readonly name: string;
-  initialize(config: RuntimeConfig): Promise<void>;
-  createSession(options: SessionOptions): Promise<AgentSession>;
-  listSessions(): Promise<SessionInfo[]>;
-  dispose(): Promise<void>;
+  readonly displayName: string;
+  getState(): DriverConnectionState;
+  isConnected(): boolean;
+  connect(): Promise<void>;
+  disconnect(): Promise<Error[]>;
+  createSession(config?: DriverSessionConfig): Promise<AgentSession>;
+  resumeSession(sessionId: string, config?: DriverSessionConfig): Promise<AgentSession>;
+  listSessions(): Promise<DriverSessionMetadata[]>;
+  deleteSession(sessionId: string): Promise<void>;
+  getAuthStatus(): Promise<DriverAuthStatus>;
+  listModels(): Promise<DriverModelInfo[]>;
+  sendMessage(session: AgentSession, options: DriverMessageOptions): Promise<void>;
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  off(event: string, handler: (...args: unknown[]) => void): void;
 }
 ```
 

--- a/docs/src/content/docs/sdk-first-mode.md
+++ b/docs/src/content/docs/sdk-first-mode.md
@@ -419,8 +419,41 @@ export default defineSquad({
   hooks: defineHooks({ /* ... */ }),
   casting: defineCasting({ /* ... */ }),
   telemetry: defineTelemetry({ /* ... */ }),
+  runtime: defineRuntime({ /* ... */ }),
 });
 ```
+
+---
+
+### `defineRuntime(config)`
+
+Define which AI coding agent runtime to use. Squad supports multiple runtimes via a driver abstraction layer.
+
+```typescript
+const runtime = defineRuntime({
+  name: 'copilot',  // or 'opencode', 'claude-code', 'cursor'
+  config: {
+    // runtime-specific configuration
+  },
+  cliPath: '/path/to/cli',  // optional override
+});
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | ✅ | Runtime name: `'copilot'` (default), `'opencode'`, `'claude-code'`, `'cursor'` |
+| `config` | object | ❌ | Runtime-specific configuration passed to the driver |
+| `cliPath` | string | ❌ | Path to runtime CLI executable |
+| `cliUrl` | string | ❌ | URL for external server connection (mutually exclusive with `cliPath`) |
+
+**Supported Runtimes:**
+
+| Runtime | Status | Notes |
+|---------|--------|-------|
+| `copilot` | Stable | GitHub Copilot (default) |
+| `opencode` | Planned | OpenCode CLI support in development |
+| `claude-code` | Planned | Anthropic Claude Code support |
+| `cursor` | Planned | Cursor AI support |
 
 ---
 

--- a/docs/src/content/docs/sdk-first-mode.md
+++ b/docs/src/content/docs/sdk-first-mode.md
@@ -563,6 +563,7 @@ import {
   defineHooks,
   defineCasting,
   defineTelemetry,
+  defineRuntime,
 } from '@bradygaster/squad-sdk';
 
 export default defineSquad({
@@ -653,6 +654,11 @@ export default defineSquad({
     fallback: 'coordinator',
   }),
 
+  runtime: defineRuntime({
+    name: 'copilot',
+    config: {},
+  }),
+
   hooks: defineHooks({
     allowedWritePaths: [
       'src/**',
@@ -690,5 +696,6 @@ export default defineSquad({
 ## See Also
 
 - [SDK Reference](./reference/sdk.md) — all SDK exports
+- [Runtime Configuration](./reference/runtime.md) — runtime drivers and configuration
 - [Routing Guide](./features/routing.md) — deep dive on routing tiers
 - [Governance & Hooks](./reference/sdk.md) — hook pipeline and governance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.9.1",
+  "version": "0.9.1-build.1",
   "private": true,
   "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.9.1",
+  "version": "0.9.1-build.1",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.9.1",
+  "version": "0.9.1-build.1",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/squad-sdk/src/builders/index.ts
+++ b/packages/squad-sdk/src/builders/index.ts
@@ -22,6 +22,7 @@ import type {
   TelemetryDefinition,
   SkillDefinition,
   SquadSDKConfig,
+  RuntimeDefinition,
 } from './types.js';
 
 // Re-export every type so consumers can `import { defineTeam, TeamDefinition } from './builders'`
@@ -44,6 +45,7 @@ export type {
   SkillDefinition,
   SkillTool,
   SquadSDKConfig,
+  RuntimeDefinition,
 } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -451,6 +453,22 @@ export function defineSkill(config: SkillDefinition): SkillDefinition {
   return config;
 }
 
+/**
+ * Define a runtime configuration.
+ *
+ * ```ts
+ * const runtime = defineRuntime({
+ *   name: 'opencode',
+ *   config: { model: 'claude-sonnet-4' },
+ * });
+ * ```
+ */
+export function defineRuntime(config: RuntimeDefinition): RuntimeDefinition {
+  assertObject(config, 'defineRuntime');
+  assertNonEmptyString(config.name, 'name', 'defineRuntime');
+  return config;
+}
+
 // ---------------------------------------------------------------------------
 // defineDefaults
 // ---------------------------------------------------------------------------
@@ -518,6 +536,7 @@ export function defineSquad(config: SquadSDKConfig): SquadSDKConfig {
       defineSkill(skill);
     }
   }
+  if (config.runtime !== undefined) defineRuntime(config.runtime);
 
   return config;
 }

--- a/packages/squad-sdk/src/builders/types.ts
+++ b/packages/squad-sdk/src/builders/types.ts
@@ -276,6 +276,39 @@ export interface SkillDefinition {
 }
 
 // ---------------------------------------------------------------------------
+// RuntimeDefinition — runtime-agnostic configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Runtime definition for specifying which AI coding agent runtime to use.
+ */
+export interface RuntimeDefinition {
+  /**
+   * Runtime name (e.g., "copilot", "opencode", "claude-code", "cursor").
+   * @default "copilot"
+   */
+  readonly name: string;
+
+  /**
+   * Driver-specific configuration options.
+   * These are passed to the runtime driver.
+   */
+  readonly config?: Record<string, unknown>;
+
+  /**
+   * CLI path override for this runtime.
+   * If not provided, uses the runtime's default CLI detection.
+   */
+  readonly cliPath?: string;
+
+  /**
+   * CLI URL for external server connection.
+   * Mutually exclusive with cliPath.
+   */
+  readonly cliUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
 // SquadSDKConfig — top-level config that composes all builders
 // ---------------------------------------------------------------------------
 
@@ -309,4 +342,11 @@ export interface SquadSDKConfig {
 
   /** Skill definitions. */
   readonly skills?: readonly SkillDefinition[];
+
+  /**
+   * Runtime configuration.
+   * Specifies which AI coding agent runtime to use (copilot, opencode, etc.).
+   * @default { name: "copilot" }
+   */
+  readonly runtime?: RuntimeDefinition;
 }

--- a/packages/squad-sdk/src/drivers/copilot/driver.ts
+++ b/packages/squad-sdk/src/drivers/copilot/driver.ts
@@ -1,0 +1,727 @@
+/**
+ * Copilot Runtime Driver
+ *
+ * Implements AgentRuntimeDriver for GitHub Copilot using @github/copilot-sdk.
+ *
+ * @module drivers/copilot/driver
+ */
+
+import { CopilotClient } from '@github/copilot-sdk';
+import { trace, SpanStatusCode } from '../../runtime/otel-api.js';
+import { recordSessionCreated, recordSessionClosed, recordSessionError, recordTokenUsage } from '../../runtime/otel-metrics.js';
+import { estimateCost } from '../../config/models.js';
+import type { EventBus } from '../../runtime/event-bus.js';
+import type { UsageEvent } from '../../runtime/streaming.js';
+import type {
+  AgentRuntimeDriver,
+  DriverOptions,
+  DriverSessionConfig,
+  DriverSessionMetadata,
+  DriverMessageOptions,
+  DriverAuthStatus,
+  DriverStatus,
+  DriverModelInfo,
+  DriverConnectionState,
+  AgentSession,
+  DriverSessionEvent,
+  DriverSessionEventHandler,
+} from '../../runtime/driver.js';
+import {
+  DriverError,
+  DriverConnectionError,
+  DriverSessionError,
+} from '../../runtime/driver.js';
+
+const tracer = trace.getTracer('squad-sdk');
+
+/**
+ * Maps Squad short event names → @github/copilot-sdk dotted event names.
+ */
+const EVENT_MAP: Record<string, string> = {
+  message_delta: 'assistant.message_delta',
+  message: 'assistant.message',
+  usage: 'assistant.usage',
+  reasoning_delta: 'assistant.reasoning_delta',
+  reasoning: 'assistant.reasoning',
+  turn_start: 'assistant.turn_start',
+  turn_end: 'assistant.turn_end',
+  intent: 'assistant.intent',
+  idle: 'session.idle',
+  error: 'session.error',
+};
+
+/**
+ * Reverse map: SDK dotted names → Squad short names.
+ */
+const REVERSE_EVENT_MAP: Record<string, string> = Object.fromEntries(
+  Object.entries(EVENT_MAP).map(([k, v]) => [v, k])
+);
+
+/**
+ * Adapts @github/copilot-sdk CopilotSession to our AgentSession interface.
+ */
+class CopilotSessionAdapter implements AgentSession {
+  private readonly inner: unknown;
+  private readonly unsubscribers = new Map<DriverSessionEventHandler, Map<string, () => void>>();
+
+  constructor(copilotSession: unknown) {
+    this.inner = copilotSession;
+  }
+
+  get sessionId(): string {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this.inner as any).sessionId ?? 'unknown';
+  }
+
+  async sendMessage(options: DriverMessageOptions): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (this.inner as any).send(options);
+  }
+
+  async sendAndWait(options: DriverMessageOptions, timeout?: number): Promise<unknown> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return await (this.inner as any).sendAndWait(options, timeout);
+  }
+
+  async abort(): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (this.inner as any).abort();
+  }
+
+  async getMessages(): Promise<unknown[]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return await (this.inner as any).getMessages();
+  }
+
+  private static normalizeEvent(sdkEvent: unknown): DriverSessionEvent {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const event = sdkEvent as any;
+    const squadType = REVERSE_EVENT_MAP[event.type] ?? event.type;
+    return {
+      type: squadType,
+      ...(event.data ?? {}),
+    };
+  }
+
+  on(eventType: string, handler: DriverSessionEventHandler): void {
+    const sdkType = EVENT_MAP[eventType] ?? eventType;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wrappedHandler = (sdkEvent: any) => {
+      handler(CopilotSessionAdapter.normalizeEvent(sdkEvent));
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const unsubscribe = (this.inner as any).on(sdkType, wrappedHandler);
+    if (!this.unsubscribers.has(handler)) {
+      this.unsubscribers.set(handler, new Map());
+    }
+    this.unsubscribers.get(handler)!.set(eventType, unsubscribe);
+  }
+
+  off(eventType: string, handler: DriverSessionEventHandler): void {
+    const handlerMap = this.unsubscribers.get(handler);
+    if (handlerMap) {
+      const unsubscribe = handlerMap.get(eventType);
+      if (unsubscribe) {
+        unsubscribe();
+        handlerMap.delete(eventType);
+      }
+      if (handlerMap.size === 0) {
+        this.unsubscribers.delete(handler);
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (this.inner as any).destroy();
+    this.unsubscribers.clear();
+  }
+}
+
+/**
+ * Copilot Runtime Driver
+ *
+ * Implements AgentRuntimeDriver for GitHub Copilot using @github/copilot-sdk.
+ * This driver wraps CopilotClient to provide connection lifecycle management,
+ * error recovery, automatic reconnection, and protocol version validation.
+ */
+export class CopilotDriver implements AgentRuntimeDriver {
+  readonly name = 'copilot';
+
+  private client: CopilotClient;
+  private state: DriverConnectionState = 'disconnected';
+  private connectPromise: Promise<void> | null = null;
+  private reconnectAttempts: number = 0;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private manualDisconnect: boolean = false;
+  private options: Required<Omit<DriverOptions, 'cliUrl' | 'authToken' | 'useLoggedInUser' | 'cliPath' | 'cliArgs' | 'eventBus'>> & {
+    cliUrl?: string;
+    authToken?: string;
+    useLoggedInUser?: boolean;
+    cliPath?: string;
+    cliArgs: string[];
+    eventBus?: EventBus;
+  };
+
+  constructor(options: DriverOptions = {}) {
+    this.options = {
+      cliPath: options.cliPath,
+      cliArgs: options.cliArgs ?? [],
+      cwd: options.cwd ?? process.cwd(),
+      port: options.port ?? 0,
+      useStdio: options.useStdio ?? true,
+      cliUrl: options.cliUrl,
+      logLevel: options.logLevel ?? 'debug',
+      autoStart: options.autoStart ?? true,
+      autoReconnect: options.autoReconnect ?? true,
+      env: options.env ?? (process.env as Record<string, string>),
+      authToken: options.authToken,
+      useLoggedInUser: options.useLoggedInUser ?? (options.authToken ? false : true),
+      maxReconnectAttempts: options.maxReconnectAttempts ?? 3,
+      reconnectDelayMs: options.reconnectDelayMs ?? 1000,
+      eventBus: options.eventBus,
+    };
+
+    this.client = new CopilotClient({
+      cliPath: this.options.cliPath,
+      cliArgs: this.options.cliArgs,
+      cwd: this.options.cwd,
+      port: this.options.port,
+      useStdio: this.options.useStdio,
+      cliUrl: this.options.cliUrl,
+      logLevel: this.options.logLevel,
+      autoStart: false,
+      autoRestart: false,
+      env: this.options.env,
+      githubToken: this.options.authToken,
+      useLoggedInUser: this.options.useLoggedInUser,
+    });
+  }
+
+  getState(): DriverConnectionState {
+    return this.state;
+  }
+
+  isConnected(): boolean {
+    return this.state === 'connected';
+  }
+
+  async connect(): Promise<void> {
+    if (this.state === 'connected') {
+      return;
+    }
+
+    if (this.state === 'connecting' && this.connectPromise) {
+      return this.connectPromise;
+    }
+
+    const span = tracer.startSpan('squad.driver.copilot.connect');
+    span.setAttribute('connection.transport', this.options.useStdio ? 'stdio' : 'tcp');
+
+    this.state = 'connecting';
+    this.manualDisconnect = false;
+
+    this.connectPromise = (async () => {
+      const startTime = Date.now();
+      try {
+        await this.client.start();
+        const elapsed = Date.now() - startTime;
+
+        this.state = 'connected';
+        this.reconnectAttempts = 0;
+
+        span.setAttribute('connection.duration_ms', elapsed);
+
+        if (elapsed > 2000) {
+          console.warn(`CopilotDriver connection took ${elapsed}ms (> 2s threshold)`);
+        }
+      } catch (error) {
+        this.state = 'error';
+        const wrapped = new DriverConnectionError(
+          this.name,
+          `Failed to connect to Copilot CLI: ${error instanceof Error ? error.message : String(error)}`
+        );
+        span.setStatus({ code: SpanStatusCode.ERROR, message: wrapped.message });
+        span.recordException(wrapped);
+        throw wrapped;
+      } finally {
+        this.connectPromise = null;
+        span.end();
+      }
+    })();
+
+    return this.connectPromise;
+  }
+
+  async disconnect(): Promise<Error[]> {
+    const span = tracer.startSpan('squad.driver.copilot.disconnect');
+    try {
+      this.manualDisconnect = true;
+
+      if (this.reconnectTimer) {
+        clearTimeout(this.reconnectTimer);
+        this.reconnectTimer = null;
+      }
+
+      const errors = await this.client.stop();
+      this.state = 'disconnected';
+      this.reconnectAttempts = 0;
+      this.connectPromise = null;
+      return errors;
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  async forceDisconnect(): Promise<void> {
+    this.manualDisconnect = true;
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    await this.client.forceStop();
+    this.state = 'disconnected';
+    this.reconnectAttempts = 0;
+    this.connectPromise = null;
+  }
+
+  async createSession(config?: DriverSessionConfig): Promise<AgentSession> {
+    const span = tracer.startSpan('squad.driver.copilot.session.create');
+    span.setAttribute('session.auto_start', this.options.autoStart);
+
+    try {
+      if (!this.isConnected() && this.options.autoStart) {
+        await this.connect();
+      }
+
+      if (!this.isConnected()) {
+        throw new DriverSessionError(this.name, 'Client not connected. Call connect() first.');
+      }
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const session = await this.client.createSession(config as any);
+        const result = new CopilotSessionAdapter(session);
+
+        if (result.sessionId) {
+          span.setAttribute('session.id', result.sessionId);
+        }
+
+        recordSessionCreated();
+
+        if (this.options.eventBus) {
+          const bus = this.options.eventBus;
+          const sid = result.sessionId;
+          result.on('usage', (event: DriverSessionEvent) => {
+            const inputTokens = typeof event['inputTokens'] === 'number' ? event['inputTokens'] : 0;
+            const outputTokens = typeof event['outputTokens'] === 'number' ? event['outputTokens'] : 0;
+            const model = typeof event['model'] === 'string' ? event['model'] : 'unknown';
+            const cost = estimateCost(model, inputTokens, outputTokens);
+            void bus.emit({
+              type: 'session:message',
+              sessionId: sid,
+              payload: {
+                inputTokens,
+                outputTokens,
+                model,
+                estimatedCost: cost,
+              },
+              timestamp: new Date(),
+            });
+          });
+        }
+
+        return result;
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (msg.includes('onPermissionRequest')) {
+          throw new DriverSessionError(
+            this.name,
+            'Session creation failed: an onPermissionRequest handler is required. ' +
+            'Pass { onPermissionRequest: () => ({ kind: "approved" }) } in your session config ' +
+            'to approve all permissions, or provide a custom handler.'
+          );
+        }
+        recordSessionError();
+        if (this.shouldAttemptReconnect(error)) {
+          await this.attemptReconnection();
+          return this.createSession(config);
+        }
+        throw error;
+      }
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  async resumeSession(sessionId: string, config?: DriverSessionConfig): Promise<AgentSession> {
+    const span = tracer.startSpan('squad.driver.copilot.session.resume');
+    span.setAttribute('session.id', sessionId);
+
+    try {
+      if (!this.isConnected() && this.options.autoStart) {
+        await this.connect();
+      }
+
+      if (!this.isConnected()) {
+        throw new DriverSessionError(this.name, 'Client not connected. Call connect() first.');
+      }
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const session = await this.client.resumeSession(sessionId, config as any);
+        return new CopilotSessionAdapter(session);
+      } catch (error) {
+        if (this.shouldAttemptReconnect(error)) {
+          await this.attemptReconnection();
+          return this.resumeSession(sessionId, config);
+        }
+        throw error;
+      }
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  async listSessions(): Promise<DriverSessionMetadata[]> {
+    const span = tracer.startSpan('squad.driver.copilot.session.list');
+
+    try {
+      if (!this.isConnected()) {
+        throw new DriverSessionError(this.name, 'Client not connected');
+      }
+
+      try {
+        const sessions = await this.client.listSessions();
+        const result = sessions.map((s): DriverSessionMetadata => ({
+          sessionId: s.sessionId,
+          startTime: s.startTime,
+          modifiedTime: s.modifiedTime,
+          summary: s.summary,
+          isRemote: s.isRemote,
+          context: s.context as Record<string, unknown> | undefined,
+        }));
+        span.setAttribute('sessions.count', result.length);
+        return result;
+      } catch (error) {
+        if (this.shouldAttemptReconnect(error)) {
+          await this.attemptReconnection();
+          return this.listSessions();
+        }
+        throw error;
+      }
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    const span = tracer.startSpan('squad.driver.copilot.session.delete');
+    span.setAttribute('session.id', sessionId);
+
+    try {
+      if (!this.isConnected()) {
+        throw new DriverSessionError(this.name, 'Client not connected');
+      }
+
+      try {
+        await this.client.deleteSession(sessionId);
+        recordSessionClosed();
+      } catch (error) {
+        recordSessionError();
+        if (this.shouldAttemptReconnect(error)) {
+          await this.attemptReconnection();
+          return this.deleteSession(sessionId);
+        }
+        throw error;
+      }
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  async getLastSessionId(): Promise<string | undefined> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      return await this.client.getLastSessionId();
+    } catch (error) {
+      if (this.shouldAttemptReconnect(error)) {
+        await this.attemptReconnection();
+        return this.getLastSessionId();
+      }
+      throw error;
+    }
+  }
+
+  async ping(message?: string): Promise<{ message: string; timestamp: number; protocolVersion?: number }> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      return await this.client.ping(message);
+    } catch (error) {
+      if (this.shouldAttemptReconnect(error)) {
+        await this.attemptReconnection();
+        return this.ping(message);
+      }
+      throw error;
+    }
+  }
+
+  async getStatus(): Promise<DriverStatus> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      const raw = await this.client.getStatus();
+      return {
+        version: raw.version,
+        protocolVersion: raw.protocolVersion,
+      };
+    } catch (error) {
+      if (this.shouldAttemptReconnect(error)) {
+        await this.attemptReconnection();
+        return this.getStatus();
+      }
+      throw error;
+    }
+  }
+
+  async getAuthStatus(): Promise<DriverAuthStatus> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      const raw = await this.client.getAuthStatus();
+      return {
+        isAuthenticated: raw.isAuthenticated,
+        authType: raw.authType === 'gh-cli' ? 'cli' : raw.authType,
+        host: raw.host,
+        login: raw.login,
+        statusMessage: raw.statusMessage,
+      };
+    } catch (error) {
+      if (this.shouldAttemptReconnect(error)) {
+        await this.attemptReconnection();
+        return this.getAuthStatus();
+      }
+      throw error;
+    }
+  }
+
+  async listModels(): Promise<DriverModelInfo[]> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      const models = await this.client.listModels();
+      return models.map((m): DriverModelInfo => ({
+        id: m.id,
+        name: m.name,
+        capabilities: m.capabilities,
+        supportedReasoningEfforts: m.supportedReasoningEfforts,
+        defaultReasoningEffort: m.defaultReasoningEffort,
+      }));
+    } catch (error) {
+      if (this.shouldAttemptReconnect(error)) {
+        await this.attemptReconnection();
+        return this.listModels();
+      }
+      throw error;
+    }
+  }
+
+  async sendMessage(session: AgentSession, options: DriverMessageOptions): Promise<void> {
+    const messageSpan = tracer.startSpan('squad.driver.copilot.session.message');
+    messageSpan.setAttribute('session.id', session.sessionId);
+    messageSpan.setAttribute('prompt.length', options.prompt.length);
+    messageSpan.setAttribute('streaming', true);
+    const streamSpan = tracer.startSpan('squad.driver.copilot.session.stream');
+    streamSpan.setAttribute('session.id', session.sessionId);
+    const messageStartMs = Date.now();
+    let firstTokenRecorded = false;
+    let outputTokens = 0;
+    let inputTokens = 0;
+
+    let model = 'unknown';
+
+    const origOn = session.on.bind(session);
+
+    const streamListener = (event: DriverSessionEvent) => {
+      if (event.type === 'message_delta' && !firstTokenRecorded) {
+        firstTokenRecorded = true;
+        streamSpan.addEvent('first_token');
+      }
+      if (event.type === 'usage') {
+        inputTokens = typeof event['inputTokens'] === 'number' ? event['inputTokens'] : 0;
+        outputTokens = typeof event['outputTokens'] === 'number' ? event['outputTokens'] : 0;
+        model = typeof event['model'] === 'string' ? event['model'] : 'unknown';
+      }
+    };
+
+    origOn('message_delta', streamListener);
+    origOn('usage', streamListener);
+
+    try {
+      await session.sendMessage(options);
+
+      const durationMs = Date.now() - messageStartMs;
+      streamSpan.addEvent('last_token');
+      streamSpan.setAttribute('tokens.input', inputTokens);
+      streamSpan.setAttribute('tokens.output', outputTokens);
+      streamSpan.setAttribute('duration_ms', durationMs);
+
+      if (inputTokens > 0 || outputTokens > 0) {
+        const usageEvent: UsageEvent = {
+          type: 'usage',
+          sessionId: session.sessionId,
+          model,
+          inputTokens,
+          outputTokens,
+          estimatedCost: estimateCost(model, inputTokens, outputTokens),
+          timestamp: new Date(),
+        };
+        recordTokenUsage(usageEvent);
+      }
+    } catch (err) {
+      streamSpan.addEvent('stream_error');
+      streamSpan.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      streamSpan.recordException(err instanceof Error ? err : new Error(String(err)));
+      messageSpan.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      messageSpan.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      streamSpan.end();
+      messageSpan.end();
+      try {
+        session.off('message_delta', streamListener);
+        session.off('usage', streamListener);
+      } catch {
+        // session may not support off — ignore
+      }
+    }
+  }
+
+  async closeSession(sessionId: string): Promise<void> {
+    const span = tracer.startSpan('squad.driver.copilot.session.close');
+    span.setAttribute('session.id', sessionId);
+
+    try {
+      await this.deleteSession(sessionId);
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  private shouldAttemptReconnect(error: unknown): boolean {
+    if (!this.options.autoReconnect) {
+      return false;
+    }
+
+    if (this.manualDisconnect) {
+      return false;
+    }
+
+    if (this.reconnectAttempts >= this.options.maxReconnectAttempts) {
+      return false;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (
+      message.includes('ECONNREFUSED') ||
+      message.includes('ECONNRESET') ||
+      message.includes('EPIPE') ||
+      message.includes('Client not connected') ||
+      message.includes('Connection closed')
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private async attemptReconnection(): Promise<void> {
+    if (this.state === 'reconnecting') {
+      throw new DriverError(this.name, 'Reconnection already in progress', 'reconnect', true);
+    }
+
+    this.state = 'reconnecting';
+    this.reconnectAttempts++;
+
+    const delay = this.options.reconnectDelayMs * Math.pow(2, this.reconnectAttempts - 1);
+
+    await new Promise((resolve) => {
+      this.reconnectTimer = setTimeout(resolve, delay);
+    });
+
+    try {
+      await this.client.stop();
+      await this.client.start();
+      this.state = 'connected';
+      this.reconnectAttempts = 0;
+    } catch (error) {
+      this.state = 'error';
+      throw new DriverError(
+        this.name,
+        `Reconnection attempt ${this.reconnectAttempts} failed: ${error instanceof Error ? error.message : String(error)}`,
+        'reconnect',
+        true
+      );
+    }
+  }
+}
+
+/**
+ * Create a Copilot driver instance.
+ */
+export function createCopilotDriver(options?: DriverOptions): AgentRuntimeDriver {
+  return new CopilotDriver(options);
+}
+
+/**
+ * Register the Copilot driver with the global registry.
+ */
+export async function registerCopilotDriver(
+  registry?: { registerDriverFactory: (name: string, factory: () => Promise<AgentRuntimeDriver>) => void },
+  options?: DriverOptions
+): Promise<AgentRuntimeDriver> {
+  const driver = new CopilotDriver(options);
+  if (registry) {
+    registry.registerDriverFactory('copilot', async () => driver);
+  }
+  return driver;
+}

--- a/packages/squad-sdk/src/drivers/index.ts
+++ b/packages/squad-sdk/src/drivers/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Drivers Module
+ *
+ * Exports all runtime drivers for the Squad SDK.
+ *
+ * @module drivers
+ */
+
+export { CopilotDriver, createCopilotDriver, registerCopilotDriver } from './copilot/driver.js';
+export { OpenCodeDriver, createOpenCodeDriver, registerOpenCodeDriver } from './opencode/driver.js';

--- a/packages/squad-sdk/src/drivers/opencode/driver.ts
+++ b/packages/squad-sdk/src/drivers/opencode/driver.ts
@@ -1,11 +1,9 @@
 /**
  * OpenCode Runtime Driver
  *
- * Implements AgentRuntimeDriver for OpenCode CLI.
- *
- * This driver communicates with the OpenCode CLI via stdio JSON-RPC.
- * The implementation is a skeleton that needs to be completed once
- * OpenCode's stdio protocol is documented or discovered.
+ * Implements AgentRuntimeDriver for OpenCode CLI using subprocess mode.
+ * Communicates via `opencode run` command which spawns a headless agent
+ * process and streams output to stdout.
  *
  * @module drivers/opencode/driver
  */
@@ -36,153 +34,253 @@ import {
 const tracer = trace.getTracer('squad-sdk');
 
 /**
- * OpenCode JSON-RPC message types.
- * These are guesses based on common patterns for CLI tools.
+ * OpenCode server connection configuration.
  */
-interface OpenCodeRPCRequest {
-  id: string;
-  method: string;
-  params?: Record<string, unknown>;
-}
-
-interface OpenCodeRPCResponse {
-  id: string;
-  result?: unknown;
-  error?: {
-    code: number;
-    message: string;
-  };
-}
-
-interface OpenCodeSessionInfo {
-  sessionId: string;
-  // Add other session fields as OpenCode protocol is discovered
+export interface OpenCodeOptions extends DriverOptions {
+  /** Request timeout in ms (default: 120000) */
+  requestTimeout?: number;
+  /** Session inactivity timeout in ms (default: 300000) */
+  sessionTimeout?: number;
 }
 
 /**
- * Adapts an OpenCode CLI process to our AgentSession interface.
+ * Raw output line from opencode subprocess.
  */
-class OpenCodeSessionAdapter implements AgentSession {
-  private _sessionId: string;
-  private readonly process: ChildProcess;
+interface OpenCodeJsonEvent {
+  type: string;
+  timestamp?: number;
+  sessionID?: string;
+  part?: {
+    id?: string;
+    messageID?: string;
+    type?: string;
+    text?: string;
+    error?: string;
+    time?: {
+      start?: number;
+      end?: number;
+    };
+  };
+  error?: string;
+  reason?: string;
+  tokens?: {
+    total?: number;
+    input?: number;
+    output?: number;
+    reasoning?: number;
+    cache?: {
+      write?: number;
+      read?: number;
+    };
+  };
+  snapshot?: string;
+}
+
+/**
+ * OpenCode Session implementation.
+ * Each session spawns a new `opencode run` subprocess.
+ */
+class OpenCodeSessionImpl implements AgentSession {
+  private readonly _sessionId: string;
+  private readonly cliPath: string;
+  private readonly cwd: string;
+  private readonly env: Record<string, string>;
+  private readonly requestTimeout: number;
   private readonly eventEmitter = new EventEmitter();
-  private pendingRequests = new Map<string, {
-    resolve: (value: unknown) => void;
-    reject: (error: Error) => void;
-  }>();
+  private process: ChildProcess | null = null;
+  private _isAborted = false;
+  private _lastActivity = Date.now();
+  private outputBuffer = '';
+  private fullOutput = '';
+  private openCodeSessionId: string | null = null;
+  private _isContinued = false;
 
-  constructor(sessionId: string, process: ChildProcess) {
+  constructor(
+    sessionId: string,
+    cliPath: string,
+    cwd: string,
+    env: Record<string, string>,
+    requestTimeout: number
+  ) {
     this._sessionId = sessionId;
-    this.process = process;
-
-    // Listen to stdout for responses
-    this.process.stdout?.on('data', (data: Buffer) => {
-      this.handleResponse(data.toString());
-    });
-
-    // Listen to stderr for events/errors
-    this.process.stderr?.on('data', (data: Buffer) => {
-      this.handleEvent(data.toString());
-    });
-
-    this.process.on('error', (err) => {
-      this.eventEmitter.emit('error', { type: 'error', error: err.message });
-    });
-
-    this.process.on('exit', (code) => {
-      if (code !== 0 && code !== null) {
-        this.eventEmitter.emit('error', { type: 'error', error: `Process exited with code ${code}` });
-      }
-      this.eventEmitter.emit('idle', { type: 'idle' });
-    });
-  }
-
-  private handleResponse(data: string): void {
-    // Parse JSON-RPC responses
-    for (const line of data.split('\n').filter(Boolean)) {
-      try {
-        const response = JSON.parse(line) as OpenCodeRPCResponse;
-        if (response.id) {
-          const pending = this.pendingRequests.get(response.id);
-          if (pending) {
-            if (response.error) {
-              pending.reject(new Error(response.error.message));
-            } else {
-              pending.resolve(response.result);
-            }
-            this.pendingRequests.delete(response.id);
-          }
-        }
-      } catch {
-        // Ignore parse errors for non-JSON lines
-      }
-    }
-  }
-
-  private handleEvent(data: string): void {
-    // Parse event lines (prefixed with "event:" or similar)
-    for (const line of data.split('\n').filter(Boolean)) {
-      try {
-        // Events might be prefixed - adjust as needed based on OpenCode protocol
-        const eventData = line.startsWith('event:') ? JSON.parse(line.slice(6)) : JSON.parse(line);
-        if (eventData.type) {
-          this.eventEmitter.emit(eventData.type, eventData);
-        }
-      } catch {
-        // Ignore parse errors
-      }
-    }
-  }
-
-  private sendRPC(method: string, params?: Record<string, unknown>): Promise<unknown> {
-    return new Promise((resolve, reject) => {
-      const id = Math.random().toString(36).slice(2);
-      const request: OpenCodeRPCRequest = { id, method, params };
-      this.pendingRequests.set(id, { resolve, reject });
-
-      this.process.stdin?.write(JSON.stringify(request) + '\n');
-
-      // Timeout after 60 seconds
-      setTimeout(() => {
-        if (this.pendingRequests.has(id)) {
-          this.pendingRequests.delete(id);
-          reject(new Error(`Request ${method} timed out`));
-        }
-      }, 60000);
-    });
+    this.cliPath = cliPath;
+    this.cwd = cwd;
+    this.env = env;
+    this.requestTimeout = requestTimeout;
   }
 
   get sessionId(): string {
     return this._sessionId;
   }
 
-  async sendMessage(options: DriverMessageOptions): Promise<void> {
-    await this.sendRPC('session.send', {
-      sessionId: this.sessionId,
-      prompt: options.prompt,
-      attachments: options.attachments,
+  get isContinued(): boolean {
+    return this._isContinued;
+  }
+
+  markContinued(): void {
+    this._isContinued = true;
+  }
+
+  private updateActivity(): void {
+    this._lastActivity = Date.now();
+  }
+
+  private stripAnsiCodes(text: string): string {
+    return text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\x1b\][^\x07]+\x07/g, '');
+  }
+
+  private parseOutputLine(line: string): { content: string; isError: boolean } {
+    const stripped = this.stripAnsiCodes(line);
+    const isError = stripped.startsWith('[ERROR]') || stripped.startsWith('Error:');
+    return { content: stripped, isError };
+  }
+
+  private emitChunk(content: string): void {
+    this.eventEmitter.emit('chunk', {
+      type: 'chunk',
+      content,
+      sessionId: this._sessionId,
     });
   }
 
-  async sendAndWait(options: DriverMessageOptions, timeout?: number): Promise<unknown> {
-    const response = await this.sendRPC('session.sendAndWait', {
-      sessionId: this.sessionId,
-      prompt: options.prompt,
-      attachments: options.attachments,
-      timeout,
+  private emitError(message: string): void {
+    this.eventEmitter.emit('error', {
+      type: 'error',
+      message,
+      sessionId: this._sessionId,
     });
-    return response;
+  }
+
+  private spawnProcess(prompt: string, continueSession?: boolean): ChildProcess {
+    const args = ['run', '--format', 'json'];
+
+    if (continueSession || this.openCodeSessionId) {
+      args.push('--continue');
+    }
+
+    args.push('--', prompt);
+
+    const proc = spawn(this.cliPath, args, {
+      cwd: this.cwd,
+      env: { ...this.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    return proc;
+  }
+
+  private parseJsonEvent(line: string): OpenCodeJsonEvent | null {
+    try {
+      const event = JSON.parse(line) as OpenCodeJsonEvent;
+      return event;
+    } catch {
+      return null;
+    }
+  }
+
+  async sendMessage(options: DriverMessageOptions): Promise<void> {
+    this.updateActivity();
+    this._isAborted = false;
+    this.outputBuffer = '';
+    this.fullOutput = '';
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this._isAborted = true;
+        this.process?.kill('SIGTERM');
+        reject(new DriverSessionError('opencode', 'Session timed out'));
+      }, this.requestTimeout);
+
+      const continueSession = this._isContinued;
+      this.process = this.spawnProcess(options.prompt, continueSession);
+
+      this.process.stdout?.on('data', (data: Buffer) => {
+        const text = data.toString();
+        this.fullOutput += text;
+        this.outputBuffer += text;
+
+        const lines = this.outputBuffer.split('\n');
+        this.outputBuffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (line.trim()) {
+            const event = this.parseJsonEvent(line);
+            if (event) {
+              if (event.sessionID && !this.openCodeSessionId) {
+                this.openCodeSessionId = event.sessionID;
+              }
+
+              if (event.type === 'text' && event.part?.text) {
+                this.emitChunk(event.part.text);
+              } else if (event.type === 'error' || event.type === 'error_event') {
+                this.emitError(event.error || event.part?.text || 'Unknown error');
+              } else if (event.type === 'step_finish' && event.reason === 'error') {
+                this.emitError(event.part?.error || 'Step finished with error');
+              }
+            } else {
+              const parsed = this.parseOutputLine(line);
+              if (parsed.isError) {
+                this.emitError(parsed.content);
+              }
+            }
+          }
+        }
+
+        this.updateActivity();
+      });
+
+      this.process.stderr?.on('data', (data: Buffer) => {
+        const text = data.toString();
+        this.fullOutput += text;
+      });
+
+      this.process.on('error', (err) => {
+        clearTimeout(timeout);
+        reject(new DriverSessionError('opencode', `Process error: ${err.message}`));
+      });
+
+      this.process.on('close', (code) => {
+        clearTimeout(timeout);
+
+        if (this.outputBuffer.trim()) {
+          const event = this.parseJsonEvent(this.outputBuffer);
+          if (event && event.type === 'text' && event.part?.text) {
+            this.emitChunk(event.part.text);
+          }
+        }
+
+        if (this._isAborted) {
+          this.eventEmitter.emit('idle', { type: 'idle', sessionId: this._sessionId });
+          resolve();
+        } else if (code === 0) {
+          this.eventEmitter.emit('complete', {
+            type: 'complete',
+            sessionId: this._sessionId,
+            exitCode: code,
+          });
+          resolve();
+        } else {
+          reject(new DriverSessionError('opencode', `Process exited with code ${code}`));
+        }
+      });
+    });
+  }
+
+  async sendAndWait(options: DriverMessageOptions, _timeoutMs?: number): Promise<unknown> {
+    await this.sendMessage(options);
+    return { message: this.fullOutput, sessionId: this._sessionId };
   }
 
   async abort(): Promise<void> {
-    await this.sendRPC('session.abort', { sessionId: this.sessionId });
+    this._isAborted = true;
+    this.process?.kill('SIGTERM');
+    this.eventEmitter.emit('idle', { type: 'idle', sessionId: this._sessionId });
   }
 
   async getMessages(): Promise<unknown[]> {
-    const response = await this.sendRPC('session.getMessages', {
-      sessionId: this.sessionId,
-    });
-    return response as unknown[];
+    return [
+      { role: 'assistant', content: this.fullOutput },
+    ];
   }
 
   on(eventType: string, handler: DriverSessionEventHandler): void {
@@ -194,42 +292,53 @@ class OpenCodeSessionAdapter implements AgentSession {
   }
 
   async close(): Promise<void> {
-    await this.sendRPC('session.close', { sessionId: this.sessionId });
-    this.process.kill();
-    this.pendingRequests.clear();
+    if (this.process) {
+      this.process.kill('SIGTERM');
+      this.process = null;
+    }
+    this.eventEmitter.emit('closed', { type: 'closed', sessionId: this._sessionId });
   }
 }
 
 /**
  * OpenCode Runtime Driver
  *
- * Implements AgentRuntimeDriver for OpenCode CLI.
- *
- * Note: This is a skeleton implementation. The actual OpenCode protocol
- * needs to be discovered or documented to complete the implementation.
- *
- * OpenCode CLI is expected to communicate via stdio JSON-RPC, similar to
- * other CLI tools like GitHub Copilot and Anthropic's Claude CLI.
+ * Implements AgentRuntimeDriver for OpenCode CLI using headless subprocess mode.
+ * Each session spawns a new `opencode run` process.
  */
 export class OpenCodeDriver implements AgentRuntimeDriver {
   readonly name = 'opencode';
+  readonly displayName = 'OpenCode';
 
   private state: DriverConnectionState = 'disconnected';
-  private process: ChildProcess | null = null;
   private eventEmitter = new EventEmitter();
-  private sessions = new Map<string, AgentSession>();
-  private options: DriverOptions;
+  private sessions = new Map<string, OpenCodeSessionImpl>();
+  private options: {
+    cliPath: string;
+    cliArgs: string[];
+    cwd: string;
+    useStdio: boolean;
+    logLevel: 'error' | 'warning' | 'info' | 'debug' | 'all' | 'none';
+    autoStart: boolean;
+    autoReconnect: boolean;
+    env: Record<string, string>;
+    requestTimeout: number;
+    sessionTimeout: number;
+  };
+  private sessionCounter = 0;
 
-  constructor(options: DriverOptions = {}) {
+  constructor(userOptions: OpenCodeOptions = {}) {
     this.options = {
-      cliPath: options.cliPath ?? 'opencode',
-      cwd: options.cwd ?? process.cwd(),
-      useStdio: options.useStdio ?? true,
-      logLevel: options.logLevel ?? 'debug',
-      autoStart: options.autoStart ?? true,
-      autoReconnect: options.autoReconnect ?? true,
-      env: (options.env ?? process.env) as Record<string, string>,
-      ...options,
+      cliPath: userOptions.cliPath ?? 'opencode',
+      cliArgs: userOptions.cliArgs ?? ['run'],
+      cwd: userOptions.cwd ?? process.cwd(),
+      useStdio: userOptions.useStdio ?? false,
+      logLevel: userOptions.logLevel ?? 'info',
+      autoStart: userOptions.autoStart ?? true,
+      autoReconnect: userOptions.autoReconnect ?? true,
+      env: userOptions.env ?? (process.env as Record<string, string>),
+      requestTimeout: userOptions.requestTimeout ?? 120000,
+      sessionTimeout: userOptions.sessionTimeout ?? 300000,
     };
   }
 
@@ -238,71 +347,42 @@ export class OpenCodeDriver implements AgentRuntimeDriver {
   }
 
   isConnected(): boolean {
-    return this.state === 'connected' && this.process !== null;
+    return this.state === 'connected';
   }
 
   async connect(): Promise<void> {
-    if (this.state === 'connected') {
-      return;
-    }
+    if (this.state === 'connected') return;
 
     const span = tracer.startSpan('squad.driver.opencode.connect');
 
-    this.state = 'connecting';
-
     try {
-      return new Promise<void>((resolve, reject) => {
-        const args = ['--stdio', '--json'];
-        if (this.options.cliArgs) {
-          args.push(...this.options.cliArgs);
-        }
+      this.state = 'connecting';
 
-        const env = this.options.env as Record<string, string>;
-        this.process = spawn(this.options.cliPath!, args, {
-          cwd: this.options.cwd,
-          env,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        });
-
-        this.process.on('error', (err) => {
-          this.state = 'error';
-          span.recordException(err);
-          reject(new DriverConnectionError(this.name, `Failed to start OpenCode: ${err.message}`));
-        });
-
-        this.process.on('exit', (code) => {
-          if (code !== 0) {
-            this.state = 'error';
-          } else {
-            this.state = 'disconnected';
-          }
-          this.eventEmitter.emit('disconnected');
-        });
-
-        // Wait for ready signal
-        this.process.stdout?.on('data', (data: Buffer) => {
-          const output = data.toString();
-          // OpenCode might send a "ready" message or similar
-          if (output.includes('ready') || output.includes('listening')) {
-            this.state = 'connected';
-            span.setAttribute('connection.transport', 'stdio');
-            resolve();
-          }
-        });
-
-        // Timeout after 10 seconds
-        setTimeout(() => {
-          if (this.state !== 'connected') {
-            this.process?.kill();
-            reject(new DriverConnectionError(this.name, 'Connection timeout'));
-          }
-        }, 10000);
+      const proc = spawn(this.options.cliPath, ['--version'], {
+        cwd: this.options.cwd,
+        env: this.options.env as Record<string, string>,
+        stdio: 'pipe',
       });
+
+      await new Promise<void>((resolve, reject) => {
+        proc.on('error', reject);
+        proc.on('close', (code) => {
+          if (code === 0) resolve();
+          else reject(new Error(`opencode --version exited with code ${code}`));
+        });
+        setTimeout(() => {
+          proc.kill();
+          reject(new Error('Timeout checking opencode version'));
+        }, 5000);
+      });
+
+      this.state = 'connected';
+      span.setAttribute('connection.transport', 'subprocess');
     } catch (err) {
       this.state = 'error';
-      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
-      span.recordException(err instanceof Error ? err : new Error(String(err)));
-      throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      span.recordException(err as Error);
+      throw new DriverConnectionError(this.name, `Failed to connect to OpenCode: ${message}`);
     } finally {
       span.end();
     }
@@ -310,200 +390,154 @@ export class OpenCodeDriver implements AgentRuntimeDriver {
 
   async disconnect(): Promise<Error[]> {
     const span = tracer.startSpan('squad.driver.opencode.disconnect');
+    const errors: Error[] = [];
 
     try {
-      // Close all sessions
       for (const session of this.sessions.values()) {
         try {
           await session.close();
-        } catch {
-          // Ignore session close errors
+        } catch (err) {
+          errors.push(err instanceof Error ? err : new Error(String(err)));
         }
       }
       this.sessions.clear();
-
-      // Kill the process
-      if (this.process) {
-        this.process.kill();
-        this.process = null;
-      }
-
       this.state = 'disconnected';
-      return [];
     } catch (err) {
-      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
-      span.recordException(err instanceof Error ? err : new Error(String(err)));
-      return [err instanceof Error ? err : new Error(String(err))];
+      errors.push(err instanceof Error ? err : new Error(String(err)));
     } finally {
       span.end();
     }
+
+    return errors;
   }
 
   async forceDisconnect(): Promise<void> {
-    this.process?.kill('SIGKILL');
-    this.process = null;
+    for (const session of this.sessions.values()) {
+      try {
+        await session.close();
+      } catch {
+        // Ignore
+      }
+    }
     this.sessions.clear();
     this.state = 'disconnected';
   }
 
   async createSession(config?: DriverSessionConfig): Promise<AgentSession> {
-    if (!this.isConnected()) {
-      throw new DriverSessionError(this.name, 'Client not connected. Call connect() first.');
-    }
-
     const span = tracer.startSpan('squad.driver.opencode.session.create');
 
     try {
-      // Send session creation request
-      // This is a placeholder - actual protocol needs to be discovered
-      const response = await this.sendRPC('session.create', {
-        model: config?.model,
-        reasoningEffort: config?.reasoningEffort,
-      });
+      const sessionId = `oc-${Date.now()}-${++this.sessionCounter}`;
+      const session = new OpenCodeSessionImpl(
+        sessionId,
+        this.options.cliPath,
+        this.options.cwd,
+        this.options.env,
+        this.options.requestTimeout
+      );
 
-      const sessionInfo = response as OpenCodeSessionInfo;
-      const session = new OpenCodeSessionAdapter(sessionInfo.sessionId, this.process!);
-      this.sessions.set(sessionInfo.sessionId, session);
+      this.sessions.set(sessionId, session);
+      span.setAttribute('session.id', sessionId);
 
-      span.setAttribute('session.id', sessionInfo.sessionId);
+      if (this.state !== 'connected') {
+        await this.connect();
+      }
+
       return session;
-    } catch (err) {
-      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
-      span.recordException(err instanceof Error ? err : new Error(String(err)));
-      throw err;
     } finally {
       span.end();
     }
   }
 
   async resumeSession(sessionId: string, config?: DriverSessionConfig): Promise<AgentSession> {
-    if (!this.isConnected()) {
-      throw new DriverSessionError(this.name, 'Client not connected. Call connect() first.');
-    }
-
-    // Check if we already have this session
     if (this.sessions.has(sessionId)) {
-      return this.sessions.get(sessionId)!;
+      const session = this.sessions.get(sessionId)!;
+      return session;
     }
 
     const span = tracer.startSpan('squad.driver.opencode.session.resume');
     span.setAttribute('session.id', sessionId);
 
     try {
-      const response = await this.sendRPC('session.resume', { sessionId });
-      const sessionInfo = response as OpenCodeSessionInfo;
-      const session = new OpenCodeSessionAdapter(sessionInfo.sessionId, this.process!);
-      this.sessions.set(sessionInfo.sessionId, session);
+      if (this.state !== 'connected') {
+        await this.connect();
+      }
+
+      const sessionId = `oc-${Date.now()}-${++this.sessionCounter}`;
+      const session = new OpenCodeSessionImpl(
+        sessionId,
+        this.options.cliPath,
+        this.options.cwd,
+        this.options.env,
+        this.options.requestTimeout
+      );
+
+      session.markContinued();
+
+      this.sessions.set(sessionId, session);
+      span.setAttribute('session.id', sessionId);
+
       return session;
-    } catch (err) {
-      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
-      span.recordException(err instanceof Error ? err : new Error(String(err)));
-      throw err;
     } finally {
       span.end();
     }
   }
 
   async listSessions(): Promise<DriverSessionMetadata[]> {
-    if (!this.isConnected()) {
-      throw new DriverSessionError(this.name, 'Client not connected');
-    }
-
-    try {
-      const response = await this.sendRPC('session.list');
-      const sessions = response as OpenCodeSessionInfo[];
-      return sessions.map((s) => ({
-        sessionId: s.sessionId,
-        startTime: new Date(),
-        modifiedTime: new Date(),
-        isRemote: false,
-      }));
-    } catch (err) {
-      throw new DriverSessionError(this.name, `Failed to list sessions: ${err instanceof Error ? err.message : String(err)}`);
-    }
+    return Array.from(this.sessions.values()).map((s) => ({
+      sessionId: s.sessionId,
+      startTime: new Date(),
+      modifiedTime: new Date(),
+      isRemote: false,
+    }));
   }
 
   async deleteSession(sessionId: string): Promise<void> {
-    if (!this.isConnected()) {
-      throw new DriverSessionError(this.name, 'Client not connected');
-    }
-
-    try {
-      await this.sendRPC('session.delete', { sessionId });
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      await session.close();
       this.sessions.delete(sessionId);
-    } catch (err) {
-      throw new DriverSessionError(this.name, `Failed to delete session: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
   async getLastSessionId(): Promise<string | undefined> {
-    if (!this.isConnected()) {
-      throw new DriverSessionError(this.name, 'Client not connected');
-    }
-
-    try {
-      const response = await this.sendRPC('session.getLastSessionId');
-      return response as string | undefined;
-    } catch (err) {
-      throw new DriverSessionError(this.name, `Failed to get last session: ${err instanceof Error ? err.message : String(err)}`);
-    }
+    const sessions = Array.from(this.sessions.keys());
+    return sessions[sessions.length - 1];
   }
 
-  async ping(message?: string): Promise<{ message: string; timestamp: number; protocolVersion?: number }> {
-    if (!this.isConnected()) {
-      throw new DriverSessionError(this.name, 'Client not connected');
-    }
-
-    try {
-      const response = await this.sendRPC('ping', { message });
-      return response as { message: string; timestamp: number; protocolVersion?: number };
-    } catch (err) {
-      throw new DriverSessionError(this.name, `Ping failed: ${err instanceof Error ? err.message : String(err)}`);
-    }
+  async ping(): Promise<{ message: string; timestamp: number; protocolVersion?: number }> {
+    return {
+      message: 'OpenCode driver ready',
+      timestamp: Date.now(),
+      protocolVersion: 1,
+    };
   }
 
   async getStatus(): Promise<DriverStatus> {
-    if (!this.isConnected()) {
-      throw new DriverSessionError(this.name, 'Client not connected');
-    }
-
-    try {
-      const response = await this.sendRPC('status');
-      return response as DriverStatus;
-    } catch (err) {
-      throw new DriverSessionError(this.name, `Failed to get status: ${err instanceof Error ? err.message : String(err)}`);
-    }
+    return {
+      version: '1.14.31',
+    };
   }
 
   async getAuthStatus(): Promise<DriverAuthStatus> {
-    if (!this.isConnected()) {
-      throw new DriverSessionError(this.name, 'Client not connected');
-    }
-
-    try {
-      const response = await this.sendRPC('auth.status');
-      return response as DriverAuthStatus;
-    } catch (err) {
-      // OpenCode might not require auth - return a default status
-      return {
-        isAuthenticated: true,
-        authType: 'cli',
-        statusMessage: 'OpenCode CLI authentication',
-      };
-    }
+    return {
+      isAuthenticated: true,
+      authType: 'cli' as const,
+      statusMessage: 'OpenCode CLI authentication',
+    };
   }
 
   async listModels(): Promise<DriverModelInfo[]> {
-    if (!this.isConnected()) {
-      throw new DriverSessionError(this.name, 'Client not connected');
-    }
-
-    try {
-      const response = await this.sendRPC('models.list');
-      return response as DriverModelInfo[];
-    } catch (err) {
-      throw new DriverSessionError(this.name, `Failed to list models: ${err instanceof Error ? err.message : String(err)}`);
-    }
+    return [
+      {
+        id: 'auto',
+        name: 'Auto-select',
+        capabilities: {
+          supports: { vision: true, reasoningEffort: true },
+          limits: { max_context_window_tokens: 200000 },
+        },
+      },
+    ];
   }
 
   async sendMessage(session: AgentSession, options: DriverMessageOptions): Promise<void> {
@@ -514,8 +548,7 @@ export class OpenCodeDriver implements AgentRuntimeDriver {
     try {
       await session.sendMessage(options);
     } catch (err) {
-      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
-      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      span.recordException(err as Error);
       throw err;
     } finally {
       span.end();
@@ -528,74 +561,33 @@ export class OpenCodeDriver implements AgentRuntimeDriver {
 
     try {
       await this.deleteSession(sessionId);
-    } catch (err) {
-      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
-      span.recordException(err instanceof Error ? err : new Error(String(err)));
-      throw err;
     } finally {
       span.end();
     }
   }
 
-  private sendRPC(method: string, params?: Record<string, unknown>): Promise<unknown> {
-    return new Promise((resolve, reject) => {
-      if (!this.process || !this.process.stdin) {
-        reject(new DriverConnectionError(this.name, 'Process not connected'));
-        return;
-      }
+  on(event: string, handler: (...args: unknown[]) => void): void {
+    this.eventEmitter.on(event, handler);
+  }
 
-      const id = Math.random().toString(36).slice(2);
-      const request = { id, method, params };
-
-      const timeout = setTimeout(() => {
-        pendingRequests.delete(id);
-        reject(new Error(`Request ${method} timed out`));
-      }, 60000);
-
-      const pendingRequests = new Map<string, {
-        resolve: (value: unknown) => void;
-        reject: (error: Error) => void;
-      }>();
-
-      pendingRequests.set(id, { resolve, reject });
-
-      this.process.stdin.write(JSON.stringify(request) + '\n');
-
-      this.process.stdout?.on('data', (data: Buffer) => {
-        for (const line of data.toString().split('\n').filter(Boolean)) {
-          try {
-            const response = JSON.parse(line) as OpenCodeRPCResponse;
-            if (response.id === id) {
-              clearTimeout(timeout);
-              if (response.error) {
-                reject(new Error(response.error.message));
-              } else {
-                resolve(response.result);
-              }
-              pendingRequests.delete(id);
-            }
-          } catch {
-            // Ignore parse errors
-          }
-        }
-      });
-    });
+  off(event: string, handler: (...args: unknown[]) => void): void {
+    this.eventEmitter.off(event, handler);
   }
 }
 
 /**
  * Create an OpenCode driver instance.
  */
-export function createOpenCodeDriver(options?: DriverOptions): AgentRuntimeDriver {
+export function createOpenCodeDriver(options?: OpenCodeOptions): AgentRuntimeDriver {
   return new OpenCodeDriver(options);
 }
 
 /**
- * Register the OpenCode driver with the global registry.
+ * Register the OpenCode driver with the runtime registry.
  */
 export async function registerOpenCodeDriver(
   registry?: { registerDriverFactory: (name: string, factory: () => Promise<AgentRuntimeDriver>) => void },
-  options?: DriverOptions
+  options?: OpenCodeOptions
 ): Promise<AgentRuntimeDriver> {
   const driver = new OpenCodeDriver(options);
   if (registry) {

--- a/packages/squad-sdk/src/drivers/opencode/driver.ts
+++ b/packages/squad-sdk/src/drivers/opencode/driver.ts
@@ -1,0 +1,605 @@
+/**
+ * OpenCode Runtime Driver
+ *
+ * Implements AgentRuntimeDriver for OpenCode CLI.
+ *
+ * This driver communicates with the OpenCode CLI via stdio JSON-RPC.
+ * The implementation is a skeleton that needs to be completed once
+ * OpenCode's stdio protocol is documented or discovered.
+ *
+ * @module drivers/opencode/driver
+ */
+
+import { spawn, ChildProcess } from 'child_process';
+import { EventEmitter } from 'events';
+import { trace, SpanStatusCode } from '../../runtime/otel-api.js';
+import type {
+  AgentRuntimeDriver,
+  DriverOptions,
+  DriverSessionConfig,
+  DriverSessionMetadata,
+  DriverMessageOptions,
+  DriverAuthStatus,
+  DriverStatus,
+  DriverModelInfo,
+  DriverConnectionState,
+  AgentSession,
+  DriverSessionEvent,
+  DriverSessionEventHandler,
+} from '../../runtime/driver.js';
+import {
+  DriverError,
+  DriverConnectionError,
+  DriverSessionError,
+} from '../../runtime/driver.js';
+
+const tracer = trace.getTracer('squad-sdk');
+
+/**
+ * OpenCode JSON-RPC message types.
+ * These are guesses based on common patterns for CLI tools.
+ */
+interface OpenCodeRPCRequest {
+  id: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+interface OpenCodeRPCResponse {
+  id: string;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+interface OpenCodeSessionInfo {
+  sessionId: string;
+  // Add other session fields as OpenCode protocol is discovered
+}
+
+/**
+ * Adapts an OpenCode CLI process to our AgentSession interface.
+ */
+class OpenCodeSessionAdapter implements AgentSession {
+  private _sessionId: string;
+  private readonly process: ChildProcess;
+  private readonly eventEmitter = new EventEmitter();
+  private pendingRequests = new Map<string, {
+    resolve: (value: unknown) => void;
+    reject: (error: Error) => void;
+  }>();
+
+  constructor(sessionId: string, process: ChildProcess) {
+    this._sessionId = sessionId;
+    this.process = process;
+
+    // Listen to stdout for responses
+    this.process.stdout?.on('data', (data: Buffer) => {
+      this.handleResponse(data.toString());
+    });
+
+    // Listen to stderr for events/errors
+    this.process.stderr?.on('data', (data: Buffer) => {
+      this.handleEvent(data.toString());
+    });
+
+    this.process.on('error', (err) => {
+      this.eventEmitter.emit('error', { type: 'error', error: err.message });
+    });
+
+    this.process.on('exit', (code) => {
+      if (code !== 0 && code !== null) {
+        this.eventEmitter.emit('error', { type: 'error', error: `Process exited with code ${code}` });
+      }
+      this.eventEmitter.emit('idle', { type: 'idle' });
+    });
+  }
+
+  private handleResponse(data: string): void {
+    // Parse JSON-RPC responses
+    for (const line of data.split('\n').filter(Boolean)) {
+      try {
+        const response = JSON.parse(line) as OpenCodeRPCResponse;
+        if (response.id) {
+          const pending = this.pendingRequests.get(response.id);
+          if (pending) {
+            if (response.error) {
+              pending.reject(new Error(response.error.message));
+            } else {
+              pending.resolve(response.result);
+            }
+            this.pendingRequests.delete(response.id);
+          }
+        }
+      } catch {
+        // Ignore parse errors for non-JSON lines
+      }
+    }
+  }
+
+  private handleEvent(data: string): void {
+    // Parse event lines (prefixed with "event:" or similar)
+    for (const line of data.split('\n').filter(Boolean)) {
+      try {
+        // Events might be prefixed - adjust as needed based on OpenCode protocol
+        const eventData = line.startsWith('event:') ? JSON.parse(line.slice(6)) : JSON.parse(line);
+        if (eventData.type) {
+          this.eventEmitter.emit(eventData.type, eventData);
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+  }
+
+  private sendRPC(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = Math.random().toString(36).slice(2);
+      const request: OpenCodeRPCRequest = { id, method, params };
+      this.pendingRequests.set(id, { resolve, reject });
+
+      this.process.stdin?.write(JSON.stringify(request) + '\n');
+
+      // Timeout after 60 seconds
+      setTimeout(() => {
+        if (this.pendingRequests.has(id)) {
+          this.pendingRequests.delete(id);
+          reject(new Error(`Request ${method} timed out`));
+        }
+      }, 60000);
+    });
+  }
+
+  get sessionId(): string {
+    return this._sessionId;
+  }
+
+  async sendMessage(options: DriverMessageOptions): Promise<void> {
+    await this.sendRPC('session.send', {
+      sessionId: this.sessionId,
+      prompt: options.prompt,
+      attachments: options.attachments,
+    });
+  }
+
+  async sendAndWait(options: DriverMessageOptions, timeout?: number): Promise<unknown> {
+    const response = await this.sendRPC('session.sendAndWait', {
+      sessionId: this.sessionId,
+      prompt: options.prompt,
+      attachments: options.attachments,
+      timeout,
+    });
+    return response;
+  }
+
+  async abort(): Promise<void> {
+    await this.sendRPC('session.abort', { sessionId: this.sessionId });
+  }
+
+  async getMessages(): Promise<unknown[]> {
+    const response = await this.sendRPC('session.getMessages', {
+      sessionId: this.sessionId,
+    });
+    return response as unknown[];
+  }
+
+  on(eventType: string, handler: DriverSessionEventHandler): void {
+    this.eventEmitter.on(eventType, handler);
+  }
+
+  off(eventType: string, handler: DriverSessionEventHandler): void {
+    this.eventEmitter.off(eventType, handler);
+  }
+
+  async close(): Promise<void> {
+    await this.sendRPC('session.close', { sessionId: this.sessionId });
+    this.process.kill();
+    this.pendingRequests.clear();
+  }
+}
+
+/**
+ * OpenCode Runtime Driver
+ *
+ * Implements AgentRuntimeDriver for OpenCode CLI.
+ *
+ * Note: This is a skeleton implementation. The actual OpenCode protocol
+ * needs to be discovered or documented to complete the implementation.
+ *
+ * OpenCode CLI is expected to communicate via stdio JSON-RPC, similar to
+ * other CLI tools like GitHub Copilot and Anthropic's Claude CLI.
+ */
+export class OpenCodeDriver implements AgentRuntimeDriver {
+  readonly name = 'opencode';
+
+  private state: DriverConnectionState = 'disconnected';
+  private process: ChildProcess | null = null;
+  private eventEmitter = new EventEmitter();
+  private sessions = new Map<string, AgentSession>();
+  private options: DriverOptions;
+
+  constructor(options: DriverOptions = {}) {
+    this.options = {
+      cliPath: options.cliPath ?? 'opencode',
+      cwd: options.cwd ?? process.cwd(),
+      useStdio: options.useStdio ?? true,
+      logLevel: options.logLevel ?? 'debug',
+      autoStart: options.autoStart ?? true,
+      autoReconnect: options.autoReconnect ?? true,
+      env: (options.env ?? process.env) as Record<string, string>,
+      ...options,
+    };
+  }
+
+  getState(): DriverConnectionState {
+    return this.state;
+  }
+
+  isConnected(): boolean {
+    return this.state === 'connected' && this.process !== null;
+  }
+
+  async connect(): Promise<void> {
+    if (this.state === 'connected') {
+      return;
+    }
+
+    const span = tracer.startSpan('squad.driver.opencode.connect');
+
+    this.state = 'connecting';
+
+    try {
+      return new Promise<void>((resolve, reject) => {
+        const args = ['--stdio', '--json'];
+        if (this.options.cliArgs) {
+          args.push(...this.options.cliArgs);
+        }
+
+        const env = this.options.env as Record<string, string>;
+        this.process = spawn(this.options.cliPath!, args, {
+          cwd: this.options.cwd,
+          env,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+
+        this.process.on('error', (err) => {
+          this.state = 'error';
+          span.recordException(err);
+          reject(new DriverConnectionError(this.name, `Failed to start OpenCode: ${err.message}`));
+        });
+
+        this.process.on('exit', (code) => {
+          if (code !== 0) {
+            this.state = 'error';
+          } else {
+            this.state = 'disconnected';
+          }
+          this.eventEmitter.emit('disconnected');
+        });
+
+        // Wait for ready signal
+        this.process.stdout?.on('data', (data: Buffer) => {
+          const output = data.toString();
+          // OpenCode might send a "ready" message or similar
+          if (output.includes('ready') || output.includes('listening')) {
+            this.state = 'connected';
+            span.setAttribute('connection.transport', 'stdio');
+            resolve();
+          }
+        });
+
+        // Timeout after 10 seconds
+        setTimeout(() => {
+          if (this.state !== 'connected') {
+            this.process?.kill();
+            reject(new DriverConnectionError(this.name, 'Connection timeout'));
+          }
+        }, 10000);
+      });
+    } catch (err) {
+      this.state = 'error';
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  async disconnect(): Promise<Error[]> {
+    const span = tracer.startSpan('squad.driver.opencode.disconnect');
+
+    try {
+      // Close all sessions
+      for (const session of this.sessions.values()) {
+        try {
+          await session.close();
+        } catch {
+          // Ignore session close errors
+        }
+      }
+      this.sessions.clear();
+
+      // Kill the process
+      if (this.process) {
+        this.process.kill();
+        this.process = null;
+      }
+
+      this.state = 'disconnected';
+      return [];
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      return [err instanceof Error ? err : new Error(String(err))];
+    } finally {
+      span.end();
+    }
+  }
+
+  async forceDisconnect(): Promise<void> {
+    this.process?.kill('SIGKILL');
+    this.process = null;
+    this.sessions.clear();
+    this.state = 'disconnected';
+  }
+
+  async createSession(config?: DriverSessionConfig): Promise<AgentSession> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected. Call connect() first.');
+    }
+
+    const span = tracer.startSpan('squad.driver.opencode.session.create');
+
+    try {
+      // Send session creation request
+      // This is a placeholder - actual protocol needs to be discovered
+      const response = await this.sendRPC('session.create', {
+        model: config?.model,
+        reasoningEffort: config?.reasoningEffort,
+      });
+
+      const sessionInfo = response as OpenCodeSessionInfo;
+      const session = new OpenCodeSessionAdapter(sessionInfo.sessionId, this.process!);
+      this.sessions.set(sessionInfo.sessionId, session);
+
+      span.setAttribute('session.id', sessionInfo.sessionId);
+      return session;
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  async resumeSession(sessionId: string, config?: DriverSessionConfig): Promise<AgentSession> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected. Call connect() first.');
+    }
+
+    // Check if we already have this session
+    if (this.sessions.has(sessionId)) {
+      return this.sessions.get(sessionId)!;
+    }
+
+    const span = tracer.startSpan('squad.driver.opencode.session.resume');
+    span.setAttribute('session.id', sessionId);
+
+    try {
+      const response = await this.sendRPC('session.resume', { sessionId });
+      const sessionInfo = response as OpenCodeSessionInfo;
+      const session = new OpenCodeSessionAdapter(sessionInfo.sessionId, this.process!);
+      this.sessions.set(sessionInfo.sessionId, session);
+      return session;
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  async listSessions(): Promise<DriverSessionMetadata[]> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      const response = await this.sendRPC('session.list');
+      const sessions = response as OpenCodeSessionInfo[];
+      return sessions.map((s) => ({
+        sessionId: s.sessionId,
+        startTime: new Date(),
+        modifiedTime: new Date(),
+        isRemote: false,
+      }));
+    } catch (err) {
+      throw new DriverSessionError(this.name, `Failed to list sessions: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      await this.sendRPC('session.delete', { sessionId });
+      this.sessions.delete(sessionId);
+    } catch (err) {
+      throw new DriverSessionError(this.name, `Failed to delete session: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  async getLastSessionId(): Promise<string | undefined> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      const response = await this.sendRPC('session.getLastSessionId');
+      return response as string | undefined;
+    } catch (err) {
+      throw new DriverSessionError(this.name, `Failed to get last session: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  async ping(message?: string): Promise<{ message: string; timestamp: number; protocolVersion?: number }> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      const response = await this.sendRPC('ping', { message });
+      return response as { message: string; timestamp: number; protocolVersion?: number };
+    } catch (err) {
+      throw new DriverSessionError(this.name, `Ping failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  async getStatus(): Promise<DriverStatus> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      const response = await this.sendRPC('status');
+      return response as DriverStatus;
+    } catch (err) {
+      throw new DriverSessionError(this.name, `Failed to get status: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  async getAuthStatus(): Promise<DriverAuthStatus> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      const response = await this.sendRPC('auth.status');
+      return response as DriverAuthStatus;
+    } catch (err) {
+      // OpenCode might not require auth - return a default status
+      return {
+        isAuthenticated: true,
+        authType: 'cli',
+        statusMessage: 'OpenCode CLI authentication',
+      };
+    }
+  }
+
+  async listModels(): Promise<DriverModelInfo[]> {
+    if (!this.isConnected()) {
+      throw new DriverSessionError(this.name, 'Client not connected');
+    }
+
+    try {
+      const response = await this.sendRPC('models.list');
+      return response as DriverModelInfo[];
+    } catch (err) {
+      throw new DriverSessionError(this.name, `Failed to list models: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  async sendMessage(session: AgentSession, options: DriverMessageOptions): Promise<void> {
+    const span = tracer.startSpan('squad.driver.opencode.session.message');
+    span.setAttribute('session.id', session.sessionId);
+    span.setAttribute('prompt.length', options.prompt.length);
+
+    try {
+      await session.sendMessage(options);
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  async closeSession(sessionId: string): Promise<void> {
+    const span = tracer.startSpan('squad.driver.opencode.session.close');
+    span.setAttribute('session.id', sessionId);
+
+    try {
+      await this.deleteSession(sessionId);
+    } catch (err) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+      span.recordException(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  private sendRPC(method: string, params?: Record<string, unknown>): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (!this.process || !this.process.stdin) {
+        reject(new DriverConnectionError(this.name, 'Process not connected'));
+        return;
+      }
+
+      const id = Math.random().toString(36).slice(2);
+      const request = { id, method, params };
+
+      const timeout = setTimeout(() => {
+        pendingRequests.delete(id);
+        reject(new Error(`Request ${method} timed out`));
+      }, 60000);
+
+      const pendingRequests = new Map<string, {
+        resolve: (value: unknown) => void;
+        reject: (error: Error) => void;
+      }>();
+
+      pendingRequests.set(id, { resolve, reject });
+
+      this.process.stdin.write(JSON.stringify(request) + '\n');
+
+      this.process.stdout?.on('data', (data: Buffer) => {
+        for (const line of data.toString().split('\n').filter(Boolean)) {
+          try {
+            const response = JSON.parse(line) as OpenCodeRPCResponse;
+            if (response.id === id) {
+              clearTimeout(timeout);
+              if (response.error) {
+                reject(new Error(response.error.message));
+              } else {
+                resolve(response.result);
+              }
+              pendingRequests.delete(id);
+            }
+          } catch {
+            // Ignore parse errors
+          }
+        }
+      });
+    });
+  }
+}
+
+/**
+ * Create an OpenCode driver instance.
+ */
+export function createOpenCodeDriver(options?: DriverOptions): AgentRuntimeDriver {
+  return new OpenCodeDriver(options);
+}
+
+/**
+ * Register the OpenCode driver with the global registry.
+ */
+export async function registerOpenCodeDriver(
+  registry?: { registerDriverFactory: (name: string, factory: () => Promise<AgentRuntimeDriver>) => void },
+  options?: DriverOptions
+): Promise<AgentRuntimeDriver> {
+  const driver = new OpenCodeDriver(options);
+  if (registry) {
+    registry.registerDriverFactory('opencode', async () => driver);
+  }
+  return driver;
+}

--- a/packages/squad-sdk/src/index.ts
+++ b/packages/squad-sdk/src/index.ts
@@ -56,6 +56,8 @@ export {
   findSquadByName,
 } from './runtime/cross-squad.js';
 
+export * from './runtime/index.js';
+export * from './drivers/index.js';
 export * from './marketplace/index.js';
 export * from './build/index.js';
 export * from './sharing/index.js';

--- a/packages/squad-sdk/src/runtime/driver.ts
+++ b/packages/squad-sdk/src/runtime/driver.ts
@@ -1,0 +1,425 @@
+/**
+ * Agent Runtime Driver Interface
+ *
+ * This module defines the abstraction layer for AI coding agent runtimes.
+ * Implement this interface to add support for new runtimes (OpenCode, Claude Code, Cursor, etc.)
+ *
+ * @module runtime/driver
+ */
+
+import type { EventBus } from './event-bus.js';
+import type { UsageEvent } from './streaming.js';
+
+// ============================================================================
+// Driver Types
+// ============================================================================
+
+/**
+ * Connection state for a runtime driver.
+ */
+export type DriverConnectionState =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'error';
+
+/**
+ * Authentication status for a runtime.
+ */
+export interface DriverAuthStatus {
+  isAuthenticated: boolean;
+  authType?: 'user' | 'env' | 'cli' | 'hmac' | 'api-key' | 'token';
+  host?: string;
+  login?: string;
+  statusMessage?: string;
+}
+
+/**
+ * Runtime status information.
+ */
+export interface DriverStatus {
+  version: string;
+  protocolVersion?: number;
+}
+
+/**
+ * Model information from a runtime.
+ */
+export interface DriverModelInfo {
+  id: string;
+  name: string;
+  capabilities: {
+    supports: {
+      vision: boolean;
+      reasoningEffort: boolean;
+    };
+    limits: {
+      max_prompt_tokens?: number;
+      max_context_window_tokens: number;
+      vision?: {
+        supported_media_types: string[];
+        max_prompt_images: number;
+        max_prompt_image_size: number;
+      };
+    };
+  };
+  supportedReasoningEfforts?: string[];
+  defaultReasoningEffort?: string;
+}
+
+/**
+ * Session metadata returned from list operations.
+ */
+export interface DriverSessionMetadata {
+  sessionId: string;
+  startTime: Date;
+  modifiedTime: Date;
+  summary?: string;
+  isRemote: boolean;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Message options for sending a message to a session.
+ */
+export interface DriverMessageOptions {
+  prompt: string;
+  attachments?: Array<
+    | { type: 'file'; path: string; displayName?: string }
+    | { type: 'directory'; path: string; displayName?: string }
+    | {
+        type: 'selection';
+        filePath: string;
+        displayName: string;
+        selection?: {
+          start: { line: number; character: number };
+          end: { line: number; character: number };
+        };
+        text?: string;
+      }
+  >;
+  mode?: 'enqueue' | 'immediate';
+}
+
+// ============================================================================
+// Agent Session Interface
+// ============================================================================
+
+/**
+ * Session event handler function.
+ */
+export type DriverSessionEventHandler = (event: DriverSessionEvent) => void;
+
+/**
+ * Session event payload.
+ */
+export interface DriverSessionEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Agent session interface.
+ * Represents an active agent session with lifecycle management.
+ */
+export interface AgentSession {
+  readonly sessionId: string;
+
+  /**
+   * Send a message to the session.
+   */
+  sendMessage(options: DriverMessageOptions): Promise<void>;
+
+  /**
+   * Send a message and wait for the session to become idle.
+   */
+  sendAndWait?(options: DriverMessageOptions, timeout?: number): Promise<unknown>;
+
+  /**
+   * Abort the current in-flight agent work.
+   */
+  abort?(): Promise<void>;
+
+  /**
+   * Retrieve all messages from this session.
+   */
+  getMessages?(): Promise<unknown[]>;
+
+  /**
+   * Register an event handler for session events.
+   */
+  on(eventType: string, handler: DriverSessionEventHandler): void;
+
+  /**
+   * Remove an event handler.
+   */
+  off(eventType: string, handler: DriverSessionEventHandler): void;
+
+  /**
+   * End the session and clean up resources.
+   */
+  close(): Promise<void>;
+}
+
+// ============================================================================
+// Driver Interface
+// ============================================================================
+
+/**
+ * Options for creating a runtime driver.
+ */
+export interface DriverOptions {
+  /**
+   * Path to the runtime CLI executable.
+   * Defaults to bundled CLI from the runtime package.
+   */
+  cliPath?: string;
+
+  /**
+   * Additional arguments to pass to the CLI process.
+   */
+  cliArgs?: string[];
+
+  /**
+   * Working directory for the CLI process.
+   * @default process.cwd()
+   */
+  cwd?: string;
+
+  /**
+   * Port to bind the CLI server (TCP mode).
+   * Set to 0 for random port, or undefined to use stdio mode.
+   */
+  port?: number;
+
+  /**
+   * Use stdio transport instead of TCP.
+   * @default true
+   */
+  useStdio?: boolean;
+
+  /**
+   * URL of an external CLI server to connect to.
+   * Mutually exclusive with useStdio and cliPath.
+   */
+  cliUrl?: string;
+
+  /**
+   * Log level for the CLI process.
+   * @default "debug"
+   */
+  logLevel?: 'error' | 'warning' | 'info' | 'debug' | 'all' | 'none';
+
+  /**
+   * Automatically start the connection when creating a session.
+   * @default true
+   */
+  autoStart?: boolean;
+
+  /**
+   * Automatically reconnect on transient failures.
+   * @default true
+   */
+  autoReconnect?: boolean;
+
+  /**
+   * Optional EventBus for telemetry auto-wiring.
+   */
+  eventBus?: EventBus;
+
+  /**
+   * Environment variables to pass to the CLI process.
+   * @default process.env
+   */
+  env?: Record<string, string>;
+
+  /**
+   * Authentication token for the runtime.
+   */
+  authToken?: string;
+
+  /**
+   * Use logged-in user credentials for authentication.
+   * @default true
+   */
+  useLoggedInUser?: boolean;
+
+  /**
+   * Maximum number of reconnection attempts before giving up.
+   * @default 3
+   */
+  maxReconnectAttempts?: number;
+
+  /**
+   * Initial delay in milliseconds before first reconnection attempt.
+   * @default 1000
+   */
+  reconnectDelayMs?: number;
+}
+
+/**
+ * Agent Runtime Driver Interface
+ *
+ * Implement this interface to create a driver for a new AI coding agent runtime.
+ * The driver manages the connection lifecycle, session management, and
+ * communication with the runtime CLI.
+ */
+export interface AgentRuntimeDriver {
+  /**
+   * Human-readable name of the runtime.
+   * @example "copilot" | "opencode" | "claude-code" | "cursor"
+   */
+  readonly name: string;
+
+  /**
+   * Get the current connection state.
+   */
+  getState(): DriverConnectionState;
+
+  /**
+   * Check if the driver is connected.
+   */
+  isConnected(): boolean;
+
+  /**
+   * Establish connection to the runtime CLI server.
+   */
+  connect(): Promise<void>;
+
+  /**
+   * Disconnect from the runtime CLI server.
+   */
+  disconnect(): Promise<Error[]>;
+
+  /**
+   * Force disconnect without graceful cleanup.
+   * Use only when disconnect() fails or hangs.
+   */
+  forceDisconnect(): Promise<void>;
+
+  /**
+   * Create a new agent session.
+   */
+  createSession(config?: DriverSessionConfig): Promise<AgentSession>;
+
+  /**
+   * Resume an existing session by ID.
+   */
+  resumeSession(sessionId: string, config?: DriverSessionConfig): Promise<AgentSession>;
+
+  /**
+   * List all available sessions.
+   */
+  listSessions(): Promise<DriverSessionMetadata[]>;
+
+  /**
+   * Delete a session by ID.
+   */
+  deleteSession(sessionId: string): Promise<void>;
+
+  /**
+   * Get the ID of the last updated session.
+   */
+  getLastSessionId(): Promise<string | undefined>;
+
+  /**
+   * Send a ping to verify connectivity.
+   */
+  ping(message?: string): Promise<{ message: string; timestamp: number; protocolVersion?: number }>;
+
+  /**
+   * Get CLI status information.
+   */
+  getStatus(): Promise<DriverStatus>;
+
+  /**
+   * Get authentication status.
+   */
+  getAuthStatus(): Promise<DriverAuthStatus>;
+
+  /**
+   * List available models.
+   */
+  listModels(): Promise<DriverModelInfo[]>;
+
+  /**
+   * Send a message to a session.
+   */
+  sendMessage(session: AgentSession, options: DriverMessageOptions): Promise<void>;
+
+  /**
+   * Close a session by ID.
+   */
+  closeSession(sessionId: string): Promise<void>;
+}
+
+/**
+ * Configuration for creating a driver session.
+ * Driver-specific options are passed through the options field.
+ */
+export interface DriverSessionConfig {
+  sessionId?: string;
+  model?: string;
+  reasoningEffort?: string;
+  tools?: unknown[];
+  systemMessage?: unknown;
+  availableTools?: string[];
+  excludedTools?: string[];
+  customAgents?: unknown[];
+  workingDirectory?: string;
+  streaming?: boolean;
+  mcpServers?: Record<string, unknown>;
+  skillDirectories?: string[];
+  disabledSkills?: string[];
+  options?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Driver Errors
+// ============================================================================
+
+/**
+ * Error thrown when a driver operation fails.
+ */
+export class DriverError extends Error {
+  constructor(
+    message: string,
+    public readonly driverName: string,
+    public readonly operation: string,
+    public readonly recoverable: boolean = false
+  ) {
+    super(message);
+    this.name = 'DriverError';
+  }
+}
+
+/**
+ * Error thrown when a requested runtime is not registered.
+ */
+export class UnknownRuntimeError extends Error {
+  constructor(public readonly runtimeName: string) {
+    super(`Unknown runtime: ${runtimeName}`);
+    this.name = 'UnknownRuntimeError';
+  }
+}
+
+/**
+ * Error thrown when a driver fails to connect.
+ */
+export class DriverConnectionError extends DriverError {
+  constructor(driverName: string, message: string) {
+    super(message, driverName, 'connect', true);
+    this.name = 'DriverConnectionError';
+  }
+}
+
+/**
+ * Error thrown when a session operation fails.
+ */
+export class DriverSessionError extends DriverError {
+  constructor(driverName: string, message: string, recoverable: boolean = true) {
+    super(message, driverName, 'session', recoverable);
+    this.name = 'DriverSessionError';
+  }
+}

--- a/packages/squad-sdk/src/runtime/index.ts
+++ b/packages/squad-sdk/src/runtime/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Runtime Module
+ *
+ * Exports runtime driver interface, registry, and related types.
+ *
+ * @module runtime
+ */
+
+export * from './driver.js';
+export * from './registry.js';

--- a/packages/squad-sdk/src/runtime/registry.ts
+++ b/packages/squad-sdk/src/runtime/registry.ts
@@ -1,0 +1,279 @@
+/**
+ * Runtime Registry
+ *
+ * Manages registration and selection of runtime drivers.
+ * Provides factory methods for creating drivers and accessing the active runtime.
+ *
+ * @module runtime/registry
+ */
+
+import type {
+  AgentRuntimeDriver,
+  DriverOptions,
+  DriverSessionConfig,
+  AgentSession,
+  DriverSessionMetadata,
+  DriverMessageOptions,
+  DriverAuthStatus,
+  DriverStatus,
+  DriverModelInfo,
+  DriverConnectionState,
+} from './driver.js';
+import {
+  DriverError,
+  UnknownRuntimeError,
+} from './driver.js';
+
+/**
+ * Default driver implementations by runtime name.
+ */
+const DEFAULT_DRIVERS: Record<string, () => Promise<AgentRuntimeDriver>> = {};
+
+/**
+ * Runtime configuration for squad.config.ts
+ */
+export interface RuntimeConfig {
+  /**
+   * Runtime name (e.g., "copilot", "opencode")
+   */
+  name: string;
+
+  /**
+   * Driver-specific configuration options.
+   */
+  config?: Record<string, unknown>;
+
+  /**
+   * CLI path override (optional).
+   */
+  cliPath?: string;
+
+  /**
+   * CLI URL for external server connection (optional).
+   */
+  cliUrl?: string;
+}
+
+/**
+ * Runtime Registry
+ *
+ * Singleton registry for managing runtime drivers.
+ * Register drivers at startup, then use getDriver() to access them.
+ *
+ * @example
+ * ```typescript
+ * import { runtimeRegistry } from './runtime/registry.js';
+ * import { registerCopilotDriver } from './drivers/copilot/driver.js';
+ *
+ * // Register drivers at startup
+ * runtimeRegistry.registerDriver('copilot', registerCopilotDriver);
+ *
+ * // Later, get the active driver
+ * const driver = runtimeRegistry.getDriver('copilot');
+ * await driver.connect();
+ * ```
+ */
+export class RuntimeRegistry {
+  private drivers = new Map<string, AgentRuntimeDriver>();
+  private driverFactories = new Map<string, () => Promise<AgentRuntimeDriver>>();
+  private activeRuntime: string = 'copilot';
+  private driverOptions = new Map<string, DriverOptions>();
+  private static instance: RuntimeRegistry;
+
+  private constructor() {}
+
+  /**
+   * Get the singleton RuntimeRegistry instance.
+   */
+  static getInstance(): RuntimeRegistry {
+    if (!RuntimeRegistry.instance) {
+      RuntimeRegistry.instance = new RuntimeRegistry();
+    }
+    return RuntimeRegistry.instance;
+  }
+
+  /**
+   * Register a driver factory for a runtime name.
+   * factories are called lazily when a driver is first requested.
+   *
+   * @param name - Runtime name (e.g., "copilot", "opencode")
+   * @param factory - Async function that creates the driver instance
+   */
+  registerDriverFactory(name: string, factory: () => Promise<AgentRuntimeDriver>): void {
+    if (this.drivers.has(name)) {
+      console.warn(`Driver for runtime "${name}" already registered. Skipping factory registration.`);
+      return;
+    }
+    this.driverFactories.set(name, factory);
+  }
+
+  /**
+   * Register a pre-created driver instance.
+   *
+   * @param name - Runtime name
+   * @param driver - Driver instance
+   * @param options - Driver options
+   */
+  registerDriver(name: string, driver: AgentRuntimeDriver, options?: DriverOptions): void {
+    this.drivers.set(name, driver);
+    if (options) {
+      this.driverOptions.set(name, options);
+    }
+  }
+
+  /**
+   * Set the active runtime by name.
+   *
+   * @param name - Runtime name to activate
+   * @throws {UnknownRuntimeError} if the runtime is not registered
+   */
+  setActiveRuntime(name: string): void {
+    if (!this.drivers.has(name) && !this.driverFactories.has(name)) {
+      throw new UnknownRuntimeError(name);
+    }
+    this.activeRuntime = name;
+  }
+
+  /**
+   * Get the name of the active runtime.
+   */
+  getActiveRuntimeName(): string {
+    return this.activeRuntime;
+  }
+
+  /**
+   * Get a registered driver by name, creating it lazily if needed.
+   *
+   * @param name - Runtime name
+   * @returns The driver instance
+   * @throws {UnknownRuntimeError} if the runtime is not registered
+   */
+  async getDriver(name: string): Promise<AgentRuntimeDriver> {
+    // Return existing driver
+    if (this.drivers.has(name)) {
+      return this.drivers.get(name)!;
+    }
+
+    // Create from factory if available
+    const factory = this.driverFactories.get(name);
+    if (factory) {
+      const driver = await factory();
+      this.drivers.set(name, driver);
+      this.driverFactories.delete(name);
+      return driver;
+    }
+
+    throw new UnknownRuntimeError(name);
+  }
+
+  /**
+   * Get the active runtime driver.
+   */
+  async getActiveDriver(): Promise<AgentRuntimeDriver> {
+    return this.getDriver(this.activeRuntime);
+  }
+
+  /**
+   * Check if a runtime is registered (either as instance or factory).
+   */
+  isRegistered(name: string): boolean {
+    return this.drivers.has(name) || this.driverFactories.has(name);
+  }
+
+  /**
+   * List all registered runtime names.
+   */
+  listRuntimes(): string[] {
+    const names = new Set<string>();
+    for (const name of this.drivers.keys()) {
+      names.add(name);
+    }
+    for (const name of this.driverFactories.keys()) {
+      names.add(name);
+    }
+    return Array.from(names);
+  }
+
+  /**
+   * Get driver options for a registered runtime.
+   */
+  getDriverOptions(name: string): DriverOptions | undefined {
+    return this.driverOptions.get(name);
+  }
+
+  /**
+   * Create a driver with the given options and register it.
+   *
+   * @param name - Runtime name
+   * @param options - Driver options
+   * @returns The created driver
+   */
+  async createDriver(name: string, options: DriverOptions): Promise<AgentRuntimeDriver> {
+    const factory = this.driverFactories.get(name);
+    if (!factory) {
+      throw new UnknownRuntimeError(name);
+    }
+
+    const driver = await factory();
+    this.drivers.set(name, driver);
+    this.driverOptions.set(name, options);
+    this.driverFactories.delete(name);
+    return driver;
+  }
+
+  /**
+   * Unregister a runtime driver.
+   */
+  async unregisterDriver(name: string): Promise<void> {
+    const driver = this.drivers.get(name);
+    if (driver) {
+      try {
+        await driver.disconnect();
+      } catch {
+        // Ignore disconnect errors during unregistration
+      }
+      this.drivers.delete(name);
+      this.driverOptions.delete(name);
+    }
+    this.driverFactories.delete(name);
+  }
+
+  /**
+   * Reset the registry (mainly for testing).
+   */
+  reset(): void {
+    this.drivers.clear();
+    this.driverFactories.clear();
+    this.activeRuntime = 'copilot';
+    this.driverOptions.clear();
+  }
+}
+
+/**
+ * Global runtime registry instance.
+ */
+export const runtimeRegistry = RuntimeRegistry.getInstance();
+
+/**
+ * Create a runtime-aware session wrapper that provides a consistent interface
+ * regardless of which runtime is active.
+ */
+export async function createRuntimeSession(
+  runtimeName: string,
+  config?: DriverSessionConfig
+): Promise<AgentSession> {
+  const driver = await runtimeRegistry.getDriver(runtimeName);
+  if (!driver.isConnected()) {
+    await driver.connect();
+  }
+  return driver.createSession(config);
+}
+
+/**
+ * Create a session with the active runtime.
+ */
+export async function createActiveSession(
+  config?: DriverSessionConfig
+): Promise<AgentSession> {
+  return createRuntimeSession(runtimeRegistry.getActiveRuntimeName(), config);
+}


### PR DESCRIPTION
## Summary

Add runtime driver abstraction layer enabling squad to work with alternative AI coding agent runtimes beyond GitHub Copilot.

## Changes

- `AgentRuntimeDriver` interface defining the contract for runtime implementations
- `RuntimeRegistry` for managing driver registration and selection
- `CopilotDriver` implementation wrapping existing @github/copilot-sdk
- `OpenCodeDriver` stub implementation for future OpenCode support
- `RuntimeDefinition` to SquadSDKConfig builder types
- `defineRuntime()` builder function for runtime configuration

## Motivation

See issue #1058: Users should be able to choose OpenCode (or other AI coding agents) as the underlying runtime for squad agents, not just GitHub Copilot.

## Testing

- TypeScript compilation passes
- Unit tests pass
- `npm run lint` passes

## Related Issues

Closes #1058