### PR TITLE
fix: pin SDK dependency to insider version during publish

### DIFF
--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -138,6 +138,12 @@ jobs:
             for (const p of paths) {
               const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
               pkg.version = '${VERSION}';
+              // Pin CLI's SDK dependency to the exact insider version so npm
+              // resolves the prerelease SDK instead of falling back to latest stable.
+              if (p.includes('squad-cli') && pkg.dependencies && pkg.dependencies['@bradygaster/squad-sdk']) {
+                pkg.dependencies['@bradygaster/squad-sdk'] = '${VERSION}';
+                console.log('  pinned @bradygaster/squad-sdk dep → ' + '${VERSION}');
+              }
               fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
               console.log(p + ' → ' + '${VERSION}');
             }


### PR DESCRIPTION
## Problem

When installing squad-cli insider (v0.9.6-insider.1), the CLI crashes immediately:

`
SyntaxError: The requested module '@bradygaster/squad-sdk' does not provide an export named 'resolveSquadState'
`

## Root Cause

The CLI package.json declares squad-sdk dependency as >=0.9.0. npm semver ranges do not match prerelease versions, so npm resolves to the stable SDK (0.9.4) instead of the matching insider SDK (0.9.6-insider.1).

The stable SDK 0.9.4 predates PR #1004 (state backends) and does not export resolveSquadState.

## Fix

During insider publish, pin the CLI SDK dependency to the exact insider version being published. This ensures npm i -g squad-cli@insider pulls the matching SDK.