### PR TITLE
fix: auto-generate insider prerelease versions + bump to 0.9.6

### DIFF
--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -100,15 +100,57 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Compute insider version
+        id: version
+        run: |
+          # Read base version from root package.json
+          BASE=$(node -p "require('./package.json').version")
+          echo "Base version: $BASE"
+
+          # Query npm for the latest insider build number for this base version
+          LATEST_SDK=$(npm view @bradygaster/squad-sdk versions --json 2>/dev/null | \
+            node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).filter(v => v.startsWith('${BASE}-insider.')).map(v => parseInt(v.split('.').pop())).sort((a,b) => b-a)[0] || 0" 2>/dev/null || echo "0")
+          LATEST_CLI=$(npm view @bradygaster/squad-cli versions --json 2>/dev/null | \
+            node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).filter(v => v.startsWith('${BASE}-insider.')).map(v => parseInt(v.split('.').pop())).sort((a,b) => b-a)[0] || 0" 2>/dev/null || echo "0")
+
+          # Take the higher of the two and increment
+          NEXT=$(( (LATEST_SDK > LATEST_CLI ? LATEST_SDK : LATEST_CLI) + 1 ))
+          INSIDER_VERSION="${BASE}-insider.${NEXT}"
+          echo "Publishing as: $INSIDER_VERSION"
+          echo "insider_version=$INSIDER_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set insider version in package.json files
+        run: |
+          VERSION="${{ steps.version.outputs.insider_version }}"
+          node -e "
+            const fs = require('fs');
+            const paths = ['package.json', 'packages/squad-sdk/package.json', 'packages/squad-cli/package.json'];
+            for (const p of paths) {
+              const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
+              pkg.version = '${VERSION}';
+              fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
+              console.log(p + ' → ' + '${VERSION}');
+            }
+          "
+
       - name: Build packages
         run: npm -w packages/squad-sdk run build && npm -w packages/squad-cli run build
 
       - name: Publish squad-sdk with insider tag
+        if: ${{ inputs.dry_run != 'true' }}
         run: npm -w packages/squad-sdk publish --tag insider --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish squad-cli with insider tag
+        if: ${{ inputs.dry_run != 'true' }}
         run: npm -w packages/squad-cli publish --tag insider --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run == 'true' }}
+        run: |
+          echo "🏜️ DRY RUN — would have published:"
+          echo "  @bradygaster/squad-sdk@${{ steps.version.outputs.insider_version }}"
+          echo "  @bradygaster/squad-cli@${{ steps.version.outputs.insider_version }}"

--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -108,10 +108,20 @@ jobs:
           echo "Base version: $BASE"
 
           # Query npm for the latest insider build number for this base version
-          LATEST_SDK=$(npm view @bradygaster/squad-sdk versions --json 2>/dev/null | \
-            node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).filter(v => v.startsWith('${BASE}-insider.')).map(v => parseInt(v.split('.').pop())).sort((a,b) => b-a)[0] || 0" 2>/dev/null || echo "0")
-          LATEST_CLI=$(npm view @bradygaster/squad-cli versions --json 2>/dev/null | \
-            node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).filter(v => v.startsWith('${BASE}-insider.')).map(v => parseInt(v.split('.').pop())).sort((a,b) => b-a)[0] || 0" 2>/dev/null || echo "0")
+          # Fail hard if npm is unreachable — defaulting to 0 risks republishing an existing version
+          SDK_VERSIONS=$(npm view @bradygaster/squad-sdk versions --json 2>&1) || {
+            echo "::error::Failed to query npm for squad-sdk versions. Cannot safely compute insider version."
+            exit 1
+          }
+          CLI_VERSIONS=$(npm view @bradygaster/squad-cli versions --json 2>&1) || {
+            echo "::error::Failed to query npm for squad-cli versions. Cannot safely compute insider version."
+            exit 1
+          }
+
+          LATEST_SDK=$(echo "$SDK_VERSIONS" | \
+            node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).filter(v => v.startsWith('${BASE}-insider.')).map(v => parseInt(v.split('.').pop())).sort((a,b) => b-a)[0] || 0")
+          LATEST_CLI=$(echo "$CLI_VERSIONS" | \
+            node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).filter(v => v.startsWith('${BASE}-insider.')).map(v => parseInt(v.split('.').pop())).sort((a,b) => b-a)[0] || 0")
 
           # Take the higher of the two and increment
           NEXT=$(( (LATEST_SDK > LATEST_CLI ? LATEST_SDK : LATEST_CLI) + 1 ))

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.9.1",
+  "version": "0.9.6",
   "private": true,
-  "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
+  "description": "Squad \u00e2\u20ac\u201d Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bradygaster/squad",
   "version": "0.9.6",
   "private": true,
-  "description": "Squad \u00e2\u20ac\u201d Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
+  "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.9.1",
-  "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
+  "version": "0.9.6",
+  "description": "Squad CLI \u00e2\u20ac\u201d Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {
     "squad": "dist/cli-entry.js",

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bradygaster/squad-cli",
   "version": "0.9.6",
-  "description": "Squad CLI \u00e2\u20ac\u201d Command-line interface for the Squad multi-agent runtime",
+  "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {
     "squad": "dist/cli-entry.js",

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.9.1",
-  "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
+  "version": "0.9.6",
+  "description": "Squad SDK \u00e2\u20ac\u201d Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bradygaster/squad-sdk",
   "version": "0.9.6",
-  "description": "Squad SDK \u00e2\u20ac\u201d Programmable multi-agent runtime for GitHub Copilot",
+  "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Problem

The insider publish workflow failed with E403 because it tried to publish \@bradygaster/squad-sdk@0.9.1\ which already exists on npm. The workflow had no version-bump step.

## Fix

1. **Auto-version**: Added a step that queries npm for the latest \X.Y.Z-insider.N\ version and increments N. Each publish is guaranteed unique.
2. **Version bump**: Bumped all packages from 0.9.1 → 0.9.6 (above main's 0.9.4 and old insider's 0.9.5-insider.2).
3. **Dry run support**: The \dry_run\ input now gates the actual publish steps.

## Result

After merge, triggering the workflow will publish \