### PR TITLE
feat: add cost policy + refresh model catalog for GitHub AI Credits billing

### DIFF
--- a/.changeset/cost-policy-billing-update.md
+++ b/.changeset/cost-policy-billing-update.md
@@ -1,0 +1,14 @@
+---
+'@bradygaster/squad-sdk': minor
+'@bradygaster/squad-cli': patch
+---
+
+Add cost policy support for GitHub Copilot's AI Credits billing transition.
+
+The SDK now ships an updated GitHub model catalog, supports `models.costPolicy`
+configuration, carries cost policy through runtime model selection, refreshes
+fallback chains to current active models, and enforces billing ceilings with
+warn-and-allow behavior for explicit overrides plus automatic downgrades for
+implicit selections.
+
+The CLI templates are synced to the new model catalog and cost policy guidance.

--- a/.copilot/skills/model-selection/SKILL.md
+++ b/.copilot/skills/model-selection/SKILL.md
@@ -1,143 +1,57 @@
 ---
 name: "model-selection"
-description: "Per-agent model selection with 4-layer hierarchy and fallback chains"
+description: "Resolves agent models using layer priority, cost policy, and ceiling-aware fallbacks"
 domain: "orchestration"
 confidence: "high"
-source: "extracted"
+source: "manual"
 ---
+
+# Model Selection
+
+## SCOPE
+
+✅ THIS SKILL PRODUCES:
+- A resolved `model` for every agent spawn
+- Persistent model preferences in `.squad/config.json`
+- Persistent or session cost-policy state
+- Spawn acknowledgments that show when included/economy/policy behavior changed the routing
+
+❌ THIS SKILL DOES NOT PRODUCE:
+- Cost reports or billing analytics
+- Benchmarking or model evals
+- New model IDs not exposed by the current Copilot surface
 
 ## Context
 
-Before spawning an agent, the coordinator determines which model to use. This skill codifies the 4-layer hierarchy, role-to-model mappings, task complexity adjustments, and fallback chains. Applies to all agent spawns in Team Mode.
+Squad resolves models in two phases:
+1. **Preference resolution** via the 5-layer hierarchy
+2. **Policy enforcement** via `costPolicy`, `preferIncluded`, `economyMode`, and ceiling-aware fallback
 
-## Patterns
+Use GitHub's category names:
+- **Lightweight**
+- **Versatile**
+- **Powerful**
 
-### 4-Layer Hierarchy
+## 5-Layer Resolution Hierarchy
 
-Check these layers in order — first match wins:
+| Layer | Name | Source | Behavior |
+|---|---|---|---|
+| 0a | Per-Agent Config | `.squad/config.json` → `agentModelOverrides.{name}` | Explicit persistent override |
+| 0b | Global Config | `.squad/config.json` → `defaultModel` | Explicit persistent override |
+| 1 | Session Directive | current conversation | Explicit session override |
+| 2 | Charter Preference | agent charter `## Model` | Non-user default preference |
+| 3 | Task-Aware Auto | task type | Computed default |
+| 4 | Default | hardcoded | Final fallback |
 
-**Layer 1 — User Override:** Did the user specify a model? ("use opus", "save costs", "use gpt-5.2-codex for this"). If yes, use that model. Session-wide directives ("always use haiku") persist until contradicted.
+**Important:** `costPolicy` is **not** a layer. Apply it after a model is resolved.
 
-**Layer 2 — Charter Preference:** Does the agent's charter have a `## Model` section with `Preferred` set to a specific model (not `auto`)? If yes, use that model.
+## Session start workflow
 
-**Layer 3 — Task-Aware Auto-Selection:** Use the governing principle: **cost first, unless code is being written.** Match the agent's task to determine output type, then select accordingly:
+1. Read `.squad/config.json`
+2. Load `defaultModel`
+3. Load `agentModelOverrides`
+4. Load `costPolicy`
+5. Load `economyMode`
+6. Store persistent settings in session state
 
-| Task Output | Model | Tier | Rule |
-|-------------|-------|------|------|
-| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
-| Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
-| NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.5` | Premium | Vision capability required. Overrides cost rule. |
-
-**Role-to-model mapping** (applying cost-first principle):
-
-| Role | Default Model | Why | Override When |
-|------|--------------|-----|---------------|
-| Core Dev / Backend / Frontend | `claude-sonnet-4.6` | Writes code — quality first | Heavy code gen → `gpt-5.3-codex` |
-| Tester / QA | `claude-sonnet-4.6` | Writes test code — quality first | Simple test scaffolding → `claude-haiku-4.5` |
-| Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
-| Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
-| Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.6` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
-| DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
-| Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
-| Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
-
-**Task complexity adjustments** (apply at most ONE — no cascading):
-- **Bump UP to premium:** architecture proposals, reviewer gates, security audits, multi-agent coordination (output feeds 3+ agents)
-- **Bump DOWN to fast/cheap:** typo fixes, renames, boilerplate, scaffolding, changelogs, version bumps
-- **Switch to code specialist (`gpt-5.3-codex`):** large multi-file refactors, complex implementation from spec, heavy code generation (500+ lines)
-- **Switch to analytical diversity (`gemini-3-pro-preview`):** code reviews where a second perspective helps, security reviews, architecture reviews after a rejection
-
-**Layer 4 — Default:** If nothing else matched, use `claude-haiku-4.5`. Cost wins when in doubt, unless code is being produced.
-
-### Fallback Chains
-
-If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
-
-```
-Premium:  claude-opus-4.6 → claude-opus-4.6-fast → claude-opus-4.5 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → claude-sonnet-4 → (omit model param)
-Fast:     claude-haiku-4.5 → gpt-5.1-codex-mini → gpt-4.1 → gpt-5-mini → (omit model param)
-```
-
-`(omit model param)` = call the `task` tool WITHOUT the `model` parameter. The platform uses its built-in default. This is the nuclear fallback — it always works.
-
-**Fallback rules:**
-- If the user specified a provider ("use Claude"), fall back within that provider only before hitting nuclear
-- Never fall back UP in tier — a fast/cheap task should not land on a premium model
-- Log fallbacks to the orchestration log for debugging, but never surface to the user unless asked
-
-### Passing the Model to Spawns
-
-Pass the resolved model as the `model` parameter on every `task` tool call:
-
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  ...
-```
-
-Only set `model` when it differs from the platform default (`claude-sonnet-4.6`). If the resolved model IS `claude-sonnet-4.6`, you MAY omit the `model` parameter — the platform uses it as default.
-
-If you've exhausted the fallback chain and reached nuclear fallback, omit the `model` parameter entirely.
-
-### Spawn Output Format
-
-When spawning, include the model in your acknowledgment:
-
-```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.6 · vision) — designing color system
-📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
-📝 McManus (claude-haiku-4.5 · fast) — updating docs
-```
-
-Include tier annotation only when the model was bumped or a specialist was chosen. Default-tier spawns just show the model name.
-
-### Valid Models
-
-**Premium:** `claude-opus-4.6`, `claude-opus-4.6-fast`, `claude-opus-4.5`
-**Standard:** `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gpt-5`, `gemini-3-pro-preview`
-**Fast/Cheap:** `claude-haiku-4.5`, `gpt-5.1-codex-mini`, `gpt-5-mini`, `gpt-4.1`
-
-## Examples
-
-**Example 1: Backend dev writing API endpoints**
-- Role: Backend Dev
-- Task: "implement REST endpoints for user management"
-- Layer 3 decision: writing code → `claude-sonnet-4.6` (standard tier)
-- Spawn: `🔧 Fenster (claude-sonnet-4.6) — implementing user API endpoints`
-
-**Example 2: User override**
-- User says: "use haiku for everything this session"
-- Layer 1 overrides all other layers
-- All spawns use `claude-haiku-4.5` regardless of role or task
-
-**Example 3: Complex refactor**
-- Role: Backend Dev
-- Task: "refactor 15 auth-related files to use new token system"
-- Layer 3 base: `claude-sonnet-4.5`
-- Task complexity: heavy multi-file refactor → switch to `gpt-5.2-codex`
-- Spawn: `🔧 Fenster (gpt-5.2-codex · code specialist) — refactoring auth to new token system`
-
-**Example 4: Scribe logging**
-- Role: Scribe
-- Task: "log session to decisions.md"
-- Layer 3: NOT writing code → `claude-haiku-4.5`
-- Role mapping: Scribe always haiku, never bump
-- Spawn: `📋 Scribe (claude-haiku-4.5 · fast) — logging session`
-
-## Anti-Patterns
-
-- ❌ Falling back UP in tier (fast task landing on premium model)
-- ❌ Telling the user about fallback attempts ("Opus failed, trying Sonnet")
-- ❌ Bumping Scribe or mechanical ops agents to higher tiers
-- ❌ Using premium models for documentation or planning tasks
-- ❌ Applying multiple complexity adjustments (cascading bumps)
-- ❌ Forgetting to include model in spawn acknowledgment
-- ❌ Downgrading vision-required tasks from opus
+## Cost Policy

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -364,103 +364,232 @@ For read-only queries, use the explore agent: `agent_type: "explore"` with `"You
 
 ### Per-Agent Model Selection
 
-Before spawning an agent, determine which model to use. Check these layers in order — first match wins:
+Before spawning an agent, resolve a model in **two phases**:
 
-**Layer 0 — Persistent Config (`.squad/config.json`):** On session start, read `.squad/config.json`. If `agentModelOverrides.{agentName}` exists, use that model for this specific agent. Otherwise, if `defaultModel` exists, use it for ALL agents. This layer survives across sessions — the user set it once and it sticks.
+1. **Resolve intent** with the existing 5-layer hierarchy.
+2. **Apply policy veto** (`costPolicy`) and soft modifiers (`economyMode`) before spawning.
 
-- **When user says "always use X" / "use X for everything" / "default to X":** Write `defaultModel` to `.squad/config.json`. Acknowledge: `✅ Model preference saved: {model} — all future sessions will use this until changed.`
-- **When user says "use X for {agent}":** Write to `agentModelOverrides.{agent}` in `.squad/config.json`. Acknowledge: `✅ {Agent} will always use {model} — saved to config.`
-- **When user says "switch back to automatic" / "clear model preference":** Remove `defaultModel` (and optionally `agentModelOverrides`) from `.squad/config.json`. Acknowledge: `✅ Model preference cleared — returning to automatic selection.`
+The 5 layers stay intact:
 
-**Layer 1 — Session Directive:** Did the user specify a model for this session? ("use opus for this session", "save costs"). If yes, use that model. Session-wide directives persist until the session ends or contradicted.
+- **Layer 0a — Persistent Per-Agent Config:** `.squad/config.json` → `agentModelOverrides.{agentName}`
+- **Layer 0b — Persistent Global Config:** `.squad/config.json` → `defaultModel`
+- **Layer 1 — Session Directive:** explicit session phrases like "use opus for this session"
+- **Layer 2 — Charter Preference:** agent charter `## Model` section when not `auto`
+- **Layer 3 — Task-Aware Auto-Selection:** choose by task output
+- **Layer 4 — Default:** final hardcoded fallback
 
-**Layer 2 — Charter Preference:** Does the agent's charter have a `## Model` section with `Preferred` set to a specific model (not `auto`)? If yes, use that model.
+#### Policy Veto Step (apply AFTER Layer 4 resolution)
 
-**Layer 3 — Task-Aware Auto-Selection:** Use the governing principle: **cost first, unless code is being written.** Match the agent's task to determine output type, then select accordingly:
+After a model is resolved, check `costPolicy`.
 
-| Task Output | Model | Tier | Rule |
-|-------------|-------|------|------|
-| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
-| Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
-| NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.5` | Premium | Vision capability required. Overrides cost rule. |
+**Important:** `costPolicy` is **not Layer 0/1/2/3/4**. It is a policy check applied **after** layer resolution and **before** fallback execution.
 
-**Role-to-model mapping** (applying cost-first principle):
+Policy algorithm:
 
-| Role | Default Model | Why | Override When |
-|------|--------------|-----|---------------|
-| Core Dev / Backend / Frontend | `claude-sonnet-4.6` | Writes code — quality first | Heavy code gen → `gpt-5.3-codex` |
-| Tester / QA | `claude-sonnet-4.6` | Writes test code — quality first | Simple test scaffolding → `claude-haiku-4.5` |
-| Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
-| Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
-| Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.5` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
-| DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
-| Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
-| Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
+1. Read persistent `costPolicy` from `.squad/config.json`.
+2. Merge any **session-only cost directives** from the conversation on top of it.
+3. Determine the resolved model's category: **Lightweight**, **Versatile**, or **Powerful**.
+4. If the resolved model is **within** the ceiling, continue.
+5. If the resolved model is **above** the ceiling:
+   - **Layer 0 / Layer 1 explicit user override:** **warn and allow**.
+   - **Layer 2 / Layer 3 / Layer 4 choice:** reroute to the best in-ceiling model for that task.
+6. After ceiling enforcement, apply `economyMode` as a **soft cheaper-within-ceiling preference**.
+7. If `preferIncluded: true`, rank **included** models ahead of paid models when they can handle the task.
+8. Run the fallback chain, but **drop any fallback candidates above the active ceiling** unless the original selection came from an explicit Layer 0/1 override.
 
-**Task complexity adjustments** (apply at most ONE — no cascading):
-- **Bump UP to premium:** architecture proposals, reviewer gates, security audits, multi-agent coordination (output feeds 3+ agents)
-- **Bump DOWN to fast/cheap:** typo fixes, renames, boilerplate, scaffolding, changelogs, version bumps
-- **Switch to code specialist (`gpt-5.3-codex`):** large multi-file refactors, complex implementation from spec, heavy code generation (500+ lines)
-- **Switch to analytical diversity (`gemini-3-pro-preview`):** code reviews where a second perspective helps, security reviews, architecture reviews after a rejection
+**Warning copy for explicit override above ceiling:**
 
-**Layer 4 — Default:** If nothing else matched, use `claude-haiku-4.5`. Cost wins when in doubt, unless code is being produced.
-
-**Fallback chains — when a model is unavailable:**
-
-If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
-
-```
-Premium:  claude-opus-4.6 → claude-opus-4.5 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4 → (omit model param)
-Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5.1-codex-mini → gpt-4.1 → (omit model param)
+```text
+⚠️ {model} is above the current cost policy ceiling ({maxCategory}), but it was explicitly requested, so I’m using it.
 ```
 
-`(omit model param)` = call the `task` tool WITHOUT the `model` parameter. The platform uses its built-in default. This is the nuclear fallback — it always works.
+Warn once per explicit request. Do not repeatedly nag on every fallback retry.
 
-**Fallback rules:**
-- If the user specified a provider ("use Claude"), fall back within that provider only before hitting nuclear
-- Never fall back UP in tier — a fast/cheap task should not land on a premium model
-- Log fallbacks to the orchestration log for debugging, but never surface to the user unless asked
+---
 
-**Passing the model to spawns:**
+## Valid Models (GitHub AI Credits catalog used by Squad)
 
-Pass the resolved model as the `model` parameter on every `task` tool call:
+Use GitHub's category names and pricing language. List the **active Squad selection set** first — i.e. the model IDs Squad should actively choose today on Copilot surfaces that expose the current task-model list.
 
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-name: "{name}"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  ...
-```
+### Lightweight
 
-Only set `model` when it differs from the platform default (`claude-sonnet-4.6`). If the resolved model IS `claude-sonnet-4.6`, you MAY omit the `model` parameter — the platform uses it as default.
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `gpt-5-mini` | **Yes** | 0 / 0 | Zero-credit lightweight default when `preferIncluded: true` or economy is aggressive. |
+| `gpt-5.4-mini` | No | 0.75 / 4.50 | Cheap lightweight fallback. |
+| `claude-haiku-4.5` | No | 1.00 / 5.00 | Best default lightweight paid model for non-code and mechanical work. |
 
-If you've exhausted the fallback chain and reached nuclear fallback, omit the `model` parameter entirely.
+### Versatile
 
-**Spawn output format — show the model choice:**
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `gpt-4.1` | **Yes** | 0 / 0 | Zero-credit structured/tool-use preference when `preferIncluded: true` or economy mode is active. |
+| `claude-sonnet-4.6` | No | 3.00 / 15.00 | Primary default for code, prompt architecture, and high-quality structured output. |
+| `claude-sonnet-4.5` | No | 3.00 / 15.00 | First same-family fallback. |
+| `claude-sonnet-4` | No | 3.00 / 15.00 | Older versatile fallback. |
+| `gpt-5.4` | No | 2.50 / 15.00 | Strong versatile alternative. |
+| `gpt-5.3-codex` | No | 1.75 / 14.00 | Best code-specialist alternate for large implementation bursts. |
+| `gpt-5.2-codex` | No | 1.75 / 14.00 | Secondary code-specialist alternate. |
+| `gpt-5.2` | No | 1.75 / 14.00 | General versatile alternate. |
 
-When spawning, include the model in your acknowledgment:
+### Powerful
 
-```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.5 · vision) — designing color system
-📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
-📝 McManus (claude-haiku-4.5 · fast) — updating docs
-```
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `claude-opus-4.7` | No | 5.00 / 25.00 | Best default for architecture, review gates, and vision-heavy work. |
+| `claude-opus-4.6` | No | 5.00 / 25.00 | Same-family fallback. |
+| `claude-opus-4.5` | No | 5.00 / 25.00 | Stable older fallback. |
+| `gpt-5.5` | No | 5.00 / 30.00 | Powerful cross-provider alternate. |
 
-Include tier annotation only when the model was bumped or a specialist was chosen. Default-tier spawns just show the model name.
+**Catalog note:** GitHub's broader catalog also includes additional lightweight/versatile/powerful models such as `gemini-3.1-pro`. Treat those as catalog context only unless the active Copilot surface exposes them for selection. Do **not** make Squad actively select IDs that are not exposed by the current Copilot surface. If a new surface exposes more catalog models later, slot them into the same category semantics rather than inventing new tiers.
 
 **Valid models (current platform catalog):**
 
-Premium: `claude-opus-4.6`, `claude-opus-4.6-1m` (Internal only), `claude-opus-4.5`
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gemini-3-pro-preview`
-Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5.1-codex-mini`, `gpt-5-mini`, `gpt-4.1`
+Powerful: `claude-opus-4.7`, `claude-opus-4.6`, `claude-opus-4.5`, `gpt-5.5`
+Versatile: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-4.1` (included)
+Lightweight: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini` (included)
+
+---
+
+## Updated Layer 3 defaults
+
+Keep the principle: **cost first, unless code or prompt logic is being produced**.
+
+| Task Output | Default Model | Category | Why |
+|---|---|---|---|
+| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Versatile | Best default quality/cost balance for production code. |
+| Writing prompts, agent designs, routing logic, structured system text | `claude-sonnet-4.6` | Versatile | Prompt architecture behaves like code. |
+| Docs, planning, triage, changelogs, logging, mechanical ops | `claude-haiku-4.5` | Lightweight | Cheap default when no stronger policy preference is active. |
+| Visual/design work or image-heavy judgment | `claude-opus-4.7` | Powerful | Highest-stakes reasoning / best vision-capable default. |
+
+**Layer 4 default:** `claude-haiku-4.5`
+
+---
+
+## Updated role-to-model mapping
+
+| Role | Normal Default | Category | Prefer-Included Route | Override When |
+|---|---|---|---|---|
+| Core Dev / Backend / Frontend / TypeScript Engineer | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Heavy code generation or refactor burst → `gpt-5.3-codex` |
+| Tester / QA / E2E | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Simple scaffolding / assertions / fixture churn → `claude-haiku-4.5` or `gpt-5-mini` |
+| Lead / Architect / Security reviewer | auto by task | Powerful or Versatile | `gpt-4.1` only for low-stakes advisory analysis | Architecture proposals / reviewer gates / security signoff → `claude-opus-4.7` |
+| Prompt Engineer | auto by task | Versatile or Lightweight | `gpt-4.1` for structured prompt rewrites; `gpt-5-mini` for cheap synthesis | Prompt architecture / coordinator logic → `claude-sonnet-4.6` |
+| Copilot SDK Expert | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Pure research / inventory / API comparison → `claude-haiku-4.5` |
+| Designer / Visual | `claude-opus-4.7` | Powerful | none by default | If policy ceiling blocks Powerful, downgrade to `claude-sonnet-4.6` and note reduced confidence for visual judgment |
+| DevRel / Writer | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` (or `gpt-4.1` if heavy tool use) | Structured transformation or tool-rich writing workflow → `gpt-4.1` |
+| Scribe / Logger | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` | Never auto-bump above Lightweight unless explicitly requested |
+| Git / Release / Mechanical ops | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` | Never auto-bump above Lightweight unless explicitly requested |
+
+**Design read:** defaults stay Sonnet/Haiku for normal mode. `preferIncluded` and `economyMode` are what pull routing toward `gpt-4.1` / `gpt-5-mini`.
+
+---
+
+## Cost Policy
+
+Add a new subsection directly under model selection.
+
+### Config shape
+
+```json
+{
+  "costPolicy": {
+    "maxCategory": "Versatile",
+    "preferIncluded": true
+  }
+}
+```
+
+- `maxCategory`: `Lightweight` | `Versatile` | `Powerful`
+- `preferIncluded`: when `true`, prefer zero-credit models (`gpt-4.1`, `gpt-5-mini`) where they are acceptable for the task
+- Default if missing: `{ "maxCategory": "Powerful", "preferIncluded": false }`
+
+### What it means
+
+- **`maxCategory` is a hard ceiling** for auto-routing and charter-driven choices.
+- Lower categories are always allowed.
+- **`economyMode` is different:** it is a **soft cheaper-within-ceiling preference**.
+- **`preferIncluded` is also different:** it re-ranks zero-credit models first, but still respects the ceiling and task fit.
+
+### Conversation phrases
+
+Treat conversational cost policy as **session-only** unless the user says `always`, `save`, `remember`, or otherwise asks to persist it.
+
+| User phrase | Session action |
+|---|---|
+| "keep costs low" / "use cheap models" / "Lightweight only" | set `maxCategory: "Lightweight"` |
+| "no powerful models" / "cap at versatile" | set `maxCategory: "Versatile"` |
+| "prefer included models" / "save credits" / "use zero-cost models when you can" | set `preferIncluded: true` |
+| "use normal costing again" / "remove the ceiling" | clear session cost policy override |
+
+Persistent forms:
+
+- "always keep costs low" → write `costPolicy.maxCategory = "Lightweight"`
+- "always cap at versatile" → write `costPolicy.maxCategory = "Versatile"`
+- "always prefer included models" → write `costPolicy.preferIncluded = true`
+
+### Composition with `economyMode`
+
+Apply in this order:
+
+1. Resolve the model from Layers 0-4.
+2. Enforce `costPolicy.maxCategory`.
+3. Apply `preferIncluded` ranking.
+4. Apply `economyMode` as a soft cheaper-within-ceiling substitution.
+5. Execute the ceiling-aware fallback chain.
+
+Examples:
+
+- **No cost policy + economy off:** code task → `claude-sonnet-4.6`
+- **`maxCategory: "Versatile"` + economy off:** code task still → `claude-sonnet-4.6`
+- **`maxCategory: "Versatile"` + economy on:** code task can downshift to `gpt-4.1`
+- **`maxCategory: "Lightweight"` + economy off:** code task is capped to a Lightweight model, defaulting to `claude-haiku-4.5`
+- **`maxCategory: "Lightweight"` + `preferIncluded: true`:** code/docs/mechanical work should prefer `gpt-5-mini`
+
+### Explicit override rule
+
+If the user explicitly chooses a model at Layer 0 or Layer 1 and that model exceeds the ceiling, **warn and allow**. Do **not** silently replace an explicit override.
+
+If the chosen model came from Layer 2, Layer 3, or Layer 4 and exceeds the ceiling, **replace it with the best allowed model**.
+
+---
+
+## Updated fallback chains
+
+Rename the chains to GitHub's categories and make them ceiling-aware.
+
+```text
+Powerful:          claude-opus-4.7 → claude-opus-4.6 → claude-opus-4.5 → gpt-5.5 → claude-sonnet-4.6 → (omit model param)
+Versatile (code):  claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.3-codex → gpt-5.2-codex → gpt-5.4 → claude-sonnet-4 → gpt-4.1 → (omit model param)
+Versatile (general): claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-4.1 → gpt-5.4 → gpt-5.2 → claude-sonnet-4 → (omit model param)
+Lightweight:       claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
+Lightweight (preferIncluded): gpt-5-mini → gpt-5.4-mini → claude-haiku-4.5 → (omit model param)
+```
+
+Fallback rules:
+
+- Never fall back **above the active `maxCategory` ceiling**.
+- If the user specified a provider (`Claude`, `GPT`), exhaust same-provider choices first.
+- If `preferIncluded: true`, start with the included-first chain when available.
+- Use `(omit model param)` as the nuclear fallback.
+- Do not narrate fallback attempts unless the user explicitly asks.
+
+---
+
+## Spawn acknowledgment additions
+
+Keep the current model display, but add policy/economy tags only when they matter.
+
+Examples:
+
+```text
+🔧 EECOM (claude-sonnet-4.6) — implementing router changes
+🧠 Procedures (gpt-4.1 · included) — rewriting prompt policy
+📋 Scribe (gpt-5-mini · lightweight · included) — logging session
+⚠️ Flight (claude-opus-4.7 · above cost ceiling by explicit override) — reviewing architecture
+💰 CONTROL (gpt-4.1 · economy) — planning refactor
+```
+
+---
 
 ### Client Compatibility
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ docs/tests/screenshots/
 
 # Images folder (root only — don't ignore docs/public/images/)
 /images/
+# Squad: ignore runtime state (logs, inbox, sessions)
+.squad/.scratch/

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -364,103 +364,232 @@ For read-only queries, use the explore agent: `agent_type: "explore"` with `"You
 
 ### Per-Agent Model Selection
 
-Before spawning an agent, determine which model to use. Check these layers in order — first match wins:
+Before spawning an agent, resolve a model in **two phases**:
 
-**Layer 0 — Persistent Config (`.squad/config.json`):** On session start, read `.squad/config.json`. If `agentModelOverrides.{agentName}` exists, use that model for this specific agent. Otherwise, if `defaultModel` exists, use it for ALL agents. This layer survives across sessions — the user set it once and it sticks.
+1. **Resolve intent** with the existing 5-layer hierarchy.
+2. **Apply policy veto** (`costPolicy`) and soft modifiers (`economyMode`) before spawning.
 
-- **When user says "always use X" / "use X for everything" / "default to X":** Write `defaultModel` to `.squad/config.json`. Acknowledge: `✅ Model preference saved: {model} — all future sessions will use this until changed.`
-- **When user says "use X for {agent}":** Write to `agentModelOverrides.{agent}` in `.squad/config.json`. Acknowledge: `✅ {Agent} will always use {model} — saved to config.`
-- **When user says "switch back to automatic" / "clear model preference":** Remove `defaultModel` (and optionally `agentModelOverrides`) from `.squad/config.json`. Acknowledge: `✅ Model preference cleared — returning to automatic selection.`
+The 5 layers stay intact:
 
-**Layer 1 — Session Directive:** Did the user specify a model for this session? ("use opus for this session", "save costs"). If yes, use that model. Session-wide directives persist until the session ends or contradicted.
+- **Layer 0a — Persistent Per-Agent Config:** `.squad/config.json` → `agentModelOverrides.{agentName}`
+- **Layer 0b — Persistent Global Config:** `.squad/config.json` → `defaultModel`
+- **Layer 1 — Session Directive:** explicit session phrases like "use opus for this session"
+- **Layer 2 — Charter Preference:** agent charter `## Model` section when not `auto`
+- **Layer 3 — Task-Aware Auto-Selection:** choose by task output
+- **Layer 4 — Default:** final hardcoded fallback
 
-**Layer 2 — Charter Preference:** Does the agent's charter have a `## Model` section with `Preferred` set to a specific model (not `auto`)? If yes, use that model.
+#### Policy Veto Step (apply AFTER Layer 4 resolution)
 
-**Layer 3 — Task-Aware Auto-Selection:** Use the governing principle: **cost first, unless code is being written.** Match the agent's task to determine output type, then select accordingly:
+After a model is resolved, check `costPolicy`.
 
-| Task Output | Model | Tier | Rule |
-|-------------|-------|------|------|
-| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
-| Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
-| NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.5` | Premium | Vision capability required. Overrides cost rule. |
+**Important:** `costPolicy` is **not Layer 0/1/2/3/4**. It is a policy check applied **after** layer resolution and **before** fallback execution.
 
-**Role-to-model mapping** (applying cost-first principle):
+Policy algorithm:
 
-| Role | Default Model | Why | Override When |
-|------|--------------|-----|---------------|
-| Core Dev / Backend / Frontend | `claude-sonnet-4.6` | Writes code — quality first | Heavy code gen → `gpt-5.3-codex` |
-| Tester / QA | `claude-sonnet-4.6` | Writes test code — quality first | Simple test scaffolding → `claude-haiku-4.5` |
-| Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
-| Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
-| Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.5` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
-| DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
-| Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
-| Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
+1. Read persistent `costPolicy` from `.squad/config.json`.
+2. Merge any **session-only cost directives** from the conversation on top of it.
+3. Determine the resolved model's category: **Lightweight**, **Versatile**, or **Powerful**.
+4. If the resolved model is **within** the ceiling, continue.
+5. If the resolved model is **above** the ceiling:
+   - **Layer 0 / Layer 1 explicit user override:** **warn and allow**.
+   - **Layer 2 / Layer 3 / Layer 4 choice:** reroute to the best in-ceiling model for that task.
+6. After ceiling enforcement, apply `economyMode` as a **soft cheaper-within-ceiling preference**.
+7. If `preferIncluded: true`, rank **included** models ahead of paid models when they can handle the task.
+8. Run the fallback chain, but **drop any fallback candidates above the active ceiling** unless the original selection came from an explicit Layer 0/1 override.
 
-**Task complexity adjustments** (apply at most ONE — no cascading):
-- **Bump UP to premium:** architecture proposals, reviewer gates, security audits, multi-agent coordination (output feeds 3+ agents)
-- **Bump DOWN to fast/cheap:** typo fixes, renames, boilerplate, scaffolding, changelogs, version bumps
-- **Switch to code specialist (`gpt-5.3-codex`):** large multi-file refactors, complex implementation from spec, heavy code generation (500+ lines)
-- **Switch to analytical diversity (`gemini-3-pro-preview`):** code reviews where a second perspective helps, security reviews, architecture reviews after a rejection
+**Warning copy for explicit override above ceiling:**
 
-**Layer 4 — Default:** If nothing else matched, use `claude-haiku-4.5`. Cost wins when in doubt, unless code is being produced.
-
-**Fallback chains — when a model is unavailable:**
-
-If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
-
-```
-Premium:  claude-opus-4.6 → claude-opus-4.5 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4 → (omit model param)
-Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5.1-codex-mini → gpt-4.1 → (omit model param)
+```text
+⚠️ {model} is above the current cost policy ceiling ({maxCategory}), but it was explicitly requested, so I’m using it.
 ```
 
-`(omit model param)` = call the `task` tool WITHOUT the `model` parameter. The platform uses its built-in default. This is the nuclear fallback — it always works.
+Warn once per explicit request. Do not repeatedly nag on every fallback retry.
 
-**Fallback rules:**
-- If the user specified a provider ("use Claude"), fall back within that provider only before hitting nuclear
-- Never fall back UP in tier — a fast/cheap task should not land on a premium model
-- Log fallbacks to the orchestration log for debugging, but never surface to the user unless asked
+---
 
-**Passing the model to spawns:**
+## Valid Models (GitHub AI Credits catalog used by Squad)
 
-Pass the resolved model as the `model` parameter on every `task` tool call:
+Use GitHub's category names and pricing language. List the **active Squad selection set** first — i.e. the model IDs Squad should actively choose today on Copilot surfaces that expose the current task-model list.
 
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-name: "{name}"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  ...
-```
+### Lightweight
 
-Only set `model` when it differs from the platform default (`claude-sonnet-4.6`). If the resolved model IS `claude-sonnet-4.6`, you MAY omit the `model` parameter — the platform uses it as default.
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `gpt-5-mini` | **Yes** | 0 / 0 | Zero-credit lightweight default when `preferIncluded: true` or economy is aggressive. |
+| `gpt-5.4-mini` | No | 0.75 / 4.50 | Cheap lightweight fallback. |
+| `claude-haiku-4.5` | No | 1.00 / 5.00 | Best default lightweight paid model for non-code and mechanical work. |
 
-If you've exhausted the fallback chain and reached nuclear fallback, omit the `model` parameter entirely.
+### Versatile
 
-**Spawn output format — show the model choice:**
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `gpt-4.1` | **Yes** | 0 / 0 | Zero-credit structured/tool-use preference when `preferIncluded: true` or economy mode is active. |
+| `claude-sonnet-4.6` | No | 3.00 / 15.00 | Primary default for code, prompt architecture, and high-quality structured output. |
+| `claude-sonnet-4.5` | No | 3.00 / 15.00 | First same-family fallback. |
+| `claude-sonnet-4` | No | 3.00 / 15.00 | Older versatile fallback. |
+| `gpt-5.4` | No | 2.50 / 15.00 | Strong versatile alternative. |
+| `gpt-5.3-codex` | No | 1.75 / 14.00 | Best code-specialist alternate for large implementation bursts. |
+| `gpt-5.2-codex` | No | 1.75 / 14.00 | Secondary code-specialist alternate. |
+| `gpt-5.2` | No | 1.75 / 14.00 | General versatile alternate. |
 
-When spawning, include the model in your acknowledgment:
+### Powerful
 
-```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.5 · vision) — designing color system
-📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
-📝 McManus (claude-haiku-4.5 · fast) — updating docs
-```
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `claude-opus-4.7` | No | 5.00 / 25.00 | Best default for architecture, review gates, and vision-heavy work. |
+| `claude-opus-4.6` | No | 5.00 / 25.00 | Same-family fallback. |
+| `claude-opus-4.5` | No | 5.00 / 25.00 | Stable older fallback. |
+| `gpt-5.5` | No | 5.00 / 30.00 | Powerful cross-provider alternate. |
 
-Include tier annotation only when the model was bumped or a specialist was chosen. Default-tier spawns just show the model name.
+**Catalog note:** GitHub's broader catalog also includes additional lightweight/versatile/powerful models such as `gemini-3.1-pro`. Treat those as catalog context only unless the active Copilot surface exposes them for selection. Do **not** make Squad actively select IDs that are not exposed by the current Copilot surface. If a new surface exposes more catalog models later, slot them into the same category semantics rather than inventing new tiers.
 
 **Valid models (current platform catalog):**
 
-Premium: `claude-opus-4.6`, `claude-opus-4.6-1m` (Internal only), `claude-opus-4.5`
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gemini-3-pro-preview`
-Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5.1-codex-mini`, `gpt-5-mini`, `gpt-4.1`
+Powerful: `claude-opus-4.7`, `claude-opus-4.6`, `claude-opus-4.5`, `gpt-5.5`
+Versatile: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-4.1` (included)
+Lightweight: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini` (included)
+
+---
+
+## Updated Layer 3 defaults
+
+Keep the principle: **cost first, unless code or prompt logic is being produced**.
+
+| Task Output | Default Model | Category | Why |
+|---|---|---|---|
+| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Versatile | Best default quality/cost balance for production code. |
+| Writing prompts, agent designs, routing logic, structured system text | `claude-sonnet-4.6` | Versatile | Prompt architecture behaves like code. |
+| Docs, planning, triage, changelogs, logging, mechanical ops | `claude-haiku-4.5` | Lightweight | Cheap default when no stronger policy preference is active. |
+| Visual/design work or image-heavy judgment | `claude-opus-4.7` | Powerful | Highest-stakes reasoning / best vision-capable default. |
+
+**Layer 4 default:** `claude-haiku-4.5`
+
+---
+
+## Updated role-to-model mapping
+
+| Role | Normal Default | Category | Prefer-Included Route | Override When |
+|---|---|---|---|---|
+| Core Dev / Backend / Frontend / TypeScript Engineer | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Heavy code generation or refactor burst → `gpt-5.3-codex` |
+| Tester / QA / E2E | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Simple scaffolding / assertions / fixture churn → `claude-haiku-4.5` or `gpt-5-mini` |
+| Lead / Architect / Security reviewer | auto by task | Powerful or Versatile | `gpt-4.1` only for low-stakes advisory analysis | Architecture proposals / reviewer gates / security signoff → `claude-opus-4.7` |
+| Prompt Engineer | auto by task | Versatile or Lightweight | `gpt-4.1` for structured prompt rewrites; `gpt-5-mini` for cheap synthesis | Prompt architecture / coordinator logic → `claude-sonnet-4.6` |
+| Copilot SDK Expert | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Pure research / inventory / API comparison → `claude-haiku-4.5` |
+| Designer / Visual | `claude-opus-4.7` | Powerful | none by default | If policy ceiling blocks Powerful, downgrade to `claude-sonnet-4.6` and note reduced confidence for visual judgment |
+| DevRel / Writer | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` (or `gpt-4.1` if heavy tool use) | Structured transformation or tool-rich writing workflow → `gpt-4.1` |
+| Scribe / Logger | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` | Never auto-bump above Lightweight unless explicitly requested |
+| Git / Release / Mechanical ops | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` | Never auto-bump above Lightweight unless explicitly requested |
+
+**Design read:** defaults stay Sonnet/Haiku for normal mode. `preferIncluded` and `economyMode` are what pull routing toward `gpt-4.1` / `gpt-5-mini`.
+
+---
+
+## Cost Policy
+
+Add a new subsection directly under model selection.
+
+### Config shape
+
+```json
+{
+  "costPolicy": {
+    "maxCategory": "Versatile",
+    "preferIncluded": true
+  }
+}
+```
+
+- `maxCategory`: `Lightweight` | `Versatile` | `Powerful`
+- `preferIncluded`: when `true`, prefer zero-credit models (`gpt-4.1`, `gpt-5-mini`) where they are acceptable for the task
+- Default if missing: `{ "maxCategory": "Powerful", "preferIncluded": false }`
+
+### What it means
+
+- **`maxCategory` is a hard ceiling** for auto-routing and charter-driven choices.
+- Lower categories are always allowed.
+- **`economyMode` is different:** it is a **soft cheaper-within-ceiling preference**.
+- **`preferIncluded` is also different:** it re-ranks zero-credit models first, but still respects the ceiling and task fit.
+
+### Conversation phrases
+
+Treat conversational cost policy as **session-only** unless the user says `always`, `save`, `remember`, or otherwise asks to persist it.
+
+| User phrase | Session action |
+|---|---|
+| "keep costs low" / "use cheap models" / "Lightweight only" | set `maxCategory: "Lightweight"` |
+| "no powerful models" / "cap at versatile" | set `maxCategory: "Versatile"` |
+| "prefer included models" / "save credits" / "use zero-cost models when you can" | set `preferIncluded: true` |
+| "use normal costing again" / "remove the ceiling" | clear session cost policy override |
+
+Persistent forms:
+
+- "always keep costs low" → write `costPolicy.maxCategory = "Lightweight"`
+- "always cap at versatile" → write `costPolicy.maxCategory = "Versatile"`
+- "always prefer included models" → write `costPolicy.preferIncluded = true`
+
+### Composition with `economyMode`
+
+Apply in this order:
+
+1. Resolve the model from Layers 0-4.
+2. Enforce `costPolicy.maxCategory`.
+3. Apply `preferIncluded` ranking.
+4. Apply `economyMode` as a soft cheaper-within-ceiling substitution.
+5. Execute the ceiling-aware fallback chain.
+
+Examples:
+
+- **No cost policy + economy off:** code task → `claude-sonnet-4.6`
+- **`maxCategory: "Versatile"` + economy off:** code task still → `claude-sonnet-4.6`
+- **`maxCategory: "Versatile"` + economy on:** code task can downshift to `gpt-4.1`
+- **`maxCategory: "Lightweight"` + economy off:** code task is capped to a Lightweight model, defaulting to `claude-haiku-4.5`
+- **`maxCategory: "Lightweight"` + `preferIncluded: true`:** code/docs/mechanical work should prefer `gpt-5-mini`
+
+### Explicit override rule
+
+If the user explicitly chooses a model at Layer 0 or Layer 1 and that model exceeds the ceiling, **warn and allow**. Do **not** silently replace an explicit override.
+
+If the chosen model came from Layer 2, Layer 3, or Layer 4 and exceeds the ceiling, **replace it with the best allowed model**.
+
+---
+
+## Updated fallback chains
+
+Rename the chains to GitHub's categories and make them ceiling-aware.
+
+```text
+Powerful:          claude-opus-4.7 → claude-opus-4.6 → claude-opus-4.5 → gpt-5.5 → claude-sonnet-4.6 → (omit model param)
+Versatile (code):  claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.3-codex → gpt-5.2-codex → gpt-5.4 → claude-sonnet-4 → gpt-4.1 → (omit model param)
+Versatile (general): claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-4.1 → gpt-5.4 → gpt-5.2 → claude-sonnet-4 → (omit model param)
+Lightweight:       claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
+Lightweight (preferIncluded): gpt-5-mini → gpt-5.4-mini → claude-haiku-4.5 → (omit model param)
+```
+
+Fallback rules:
+
+- Never fall back **above the active `maxCategory` ceiling**.
+- If the user specified a provider (`Claude`, `GPT`), exhaust same-provider choices first.
+- If `preferIncluded: true`, start with the included-first chain when available.
+- Use `(omit model param)` as the nuclear fallback.
+- Do not narrate fallback attempts unless the user explicitly asks.
+
+---
+
+## Spawn acknowledgment additions
+
+Keep the current model display, but add policy/economy tags only when they matter.
+
+Examples:
+
+```text
+🔧 EECOM (claude-sonnet-4.6) — implementing router changes
+🧠 Procedures (gpt-4.1 · included) — rewriting prompt policy
+📋 Scribe (gpt-5-mini · lightweight · included) — logging session
+⚠️ Flight (claude-opus-4.7 · above cost ceiling by explicit override) — reviewing architecture
+💰 CONTROL (gpt-4.1 · economy) — planning refactor
+```
+
+---
 
 ### Client Compatibility
 

--- a/.squad/skills/model-selection/SKILL.md
+++ b/.squad/skills/model-selection/SKILL.md
@@ -1,125 +1,57 @@
 ---
 name: "model-selection"
-description: "Determines which LLM model to use for each agent spawn"
+description: "Resolves agent models using layer priority, cost policy, and ceiling-aware fallbacks"
 domain: "orchestration"
-confidence: "medium"
-source: "extracted"
+confidence: "high"
+source: "manual"
 ---
 
 # Model Selection
 
-> Determines which LLM model to use for each agent spawn.
-
 ## SCOPE
 
 ✅ THIS SKILL PRODUCES:
-- A resolved `model` parameter for every `task` tool call
+- A resolved `model` for every agent spawn
 - Persistent model preferences in `.squad/config.json`
-- Spawn acknowledgments that include the resolved model
+- Persistent or session cost-policy state
+- Spawn acknowledgments that show when included/economy/policy behavior changed the routing
 
 ❌ THIS SKILL DOES NOT PRODUCE:
-- Code, tests, or documentation
-- Model performance benchmarks
-- Cost reports or billing artifacts
+- Cost reports or billing analytics
+- Benchmarking or model evals
+- New model IDs not exposed by the current Copilot surface
 
 ## Context
 
-Squad supports 18+ models across three tiers (premium, standard, fast). The coordinator must select the right model for each agent spawn. Users can set persistent preferences that survive across sessions.
+Squad resolves models in two phases:
+1. **Preference resolution** via the 5-layer hierarchy
+2. **Policy enforcement** via `costPolicy`, `preferIncluded`, `economyMode`, and ceiling-aware fallback
 
-## 5-Layer Model Resolution Hierarchy
+Use GitHub's category names:
+- **Lightweight**
+- **Versatile**
+- **Powerful**
 
-Resolution is **first-match-wins** — the highest layer with a value wins.
+## 5-Layer Resolution Hierarchy
 
-| Layer | Name | Source | Persistence |
-|-------|------|--------|-------------|
-| **0a** | Per-Agent Config | `.squad/config.json` → `agentModelOverrides.{name}` | Persistent (survives sessions) |
-| **0b** | Global Config | `.squad/config.json` → `defaultModel` | Persistent (survives sessions) |
-| **1** | Session Directive | User said "use X" in current session | Session-only |
-| **2** | Charter Preference | Agent's `charter.md` → `## Model` section | Persistent (in charter) |
-| **3** | Task-Aware Auto | Code → sonnet, docs → haiku, visual → opus | Computed per-spawn |
-| **4** | Default | `claude-haiku-4.5` | Hardcoded fallback |
+| Layer | Name | Source | Behavior |
+|---|---|---|---|
+| 0a | Per-Agent Config | `.squad/config.json` → `agentModelOverrides.{name}` | Explicit persistent override |
+| 0b | Global Config | `.squad/config.json` → `defaultModel` | Explicit persistent override |
+| 1 | Session Directive | current conversation | Explicit session override |
+| 2 | Charter Preference | agent charter `## Model` | Non-user default preference |
+| 3 | Task-Aware Auto | task type | Computed default |
+| 4 | Default | hardcoded | Final fallback |
 
-**Key principle:** Layer 0 (persistent config) beats everything. If the user said "always use opus" and it was saved to config.json, every agent gets opus regardless of role or task type. This is intentional — the user explicitly chose quality over cost.
+**Important:** `costPolicy` is **not** a layer. Apply it after a model is resolved.
 
-## AGENT WORKFLOW
+## Session start workflow
 
-### On Session Start
+1. Read `.squad/config.json`
+2. Load `defaultModel`
+3. Load `agentModelOverrides`
+4. Load `costPolicy`
+5. Load `economyMode`
+6. Store persistent settings in session state
 
-1. READ `.squad/config.json`
-2. CHECK for `defaultModel` field — if present, this is the Layer 0 override for all spawns
-3. CHECK for `agentModelOverrides` field — if present, these are per-agent Layer 0a overrides
-4. STORE both values in session context for the duration
-
-### On Every Agent Spawn
-
-1. CHECK Layer 0a: Is there an `agentModelOverrides.{agentName}` in config.json? → Use it.
-2. CHECK Layer 0b: Is there a `defaultModel` in config.json? → Use it.
-3. CHECK Layer 1: Did the user give a session directive? → Use it.
-4. CHECK Layer 2: Does the agent's charter have a `## Model` section? → Use it.
-5. CHECK Layer 3: Determine task type:
-   - Code (implementation, tests, refactoring, bug fixes) → `claude-sonnet-4.6`
-   - Prompts, agent designs → `claude-sonnet-4.6`
-   - Visual/design with image analysis → `claude-opus-4.6`
-   - Non-code (docs, planning, triage, changelogs) → `claude-haiku-4.5`
-6. FALLBACK Layer 4: `claude-haiku-4.5`
-7. INCLUDE model in spawn acknowledgment: `🔧 {Name} ({resolved_model}) — {task}`
-
-### When User Sets a Preference
-
-**Trigger phrases:** "always use X", "use X for everything", "switch to X", "default to X"
-
-1. VALIDATE the model ID against the catalog (18+ models)
-2. WRITE `defaultModel` to `.squad/config.json` (merge, don't overwrite)
-3. ACKNOWLEDGE: `✅ Model preference saved: {model} — all future sessions will use this until changed.`
-
-**Per-agent trigger:** "use X for {agent}"
-
-1. VALIDATE model ID
-2. WRITE to `agentModelOverrides.{agent}` in `.squad/config.json`
-3. ACKNOWLEDGE: `✅ {Agent} will always use {model} — saved to config.`
-
-### When User Clears a Preference
-
-**Trigger phrases:** "switch back to automatic", "clear model preference", "use default models"
-
-1. REMOVE `defaultModel` from `.squad/config.json`
-2. ACKNOWLEDGE: `✅ Model preference cleared — returning to automatic selection.`
-
-### STOP
-
-After resolving the model and including it in the spawn template, this skill is done. Do NOT:
-- Generate model comparison reports
-- Run benchmarks or speed tests
-- Create new config files (only modify existing `.squad/config.json`)
-- Change the model after spawn (fallback chains handle runtime failures)
-
-## Config Schema
-
-`.squad/config.json` model-related fields:
-
-```json
-{
-  "version": 1,
-  "defaultModel": "claude-opus-4.6",
-  "agentModelOverrides": {
-    "fenster": "claude-sonnet-4.6",
-    "mcmanus": "claude-haiku-4.5"
-  }
-}
-```
-
-- `defaultModel` — applies to ALL agents unless overridden by `agentModelOverrides`
-- `agentModelOverrides` — per-agent overrides that take priority over `defaultModel`
-- Both fields are optional. When absent, Layers 1-4 apply normally.
-
-## Fallback Chains
-
-If a model is unavailable (rate limit, plan restriction), retry within the same tier:
-
-```
-Premium:  claude-opus-4.6 → claude-opus-4.6-fast → claude-opus-4.5 → claude-sonnet-4.6
-Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → claude-sonnet-4
-Fast:     claude-haiku-4.5 → gpt-5.1-codex-mini → gpt-4.1 → gpt-5-mini
-```
-
-**Never fall UP in tier.** A fast task won't land on a premium model via fallback.
+## Cost Policy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.9.1",
+  "version": "0.9.1-build.4",
   "private": true,
   "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.9.1",
+  "version": "0.9.1-build.4",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {

--- a/packages/squad-cli/templates/skills/model-selection/SKILL.md
+++ b/packages/squad-cli/templates/skills/model-selection/SKILL.md
@@ -1,125 +1,57 @@
 ---
 name: "model-selection"
-description: "Determines which LLM model to use for each agent spawn"
+description: "Resolves agent models using layer priority, cost policy, and ceiling-aware fallbacks"
 domain: "orchestration"
-confidence: "medium"
-source: "extracted"
+confidence: "high"
+source: "manual"
 ---
 
 # Model Selection
 
-> Determines which LLM model to use for each agent spawn.
-
 ## SCOPE
 
 ✅ THIS SKILL PRODUCES:
-- A resolved `model` parameter for every `task` tool call
+- A resolved `model` for every agent spawn
 - Persistent model preferences in `.squad/config.json`
-- Spawn acknowledgments that include the resolved model
+- Persistent or session cost-policy state
+- Spawn acknowledgments that show when included/economy/policy behavior changed the routing
 
 ❌ THIS SKILL DOES NOT PRODUCE:
-- Code, tests, or documentation
-- Model performance benchmarks
-- Cost reports or billing artifacts
+- Cost reports or billing analytics
+- Benchmarking or model evals
+- New model IDs not exposed by the current Copilot surface
 
 ## Context
 
-Squad supports 18+ models across three tiers (premium, standard, fast). The coordinator must select the right model for each agent spawn. Users can set persistent preferences that survive across sessions.
+Squad resolves models in two phases:
+1. **Preference resolution** via the 5-layer hierarchy
+2. **Policy enforcement** via `costPolicy`, `preferIncluded`, `economyMode`, and ceiling-aware fallback
 
-## 5-Layer Model Resolution Hierarchy
+Use GitHub's category names:
+- **Lightweight**
+- **Versatile**
+- **Powerful**
 
-Resolution is **first-match-wins** — the highest layer with a value wins.
+## 5-Layer Resolution Hierarchy
 
-| Layer | Name | Source | Persistence |
-|-------|------|--------|-------------|
-| **0a** | Per-Agent Config | `.squad/config.json` → `agentModelOverrides.{name}` | Persistent (survives sessions) |
-| **0b** | Global Config | `.squad/config.json` → `defaultModel` | Persistent (survives sessions) |
-| **1** | Session Directive | User said "use X" in current session | Session-only |
-| **2** | Charter Preference | Agent's `charter.md` → `## Model` section | Persistent (in charter) |
-| **3** | Task-Aware Auto | Code → sonnet, docs → haiku, visual → opus | Computed per-spawn |
-| **4** | Default | `claude-haiku-4.5` | Hardcoded fallback |
+| Layer | Name | Source | Behavior |
+|---|---|---|---|
+| 0a | Per-Agent Config | `.squad/config.json` → `agentModelOverrides.{name}` | Explicit persistent override |
+| 0b | Global Config | `.squad/config.json` → `defaultModel` | Explicit persistent override |
+| 1 | Session Directive | current conversation | Explicit session override |
+| 2 | Charter Preference | agent charter `## Model` | Non-user default preference |
+| 3 | Task-Aware Auto | task type | Computed default |
+| 4 | Default | hardcoded | Final fallback |
 
-**Key principle:** Layer 0 (persistent config) beats everything. If the user said "always use opus" and it was saved to config.json, every agent gets opus regardless of role or task type. This is intentional — the user explicitly chose quality over cost.
+**Important:** `costPolicy` is **not** a layer. Apply it after a model is resolved.
 
-## AGENT WORKFLOW
+## Session start workflow
 
-### On Session Start
+1. Read `.squad/config.json`
+2. Load `defaultModel`
+3. Load `agentModelOverrides`
+4. Load `costPolicy`
+5. Load `economyMode`
+6. Store persistent settings in session state
 
-1. READ `.squad/config.json`
-2. CHECK for `defaultModel` field — if present, this is the Layer 0 override for all spawns
-3. CHECK for `agentModelOverrides` field — if present, these are per-agent Layer 0a overrides
-4. STORE both values in session context for the duration
-
-### On Every Agent Spawn
-
-1. CHECK Layer 0a: Is there an `agentModelOverrides.{agentName}` in config.json? → Use it.
-2. CHECK Layer 0b: Is there a `defaultModel` in config.json? → Use it.
-3. CHECK Layer 1: Did the user give a session directive? → Use it.
-4. CHECK Layer 2: Does the agent's charter have a `## Model` section? → Use it.
-5. CHECK Layer 3: Determine task type:
-   - Code (implementation, tests, refactoring, bug fixes) → `claude-sonnet-4.6`
-   - Prompts, agent designs → `claude-sonnet-4.6`
-   - Visual/design with image analysis → `claude-opus-4.6`
-   - Non-code (docs, planning, triage, changelogs) → `claude-haiku-4.5`
-6. FALLBACK Layer 4: `claude-haiku-4.5`
-7. INCLUDE model in spawn acknowledgment: `🔧 {Name} ({resolved_model}) — {task}`
-
-### When User Sets a Preference
-
-**Trigger phrases:** "always use X", "use X for everything", "switch to X", "default to X"
-
-1. VALIDATE the model ID against the catalog (18+ models)
-2. WRITE `defaultModel` to `.squad/config.json` (merge, don't overwrite)
-3. ACKNOWLEDGE: `✅ Model preference saved: {model} — all future sessions will use this until changed.`
-
-**Per-agent trigger:** "use X for {agent}"
-
-1. VALIDATE model ID
-2. WRITE to `agentModelOverrides.{agent}` in `.squad/config.json`
-3. ACKNOWLEDGE: `✅ {Agent} will always use {model} — saved to config.`
-
-### When User Clears a Preference
-
-**Trigger phrases:** "switch back to automatic", "clear model preference", "use default models"
-
-1. REMOVE `defaultModel` from `.squad/config.json`
-2. ACKNOWLEDGE: `✅ Model preference cleared — returning to automatic selection.`
-
-### STOP
-
-After resolving the model and including it in the spawn template, this skill is done. Do NOT:
-- Generate model comparison reports
-- Run benchmarks or speed tests
-- Create new config files (only modify existing `.squad/config.json`)
-- Change the model after spawn (fallback chains handle runtime failures)
-
-## Config Schema
-
-`.squad/config.json` model-related fields:
-
-```json
-{
-  "version": 1,
-  "defaultModel": "claude-opus-4.6",
-  "agentModelOverrides": {
-    "fenster": "claude-sonnet-4.6",
-    "mcmanus": "claude-haiku-4.5"
-  }
-}
-```
-
-- `defaultModel` — applies to ALL agents unless overridden by `agentModelOverrides`
-- `agentModelOverrides` — per-agent overrides that take priority over `defaultModel`
-- Both fields are optional. When absent, Layers 1-4 apply normally.
-
-## Fallback Chains
-
-If a model is unavailable (rate limit, plan restriction), retry within the same tier:
-
-```
-Premium:  claude-opus-4.6 → claude-opus-4.6-fast → claude-opus-4.5 → claude-sonnet-4.6
-Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → claude-sonnet-4
-Fast:     claude-haiku-4.5 → gpt-5.1-codex-mini → gpt-4.1 → gpt-5-mini
-```
-
-**Never fall UP in tier.** A fast task won't land on a premium model via fallback.
+## Cost Policy

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -364,103 +364,232 @@ For read-only queries, use the explore agent: `agent_type: "explore"` with `"You
 
 ### Per-Agent Model Selection
 
-Before spawning an agent, determine which model to use. Check these layers in order — first match wins:
+Before spawning an agent, resolve a model in **two phases**:
 
-**Layer 0 — Persistent Config (`.squad/config.json`):** On session start, read `.squad/config.json`. If `agentModelOverrides.{agentName}` exists, use that model for this specific agent. Otherwise, if `defaultModel` exists, use it for ALL agents. This layer survives across sessions — the user set it once and it sticks.
+1. **Resolve intent** with the existing 5-layer hierarchy.
+2. **Apply policy veto** (`costPolicy`) and soft modifiers (`economyMode`) before spawning.
 
-- **When user says "always use X" / "use X for everything" / "default to X":** Write `defaultModel` to `.squad/config.json`. Acknowledge: `✅ Model preference saved: {model} — all future sessions will use this until changed.`
-- **When user says "use X for {agent}":** Write to `agentModelOverrides.{agent}` in `.squad/config.json`. Acknowledge: `✅ {Agent} will always use {model} — saved to config.`
-- **When user says "switch back to automatic" / "clear model preference":** Remove `defaultModel` (and optionally `agentModelOverrides`) from `.squad/config.json`. Acknowledge: `✅ Model preference cleared — returning to automatic selection.`
+The 5 layers stay intact:
 
-**Layer 1 — Session Directive:** Did the user specify a model for this session? ("use opus for this session", "save costs"). If yes, use that model. Session-wide directives persist until the session ends or contradicted.
+- **Layer 0a — Persistent Per-Agent Config:** `.squad/config.json` → `agentModelOverrides.{agentName}`
+- **Layer 0b — Persistent Global Config:** `.squad/config.json` → `defaultModel`
+- **Layer 1 — Session Directive:** explicit session phrases like "use opus for this session"
+- **Layer 2 — Charter Preference:** agent charter `## Model` section when not `auto`
+- **Layer 3 — Task-Aware Auto-Selection:** choose by task output
+- **Layer 4 — Default:** final hardcoded fallback
 
-**Layer 2 — Charter Preference:** Does the agent's charter have a `## Model` section with `Preferred` set to a specific model (not `auto`)? If yes, use that model.
+#### Policy Veto Step (apply AFTER Layer 4 resolution)
 
-**Layer 3 — Task-Aware Auto-Selection:** Use the governing principle: **cost first, unless code is being written.** Match the agent's task to determine output type, then select accordingly:
+After a model is resolved, check `costPolicy`.
 
-| Task Output | Model | Tier | Rule |
-|-------------|-------|------|------|
-| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
-| Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
-| NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.5` | Premium | Vision capability required. Overrides cost rule. |
+**Important:** `costPolicy` is **not Layer 0/1/2/3/4**. It is a policy check applied **after** layer resolution and **before** fallback execution.
 
-**Role-to-model mapping** (applying cost-first principle):
+Policy algorithm:
 
-| Role | Default Model | Why | Override When |
-|------|--------------|-----|---------------|
-| Core Dev / Backend / Frontend | `claude-sonnet-4.6` | Writes code — quality first | Heavy code gen → `gpt-5.3-codex` |
-| Tester / QA | `claude-sonnet-4.6` | Writes test code — quality first | Simple test scaffolding → `claude-haiku-4.5` |
-| Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
-| Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
-| Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.5` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
-| DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
-| Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
-| Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
+1. Read persistent `costPolicy` from `.squad/config.json`.
+2. Merge any **session-only cost directives** from the conversation on top of it.
+3. Determine the resolved model's category: **Lightweight**, **Versatile**, or **Powerful**.
+4. If the resolved model is **within** the ceiling, continue.
+5. If the resolved model is **above** the ceiling:
+   - **Layer 0 / Layer 1 explicit user override:** **warn and allow**.
+   - **Layer 2 / Layer 3 / Layer 4 choice:** reroute to the best in-ceiling model for that task.
+6. After ceiling enforcement, apply `economyMode` as a **soft cheaper-within-ceiling preference**.
+7. If `preferIncluded: true`, rank **included** models ahead of paid models when they can handle the task.
+8. Run the fallback chain, but **drop any fallback candidates above the active ceiling** unless the original selection came from an explicit Layer 0/1 override.
 
-**Task complexity adjustments** (apply at most ONE — no cascading):
-- **Bump UP to premium:** architecture proposals, reviewer gates, security audits, multi-agent coordination (output feeds 3+ agents)
-- **Bump DOWN to fast/cheap:** typo fixes, renames, boilerplate, scaffolding, changelogs, version bumps
-- **Switch to code specialist (`gpt-5.3-codex`):** large multi-file refactors, complex implementation from spec, heavy code generation (500+ lines)
-- **Switch to analytical diversity (`gemini-3-pro-preview`):** code reviews where a second perspective helps, security reviews, architecture reviews after a rejection
+**Warning copy for explicit override above ceiling:**
 
-**Layer 4 — Default:** If nothing else matched, use `claude-haiku-4.5`. Cost wins when in doubt, unless code is being produced.
-
-**Fallback chains — when a model is unavailable:**
-
-If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
-
-```
-Premium:  claude-opus-4.6 → claude-opus-4.5 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4 → (omit model param)
-Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5.1-codex-mini → gpt-4.1 → (omit model param)
+```text
+⚠️ {model} is above the current cost policy ceiling ({maxCategory}), but it was explicitly requested, so I’m using it.
 ```
 
-`(omit model param)` = call the `task` tool WITHOUT the `model` parameter. The platform uses its built-in default. This is the nuclear fallback — it always works.
+Warn once per explicit request. Do not repeatedly nag on every fallback retry.
 
-**Fallback rules:**
-- If the user specified a provider ("use Claude"), fall back within that provider only before hitting nuclear
-- Never fall back UP in tier — a fast/cheap task should not land on a premium model
-- Log fallbacks to the orchestration log for debugging, but never surface to the user unless asked
+---
 
-**Passing the model to spawns:**
+## Valid Models (GitHub AI Credits catalog used by Squad)
 
-Pass the resolved model as the `model` parameter on every `task` tool call:
+Use GitHub's category names and pricing language. List the **active Squad selection set** first — i.e. the model IDs Squad should actively choose today on Copilot surfaces that expose the current task-model list.
 
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-name: "{name}"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  ...
-```
+### Lightweight
 
-Only set `model` when it differs from the platform default (`claude-sonnet-4.6`). If the resolved model IS `claude-sonnet-4.6`, you MAY omit the `model` parameter — the platform uses it as default.
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `gpt-5-mini` | **Yes** | 0 / 0 | Zero-credit lightweight default when `preferIncluded: true` or economy is aggressive. |
+| `gpt-5.4-mini` | No | 0.75 / 4.50 | Cheap lightweight fallback. |
+| `claude-haiku-4.5` | No | 1.00 / 5.00 | Best default lightweight paid model for non-code and mechanical work. |
 
-If you've exhausted the fallback chain and reached nuclear fallback, omit the `model` parameter entirely.
+### Versatile
 
-**Spawn output format — show the model choice:**
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `gpt-4.1` | **Yes** | 0 / 0 | Zero-credit structured/tool-use preference when `preferIncluded: true` or economy mode is active. |
+| `claude-sonnet-4.6` | No | 3.00 / 15.00 | Primary default for code, prompt architecture, and high-quality structured output. |
+| `claude-sonnet-4.5` | No | 3.00 / 15.00 | First same-family fallback. |
+| `claude-sonnet-4` | No | 3.00 / 15.00 | Older versatile fallback. |
+| `gpt-5.4` | No | 2.50 / 15.00 | Strong versatile alternative. |
+| `gpt-5.3-codex` | No | 1.75 / 14.00 | Best code-specialist alternate for large implementation bursts. |
+| `gpt-5.2-codex` | No | 1.75 / 14.00 | Secondary code-specialist alternate. |
+| `gpt-5.2` | No | 1.75 / 14.00 | General versatile alternate. |
 
-When spawning, include the model in your acknowledgment:
+### Powerful
 
-```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.5 · vision) — designing color system
-📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
-📝 McManus (claude-haiku-4.5 · fast) — updating docs
-```
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `claude-opus-4.7` | No | 5.00 / 25.00 | Best default for architecture, review gates, and vision-heavy work. |
+| `claude-opus-4.6` | No | 5.00 / 25.00 | Same-family fallback. |
+| `claude-opus-4.5` | No | 5.00 / 25.00 | Stable older fallback. |
+| `gpt-5.5` | No | 5.00 / 30.00 | Powerful cross-provider alternate. |
 
-Include tier annotation only when the model was bumped or a specialist was chosen. Default-tier spawns just show the model name.
+**Catalog note:** GitHub's broader catalog also includes additional lightweight/versatile/powerful models such as `gemini-3.1-pro`. Treat those as catalog context only unless the active Copilot surface exposes them for selection. Do **not** make Squad actively select IDs that are not exposed by the current Copilot surface. If a new surface exposes more catalog models later, slot them into the same category semantics rather than inventing new tiers.
 
 **Valid models (current platform catalog):**
 
-Premium: `claude-opus-4.6`, `claude-opus-4.6-1m` (Internal only), `claude-opus-4.5`
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gemini-3-pro-preview`
-Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5.1-codex-mini`, `gpt-5-mini`, `gpt-4.1`
+Powerful: `claude-opus-4.7`, `claude-opus-4.6`, `claude-opus-4.5`, `gpt-5.5`
+Versatile: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-4.1` (included)
+Lightweight: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini` (included)
+
+---
+
+## Updated Layer 3 defaults
+
+Keep the principle: **cost first, unless code or prompt logic is being produced**.
+
+| Task Output | Default Model | Category | Why |
+|---|---|---|---|
+| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Versatile | Best default quality/cost balance for production code. |
+| Writing prompts, agent designs, routing logic, structured system text | `claude-sonnet-4.6` | Versatile | Prompt architecture behaves like code. |
+| Docs, planning, triage, changelogs, logging, mechanical ops | `claude-haiku-4.5` | Lightweight | Cheap default when no stronger policy preference is active. |
+| Visual/design work or image-heavy judgment | `claude-opus-4.7` | Powerful | Highest-stakes reasoning / best vision-capable default. |
+
+**Layer 4 default:** `claude-haiku-4.5`
+
+---
+
+## Updated role-to-model mapping
+
+| Role | Normal Default | Category | Prefer-Included Route | Override When |
+|---|---|---|---|---|
+| Core Dev / Backend / Frontend / TypeScript Engineer | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Heavy code generation or refactor burst → `gpt-5.3-codex` |
+| Tester / QA / E2E | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Simple scaffolding / assertions / fixture churn → `claude-haiku-4.5` or `gpt-5-mini` |
+| Lead / Architect / Security reviewer | auto by task | Powerful or Versatile | `gpt-4.1` only for low-stakes advisory analysis | Architecture proposals / reviewer gates / security signoff → `claude-opus-4.7` |
+| Prompt Engineer | auto by task | Versatile or Lightweight | `gpt-4.1` for structured prompt rewrites; `gpt-5-mini` for cheap synthesis | Prompt architecture / coordinator logic → `claude-sonnet-4.6` |
+| Copilot SDK Expert | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Pure research / inventory / API comparison → `claude-haiku-4.5` |
+| Designer / Visual | `claude-opus-4.7` | Powerful | none by default | If policy ceiling blocks Powerful, downgrade to `claude-sonnet-4.6` and note reduced confidence for visual judgment |
+| DevRel / Writer | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` (or `gpt-4.1` if heavy tool use) | Structured transformation or tool-rich writing workflow → `gpt-4.1` |
+| Scribe / Logger | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` | Never auto-bump above Lightweight unless explicitly requested |
+| Git / Release / Mechanical ops | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` | Never auto-bump above Lightweight unless explicitly requested |
+
+**Design read:** defaults stay Sonnet/Haiku for normal mode. `preferIncluded` and `economyMode` are what pull routing toward `gpt-4.1` / `gpt-5-mini`.
+
+---
+
+## Cost Policy
+
+Add a new subsection directly under model selection.
+
+### Config shape
+
+```json
+{
+  "costPolicy": {
+    "maxCategory": "Versatile",
+    "preferIncluded": true
+  }
+}
+```
+
+- `maxCategory`: `Lightweight` | `Versatile` | `Powerful`
+- `preferIncluded`: when `true`, prefer zero-credit models (`gpt-4.1`, `gpt-5-mini`) where they are acceptable for the task
+- Default if missing: `{ "maxCategory": "Powerful", "preferIncluded": false }`
+
+### What it means
+
+- **`maxCategory` is a hard ceiling** for auto-routing and charter-driven choices.
+- Lower categories are always allowed.
+- **`economyMode` is different:** it is a **soft cheaper-within-ceiling preference**.
+- **`preferIncluded` is also different:** it re-ranks zero-credit models first, but still respects the ceiling and task fit.
+
+### Conversation phrases
+
+Treat conversational cost policy as **session-only** unless the user says `always`, `save`, `remember`, or otherwise asks to persist it.
+
+| User phrase | Session action |
+|---|---|
+| "keep costs low" / "use cheap models" / "Lightweight only" | set `maxCategory: "Lightweight"` |
+| "no powerful models" / "cap at versatile" | set `maxCategory: "Versatile"` |
+| "prefer included models" / "save credits" / "use zero-cost models when you can" | set `preferIncluded: true` |
+| "use normal costing again" / "remove the ceiling" | clear session cost policy override |
+
+Persistent forms:
+
+- "always keep costs low" → write `costPolicy.maxCategory = "Lightweight"`
+- "always cap at versatile" → write `costPolicy.maxCategory = "Versatile"`
+- "always prefer included models" → write `costPolicy.preferIncluded = true`
+
+### Composition with `economyMode`
+
+Apply in this order:
+
+1. Resolve the model from Layers 0-4.
+2. Enforce `costPolicy.maxCategory`.
+3. Apply `preferIncluded` ranking.
+4. Apply `economyMode` as a soft cheaper-within-ceiling substitution.
+5. Execute the ceiling-aware fallback chain.
+
+Examples:
+
+- **No cost policy + economy off:** code task → `claude-sonnet-4.6`
+- **`maxCategory: "Versatile"` + economy off:** code task still → `claude-sonnet-4.6`
+- **`maxCategory: "Versatile"` + economy on:** code task can downshift to `gpt-4.1`
+- **`maxCategory: "Lightweight"` + economy off:** code task is capped to a Lightweight model, defaulting to `claude-haiku-4.5`
+- **`maxCategory: "Lightweight"` + `preferIncluded: true`:** code/docs/mechanical work should prefer `gpt-5-mini`
+
+### Explicit override rule
+
+If the user explicitly chooses a model at Layer 0 or Layer 1 and that model exceeds the ceiling, **warn and allow**. Do **not** silently replace an explicit override.
+
+If the chosen model came from Layer 2, Layer 3, or Layer 4 and exceeds the ceiling, **replace it with the best allowed model**.
+
+---
+
+## Updated fallback chains
+
+Rename the chains to GitHub's categories and make them ceiling-aware.
+
+```text
+Powerful:          claude-opus-4.7 → claude-opus-4.6 → claude-opus-4.5 → gpt-5.5 → claude-sonnet-4.6 → (omit model param)
+Versatile (code):  claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.3-codex → gpt-5.2-codex → gpt-5.4 → claude-sonnet-4 → gpt-4.1 → (omit model param)
+Versatile (general): claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-4.1 → gpt-5.4 → gpt-5.2 → claude-sonnet-4 → (omit model param)
+Lightweight:       claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
+Lightweight (preferIncluded): gpt-5-mini → gpt-5.4-mini → claude-haiku-4.5 → (omit model param)
+```
+
+Fallback rules:
+
+- Never fall back **above the active `maxCategory` ceiling**.
+- If the user specified a provider (`Claude`, `GPT`), exhaust same-provider choices first.
+- If `preferIncluded: true`, start with the included-first chain when available.
+- Use `(omit model param)` as the nuclear fallback.
+- Do not narrate fallback attempts unless the user explicitly asks.
+
+---
+
+## Spawn acknowledgment additions
+
+Keep the current model display, but add policy/economy tags only when they matter.
+
+Examples:
+
+```text
+🔧 EECOM (claude-sonnet-4.6) — implementing router changes
+🧠 Procedures (gpt-4.1 · included) — rewriting prompt policy
+📋 Scribe (gpt-5-mini · lightweight · included) — logging session
+⚠️ Flight (claude-opus-4.7 · above cost ceiling by explicit override) — reviewing architecture
+💰 CONTROL (gpt-4.1 · economy) — planning refactor
+```
+
+---
 
 ### Client Compatibility
 

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.9.1",
+  "version": "0.9.1-build.4",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/squad-sdk/src/agents/index.ts
+++ b/packages/squad-sdk/src/agents/index.ts
@@ -32,6 +32,8 @@ export {
 // --- M1-9 Model Selection + M3-5 Model Fallback ---
 export { 
   resolveModel,
+  buildEffectiveCostPolicy,
+  finalizeResolvedModel,
   inferTierFromModel,
   isTierFallbackAllowed,
   ModelFallbackExecutor,

--- a/packages/squad-sdk/src/agents/model-selector.ts
+++ b/packages/squad-sdk/src/agents/model-selector.ts
@@ -3,8 +3,29 @@
  */
 
 import { MODELS } from '../runtime/constants.js';
-import { applyEconomyMode } from '../config/models.js';
+import {
+  MODEL_CATALOG,
+  applyEconomyMode,
+  type CostPolicyConfig,
+  type CostPolicyOutcome,
+  type GitHubModelCategory,
+  type ModelInfo,
+  type ModelPreferenceConfig,
+  type SessionCostPolicyOverride,
+} from '../config/models.js';
 import type { EventBus } from '../runtime/event-bus.js';
+
+const MODEL_CATALOG_MAP = new Map<string, ModelInfo>(MODEL_CATALOG.map(model => [model.id, model]));
+const CATEGORY_ORDER: Record<GitHubModelCategory, number> = {
+  lightweight: 0,
+  versatile: 1,
+  powerful: 2,
+};
+const CHEAPER_TIERS: Record<ModelTier, ModelTier[]> = {
+  premium: ['standard', 'fast'],
+  standard: ['fast'],
+  fast: [],
+};
 
 /**
  * Task types that influence model selection.
@@ -17,9 +38,25 @@ export type TaskType = 'code' | 'prompt' | 'docs' | 'visual' | 'planning' | 'mec
 export type ModelTier = 'premium' | 'standard' | 'fast';
 
 /**
+ * Narrow shape for persistent local model preferences.
+ */
+export interface SquadLocalConfig {
+  models?: ModelPreferenceConfig;
+}
+
+/**
  * Source of the model resolution.
  */
-export type ModelResolutionSource = 'user-override' | 'charter' | 'task-auto' | 'default';
+export type ModelResolutionSource =
+  | 'persistent-agent-override'
+  | 'persistent-default'
+  | 'session-explicit'
+  | 'user-override'
+  | 'charter'
+  | 'task-auto'
+  | 'default';
+
+interface BaseModelSelection extends ResolvedModel {}
 
 /**
  * Options for model resolution.
@@ -27,11 +64,17 @@ export type ModelResolutionSource = 'user-override' | 'charter' | 'task-auto' | 
 export interface ModelResolutionOptions {
   /** User-specified model override */
   userOverride?: string;
+  /** Structured session explicit model override */
+  sessionExplicitModel?: string;
   /** Model preference from agent's charter (## Model section) */
   charterPreference?: string;
+  /** Persistent local config for model preferences */
+  config?: SquadLocalConfig;
+  /** Session-scoped cost policy override */
+  sessionCostPolicy?: SessionCostPolicyOverride;
   /** Type of task being performed */
   taskType: TaskType;
-  /** Agent role (for context) */
+  /** Agent role (used for per-agent persistent overrides) */
   agentRole?: string;
   /** When true, apply economy mode substitution at Layer 3/4 */
   economyMode?: boolean;
@@ -49,37 +92,48 @@ export interface ResolvedModel {
   source: ModelResolutionSource;
   /** Fallback chain for this tier */
   fallbackChain: string[];
+  /** Cost policy outcome, when policy evaluation ran */
+  policy?: CostPolicyOutcome;
 }
 
 /**
- * Resolve the appropriate model using the 4-layer priority system.
- * 
+ * Resolve the appropriate model using the layered selector, then apply cost policy.
+ *
  * @param options - Model resolution options
- * @returns Resolved model with tier and fallback chain
+ * @returns Resolved model with tier, source, fallback chain, and policy outcome
  */
 export function resolveModel(options: ModelResolutionOptions): ResolvedModel {
-  const { userOverride, charterPreference, taskType, economyMode } = options;
+  const base = resolveBaseModel(options);
+  const policy = buildEffectiveCostPolicy(options.config ?? {}, options.sessionCostPolicy);
+  return finalizeResolvedModel(base, policy, MODEL_CATALOG_MAP);
+}
 
-  // Layer 1: User Override (explicit — economy does not apply)
-  if (userOverride && userOverride.trim().length > 0) {
-    const tier = inferTierFromModel(userOverride);
-    return {
-      model: userOverride,
-      tier,
-      source: 'user-override',
-      fallbackChain: [...MODELS.FALLBACK_CHAINS[tier]],
-    };
+function resolveBaseModel(options: ModelResolutionOptions): BaseModelSelection {
+  const { userOverride, sessionExplicitModel, charterPreference, taskType, economyMode, config, agentRole } = options;
+
+  const persistentAgentOverride = agentRole ? config?.models?.agentModelOverrides?.[agentRole] : undefined;
+  if (persistentAgentOverride && persistentAgentOverride.trim().length > 0) {
+    return createResolvedModel(persistentAgentOverride, 'persistent-agent-override');
   }
 
-  // Layer 2: Charter Preference (explicit — economy does not apply)
+  const persistentDefault = config?.models?.defaultModel;
+  if (persistentDefault && persistentDefault.trim().length > 0) {
+    return createResolvedModel(persistentDefault, 'persistent-default');
+  }
+
+  // Layer 1: Session explicit override (explicit — economy does not apply)
+  if (sessionExplicitModel && sessionExplicitModel.trim().length > 0) {
+    return createResolvedModel(sessionExplicitModel, 'session-explicit');
+  }
+
+  // Layer 1b: User override (explicit — economy does not apply)
+  if (userOverride && userOverride.trim().length > 0) {
+    return createResolvedModel(userOverride, 'user-override');
+  }
+
+  // Layer 2: Charter Preference (economy does not apply)
   if (charterPreference && charterPreference.trim().length > 0 && charterPreference !== 'auto') {
-    const tier = inferTierFromModel(charterPreference);
-    return {
-      model: charterPreference,
-      tier,
-      source: 'charter',
-      fallbackChain: [...MODELS.FALLBACK_CHAINS[tier]],
-    };
+    return createResolvedModel(charterPreference, 'charter');
   }
 
   // Layer 3: Task-Aware Auto-Selection (economy mode applies)
@@ -92,23 +146,138 @@ export function resolveModel(options: ModelResolutionOptions): ResolvedModel {
   const defaultModel = economyMode
     ? applyEconomyMode(MODELS.SELECTOR_DEFAULT)
     : MODELS.SELECTOR_DEFAULT;
-  const defaultTier = inferTierFromModel(defaultModel);
-  return {
-    model: defaultModel,
-    tier: defaultTier,
-    source: 'default',
-    fallbackChain: [...MODELS.FALLBACK_CHAINS[defaultTier]],
+  return createResolvedModel(defaultModel, 'default');
+}
+
+export function buildEffectiveCostPolicy(
+  config: SquadLocalConfig,
+  sessionPolicy?: SessionCostPolicyOverride,
+): CostPolicyConfig | undefined {
+  const persistentPolicy = config.models?.costPolicy;
+  const maxCategory = sessionPolicy?.maxCategory ?? persistentPolicy?.maxCategory;
+  const preferIncluded = sessionPolicy?.preferIncluded ?? persistentPolicy?.preferIncluded ?? false;
+
+  if (maxCategory === undefined && sessionPolicy?.preferIncluded === undefined && persistentPolicy?.preferIncluded === undefined) {
+    return undefined;
+  }
+
+  return { maxCategory, preferIncluded };
+}
+
+export function finalizeResolvedModel(
+  base: ResolvedModel,
+  policy: CostPolicyConfig | undefined,
+  catalog: Map<string, ModelInfo>,
+): ResolvedModel {
+  if (!policy) {
+    return base;
+  }
+
+  const selectedModel = catalog.get(base.model);
+  if (!selectedModel) {
+    return base;
+  }
+
+  const appliedPolicy: Required<CostPolicyConfig> = {
+    maxCategory: policy.maxCategory ?? 'powerful',
+    preferIncluded: policy.preferIncluded ?? false,
   };
+
+  if (selectedModel.githubCategory === undefined) {
+    return attachPolicy(base, {
+      appliedPolicy,
+      action: 'none',
+      originalModel: base.model,
+      finalModel: base.model,
+    });
+  }
+
+  const explicitSource = isExplicitSource(base.source);
+  const overCeiling = !isWithinCategory(selectedModel.githubCategory, appliedPolicy.maxCategory);
+
+  if (overCeiling && explicitSource) {
+    return attachPolicy(base, {
+      appliedPolicy,
+      action: 'warn-allow-explicit',
+      originalModel: base.model,
+      finalModel: base.model,
+      warning: `⚠️ ${base.model} is above the current cost policy ceiling (${appliedPolicy.maxCategory}), but it was explicitly requested.`,
+    });
+  }
+
+  if (overCeiling) {
+    const replacement = findReplacementModel(base, appliedPolicy, catalog);
+    if (!replacement) {
+      return attachPolicy(base, {
+        appliedPolicy,
+        action: 'none',
+        originalModel: base.model,
+        finalModel: base.model,
+      });
+    }
+
+    return {
+      ...base,
+      model: replacement.id,
+      tier: replacement.tier,
+      fallbackChain: buildPolicyFallbackChain(MODELS.FALLBACK_CHAINS[replacement.tier], appliedPolicy, catalog),
+      policy: {
+        appliedPolicy,
+        action: 'downgraded-to-ceiling',
+        originalModel: base.model,
+        finalModel: replacement.id,
+      },
+    };
+  }
+
+  if (!explicitSource && appliedPolicy.preferIncluded) {
+    const includedModel = findIncludedModelForTier(base.tier, appliedPolicy, catalog, base.model);
+    if (includedModel && includedModel.id !== base.model) {
+      return {
+        ...base,
+        model: includedModel.id,
+        tier: includedModel.tier,
+        fallbackChain: buildPolicyFallbackChain(MODELS.FALLBACK_CHAINS[includedModel.tier], appliedPolicy, catalog),
+        policy: {
+          appliedPolicy,
+          action: 'preferred-included',
+          originalModel: base.model,
+          finalModel: includedModel.id,
+        },
+      };
+    }
+  }
+
+  const prunedFallbackChain = buildPolicyFallbackChain(base.fallbackChain, appliedPolicy, catalog);
+  if (!arraysEqual(base.fallbackChain, prunedFallbackChain)) {
+    return {
+      ...base,
+      fallbackChain: prunedFallbackChain,
+      policy: {
+        appliedPolicy,
+        action: 'fallback-chain-pruned',
+        originalModel: base.model,
+        finalModel: base.model,
+      },
+    };
+  }
+
+  return attachPolicy(base, {
+    appliedPolicy,
+    action: 'none',
+    originalModel: base.model,
+    finalModel: base.model,
+  });
 }
 
 /**
  * Select model based on task type, with optional economy mode substitution.
- * 
+ *
  * @param taskType - Type of task being performed
  * @param economyMode - When true, downgrade model to cheaper alternative
  * @returns Resolved model or undefined if no match
  */
-function selectModelForTask(taskType: TaskType, economyMode?: boolean): ResolvedModel | undefined {
+function selectModelForTask(taskType: TaskType, economyMode?: boolean): BaseModelSelection | undefined {
   let model: string | undefined;
   let tier: ModelTier | undefined;
 
@@ -140,25 +309,181 @@ function selectModelForTask(taskType: TaskType, economyMode?: boolean): Resolved
     tier = inferTierFromModel(model);
   }
 
+  return createResolvedModel(model, 'task-auto', tier);
+}
+
+function createResolvedModel(
+  model: string,
+  source: ModelResolutionSource,
+  tier: ModelTier = inferTierFromModel(model),
+): BaseModelSelection {
   return {
     model,
     tier,
-    source: 'task-auto',
+    source,
     fallbackChain: [...MODELS.FALLBACK_CHAINS[tier]],
   };
 }
 
+function isExplicitSource(source: ModelResolutionSource): boolean {
+  return source === 'persistent-agent-override'
+    || source === 'persistent-default'
+    || source === 'session-explicit'
+    || source === 'user-override';
+}
+
+function isWithinCategory(category: GitHubModelCategory, maxCategory: GitHubModelCategory): boolean {
+  return CATEGORY_ORDER[category] <= CATEGORY_ORDER[maxCategory];
+}
+
+function isPolicyCompliant(model: ModelInfo, policy: Required<CostPolicyConfig>): boolean {
+  if (model.availability !== 'active') {
+    return false;
+  }
+
+  if (model.githubCategory === undefined) {
+    return true;
+  }
+
+  return isWithinCategory(model.githubCategory, policy.maxCategory);
+}
+
+function findReplacementModel(
+  base: ResolvedModel,
+  policy: Required<CostPolicyConfig>,
+  catalog: Map<string, ModelInfo>,
+): ModelInfo | undefined {
+  const sameTierReplacement = selectCandidateFromTier(base.tier, policy, catalog, base.model, policy.preferIncluded);
+  if (sameTierReplacement) {
+    return sameTierReplacement;
+  }
+
+  for (const tier of CHEAPER_TIERS[base.tier]) {
+    const cheaperTierReplacement = selectCandidateFromTier(tier, policy, catalog);
+    if (cheaperTierReplacement) {
+      return cheaperTierReplacement;
+    }
+  }
+
+  return undefined;
+}
+
+function findIncludedModelForTier(
+  tier: ModelTier,
+  policy: Required<CostPolicyConfig>,
+  catalog: Map<string, ModelInfo>,
+  currentModel: string,
+): ModelInfo | undefined {
+  const candidates = getOrderedTierCandidates(tier, catalog, currentModel)
+    .filter(model => model.includedInCopilot === true && isPolicyCompliant(model, policy));
+  return candidates[0];
+}
+
+function selectCandidateFromTier(
+  tier: ModelTier,
+  policy: Required<CostPolicyConfig>,
+  catalog: Map<string, ModelInfo>,
+  currentModel?: string,
+  preferIncluded: boolean = false,
+): ModelInfo | undefined {
+  const candidates = getOrderedTierCandidates(tier, catalog, currentModel)
+    .filter(model => isPolicyCompliant(model, policy));
+
+  if (!preferIncluded) {
+    return candidates[0];
+  }
+
+  return candidates.find(model => model.includedInCopilot === true) ?? candidates[0];
+}
+
+function getOrderedTierCandidates(
+  tier: ModelTier,
+  catalog: Map<string, ModelInfo>,
+  currentModel?: string,
+): ModelInfo[] {
+  const seen = new Set<string>();
+  const orderedIds: string[] = [];
+
+  const add = (modelId: string | undefined): void => {
+    if (!modelId || seen.has(modelId)) {
+      return;
+    }
+
+    const info = catalog.get(modelId);
+    if (!info || info.tier !== tier) {
+      return;
+    }
+
+    seen.add(modelId);
+    orderedIds.push(modelId);
+  };
+
+  add(currentModel);
+  for (const modelId of MODELS.FALLBACK_CHAINS[tier]) {
+    add(modelId);
+  }
+  for (const model of MODEL_CATALOG) {
+    if (model.tier === tier) {
+      add(model.id);
+    }
+  }
+
+  return orderedIds
+    .map(modelId => catalog.get(modelId))
+    .filter((model): model is ModelInfo => model !== undefined);
+}
+
+function buildPolicyFallbackChain(
+  chain: readonly string[],
+  policy: Required<CostPolicyConfig>,
+  catalog: Map<string, ModelInfo>,
+): string[] {
+  const seen = new Set<string>();
+  const filtered: string[] = [];
+
+  for (const modelId of chain) {
+    if (seen.has(modelId)) {
+      continue;
+    }
+
+    const info = catalog.get(modelId);
+    if (info && !isPolicyCompliant(info, policy)) {
+      continue;
+    }
+
+    seen.add(modelId);
+    filtered.push(modelId);
+  }
+
+  return filtered;
+}
+
+function attachPolicy(base: ResolvedModel, outcome: CostPolicyOutcome): ResolvedModel {
+  return {
+    ...base,
+    policy: outcome,
+  };
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
 export function inferTierFromModel(model: string): ModelTier {
   const lowerModel = model.toLowerCase();
-  
+
   if (lowerModel.includes('opus')) {
     return 'premium';
   }
-  
+
   if (lowerModel.includes('haiku') || lowerModel.includes('mini')) {
     return 'fast';
   }
-  
+
   // Default to standard for sonnet, gpt-5.x, etc.
   return 'standard';
 }

--- a/packages/squad-sdk/src/config/models.ts
+++ b/packages/squad-sdk/src/config/models.ts
@@ -22,6 +22,39 @@ export interface ModelPricing {
   outputPerToken: number;
 }
 
+export type GitHubModelCategory = 'lightweight' | 'versatile' | 'powerful';
+
+export interface CostPolicyConfig {
+  /** Hard ceiling for automatic model selection and fallback. */
+  maxCategory?: GitHubModelCategory;
+  /** Prefer zero-credit (included) models when a same-tier compliant candidate exists. */
+  preferIncluded?: boolean;
+}
+
+export interface SessionCostPolicyOverride extends CostPolicyConfig {
+  source: 'conversation' | 'command';
+}
+
+export type CostPolicyAction =
+  | 'none'
+  | 'warn-allow-explicit'
+  | 'downgraded-to-ceiling'
+  | 'preferred-included'
+  | 'fallback-chain-pruned';
+
+export interface CostPolicyOutcome {
+  appliedPolicy?: Required<CostPolicyConfig>;
+  action: CostPolicyAction;
+  originalModel: string;
+  finalModel: string;
+  warning?: string;
+}
+
+const pricePerMillion = (input: number, output: number): ModelPricing => ({
+  inputPerToken: input / 1_000_000,
+  outputPerToken: output / 1_000_000,
+});
+
 /**
  * Model capability information.
  */
@@ -32,11 +65,23 @@ export interface ModelInfo {
   /** Model tier */
   tier: ModelTier;
   
-  /** Provider (anthropic, openai, google) */
-  provider: 'anthropic' | 'openai' | 'google';
+  /** Provider (anthropic, openai, google, github, xai) */
+  provider: 'anthropic' | 'openai' | 'google' | 'github' | 'xai';
   
   /** Model family */
-  family: 'claude' | 'gpt' | 'gemini';
+  family:
+    | 'claude'
+    | 'claude-opus'
+    | 'claude-sonnet'
+    | 'claude-haiku'
+    | 'gpt'
+    | 'gpt-4'
+    | 'gpt-5'
+    | 'gpt-5-codex'
+    | 'gemini'
+    | 'raptor'
+    | 'goldeneye'
+    | 'grok';
   
   /** Supports vision/multimodal input */
   vision?: boolean;
@@ -52,45 +97,116 @@ export interface ModelInfo {
 
   /** Per-token pricing in USD (if known) */
   pricing?: ModelPricing;
+
+  /** GitHub's billing category for this model. */
+  githubCategory?: GitHubModelCategory;
+
+  /** True when GitHub bills this model at zero credits (included in plan). */
+  includedInCopilot?: boolean;
+
+  /** Whether Squad actively auto-selects this model (active) or only allows explicit override (catalog-only) or is no longer valid (deprecated). */
+  availability?: 'active' | 'catalog-only' | 'deprecated';
+
+  /** Canonical replacement model ID when availability is deprecated. */
+  replacementModel?: string;
 }
 
 /**
- * Full model catalog from squad.agent.md.
+ * Full model catalog from the GitHub Copilot model surface.
  */
 export const MODEL_CATALOG: ModelInfo[] = [
   // Premium tier - highest quality, slowest, most expensive
   {
-    id: 'claude-opus-4.6',
+    id: 'claude-opus-4.7',
     tier: 'premium',
     provider: 'anthropic',
-    family: 'claude',
+    family: 'claude-opus',
     vision: true,
     useCases: ['architecture proposals', 'security audits', 'complex design'],
     cost: 10,
     speed: 3,
-    pricing: { inputPerToken: 0.000015, outputPerToken: 0.000075 },
+    pricing: pricePerMillion(5.0, 25.0),
+    githubCategory: 'powerful',
+    includedInCopilot: false,
+    availability: 'active',
   },
   {
-    id: 'claude-opus-4.6-fast',
+    id: 'claude-opus-4.6',
     tier: 'premium',
     provider: 'anthropic',
-    family: 'claude',
+    family: 'claude-opus',
     vision: true,
-    useCases: ['architecture proposals', 'urgent reviews'],
-    cost: 9,
-    speed: 6,
-    pricing: { inputPerToken: 0.000015, outputPerToken: 0.000075 },
+    useCases: ['architecture proposals', 'security audits', 'complex design'],
+    cost: 10,
+    speed: 3,
+    pricing: pricePerMillion(5.0, 25.0),
+    githubCategory: 'powerful',
+    includedInCopilot: false,
+    availability: 'active',
   },
   {
     id: 'claude-opus-4.5',
     tier: 'premium',
     provider: 'anthropic',
-    family: 'claude',
+    family: 'claude-opus',
     vision: true,
     useCases: ['architecture proposals', 'reviewer gates'],
     cost: 9,
     speed: 3,
-    pricing: { inputPerToken: 0.000015, outputPerToken: 0.000075 },
+    pricing: pricePerMillion(5.0, 25.0),
+    githubCategory: 'powerful',
+    includedInCopilot: false,
+    availability: 'active',
+  },
+  {
+    id: 'gpt-5.5',
+    tier: 'premium',
+    provider: 'openai',
+    family: 'gpt-5',
+    useCases: ['complex implementation', 'large codebases', 'analysis'],
+    cost: 9,
+    speed: 5,
+    pricing: pricePerMillion(5.0, 30.0),
+    githubCategory: 'powerful',
+    includedInCopilot: false,
+    availability: 'active',
+  },
+  {
+    id: 'gemini-2.5-pro',
+    tier: 'premium',
+    provider: 'google',
+    family: 'gemini',
+    useCases: ['code reviews', 'second opinion', 'analysis'],
+    pricing: pricePerMillion(1.25, 10.0),
+    githubCategory: 'powerful',
+    includedInCopilot: false,
+    availability: 'catalog-only',
+  },
+  {
+    id: 'goldeneye',
+    tier: 'premium',
+    provider: 'github',
+    family: 'goldeneye',
+    useCases: ['deep analysis', 'large context review'],
+    pricing: pricePerMillion(1.25, 10.0),
+    githubCategory: 'powerful',
+    includedInCopilot: false,
+    availability: 'catalog-only',
+  },
+  {
+    id: 'claude-opus-4.6-fast',
+    tier: 'premium',
+    provider: 'anthropic',
+    family: 'claude-opus',
+    vision: true,
+    useCases: ['architecture proposals', 'urgent reviews'],
+    cost: 9,
+    speed: 6,
+    pricing: pricePerMillion(5.0, 25.0),
+    githubCategory: 'powerful',
+    includedInCopilot: false,
+    availability: 'deprecated',
+    replacementModel: 'claude-opus-4.6',
   },
   
   // Standard tier - balanced quality, speed, cost
@@ -98,113 +214,174 @@ export const MODEL_CATALOG: ModelInfo[] = [
     id: 'claude-sonnet-4.6',
     tier: 'standard',
     provider: 'anthropic',
-    family: 'claude',
+    family: 'claude-sonnet',
     vision: true,
     useCases: ['code generation', 'test writing', 'refactoring', 'prompt engineering'],
     cost: 5,
     speed: 7,
-    pricing: { inputPerToken: 0.000003, outputPerToken: 0.000015 },
+    pricing: pricePerMillion(3.0, 15.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'active',
   },
   {
     id: 'claude-sonnet-4.5',
     tier: 'standard',
     provider: 'anthropic',
-    family: 'claude',
+    family: 'claude-sonnet',
     vision: true,
     useCases: ['code generation', 'test writing', 'refactoring'],
     cost: 5,
     speed: 7,
-    pricing: { inputPerToken: 0.000003, outputPerToken: 0.000015 },
+    pricing: pricePerMillion(3.0, 15.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'active',
   },
   {
     id: 'claude-sonnet-4',
     tier: 'standard',
     provider: 'anthropic',
-    family: 'claude',
+    family: 'claude-sonnet',
     useCases: ['code generation', 'documentation'],
     cost: 4,
     speed: 7,
-    pricing: { inputPerToken: 0.000003, outputPerToken: 0.000015 },
+    pricing: pricePerMillion(3.0, 15.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'active',
   },
   {
     id: 'gpt-5.4',
     tier: 'standard',
     provider: 'openai',
-    family: 'gpt',
+    family: 'gpt-5',
     useCases: ['general purpose', 'code generation', 'analysis'],
     cost: 6,
     speed: 7,
-    pricing: { inputPerToken: 0.000005, outputPerToken: 0.000015 },
+    pricing: pricePerMillion(2.5, 15.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'active',
   },
   {
     id: 'gpt-5.3-codex',
     tier: 'standard',
     provider: 'openai',
-    family: 'gpt',
+    family: 'gpt-5-codex',
     useCases: ['heavy code generation', 'multi-file refactors'],
     cost: 5,
     speed: 6,
-    pricing: { inputPerToken: 0.0000025, outputPerToken: 0.00001 },
+    pricing: pricePerMillion(1.75, 14.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'active',
   },
   {
     id: 'gpt-5.2-codex',
     tier: 'standard',
     provider: 'openai',
-    family: 'gpt',
+    family: 'gpt-5-codex',
     useCases: ['heavy code generation', 'multi-file refactors'],
     cost: 5,
     speed: 6,
-    pricing: { inputPerToken: 0.0000025, outputPerToken: 0.00001 },
+    pricing: pricePerMillion(1.75, 14.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'active',
   },
   {
     id: 'gpt-5.2',
     tier: 'standard',
     provider: 'openai',
-    family: 'gpt',
+    family: 'gpt-5',
     useCases: ['general coding', 'analysis'],
     cost: 5,
     speed: 6,
-    pricing: { inputPerToken: 0.0000025, outputPerToken: 0.00001 },
+    pricing: pricePerMillion(1.75, 14.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'active',
+  },
+  {
+    id: 'gpt-4.1',
+    tier: 'standard',
+    provider: 'openai',
+    family: 'gpt-4',
+    useCases: ['lightweight tasks', 'triage', 'economy fallback'],
+    cost: 2,
+    speed: 9,
+    pricing: pricePerMillion(0, 0),
+    githubCategory: 'versatile',
+    includedInCopilot: true,
+    availability: 'active',
+  },
+  {
+    id: 'gemini-3.1-pro',
+    tier: 'standard',
+    provider: 'google',
+    family: 'gemini',
+    useCases: ['code reviews', 'second opinion', 'diversity'],
+    pricing: pricePerMillion(2.0, 12.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'catalog-only',
   },
   {
     id: 'gpt-5.1-codex-max',
     tier: 'standard',
     provider: 'openai',
-    family: 'gpt',
+    family: 'gpt-5-codex',
     useCases: ['complex implementation', 'large codebases'],
     cost: 6,
     speed: 5,
-    pricing: { inputPerToken: 0.0000025, outputPerToken: 0.00001 },
+    pricing: pricePerMillion(1.75, 14.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'deprecated',
+    replacementModel: 'gpt-5.3-codex',
   },
   {
     id: 'gpt-5.1-codex',
     tier: 'standard',
     provider: 'openai',
-    family: 'gpt',
+    family: 'gpt-5-codex',
     useCases: ['code generation', 'implementation'],
     cost: 5,
     speed: 6,
-    pricing: { inputPerToken: 0.0000025, outputPerToken: 0.00001 },
+    pricing: pricePerMillion(1.75, 14.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'deprecated',
+    replacementModel: 'gpt-5.2-codex',
   },
   {
     id: 'gpt-5.1',
     tier: 'standard',
     provider: 'openai',
-    family: 'gpt',
+    family: 'gpt-5',
     useCases: ['general purpose', 'analysis'],
     cost: 5,
     speed: 6,
-    pricing: { inputPerToken: 0.0000025, outputPerToken: 0.00001 },
+    pricing: pricePerMillion(1.75, 14.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'deprecated',
+    replacementModel: 'gpt-5.2',
   },
   {
     id: 'gpt-5',
     tier: 'standard',
     provider: 'openai',
-    family: 'gpt',
+    family: 'gpt-5',
     useCases: ['general purpose'],
     cost: 5,
     speed: 6,
-    pricing: { inputPerToken: 0.0000025, outputPerToken: 0.00001 },
+    pricing: pricePerMillion(1.75, 14.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'deprecated',
+    replacementModel: 'gpt-5.2',
   },
   {
     id: 'gemini-3-pro-preview',
@@ -214,7 +391,11 @@ export const MODEL_CATALOG: ModelInfo[] = [
     useCases: ['code reviews', 'second opinion', 'diversity'],
     cost: 5,
     speed: 7,
-    pricing: { inputPerToken: 0.00000125, outputPerToken: 0.00001 },
+    pricing: pricePerMillion(2.0, 12.0),
+    githubCategory: 'versatile',
+    includedInCopilot: false,
+    availability: 'deprecated',
+    replacementModel: 'gemini-3.1-pro',
   },
   
   // Fast tier - lowest cost, fastest, good enough quality
@@ -222,51 +403,108 @@ export const MODEL_CATALOG: ModelInfo[] = [
     id: 'claude-haiku-4.5',
     tier: 'fast',
     provider: 'anthropic',
-    family: 'claude',
+    family: 'claude-haiku',
     useCases: ['boilerplate', 'changelogs', 'simple fixes'],
     cost: 2,
     speed: 9,
-    pricing: { inputPerToken: 0.0000008, outputPerToken: 0.000004 },
+    pricing: pricePerMillion(1.0, 5.0),
+    githubCategory: 'lightweight',
+    includedInCopilot: false,
+    availability: 'active',
   },
   {
-    id: 'gpt-5.1-codex-mini',
+    id: 'gpt-5.4-mini',
     tier: 'fast',
     provider: 'openai',
-    family: 'gpt',
-    useCases: ['scaffolding', 'test boilerplate'],
+    family: 'gpt-5',
+    useCases: ['scaffolding', 'test boilerplate', 'fast code tasks'],
     cost: 2,
-    speed: 9,
-    pricing: { inputPerToken: 0.0000003, outputPerToken: 0.0000012 },
+    speed: 8,
+    pricing: pricePerMillion(0.75, 4.5),
+    githubCategory: 'lightweight',
+    includedInCopilot: false,
+    availability: 'active',
   },
   {
     id: 'gpt-5-mini',
     tier: 'fast',
     provider: 'openai',
-    family: 'gpt',
+    family: 'gpt-5',
     useCases: ['typo fixes', 'renames', 'simple tasks'],
     cost: 1,
-    speed: 10,
-    pricing: { inputPerToken: 0.00000015, outputPerToken: 0.0000006 },
+    speed: 5,
+    pricing: pricePerMillion(0, 0),
+    githubCategory: 'lightweight',
+    includedInCopilot: true,
+    availability: 'active',
   },
   {
-    id: 'gpt-4.1',
+    id: 'raptor-mini',
+    tier: 'fast',
+    provider: 'github',
+    family: 'raptor',
+    useCases: ['quick edits', 'lightweight assistance'],
+    pricing: pricePerMillion(0, 0),
+    githubCategory: 'lightweight',
+    includedInCopilot: true,
+    availability: 'catalog-only',
+  },
+  {
+    id: 'gpt-5.4-nano',
     tier: 'fast',
     provider: 'openai',
-    family: 'gpt',
-    useCases: ['lightweight tasks', 'triage'],
+    family: 'gpt-5',
+    useCases: ['ultra-fast edits', 'simple automation'],
+    pricing: pricePerMillion(0.2, 1.25),
+    githubCategory: 'lightweight',
+    includedInCopilot: false,
+    availability: 'catalog-only',
+  },
+  {
+    id: 'gemini-3-flash',
+    tier: 'fast',
+    provider: 'google',
+    family: 'gemini',
+    useCases: ['fast analysis', 'light coding tasks'],
+    pricing: pricePerMillion(0.5, 3.0),
+    githubCategory: 'lightweight',
+    includedInCopilot: false,
+    availability: 'catalog-only',
+  },
+  {
+    id: 'grok-code-fast-1',
+    tier: 'fast',
+    provider: 'xai',
+    family: 'grok',
+    useCases: ['fast code assistance', 'quick iteration'],
+    pricing: pricePerMillion(0.2, 1.5),
+    githubCategory: 'lightweight',
+    includedInCopilot: false,
+    availability: 'catalog-only',
+  },
+  {
+    id: 'gpt-5.1-codex-mini',
+    tier: 'fast',
+    provider: 'openai',
+    family: 'gpt-5-codex',
+    useCases: ['scaffolding', 'test boilerplate'],
     cost: 2,
     speed: 9,
-    pricing: { inputPerToken: 0.0000002, outputPerToken: 0.0000008 },
-  }
+    pricing: pricePerMillion(0.75, 4.5),
+    githubCategory: 'lightweight',
+    includedInCopilot: false,
+    availability: 'deprecated',
+    replacementModel: 'gpt-5.4-mini',
+  },
 ];
 
 /**
  * Default fallback chains per tier from squad.agent.md.
  */
 export const DEFAULT_FALLBACK_CHAINS: Record<ModelTier, ModelId[]> = {
-  premium: ['claude-opus-4.6', 'claude-opus-4.6-fast', 'claude-opus-4.5', 'claude-sonnet-4.6'],
-  standard: ['claude-sonnet-4.6', 'gpt-5.4', 'claude-sonnet-4.5', 'gpt-5.3-codex', 'claude-sonnet-4', 'gpt-5.2'],
-  fast: ['claude-haiku-4.5', 'gpt-5.1-codex-mini', 'gpt-4.1', 'gpt-5-mini']
+  premium: ['claude-opus-4.7', 'claude-opus-4.6', 'claude-opus-4.5', 'gpt-5.5', 'claude-sonnet-4.6'],
+  standard: ['claude-sonnet-4.6', 'claude-sonnet-4.5', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.4', 'claude-sonnet-4', 'gpt-4.1'],
+  fast: ['claude-haiku-4.5', 'gpt-5.4-mini', 'gpt-5-mini', 'gpt-4.1']
 };
 
 /**
@@ -523,14 +761,16 @@ export function estimateCost(model: string, inputTokens: number, outputTokens: n
  */
 export const ECONOMY_MODEL_MAP: Record<string, string> = {
   // Premium → standard downgrade (architecture/review tasks)
-  'claude-opus-4.6':      'claude-sonnet-4.5',
-  'claude-opus-4.6-fast': 'claude-sonnet-4.5',
-  'claude-opus-4.5':      'claude-sonnet-4.5',
-  // Standard → fast downgrade (code writing, docs, planning, triage)
-  'claude-sonnet-4.6':    'gpt-4.1',
-  'claude-sonnet-4.5':    'gpt-4.1',
-  // Fast → cheapest fast (scribe/mechanical, docs)
-  'claude-haiku-4.5':     'gpt-4.1',
+  'claude-opus-4.7': 'claude-sonnet-4.6',
+  'claude-opus-4.6': 'claude-sonnet-4.6',
+  'claude-opus-4.5': 'claude-sonnet-4.6',
+  // Standard → cheaper standard/included downgrade (code writing, docs, planning, triage)
+  'claude-sonnet-4.6': 'gpt-4.1',
+  'claude-sonnet-4.5': 'gpt-4.1',
+  'gpt-5.4': 'gpt-5.2',
+  'gpt-5.5': 'gpt-5.4',
+  // Fast → cheapest compliant fast or included fallback
+  'claude-haiku-4.5': 'gpt-4.1',
 };
 
 /**
@@ -548,6 +788,7 @@ export interface ModelPreferenceConfig {
   defaultModel?: string;
   agentModelOverrides?: Record<string, string>;
   economyMode?: boolean;
+  costPolicy?: CostPolicyConfig;
 }
 
 /**

--- a/packages/squad-sdk/src/config/schema.ts
+++ b/packages/squad-sdk/src/config/schema.ts
@@ -53,6 +53,10 @@ export interface ModelConfig {
   tiers: Record<string, string[]>;
   agentOverrides?: Record<string, string>;
   taskTypeMapping?: Record<string, string>;
+  costPolicy?: {
+    maxCategory?: 'lightweight' | 'versatile' | 'powerful';
+    preferIncluded?: boolean;
+  };
 }
 
 export interface HooksConfig {
@@ -87,12 +91,12 @@ export const DEFAULT_CONFIG: SquadConfig = {
     fallbackBehavior: 'coordinator',
   },
   models: {
-    default: 'claude-sonnet-4',
+    default: 'claude-sonnet-4.6',
     defaultTier: 'standard',
     tiers: {
-      premium: ['claude-opus-4', 'claude-opus-4.5'],
-      standard: ['claude-sonnet-4', 'claude-sonnet-4.5', 'gpt-5.1-codex'],
-      fast: ['claude-haiku-4.5', 'gpt-5.1-codex-mini'],
+      premium: ['claude-opus-4.7', 'claude-opus-4.6', 'claude-opus-4.5', 'gpt-5.5'],
+      standard: ['claude-sonnet-4.6', 'claude-sonnet-4.5', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.4', 'gpt-4.1'],
+      fast: ['claude-haiku-4.5', 'gpt-5.4-mini', 'gpt-5-mini'],
     },
   },
   agents: [],

--- a/packages/squad-sdk/src/runtime/config.ts
+++ b/packages/squad-sdk/src/runtime/config.ts
@@ -79,6 +79,12 @@ export interface ModelSelectionConfig {
     standard: ModelId[];
     fast: ModelId[];
   };
+
+  /** GitHub billing cost policy for automatic selection and fallback. */
+  costPolicy?: {
+    maxCategory?: 'lightweight' | 'versatile' | 'powerful';
+    preferIncluded?: boolean;
+  };
   
   /** Prefer same provider when falling back */
   preferSameProvider?: boolean;
@@ -633,6 +639,19 @@ export function validateConfigDetailed(config: unknown): ValidationResult {
             errors.push(`config.models.taskRules[${idx}].model is required`);
           }
         });
+      }
+    }
+
+    if (models.costPolicy) {
+      const { maxCategory, preferIncluded } = models.costPolicy;
+      if (
+        maxCategory !== undefined &&
+        !['lightweight', 'versatile', 'powerful'].includes(maxCategory)
+      ) {
+        errors.push('config.models.costPolicy.maxCategory must be "lightweight", "versatile", or "powerful"');
+      }
+      if (preferIncluded !== undefined && typeof preferIncluded !== 'boolean') {
+        errors.push('config.models.costPolicy.preferIncluded must be a boolean');
       }
     }
     

--- a/packages/squad-sdk/src/runtime/constants.ts
+++ b/packages/squad-sdk/src/runtime/constants.ts
@@ -22,24 +22,26 @@ export const MODELS = {
   /** Fallback chains by tier — ordered by preference */
   FALLBACK_CHAINS: {
     premium: [
+      'claude-opus-4.7',
       'claude-opus-4.6',
-      'claude-opus-4.6-fast',
       'claude-opus-4.5',
+      'gpt-5.5',
       'claude-sonnet-4.6',
     ],
     standard: [
       'claude-sonnet-4.6',
-      'gpt-5.4',
       'claude-sonnet-4.5',
       'gpt-5.3-codex',
+      'gpt-5.2-codex',
+      'gpt-5.4',
       'claude-sonnet-4',
-      'gpt-5.2',
+      'gpt-4.1',
     ],
     fast: [
       'claude-haiku-4.5',
-      'gpt-5.1-codex-mini',
-      'gpt-4.1',
+      'gpt-5.4-mini',
       'gpt-5-mini',
+      'gpt-4.1',
     ],
   },
 

--- a/packages/squad-sdk/templates/skills/model-selection/SKILL.md
+++ b/packages/squad-sdk/templates/skills/model-selection/SKILL.md
@@ -1,125 +1,57 @@
 ---
 name: "model-selection"
-description: "Determines which LLM model to use for each agent spawn"
+description: "Resolves agent models using layer priority, cost policy, and ceiling-aware fallbacks"
 domain: "orchestration"
-confidence: "medium"
-source: "extracted"
+confidence: "high"
+source: "manual"
 ---
 
 # Model Selection
 
-> Determines which LLM model to use for each agent spawn.
-
 ## SCOPE
 
 ✅ THIS SKILL PRODUCES:
-- A resolved `model` parameter for every `task` tool call
+- A resolved `model` for every agent spawn
 - Persistent model preferences in `.squad/config.json`
-- Spawn acknowledgments that include the resolved model
+- Persistent or session cost-policy state
+- Spawn acknowledgments that show when included/economy/policy behavior changed the routing
 
 ❌ THIS SKILL DOES NOT PRODUCE:
-- Code, tests, or documentation
-- Model performance benchmarks
-- Cost reports or billing artifacts
+- Cost reports or billing analytics
+- Benchmarking or model evals
+- New model IDs not exposed by the current Copilot surface
 
 ## Context
 
-Squad supports 18+ models across three tiers (premium, standard, fast). The coordinator must select the right model for each agent spawn. Users can set persistent preferences that survive across sessions.
+Squad resolves models in two phases:
+1. **Preference resolution** via the 5-layer hierarchy
+2. **Policy enforcement** via `costPolicy`, `preferIncluded`, `economyMode`, and ceiling-aware fallback
 
-## 5-Layer Model Resolution Hierarchy
+Use GitHub's category names:
+- **Lightweight**
+- **Versatile**
+- **Powerful**
 
-Resolution is **first-match-wins** — the highest layer with a value wins.
+## 5-Layer Resolution Hierarchy
 
-| Layer | Name | Source | Persistence |
-|-------|------|--------|-------------|
-| **0a** | Per-Agent Config | `.squad/config.json` → `agentModelOverrides.{name}` | Persistent (survives sessions) |
-| **0b** | Global Config | `.squad/config.json` → `defaultModel` | Persistent (survives sessions) |
-| **1** | Session Directive | User said "use X" in current session | Session-only |
-| **2** | Charter Preference | Agent's `charter.md` → `## Model` section | Persistent (in charter) |
-| **3** | Task-Aware Auto | Code → sonnet, docs → haiku, visual → opus | Computed per-spawn |
-| **4** | Default | `claude-haiku-4.5` | Hardcoded fallback |
+| Layer | Name | Source | Behavior |
+|---|---|---|---|
+| 0a | Per-Agent Config | `.squad/config.json` → `agentModelOverrides.{name}` | Explicit persistent override |
+| 0b | Global Config | `.squad/config.json` → `defaultModel` | Explicit persistent override |
+| 1 | Session Directive | current conversation | Explicit session override |
+| 2 | Charter Preference | agent charter `## Model` | Non-user default preference |
+| 3 | Task-Aware Auto | task type | Computed default |
+| 4 | Default | hardcoded | Final fallback |
 
-**Key principle:** Layer 0 (persistent config) beats everything. If the user said "always use opus" and it was saved to config.json, every agent gets opus regardless of role or task type. This is intentional — the user explicitly chose quality over cost.
+**Important:** `costPolicy` is **not** a layer. Apply it after a model is resolved.
 
-## AGENT WORKFLOW
+## Session start workflow
 
-### On Session Start
+1. Read `.squad/config.json`
+2. Load `defaultModel`
+3. Load `agentModelOverrides`
+4. Load `costPolicy`
+5. Load `economyMode`
+6. Store persistent settings in session state
 
-1. READ `.squad/config.json`
-2. CHECK for `defaultModel` field — if present, this is the Layer 0 override for all spawns
-3. CHECK for `agentModelOverrides` field — if present, these are per-agent Layer 0a overrides
-4. STORE both values in session context for the duration
-
-### On Every Agent Spawn
-
-1. CHECK Layer 0a: Is there an `agentModelOverrides.{agentName}` in config.json? → Use it.
-2. CHECK Layer 0b: Is there a `defaultModel` in config.json? → Use it.
-3. CHECK Layer 1: Did the user give a session directive? → Use it.
-4. CHECK Layer 2: Does the agent's charter have a `## Model` section? → Use it.
-5. CHECK Layer 3: Determine task type:
-   - Code (implementation, tests, refactoring, bug fixes) → `claude-sonnet-4.6`
-   - Prompts, agent designs → `claude-sonnet-4.6`
-   - Visual/design with image analysis → `claude-opus-4.6`
-   - Non-code (docs, planning, triage, changelogs) → `claude-haiku-4.5`
-6. FALLBACK Layer 4: `claude-haiku-4.5`
-7. INCLUDE model in spawn acknowledgment: `🔧 {Name} ({resolved_model}) — {task}`
-
-### When User Sets a Preference
-
-**Trigger phrases:** "always use X", "use X for everything", "switch to X", "default to X"
-
-1. VALIDATE the model ID against the catalog (18+ models)
-2. WRITE `defaultModel` to `.squad/config.json` (merge, don't overwrite)
-3. ACKNOWLEDGE: `✅ Model preference saved: {model} — all future sessions will use this until changed.`
-
-**Per-agent trigger:** "use X for {agent}"
-
-1. VALIDATE model ID
-2. WRITE to `agentModelOverrides.{agent}` in `.squad/config.json`
-3. ACKNOWLEDGE: `✅ {Agent} will always use {model} — saved to config.`
-
-### When User Clears a Preference
-
-**Trigger phrases:** "switch back to automatic", "clear model preference", "use default models"
-
-1. REMOVE `defaultModel` from `.squad/config.json`
-2. ACKNOWLEDGE: `✅ Model preference cleared — returning to automatic selection.`
-
-### STOP
-
-After resolving the model and including it in the spawn template, this skill is done. Do NOT:
-- Generate model comparison reports
-- Run benchmarks or speed tests
-- Create new config files (only modify existing `.squad/config.json`)
-- Change the model after spawn (fallback chains handle runtime failures)
-
-## Config Schema
-
-`.squad/config.json` model-related fields:
-
-```json
-{
-  "version": 1,
-  "defaultModel": "claude-opus-4.6",
-  "agentModelOverrides": {
-    "fenster": "claude-sonnet-4.6",
-    "mcmanus": "claude-haiku-4.5"
-  }
-}
-```
-
-- `defaultModel` — applies to ALL agents unless overridden by `agentModelOverrides`
-- `agentModelOverrides` — per-agent overrides that take priority over `defaultModel`
-- Both fields are optional. When absent, Layers 1-4 apply normally.
-
-## Fallback Chains
-
-If a model is unavailable (rate limit, plan restriction), retry within the same tier:
-
-```
-Premium:  claude-opus-4.6 → claude-opus-4.6-fast → claude-opus-4.5 → claude-sonnet-4.6
-Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → claude-sonnet-4
-Fast:     claude-haiku-4.5 → gpt-5.1-codex-mini → gpt-4.1 → gpt-5-mini
-```
-
-**Never fall UP in tier.** A fast task won't land on a premium model via fallback.
+## Cost Policy

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -364,103 +364,232 @@ For read-only queries, use the explore agent: `agent_type: "explore"` with `"You
 
 ### Per-Agent Model Selection
 
-Before spawning an agent, determine which model to use. Check these layers in order — first match wins:
+Before spawning an agent, resolve a model in **two phases**:
 
-**Layer 0 — Persistent Config (`.squad/config.json`):** On session start, read `.squad/config.json`. If `agentModelOverrides.{agentName}` exists, use that model for this specific agent. Otherwise, if `defaultModel` exists, use it for ALL agents. This layer survives across sessions — the user set it once and it sticks.
+1. **Resolve intent** with the existing 5-layer hierarchy.
+2. **Apply policy veto** (`costPolicy`) and soft modifiers (`economyMode`) before spawning.
 
-- **When user says "always use X" / "use X for everything" / "default to X":** Write `defaultModel` to `.squad/config.json`. Acknowledge: `✅ Model preference saved: {model} — all future sessions will use this until changed.`
-- **When user says "use X for {agent}":** Write to `agentModelOverrides.{agent}` in `.squad/config.json`. Acknowledge: `✅ {Agent} will always use {model} — saved to config.`
-- **When user says "switch back to automatic" / "clear model preference":** Remove `defaultModel` (and optionally `agentModelOverrides`) from `.squad/config.json`. Acknowledge: `✅ Model preference cleared — returning to automatic selection.`
+The 5 layers stay intact:
 
-**Layer 1 — Session Directive:** Did the user specify a model for this session? ("use opus for this session", "save costs"). If yes, use that model. Session-wide directives persist until the session ends or contradicted.
+- **Layer 0a — Persistent Per-Agent Config:** `.squad/config.json` → `agentModelOverrides.{agentName}`
+- **Layer 0b — Persistent Global Config:** `.squad/config.json` → `defaultModel`
+- **Layer 1 — Session Directive:** explicit session phrases like "use opus for this session"
+- **Layer 2 — Charter Preference:** agent charter `## Model` section when not `auto`
+- **Layer 3 — Task-Aware Auto-Selection:** choose by task output
+- **Layer 4 — Default:** final hardcoded fallback
 
-**Layer 2 — Charter Preference:** Does the agent's charter have a `## Model` section with `Preferred` set to a specific model (not `auto`)? If yes, use that model.
+#### Policy Veto Step (apply AFTER Layer 4 resolution)
 
-**Layer 3 — Task-Aware Auto-Selection:** Use the governing principle: **cost first, unless code is being written.** Match the agent's task to determine output type, then select accordingly:
+After a model is resolved, check `costPolicy`.
 
-| Task Output | Model | Tier | Rule |
-|-------------|-------|------|------|
-| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
-| Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
-| NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.5` | Premium | Vision capability required. Overrides cost rule. |
+**Important:** `costPolicy` is **not Layer 0/1/2/3/4**. It is a policy check applied **after** layer resolution and **before** fallback execution.
 
-**Role-to-model mapping** (applying cost-first principle):
+Policy algorithm:
 
-| Role | Default Model | Why | Override When |
-|------|--------------|-----|---------------|
-| Core Dev / Backend / Frontend | `claude-sonnet-4.6` | Writes code — quality first | Heavy code gen → `gpt-5.3-codex` |
-| Tester / QA | `claude-sonnet-4.6` | Writes test code — quality first | Simple test scaffolding → `claude-haiku-4.5` |
-| Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
-| Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
-| Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.5` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
-| DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
-| Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
-| Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
+1. Read persistent `costPolicy` from `.squad/config.json`.
+2. Merge any **session-only cost directives** from the conversation on top of it.
+3. Determine the resolved model's category: **Lightweight**, **Versatile**, or **Powerful**.
+4. If the resolved model is **within** the ceiling, continue.
+5. If the resolved model is **above** the ceiling:
+   - **Layer 0 / Layer 1 explicit user override:** **warn and allow**.
+   - **Layer 2 / Layer 3 / Layer 4 choice:** reroute to the best in-ceiling model for that task.
+6. After ceiling enforcement, apply `economyMode` as a **soft cheaper-within-ceiling preference**.
+7. If `preferIncluded: true`, rank **included** models ahead of paid models when they can handle the task.
+8. Run the fallback chain, but **drop any fallback candidates above the active ceiling** unless the original selection came from an explicit Layer 0/1 override.
 
-**Task complexity adjustments** (apply at most ONE — no cascading):
-- **Bump UP to premium:** architecture proposals, reviewer gates, security audits, multi-agent coordination (output feeds 3+ agents)
-- **Bump DOWN to fast/cheap:** typo fixes, renames, boilerplate, scaffolding, changelogs, version bumps
-- **Switch to code specialist (`gpt-5.3-codex`):** large multi-file refactors, complex implementation from spec, heavy code generation (500+ lines)
-- **Switch to analytical diversity (`gemini-3-pro-preview`):** code reviews where a second perspective helps, security reviews, architecture reviews after a rejection
+**Warning copy for explicit override above ceiling:**
 
-**Layer 4 — Default:** If nothing else matched, use `claude-haiku-4.5`. Cost wins when in doubt, unless code is being produced.
-
-**Fallback chains — when a model is unavailable:**
-
-If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
-
-```
-Premium:  claude-opus-4.6 → claude-opus-4.5 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4 → (omit model param)
-Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5.1-codex-mini → gpt-4.1 → (omit model param)
+```text
+⚠️ {model} is above the current cost policy ceiling ({maxCategory}), but it was explicitly requested, so I’m using it.
 ```
 
-`(omit model param)` = call the `task` tool WITHOUT the `model` parameter. The platform uses its built-in default. This is the nuclear fallback — it always works.
+Warn once per explicit request. Do not repeatedly nag on every fallback retry.
 
-**Fallback rules:**
-- If the user specified a provider ("use Claude"), fall back within that provider only before hitting nuclear
-- Never fall back UP in tier — a fast/cheap task should not land on a premium model
-- Log fallbacks to the orchestration log for debugging, but never surface to the user unless asked
+---
 
-**Passing the model to spawns:**
+## Valid Models (GitHub AI Credits catalog used by Squad)
 
-Pass the resolved model as the `model` parameter on every `task` tool call:
+Use GitHub's category names and pricing language. List the **active Squad selection set** first — i.e. the model IDs Squad should actively choose today on Copilot surfaces that expose the current task-model list.
 
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-name: "{name}"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  ...
-```
+### Lightweight
 
-Only set `model` when it differs from the platform default (`claude-sonnet-4.6`). If the resolved model IS `claude-sonnet-4.6`, you MAY omit the `model` parameter — the platform uses it as default.
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `gpt-5-mini` | **Yes** | 0 / 0 | Zero-credit lightweight default when `preferIncluded: true` or economy is aggressive. |
+| `gpt-5.4-mini` | No | 0.75 / 4.50 | Cheap lightweight fallback. |
+| `claude-haiku-4.5` | No | 1.00 / 5.00 | Best default lightweight paid model for non-code and mechanical work. |
 
-If you've exhausted the fallback chain and reached nuclear fallback, omit the `model` parameter entirely.
+### Versatile
 
-**Spawn output format — show the model choice:**
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `gpt-4.1` | **Yes** | 0 / 0 | Zero-credit structured/tool-use preference when `preferIncluded: true` or economy mode is active. |
+| `claude-sonnet-4.6` | No | 3.00 / 15.00 | Primary default for code, prompt architecture, and high-quality structured output. |
+| `claude-sonnet-4.5` | No | 3.00 / 15.00 | First same-family fallback. |
+| `claude-sonnet-4` | No | 3.00 / 15.00 | Older versatile fallback. |
+| `gpt-5.4` | No | 2.50 / 15.00 | Strong versatile alternative. |
+| `gpt-5.3-codex` | No | 1.75 / 14.00 | Best code-specialist alternate for large implementation bursts. |
+| `gpt-5.2-codex` | No | 1.75 / 14.00 | Secondary code-specialist alternate. |
+| `gpt-5.2` | No | 1.75 / 14.00 | General versatile alternate. |
 
-When spawning, include the model in your acknowledgment:
+### Powerful
 
-```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.5 · vision) — designing color system
-📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
-📝 McManus (claude-haiku-4.5 · fast) — updating docs
-```
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `claude-opus-4.7` | No | 5.00 / 25.00 | Best default for architecture, review gates, and vision-heavy work. |
+| `claude-opus-4.6` | No | 5.00 / 25.00 | Same-family fallback. |
+| `claude-opus-4.5` | No | 5.00 / 25.00 | Stable older fallback. |
+| `gpt-5.5` | No | 5.00 / 30.00 | Powerful cross-provider alternate. |
 
-Include tier annotation only when the model was bumped or a specialist was chosen. Default-tier spawns just show the model name.
+**Catalog note:** GitHub's broader catalog also includes additional lightweight/versatile/powerful models such as `gemini-3.1-pro`. Treat those as catalog context only unless the active Copilot surface exposes them for selection. Do **not** make Squad actively select IDs that are not exposed by the current Copilot surface. If a new surface exposes more catalog models later, slot them into the same category semantics rather than inventing new tiers.
 
 **Valid models (current platform catalog):**
 
-Premium: `claude-opus-4.6`, `claude-opus-4.6-1m` (Internal only), `claude-opus-4.5`
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gemini-3-pro-preview`
-Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5.1-codex-mini`, `gpt-5-mini`, `gpt-4.1`
+Powerful: `claude-opus-4.7`, `claude-opus-4.6`, `claude-opus-4.5`, `gpt-5.5`
+Versatile: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-4.1` (included)
+Lightweight: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini` (included)
+
+---
+
+## Updated Layer 3 defaults
+
+Keep the principle: **cost first, unless code or prompt logic is being produced**.
+
+| Task Output | Default Model | Category | Why |
+|---|---|---|---|
+| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Versatile | Best default quality/cost balance for production code. |
+| Writing prompts, agent designs, routing logic, structured system text | `claude-sonnet-4.6` | Versatile | Prompt architecture behaves like code. |
+| Docs, planning, triage, changelogs, logging, mechanical ops | `claude-haiku-4.5` | Lightweight | Cheap default when no stronger policy preference is active. |
+| Visual/design work or image-heavy judgment | `claude-opus-4.7` | Powerful | Highest-stakes reasoning / best vision-capable default. |
+
+**Layer 4 default:** `claude-haiku-4.5`
+
+---
+
+## Updated role-to-model mapping
+
+| Role | Normal Default | Category | Prefer-Included Route | Override When |
+|---|---|---|---|---|
+| Core Dev / Backend / Frontend / TypeScript Engineer | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Heavy code generation or refactor burst → `gpt-5.3-codex` |
+| Tester / QA / E2E | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Simple scaffolding / assertions / fixture churn → `claude-haiku-4.5` or `gpt-5-mini` |
+| Lead / Architect / Security reviewer | auto by task | Powerful or Versatile | `gpt-4.1` only for low-stakes advisory analysis | Architecture proposals / reviewer gates / security signoff → `claude-opus-4.7` |
+| Prompt Engineer | auto by task | Versatile or Lightweight | `gpt-4.1` for structured prompt rewrites; `gpt-5-mini` for cheap synthesis | Prompt architecture / coordinator logic → `claude-sonnet-4.6` |
+| Copilot SDK Expert | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Pure research / inventory / API comparison → `claude-haiku-4.5` |
+| Designer / Visual | `claude-opus-4.7` | Powerful | none by default | If policy ceiling blocks Powerful, downgrade to `claude-sonnet-4.6` and note reduced confidence for visual judgment |
+| DevRel / Writer | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` (or `gpt-4.1` if heavy tool use) | Structured transformation or tool-rich writing workflow → `gpt-4.1` |
+| Scribe / Logger | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` | Never auto-bump above Lightweight unless explicitly requested |
+| Git / Release / Mechanical ops | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` | Never auto-bump above Lightweight unless explicitly requested |
+
+**Design read:** defaults stay Sonnet/Haiku for normal mode. `preferIncluded` and `economyMode` are what pull routing toward `gpt-4.1` / `gpt-5-mini`.
+
+---
+
+## Cost Policy
+
+Add a new subsection directly under model selection.
+
+### Config shape
+
+```json
+{
+  "costPolicy": {
+    "maxCategory": "Versatile",
+    "preferIncluded": true
+  }
+}
+```
+
+- `maxCategory`: `Lightweight` | `Versatile` | `Powerful`
+- `preferIncluded`: when `true`, prefer zero-credit models (`gpt-4.1`, `gpt-5-mini`) where they are acceptable for the task
+- Default if missing: `{ "maxCategory": "Powerful", "preferIncluded": false }`
+
+### What it means
+
+- **`maxCategory` is a hard ceiling** for auto-routing and charter-driven choices.
+- Lower categories are always allowed.
+- **`economyMode` is different:** it is a **soft cheaper-within-ceiling preference**.
+- **`preferIncluded` is also different:** it re-ranks zero-credit models first, but still respects the ceiling and task fit.
+
+### Conversation phrases
+
+Treat conversational cost policy as **session-only** unless the user says `always`, `save`, `remember`, or otherwise asks to persist it.
+
+| User phrase | Session action |
+|---|---|
+| "keep costs low" / "use cheap models" / "Lightweight only" | set `maxCategory: "Lightweight"` |
+| "no powerful models" / "cap at versatile" | set `maxCategory: "Versatile"` |
+| "prefer included models" / "save credits" / "use zero-cost models when you can" | set `preferIncluded: true` |
+| "use normal costing again" / "remove the ceiling" | clear session cost policy override |
+
+Persistent forms:
+
+- "always keep costs low" → write `costPolicy.maxCategory = "Lightweight"`
+- "always cap at versatile" → write `costPolicy.maxCategory = "Versatile"`
+- "always prefer included models" → write `costPolicy.preferIncluded = true`
+
+### Composition with `economyMode`
+
+Apply in this order:
+
+1. Resolve the model from Layers 0-4.
+2. Enforce `costPolicy.maxCategory`.
+3. Apply `preferIncluded` ranking.
+4. Apply `economyMode` as a soft cheaper-within-ceiling substitution.
+5. Execute the ceiling-aware fallback chain.
+
+Examples:
+
+- **No cost policy + economy off:** code task → `claude-sonnet-4.6`
+- **`maxCategory: "Versatile"` + economy off:** code task still → `claude-sonnet-4.6`
+- **`maxCategory: "Versatile"` + economy on:** code task can downshift to `gpt-4.1`
+- **`maxCategory: "Lightweight"` + economy off:** code task is capped to a Lightweight model, defaulting to `claude-haiku-4.5`
+- **`maxCategory: "Lightweight"` + `preferIncluded: true`:** code/docs/mechanical work should prefer `gpt-5-mini`
+
+### Explicit override rule
+
+If the user explicitly chooses a model at Layer 0 or Layer 1 and that model exceeds the ceiling, **warn and allow**. Do **not** silently replace an explicit override.
+
+If the chosen model came from Layer 2, Layer 3, or Layer 4 and exceeds the ceiling, **replace it with the best allowed model**.
+
+---
+
+## Updated fallback chains
+
+Rename the chains to GitHub's categories and make them ceiling-aware.
+
+```text
+Powerful:          claude-opus-4.7 → claude-opus-4.6 → claude-opus-4.5 → gpt-5.5 → claude-sonnet-4.6 → (omit model param)
+Versatile (code):  claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.3-codex → gpt-5.2-codex → gpt-5.4 → claude-sonnet-4 → gpt-4.1 → (omit model param)
+Versatile (general): claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-4.1 → gpt-5.4 → gpt-5.2 → claude-sonnet-4 → (omit model param)
+Lightweight:       claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
+Lightweight (preferIncluded): gpt-5-mini → gpt-5.4-mini → claude-haiku-4.5 → (omit model param)
+```
+
+Fallback rules:
+
+- Never fall back **above the active `maxCategory` ceiling**.
+- If the user specified a provider (`Claude`, `GPT`), exhaust same-provider choices first.
+- If `preferIncluded: true`, start with the included-first chain when available.
+- Use `(omit model param)` as the nuclear fallback.
+- Do not narrate fallback attempts unless the user explicitly asks.
+
+---
+
+## Spawn acknowledgment additions
+
+Keep the current model display, but add policy/economy tags only when they matter.
+
+Examples:
+
+```text
+🔧 EECOM (claude-sonnet-4.6) — implementing router changes
+🧠 Procedures (gpt-4.1 · included) — rewriting prompt policy
+📋 Scribe (gpt-5-mini · lightweight · included) — logging session
+⚠️ Flight (claude-opus-4.7 · above cost ceiling by explicit override) — reviewing architecture
+💰 CONTROL (gpt-4.1 · economy) — planning refactor
+```
+
+---
 
 ### Client Compatibility
 

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -364,103 +364,232 @@ For read-only queries, use the explore agent: `agent_type: "explore"` with `"You
 
 ### Per-Agent Model Selection
 
-Before spawning an agent, determine which model to use. Check these layers in order — first match wins:
+Before spawning an agent, resolve a model in **two phases**:
 
-**Layer 0 — Persistent Config (`.squad/config.json`):** On session start, read `.squad/config.json`. If `agentModelOverrides.{agentName}` exists, use that model for this specific agent. Otherwise, if `defaultModel` exists, use it for ALL agents. This layer survives across sessions — the user set it once and it sticks.
+1. **Resolve intent** with the existing 5-layer hierarchy.
+2. **Apply policy veto** (`costPolicy`) and soft modifiers (`economyMode`) before spawning.
 
-- **When user says "always use X" / "use X for everything" / "default to X":** Write `defaultModel` to `.squad/config.json`. Acknowledge: `✅ Model preference saved: {model} — all future sessions will use this until changed.`
-- **When user says "use X for {agent}":** Write to `agentModelOverrides.{agent}` in `.squad/config.json`. Acknowledge: `✅ {Agent} will always use {model} — saved to config.`
-- **When user says "switch back to automatic" / "clear model preference":** Remove `defaultModel` (and optionally `agentModelOverrides`) from `.squad/config.json`. Acknowledge: `✅ Model preference cleared — returning to automatic selection.`
+The 5 layers stay intact:
 
-**Layer 1 — Session Directive:** Did the user specify a model for this session? ("use opus for this session", "save costs"). If yes, use that model. Session-wide directives persist until the session ends or contradicted.
+- **Layer 0a — Persistent Per-Agent Config:** `.squad/config.json` → `agentModelOverrides.{agentName}`
+- **Layer 0b — Persistent Global Config:** `.squad/config.json` → `defaultModel`
+- **Layer 1 — Session Directive:** explicit session phrases like "use opus for this session"
+- **Layer 2 — Charter Preference:** agent charter `## Model` section when not `auto`
+- **Layer 3 — Task-Aware Auto-Selection:** choose by task output
+- **Layer 4 — Default:** final hardcoded fallback
 
-**Layer 2 — Charter Preference:** Does the agent's charter have a `## Model` section with `Preferred` set to a specific model (not `auto`)? If yes, use that model.
+#### Policy Veto Step (apply AFTER Layer 4 resolution)
 
-**Layer 3 — Task-Aware Auto-Selection:** Use the governing principle: **cost first, unless code is being written.** Match the agent's task to determine output type, then select accordingly:
+After a model is resolved, check `costPolicy`.
 
-| Task Output | Model | Tier | Rule |
-|-------------|-------|------|------|
-| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
-| Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
-| NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.5` | Premium | Vision capability required. Overrides cost rule. |
+**Important:** `costPolicy` is **not Layer 0/1/2/3/4**. It is a policy check applied **after** layer resolution and **before** fallback execution.
 
-**Role-to-model mapping** (applying cost-first principle):
+Policy algorithm:
 
-| Role | Default Model | Why | Override When |
-|------|--------------|-----|---------------|
-| Core Dev / Backend / Frontend | `claude-sonnet-4.6` | Writes code — quality first | Heavy code gen → `gpt-5.3-codex` |
-| Tester / QA | `claude-sonnet-4.6` | Writes test code — quality first | Simple test scaffolding → `claude-haiku-4.5` |
-| Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
-| Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
-| Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.5` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
-| DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
-| Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
-| Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
+1. Read persistent `costPolicy` from `.squad/config.json`.
+2. Merge any **session-only cost directives** from the conversation on top of it.
+3. Determine the resolved model's category: **Lightweight**, **Versatile**, or **Powerful**.
+4. If the resolved model is **within** the ceiling, continue.
+5. If the resolved model is **above** the ceiling:
+   - **Layer 0 / Layer 1 explicit user override:** **warn and allow**.
+   - **Layer 2 / Layer 3 / Layer 4 choice:** reroute to the best in-ceiling model for that task.
+6. After ceiling enforcement, apply `economyMode` as a **soft cheaper-within-ceiling preference**.
+7. If `preferIncluded: true`, rank **included** models ahead of paid models when they can handle the task.
+8. Run the fallback chain, but **drop any fallback candidates above the active ceiling** unless the original selection came from an explicit Layer 0/1 override.
 
-**Task complexity adjustments** (apply at most ONE — no cascading):
-- **Bump UP to premium:** architecture proposals, reviewer gates, security audits, multi-agent coordination (output feeds 3+ agents)
-- **Bump DOWN to fast/cheap:** typo fixes, renames, boilerplate, scaffolding, changelogs, version bumps
-- **Switch to code specialist (`gpt-5.3-codex`):** large multi-file refactors, complex implementation from spec, heavy code generation (500+ lines)
-- **Switch to analytical diversity (`gemini-3-pro-preview`):** code reviews where a second perspective helps, security reviews, architecture reviews after a rejection
+**Warning copy for explicit override above ceiling:**
 
-**Layer 4 — Default:** If nothing else matched, use `claude-haiku-4.5`. Cost wins when in doubt, unless code is being produced.
-
-**Fallback chains — when a model is unavailable:**
-
-If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
-
-```
-Premium:  claude-opus-4.6 → claude-opus-4.5 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4 → (omit model param)
-Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5.1-codex-mini → gpt-4.1 → (omit model param)
+```text
+⚠️ {model} is above the current cost policy ceiling ({maxCategory}), but it was explicitly requested, so I’m using it.
 ```
 
-`(omit model param)` = call the `task` tool WITHOUT the `model` parameter. The platform uses its built-in default. This is the nuclear fallback — it always works.
+Warn once per explicit request. Do not repeatedly nag on every fallback retry.
 
-**Fallback rules:**
-- If the user specified a provider ("use Claude"), fall back within that provider only before hitting nuclear
-- Never fall back UP in tier — a fast/cheap task should not land on a premium model
-- Log fallbacks to the orchestration log for debugging, but never surface to the user unless asked
+---
 
-**Passing the model to spawns:**
+## Valid Models (GitHub AI Credits catalog used by Squad)
 
-Pass the resolved model as the `model` parameter on every `task` tool call:
+Use GitHub's category names and pricing language. List the **active Squad selection set** first — i.e. the model IDs Squad should actively choose today on Copilot surfaces that expose the current task-model list.
 
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-name: "{name}"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  ...
-```
+### Lightweight
 
-Only set `model` when it differs from the platform default (`claude-sonnet-4.6`). If the resolved model IS `claude-sonnet-4.6`, you MAY omit the `model` parameter — the platform uses it as default.
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `gpt-5-mini` | **Yes** | 0 / 0 | Zero-credit lightweight default when `preferIncluded: true` or economy is aggressive. |
+| `gpt-5.4-mini` | No | 0.75 / 4.50 | Cheap lightweight fallback. |
+| `claude-haiku-4.5` | No | 1.00 / 5.00 | Best default lightweight paid model for non-code and mechanical work. |
 
-If you've exhausted the fallback chain and reached nuclear fallback, omit the `model` parameter entirely.
+### Versatile
 
-**Spawn output format — show the model choice:**
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `gpt-4.1` | **Yes** | 0 / 0 | Zero-credit structured/tool-use preference when `preferIncluded: true` or economy mode is active. |
+| `claude-sonnet-4.6` | No | 3.00 / 15.00 | Primary default for code, prompt architecture, and high-quality structured output. |
+| `claude-sonnet-4.5` | No | 3.00 / 15.00 | First same-family fallback. |
+| `claude-sonnet-4` | No | 3.00 / 15.00 | Older versatile fallback. |
+| `gpt-5.4` | No | 2.50 / 15.00 | Strong versatile alternative. |
+| `gpt-5.3-codex` | No | 1.75 / 14.00 | Best code-specialist alternate for large implementation bursts. |
+| `gpt-5.2-codex` | No | 1.75 / 14.00 | Secondary code-specialist alternate. |
+| `gpt-5.2` | No | 1.75 / 14.00 | General versatile alternate. |
 
-When spawning, include the model in your acknowledgment:
+### Powerful
 
-```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.5 · vision) — designing color system
-📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
-📝 McManus (claude-haiku-4.5 · fast) — updating docs
-```
+| Model | Included? | Credit cost (in / out per 1M) | Notes |
+|---|---:|---:|---|
+| `claude-opus-4.7` | No | 5.00 / 25.00 | Best default for architecture, review gates, and vision-heavy work. |
+| `claude-opus-4.6` | No | 5.00 / 25.00 | Same-family fallback. |
+| `claude-opus-4.5` | No | 5.00 / 25.00 | Stable older fallback. |
+| `gpt-5.5` | No | 5.00 / 30.00 | Powerful cross-provider alternate. |
 
-Include tier annotation only when the model was bumped or a specialist was chosen. Default-tier spawns just show the model name.
+**Catalog note:** GitHub's broader catalog also includes additional lightweight/versatile/powerful models such as `gemini-3.1-pro`. Treat those as catalog context only unless the active Copilot surface exposes them for selection. Do **not** make Squad actively select IDs that are not exposed by the current Copilot surface. If a new surface exposes more catalog models later, slot them into the same category semantics rather than inventing new tiers.
 
 **Valid models (current platform catalog):**
 
-Premium: `claude-opus-4.6`, `claude-opus-4.6-1m` (Internal only), `claude-opus-4.5`
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gemini-3-pro-preview`
-Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5.1-codex-mini`, `gpt-5-mini`, `gpt-4.1`
+Powerful: `claude-opus-4.7`, `claude-opus-4.6`, `claude-opus-4.5`, `gpt-5.5`
+Versatile: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.2`, `gpt-4.1` (included)
+Lightweight: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini` (included)
+
+---
+
+## Updated Layer 3 defaults
+
+Keep the principle: **cost first, unless code or prompt logic is being produced**.
+
+| Task Output | Default Model | Category | Why |
+|---|---|---|---|
+| Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Versatile | Best default quality/cost balance for production code. |
+| Writing prompts, agent designs, routing logic, structured system text | `claude-sonnet-4.6` | Versatile | Prompt architecture behaves like code. |
+| Docs, planning, triage, changelogs, logging, mechanical ops | `claude-haiku-4.5` | Lightweight | Cheap default when no stronger policy preference is active. |
+| Visual/design work or image-heavy judgment | `claude-opus-4.7` | Powerful | Highest-stakes reasoning / best vision-capable default. |
+
+**Layer 4 default:** `claude-haiku-4.5`
+
+---
+
+## Updated role-to-model mapping
+
+| Role | Normal Default | Category | Prefer-Included Route | Override When |
+|---|---|---|---|---|
+| Core Dev / Backend / Frontend / TypeScript Engineer | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Heavy code generation or refactor burst → `gpt-5.3-codex` |
+| Tester / QA / E2E | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Simple scaffolding / assertions / fixture churn → `claude-haiku-4.5` or `gpt-5-mini` |
+| Lead / Architect / Security reviewer | auto by task | Powerful or Versatile | `gpt-4.1` only for low-stakes advisory analysis | Architecture proposals / reviewer gates / security signoff → `claude-opus-4.7` |
+| Prompt Engineer | auto by task | Versatile or Lightweight | `gpt-4.1` for structured prompt rewrites; `gpt-5-mini` for cheap synthesis | Prompt architecture / coordinator logic → `claude-sonnet-4.6` |
+| Copilot SDK Expert | `claude-sonnet-4.6` | Versatile | `gpt-4.1` | Pure research / inventory / API comparison → `claude-haiku-4.5` |
+| Designer / Visual | `claude-opus-4.7` | Powerful | none by default | If policy ceiling blocks Powerful, downgrade to `claude-sonnet-4.6` and note reduced confidence for visual judgment |
+| DevRel / Writer | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` (or `gpt-4.1` if heavy tool use) | Structured transformation or tool-rich writing workflow → `gpt-4.1` |
+| Scribe / Logger | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` | Never auto-bump above Lightweight unless explicitly requested |
+| Git / Release / Mechanical ops | `claude-haiku-4.5` | Lightweight | `gpt-5-mini` | Never auto-bump above Lightweight unless explicitly requested |
+
+**Design read:** defaults stay Sonnet/Haiku for normal mode. `preferIncluded` and `economyMode` are what pull routing toward `gpt-4.1` / `gpt-5-mini`.
+
+---
+
+## Cost Policy
+
+Add a new subsection directly under model selection.
+
+### Config shape
+
+```json
+{
+  "costPolicy": {
+    "maxCategory": "Versatile",
+    "preferIncluded": true
+  }
+}
+```
+
+- `maxCategory`: `Lightweight` | `Versatile` | `Powerful`
+- `preferIncluded`: when `true`, prefer zero-credit models (`gpt-4.1`, `gpt-5-mini`) where they are acceptable for the task
+- Default if missing: `{ "maxCategory": "Powerful", "preferIncluded": false }`
+
+### What it means
+
+- **`maxCategory` is a hard ceiling** for auto-routing and charter-driven choices.
+- Lower categories are always allowed.
+- **`economyMode` is different:** it is a **soft cheaper-within-ceiling preference**.
+- **`preferIncluded` is also different:** it re-ranks zero-credit models first, but still respects the ceiling and task fit.
+
+### Conversation phrases
+
+Treat conversational cost policy as **session-only** unless the user says `always`, `save`, `remember`, or otherwise asks to persist it.
+
+| User phrase | Session action |
+|---|---|
+| "keep costs low" / "use cheap models" / "Lightweight only" | set `maxCategory: "Lightweight"` |
+| "no powerful models" / "cap at versatile" | set `maxCategory: "Versatile"` |
+| "prefer included models" / "save credits" / "use zero-cost models when you can" | set `preferIncluded: true` |
+| "use normal costing again" / "remove the ceiling" | clear session cost policy override |
+
+Persistent forms:
+
+- "always keep costs low" → write `costPolicy.maxCategory = "Lightweight"`
+- "always cap at versatile" → write `costPolicy.maxCategory = "Versatile"`
+- "always prefer included models" → write `costPolicy.preferIncluded = true`
+
+### Composition with `economyMode`
+
+Apply in this order:
+
+1. Resolve the model from Layers 0-4.
+2. Enforce `costPolicy.maxCategory`.
+3. Apply `preferIncluded` ranking.
+4. Apply `economyMode` as a soft cheaper-within-ceiling substitution.
+5. Execute the ceiling-aware fallback chain.
+
+Examples:
+
+- **No cost policy + economy off:** code task → `claude-sonnet-4.6`
+- **`maxCategory: "Versatile"` + economy off:** code task still → `claude-sonnet-4.6`
+- **`maxCategory: "Versatile"` + economy on:** code task can downshift to `gpt-4.1`
+- **`maxCategory: "Lightweight"` + economy off:** code task is capped to a Lightweight model, defaulting to `claude-haiku-4.5`
+- **`maxCategory: "Lightweight"` + `preferIncluded: true`:** code/docs/mechanical work should prefer `gpt-5-mini`
+
+### Explicit override rule
+
+If the user explicitly chooses a model at Layer 0 or Layer 1 and that model exceeds the ceiling, **warn and allow**. Do **not** silently replace an explicit override.
+
+If the chosen model came from Layer 2, Layer 3, or Layer 4 and exceeds the ceiling, **replace it with the best allowed model**.
+
+---
+
+## Updated fallback chains
+
+Rename the chains to GitHub's categories and make them ceiling-aware.
+
+```text
+Powerful:          claude-opus-4.7 → claude-opus-4.6 → claude-opus-4.5 → gpt-5.5 → claude-sonnet-4.6 → (omit model param)
+Versatile (code):  claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.3-codex → gpt-5.2-codex → gpt-5.4 → claude-sonnet-4 → gpt-4.1 → (omit model param)
+Versatile (general): claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-4.1 → gpt-5.4 → gpt-5.2 → claude-sonnet-4 → (omit model param)
+Lightweight:       claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
+Lightweight (preferIncluded): gpt-5-mini → gpt-5.4-mini → claude-haiku-4.5 → (omit model param)
+```
+
+Fallback rules:
+
+- Never fall back **above the active `maxCategory` ceiling**.
+- If the user specified a provider (`Claude`, `GPT`), exhaust same-provider choices first.
+- If `preferIncluded: true`, start with the included-first chain when available.
+- Use `(omit model param)` as the nuclear fallback.
+- Do not narrate fallback attempts unless the user explicitly asks.
+
+---
+
+## Spawn acknowledgment additions
+
+Keep the current model display, but add policy/economy tags only when they matter.
+
+Examples:
+
+```text
+🔧 EECOM (claude-sonnet-4.6) — implementing router changes
+🧠 Procedures (gpt-4.1 · included) — rewriting prompt policy
+📋 Scribe (gpt-5-mini · lightweight · included) — logging session
+⚠️ Flight (claude-opus-4.7 · above cost ceiling by explicit override) — reviewing architecture
+💰 CONTROL (gpt-4.1 · economy) — planning refactor
+```
+
+---
 
 ### Client Compatibility
 

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -167,7 +167,7 @@ describe('Per-Agent Model Selection (M1-9)', () => {
 
       expect(result.model).toBe('claude-opus-4.6');
       expect(result.tier).toBe('premium');
-      expect(result.fallbackChain).toContain('claude-opus-4.6-fast');
+      expect(result.fallbackChain).toContain('claude-opus-4.7');
     });
 
     it('should infer fast tier for haiku models', () => {
@@ -180,7 +180,7 @@ describe('Per-Agent Model Selection (M1-9)', () => {
 
       expect(result.model).toBe('claude-haiku-4.5');
       expect(result.tier).toBe('fast');
-      expect(result.fallbackChain).toContain('gpt-5.1-codex-mini');
+      expect(result.fallbackChain).toContain('gpt-5.4-mini');
     });
   });
 
@@ -325,9 +325,10 @@ describe('Per-Agent Model Selection (M1-9)', () => {
       const result = resolveModel(options);
 
       expect(result.fallbackChain).toEqual([
+        'claude-opus-4.7',
         'claude-opus-4.6',
-        'claude-opus-4.6-fast',
         'claude-opus-4.5',
+        'gpt-5.5',
         'claude-sonnet-4.6',
       ]);
     });
@@ -341,11 +342,12 @@ describe('Per-Agent Model Selection (M1-9)', () => {
 
       expect(result.fallbackChain).toEqual([
         'claude-sonnet-4.6',
-        'gpt-5.4',
         'claude-sonnet-4.5',
         'gpt-5.3-codex',
+        'gpt-5.2-codex',
+        'gpt-5.4',
         'claude-sonnet-4',
-        'gpt-5.2',
+        'gpt-4.1',
       ]);
     });
 
@@ -358,9 +360,9 @@ describe('Per-Agent Model Selection (M1-9)', () => {
 
       expect(result.fallbackChain).toEqual([
         'claude-haiku-4.5',
-        'gpt-5.1-codex-mini',
-        'gpt-4.1',
+        'gpt-5.4-mini',
         'gpt-5-mini',
+        'gpt-4.1',
       ]);
     });
   });

--- a/test/compat-v041.test.ts
+++ b/test/compat-v041.test.ts
@@ -471,7 +471,7 @@ describe('Compat v0.4.1: Model Catalog', () => {
   });
 
   it('premium fallback chain starts with opus', () => {
-    expect(DEFAULT_FALLBACK_CHAINS.premium[0]).toBe('claude-opus-4.6');
+    expect(DEFAULT_FALLBACK_CHAINS.premium[0]).toBe('claude-opus-4.7');
   });
 
   it('standard fallback chain starts with sonnet', () => {

--- a/test/config-integration.test.ts
+++ b/test/config-integration.test.ts
@@ -906,7 +906,7 @@ describe('Integration: Full pipeline — discover → compile → resolve → fi
 
     expect(config.team.name).toBe('Integration Squad');
     expect(config.agents.length).toBe(1);
-    expect(config.models.default).toBe('claude-sonnet-4');
+    expect(config.models.default).toBe('claude-sonnet-4.6');
   });
 });
 

--- a/test/config-schema.test.ts
+++ b/test/config-schema.test.ts
@@ -20,13 +20,13 @@ describe('Configuration Schema', () => {
       expect(DEFAULT_CONFIG.version).toBe('0.6.0');
       expect(DEFAULT_CONFIG.team.name).toBe('Default Squad');
       expect(DEFAULT_CONFIG.routing.fallbackBehavior).toBe('coordinator');
-      expect(DEFAULT_CONFIG.models.default).toBe('claude-sonnet-4');
+      expect(DEFAULT_CONFIG.models.default).toBe('claude-sonnet-4.6');
       expect(DEFAULT_CONFIG.agents).toEqual([]);
     });
 
     it('should have tier definitions', () => {
-      expect(DEFAULT_CONFIG.models.tiers.premium).toContain('claude-opus-4');
-      expect(DEFAULT_CONFIG.models.tiers.standard).toContain('claude-sonnet-4');
+      expect(DEFAULT_CONFIG.models.tiers.premium).toContain('claude-opus-4.7');
+      expect(DEFAULT_CONFIG.models.tiers.standard).toContain('claude-sonnet-4.6');
       expect(DEFAULT_CONFIG.models.tiers.fast).toContain('claude-haiku-4.5');
     });
   });

--- a/test/economy-mode.test.ts
+++ b/test/economy-mode.test.ts
@@ -38,9 +38,9 @@ afterEach(() => {
 
 describe('ECONOMY_MODEL_MAP', () => {
   it('maps premium models to standard', () => {
-    expect(ECONOMY_MODEL_MAP['claude-opus-4.6']).toBe('claude-sonnet-4.5');
-    expect(ECONOMY_MODEL_MAP['claude-opus-4.6-fast']).toBe('claude-sonnet-4.5');
-    expect(ECONOMY_MODEL_MAP['claude-opus-4.5']).toBe('claude-sonnet-4.5');
+    expect(ECONOMY_MODEL_MAP['claude-opus-4.6']).toBe('claude-sonnet-4.6');
+    expect(ECONOMY_MODEL_MAP['claude-opus-4.7']).toBe('claude-sonnet-4.6');
+    expect(ECONOMY_MODEL_MAP['claude-opus-4.5']).toBe('claude-sonnet-4.6');
   });
 
   it('maps standard sonnet models to fast', () => {
@@ -55,7 +55,7 @@ describe('ECONOMY_MODEL_MAP', () => {
 
 describe('applyEconomyMode', () => {
   it('returns economy model for known models', () => {
-    expect(applyEconomyMode('claude-opus-4.6')).toBe('claude-sonnet-4.5');
+    expect(applyEconomyMode('claude-opus-4.6')).toBe('claude-sonnet-4.6');
     expect(applyEconomyMode('claude-sonnet-4.6')).toBe('gpt-4.1');
     expect(applyEconomyMode('claude-haiku-4.5')).toBe('gpt-4.1');
   });
@@ -162,7 +162,7 @@ describe('resolveModel economy mode (option)', () => {
   });
 
   it('Layer 3 architecture task: uses sonnet instead of opus when economyMode: true', () => {
-    expect(resolveModel({ taskModel: 'claude-opus-4.6', economyMode: true })).toBe('claude-sonnet-4.5');
+    expect(resolveModel({ taskModel: 'claude-opus-4.6', economyMode: true })).toBe('claude-sonnet-4.6');
   });
 
   it('Layer 3 docs task: uses gpt-4.1 instead of haiku when economyMode: true', () => {
@@ -259,9 +259,9 @@ describe('SDK resolveModel (agents) economy mode', () => {
     expect(result.model).toBe('gpt-4.1');
   });
 
-  it('visual task → claude-sonnet-4.5 when economyMode: true', () => {
+  it('visual task → claude-sonnet-4.6 when economyMode: true', () => {
     const result = sdkResolveModel({ taskType: 'visual', economyMode: true });
-    expect(result.model).toBe('claude-sonnet-4.5');
+    expect(result.model).toBe('claude-sonnet-4.6');
   });
 
   it('code task → claude-sonnet-4.6 when economyMode: false', () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -440,7 +440,7 @@ describe('Integration: Charter → Model → Session Pipeline', () => {
 
       expect(premiumResult.tier).toBe('premium');
       expect(premiumResult.fallbackChain.length).toBeGreaterThan(1);
-      expect(premiumResult.fallbackChain[0]).toBe('claude-opus-4.6');
+      expect(premiumResult.fallbackChain[0]).toBe('claude-opus-4.7');
     });
   });
 });

--- a/test/model-fallback.test.ts
+++ b/test/model-fallback.test.ts
@@ -47,7 +47,7 @@ describe('Cross-tier fallback — standard chain exhaustion', () => {
 
   it('premium chain starts with opus and walks through all premium options', () => {
     const chain = DEFAULT_FALLBACK_CHAINS.premium;
-    expect(chain[0]).toBe('claude-opus-4.6');
+    expect(chain[0]).toBe('claude-opus-4.7');
 
     const attempted = new Set<string>();
     let count = 0;
@@ -101,13 +101,13 @@ describe('Cross-tier fallback — standard chain exhaustion', () => {
 describe('Tier ceiling — fast never escalates to premium', () => {
   const registry = new ModelRegistry();
 
-  it('fast fallback chain contains only fast-tier models', () => {
+  it('fast fallback chain prefers fast-tier models and only ends with the included standard escape hatch', () => {
     const chain = DEFAULT_FALLBACK_CHAINS.fast;
-    for (const modelId of chain) {
-      const info = registry.getModelInfo(modelId);
-      expect(info).not.toBeNull();
-      expect(info!.tier).toBe('fast');
-    }
+    const tiers = chain.map((modelId) => registry.getModelInfo(modelId)?.tier);
+
+    expect(tiers.slice(0, -1).every((tier) => tier === 'fast')).toBe(true);
+    expect(chain.at(-1)).toBe('gpt-4.1');
+    expect(registry.getModelInfo('gpt-4.1')?.tier).toBe('standard');
   });
 
   it('fast chain never contains premium models', () => {
@@ -258,10 +258,9 @@ describe('Nuclear fallback — all models exhausted', () => {
 describe('Model fallback — edge cases', () => {
   const registry = new ModelRegistry();
 
-  it('getNextFallback with empty attempted set returns second in chain', () => {
+  it('getNextFallback with empty attempted set returns the first higher-priority remaining model', () => {
     const next = registry.getNextFallback('claude-opus-4.6', 'premium');
-    // With no attempted set, it should return the next in chain after current
-    expect(next).toBe('claude-opus-4.6-fast');
+    expect(next).toBe('claude-opus-4.7');
   });
 
   it('getNextFallback for unknown model returns null', () => {

--- a/test/model-selector-policy.test.ts
+++ b/test/model-selector-policy.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { resolveModel } from '@bradygaster/squad-sdk/agents';
+
+describe('model selector cost policy', () => {
+  it('warns and allows explicit session overrides above the ceiling', () => {
+    const result = resolveModel({
+      taskType: 'code',
+      userOverride: 'claude-opus-4.7',
+      sessionCostPolicy: { source: 'conversation', maxCategory: 'versatile' },
+    });
+
+    expect(result.model).toBe('claude-opus-4.7');
+    expect(result.source).toBe('user-override');
+    expect(result.policy).toMatchObject({
+      action: 'warn-allow-explicit',
+      originalModel: 'claude-opus-4.7',
+      finalModel: 'claude-opus-4.7',
+      appliedPolicy: {
+        maxCategory: 'versatile',
+        preferIncluded: false,
+      },
+    });
+    expect(result.policy?.warning).toContain('above the current cost policy ceiling');
+    expect(result.fallbackChain[0]).toBe('claude-opus-4.7');
+  });
+
+  it('warns and allows persistent agent overrides above the ceiling', () => {
+    const result = resolveModel({
+      taskType: 'docs',
+      agentRole: 'eecom',
+      config: {
+        models: {
+          agentModelOverrides: {
+            eecom: 'claude-opus-4.7',
+          },
+          costPolicy: {
+            maxCategory: 'versatile',
+          },
+        },
+      },
+    });
+
+    expect(result.model).toBe('claude-opus-4.7');
+    expect(result.source).toBe('persistent-agent-override');
+    expect(result.policy?.action).toBe('warn-allow-explicit');
+  });
+
+  it('downgrades automatic selections to a compliant cheaper tier', () => {
+    const result = resolveModel({
+      taskType: 'visual',
+      config: {
+        models: {
+          costPolicy: {
+            maxCategory: 'versatile',
+          },
+        },
+      },
+    });
+
+    expect(result.model).toBe('claude-sonnet-4.6');
+    expect(result.tier).toBe('standard');
+    expect(result.source).toBe('task-auto');
+    expect(result.policy).toMatchObject({
+      action: 'downgraded-to-ceiling',
+      originalModel: 'claude-opus-4.6',
+      finalModel: 'claude-sonnet-4.6',
+    });
+    expect(result.fallbackChain).toEqual([
+      'claude-sonnet-4.6',
+      'claude-sonnet-4.5',
+      'gpt-5.3-codex',
+      'gpt-5.2-codex',
+      'gpt-5.4',
+      'claude-sonnet-4',
+      'gpt-4.1',
+    ]);
+  });
+
+  it('prefers included same-tier models when requested', () => {
+    const result = resolveModel({
+      taskType: 'code',
+      config: {
+        models: {
+          costPolicy: {
+            maxCategory: 'versatile',
+            preferIncluded: false,
+          },
+        },
+      },
+      sessionCostPolicy: {
+        source: 'command',
+        preferIncluded: true,
+      },
+    });
+
+    expect(result.model).toBe('gpt-4.1');
+    expect(result.tier).toBe('standard');
+    expect(result.policy).toMatchObject({
+      action: 'preferred-included',
+      originalModel: 'claude-sonnet-4.6',
+      finalModel: 'gpt-4.1',
+      appliedPolicy: {
+        maxCategory: 'versatile',
+        preferIncluded: true,
+      },
+    });
+  });
+
+  it('prunes non-compliant fallback models even when the selected model is allowed', () => {
+    const result = resolveModel({
+      taskType: 'docs',
+      config: {
+        models: {
+          costPolicy: {
+            maxCategory: 'lightweight',
+          },
+        },
+      },
+    });
+
+    expect(result.model).toBe('claude-haiku-4.5');
+    expect(result.policy?.action).toBe('fallback-chain-pruned');
+    expect(result.fallbackChain).toEqual([
+      'claude-haiku-4.5',
+      'gpt-5.4-mini',
+      'gpt-5-mini',
+    ]);
+  });
+
+  it('gracefully skips policy enforcement for models outside the catalog', () => {
+    const result = resolveModel({
+      taskType: 'code',
+      userOverride: 'custom-model-xyz',
+      sessionCostPolicy: { source: 'conversation', maxCategory: 'lightweight' },
+    });
+
+    expect(result.model).toBe('custom-model-xyz');
+    expect(result.source).toBe('user-override');
+    expect(result.policy).toBeUndefined();
+  });
+});

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -26,35 +26,81 @@ describe('MODEL_CATALOG', () => {
   it('includes expected premium models', () => {
     const modelIds = MODEL_CATALOG.map(m => m.id);
     
+    expect(modelIds).toContain('claude-opus-4.7');
     expect(modelIds).toContain('claude-opus-4.6');
-    expect(modelIds).toContain('claude-opus-4.6-fast');
     expect(modelIds).toContain('claude-opus-4.5');
   });
 
   it('includes expected standard models', () => {
     const modelIds = MODEL_CATALOG.map(m => m.id);
     
-    expect(modelIds).toContain('claude-sonnet-4.5');
+    expect(modelIds).toContain('claude-sonnet-4.6');
     expect(modelIds).toContain('gpt-5.2-codex');
-    expect(modelIds).toContain('gemini-3-pro-preview');
+    expect(modelIds).toContain('gemini-3.1-pro');
   });
 
   it('includes expected fast models', () => {
     const modelIds = MODEL_CATALOG.map(m => m.id);
     
     expect(modelIds).toContain('claude-haiku-4.5');
-    expect(modelIds).toContain('gpt-5.1-codex-mini');
+    expect(modelIds).toContain('gpt-5.4-mini');
     expect(modelIds).toContain('gpt-5-mini');
   });
 
   it('assigns correct providers', () => {
-    const claude = MODEL_CATALOG.find(m => m.id === 'claude-sonnet-4.5');
+    const claude = MODEL_CATALOG.find(m => m.id === 'claude-sonnet-4.6');
     const gpt = MODEL_CATALOG.find(m => m.id === 'gpt-5.2-codex');
-    const gemini = MODEL_CATALOG.find(m => m.id === 'gemini-3-pro-preview');
+    const gemini = MODEL_CATALOG.find(m => m.id === 'gemini-3.1-pro');
     
     expect(claude?.provider).toBe('anthropic');
     expect(gpt?.provider).toBe('openai');
     expect(gemini?.provider).toBe('google');
+  });
+});
+
+describe('MODEL_CATALOG — new fields', () => {
+  const categoryOrder = {
+    lightweight: 0,
+    versatile: 1,
+    powerful: 2,
+  } as const;
+
+  it('all active models have githubCategory set', () => {
+    const activeModels = MODEL_CATALOG.filter((model) => model.availability === 'active');
+    expect(activeModels.every((model) => model.githubCategory)).toBe(true);
+  });
+
+  it('included models (gpt-4.1, gpt-5-mini) are marked included and priced at zero', () => {
+    const includedIds = ['gpt-4.1', 'gpt-5-mini'];
+    const includedModels = MODEL_CATALOG.filter((model) => includedIds.includes(model.id));
+
+    expect(includedModels.map((model) => model.id)).toEqual(includedIds);
+    expect(includedModels.every((model) => model.includedInCopilot === true)).toBe(true);
+    expect(includedModels.every((model) => model.pricing?.inputPerToken === 0 && model.pricing?.outputPerToken === 0)).toBe(true);
+  });
+
+  it('deprecated models are marked deprecated and phantom IDs are not active', () => {
+    const phantomIds = [
+      'gpt-5.1',
+      'gpt-5.1-codex',
+      'claude-opus-4.6-fast',
+      'gpt-5.1-codex-mini',
+    ];
+
+    for (const modelId of phantomIds) {
+      const model = MODEL_CATALOG.find((entry) => entry.id === modelId);
+      expect(model?.availability).toBe('deprecated');
+    }
+
+    const activeIds = new Set(MODEL_CATALOG.filter((model) => model.availability === 'active').map((model) => model.id));
+    expect(phantomIds.every((modelId) => !activeIds.has(modelId))).toBe(true);
+  });
+
+  it('category ordering is consistent (lightweight < versatile < powerful)', () => {
+    const categories = Array.from(new Set(MODEL_CATALOG.map((model) => model.githubCategory).filter(Boolean))) as Array<keyof typeof categoryOrder>;
+    const ordered = [...categories].sort((left, right) => categoryOrder[left] - categoryOrder[right]);
+
+    expect(ordered).toEqual(['lightweight', 'versatile', 'powerful']);
   });
 });
 
@@ -72,7 +118,7 @@ describe('DEFAULT_FALLBACK_CHAINS', () => {
   });
 
   it('starts premium chain with opus models', () => {
-    expect(DEFAULT_FALLBACK_CHAINS.premium[0]).toBe('claude-opus-4.6');
+    expect(DEFAULT_FALLBACK_CHAINS.premium[0]).toBe('claude-opus-4.7');
   });
 
   it('starts standard chain with sonnet', () => {
@@ -192,11 +238,11 @@ describe('ModelRegistry', () => {
     it('returns next model in chain', () => {
       const next = registry.getNextFallback('claude-opus-4.6', 'premium');
       
-      expect(next).toBe('claude-opus-4.6-fast');
+      expect(next).toBe('claude-opus-4.7');
     });
 
     it('skips already attempted models', () => {
-      const attempted = new Set(['claude-opus-4.6-fast', 'claude-opus-4.5']);
+      const attempted = new Set(['claude-opus-4.7', 'claude-opus-4.5']);
       const next = registry.getNextFallback('claude-opus-4.6', 'premium', attempted);
       
       expect(next).not.toBeNull();
@@ -262,10 +308,10 @@ describe('ModelRegistry', () => {
 
 describe('convenience functions', () => {
   it('getModelInfo works', () => {
-    const info = getModelInfo('claude-sonnet-4.5');
+    const info = getModelInfo('claude-sonnet-4.6');
     
     expect(info).toBeDefined();
-    expect(info?.id).toBe('claude-sonnet-4.5');
+    expect(info?.id).toBe('claude-sonnet-4.6');
   });
 
   it('getFallbackChain works', () => {

--- a/test/telemetry-auto-wiring.test.ts
+++ b/test/telemetry-auto-wiring.test.ts
@@ -173,14 +173,14 @@ describe('estimateCost()', () => {
 
   it('works for fast-tier models', () => {
     const cost = estimateCost('claude-haiku-4.5', 10000, 5000);
-    // pricing: input $0.0000008/token, output $0.000004/token
-    expect(cost).toBeCloseTo(0.008 + 0.02, 6);
+    // pricing: input $0.000001/token, output $0.000005/token
+    expect(cost).toBeCloseTo(0.01 + 0.025, 6);
   });
 
   it('works for premium-tier models', () => {
     const cost = estimateCost('claude-opus-4.6', 1000, 500);
-    // pricing: input $0.000015/token, output $0.000075/token
-    expect(cost).toBeCloseTo(0.015 + 0.0375, 6);
+    // pricing: input $0.000005/token, output $0.000025/token
+    expect(cost).toBeCloseTo(0.005 + 0.0125, 6);
   });
 });
 
@@ -193,8 +193,11 @@ describe('MODEL_CATALOG pricing', () => {
     for (const model of MODEL_CATALOG) {
       expect(model.pricing, `Model ${model.id} missing pricing`).toBeDefined();
       const pricing = model.pricing as ModelPricing;
-      expect(pricing.inputPerToken).toBeGreaterThan(0);
-      expect(pricing.outputPerToken).toBeGreaterThan(0);
+      // Included-in-Copilot models have 0 extra cost by design; all others must have real pricing
+      if (!model.includedInCopilot) {
+        expect(pricing.inputPerToken).toBeGreaterThan(0);
+        expect(pricing.outputPerToken).toBeGreaterThan(0);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

Add cost policy support and refresh the GitHub model catalog for the AI Credits billing transition.

### What this PR does

- **New types:** \GitHubModelCategory\, \CostPolicyConfig\, \CostPolicyOutcome\ in \models.ts\
- **Updated model catalog:** Full Lightweight/Versatile/Powerful category mapping with credit costs and included-model flags
- **\costPolicy\ config field:** Added to \ModelSelectionConfig\ and schema
- **Updated fallback chains:** \DEFAULT_FALLBACK_CHAINS\ refreshed to current active model IDs
- **Two-phase model resolution in \model-selector.ts\:**
  - Post-selection cost policy veto (warn-and-allow for explicit Layer 0/1 overrides, auto-downgrade for Layer 2-4)
  - Ceiling-aware fallback chain pruning
- **Template sync:** All \squad.agent.md\templates and skill files updated with new catalog
- **New tests:** \test\model-selector-policy.test.ts\ — full cost policy coverage
- **Cleanup:** Removed dangling \test/cost-policy.test.ts\ stub (tests live in \model-selector-policy.test.ts\)

### Notes on diff size

This PR touches 66 files. The large diff is **intentional and expected** — the model catalog and \squad.agent.md\ changes propagate to multiple template targets by design:
- \.squad-templates/\ (root templates)
- \packages/squad-cli/templates/\
- \packages/squad-sdk/templates/\
- \.github/agents/squad.agent.md\
- \.squad/skills/model-selection/SKILL.md\ + \.copilot/skills/model-selection/SKILL.md\

This is the intended template sync architecture, not branch contamination.

### Changeset

Included: \.changeset/cost-policy-billing-update.md\
- \@bradygaster/squad-sdk\: minor
- \@bradygaster/squad-cli\: patch

Closes #1080