### PR TITLE
feat: multi-provider LLM support (Claude, Gemini, Vertex AI)

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -3,14 +3,14 @@ name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
 ---
 
-<!-- version: 0.9.1 -->
+<!-- version: 0.0.0-source -->
 
 You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
 
 ### Coordinator Identity
 
 - **Name:** Squad (Coordinator)
-- **Version:** 0.9.1 (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v0.9.1` in your first response of each session (e.g., in the acknowledgment or greeting).
+- **Version:** 0.0.0-source (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v{version}` in your first response of each session (e.g., in the acknowledgment or greeting).
 - **Role:** Agent orchestration, handoff enforcement, reviewer gating
 - **Inputs:** User request, repository state, `.squad/decisions.md`
 - **Outputs owned:** Final assembled artifacts, orchestration log (via Scribe)

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ docs/tests/screenshots/
 
 # Images folder (root only — don't ignore docs/public/images/)
 /images/
+# Squad: ignore runtime state (logs, inbox, sessions)
+.squad/.scratch/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.9.1",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bradygaster/squad",
-      "version": "0.9.1",
+      "version": "0.9.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -4224,6 +4224,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -4338,6 +4348,37 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -4363,6 +4404,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4994,6 +5042,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5435,6 +5493,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5630,6 +5695,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensequence": {
       "version": "8.0.8",
       "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-8.0.8.tgz",
@@ -5800,12 +5897,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5846,6 +5985,20 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -6230,6 +6383,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6327,6 +6493,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -6354,6 +6530,29 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/katex": {
       "version": "0.16.44",
@@ -7247,6 +7446,27 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-pty": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
@@ -7791,6 +8011,27 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -8236,6 +8477,13 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -8386,6 +8634,21 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -8596,6 +8859,24 @@
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -8928,7 +9209,7 @@
     },
     "packages/squad-cli": {
       "name": "@bradygaster/squad-cli",
-      "version": "0.9.1",
+      "version": "0.9.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -9443,7 +9724,7 @@
     },
     "packages/squad-sdk": {
       "name": "@bradygaster/squad-sdk",
-      "version": "0.9.1",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^0.1.32",
@@ -9470,6 +9751,7 @@
         "@opentelemetry/sdk-trace-base": "^1.30.0",
         "@opentelemetry/sdk-trace-node": "^1.30.0",
         "@opentelemetry/semantic-conventions": "^1.28.0",
+        "google-auth-library": "^9.0.0",
         "sql.js": "^1.14.1",
         "ws": "^8.18.0"
       }

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -24,34 +24,27 @@ process.emit = function (evt: string, ...args: unknown[]) {
 
 // Runtime ESM Import Patcher for @github/copilot-sdk (#265)
 // ---------------------------------------------------------
-// Patch broken ESM import in @github/copilot-sdk@0.1.32 at runtime before
-// Node's module loader attempts resolution.
+// Only needed when using the Copilot provider. Non-Copilot providers
+// (anthropic, google, etc.) don't import the Copilot SDK.
 //
 // Root cause: copilot-sdk's session.js imports 'vscode-jsonrpc/node' without
 // .js extension, violating Node 24+ strict ESM resolution requirements.
 //
-// Why runtime patch?: NPX caches packages in ~/.npm/_cacache and skips
-// postinstall scripts on cache hits (documented npm behavior). The install-time
-// patch in scripts/patch-esm-imports.mjs never runs on npx cache hits, causing
-// ERR_MODULE_NOT_FOUND crashes on Node 24+.
-//
-// This runtime patch intercepts Module._resolveFilename before any imports
-// trigger copilot-sdk loading, rewriting the broken import to include .js.
-// Works everywhere: npx (cache hit/miss), global install, CI/CD.
-//
 // Upstream issue: https://github.com/github/copilot-sdk/issues/707
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
-const Module = require('node:module');
 
-const _origResolveFilename = Module._resolveFilename;
-Module._resolveFilename = function (request: string, parent: unknown, isMain: boolean, options?: unknown) {
-  // Intercept the broken import: 'vscode-jsonrpc/node' → 'vscode-jsonrpc/node.js'
-  if (request === 'vscode-jsonrpc/node') {
-    request = 'vscode-jsonrpc/node.js';
-  }
-  return _origResolveFilename.call(this, request, parent, isMain, options);
-};
+const _squadProvider = process.env['SQUAD_PROVIDER']?.toLowerCase().trim();
+if (!_squadProvider || _squadProvider === 'copilot') {
+  const Module = require('node:module');
+  const _origResolveFilename = Module._resolveFilename;
+  Module._resolveFilename = function (request: string, parent: unknown, isMain: boolean, options?: unknown) {
+    if (request === 'vscode-jsonrpc/node') {
+      request = 'vscode-jsonrpc/node.js';
+    }
+    return _origResolveFilename.call(this, request, parent, isMain, options);
+  };
+}
 
 // Pre-flight: require Node.js ≥22.5.0 for node:sqlite (#214, #502).
 // node:sqlite is used by the Copilot SDK for session storage.
@@ -128,6 +121,13 @@ async function main(): Promise<void> {
     args.splice(teamRootIdx, 2);
   }
   
+  // --provider flag: override LLM provider for this session
+  const providerIdx = args.indexOf('--provider');
+  if (providerIdx !== -1 && args[providerIdx + 1]) {
+    process.env['SQUAD_PROVIDER'] = args[providerIdx + 1]!;
+    args.splice(providerIdx, 2);
+  }
+
   const hasGlobal = args.includes('--global');
   // --economy activates economy mode for this session (sets env var for spawner)
   const hasEconomy = args.includes('--economy');
@@ -271,6 +271,7 @@ async function main(): Promise<void> {
     console.log(`  ${BOLD}--help, -h${RESET}     Show help`);
     console.log(`  ${BOLD}--global${RESET}       Use personal (global) squad path (for init, upgrade)`);
     console.log(`  ${BOLD}--economy${RESET}      Activate economy mode for this session (cheaper models)`);
+    console.log(`  ${BOLD}--provider${RESET}     LLM provider: copilot, anthropic, anthropic-vertex, google, google-vertex`);
     console.log(`  ${BOLD}--team-root${RESET}    Override team root path for resolution`);
     console.log(`\nInstallation:`);
     console.log(`  npm install --save-dev @bradygaster/squad-cli`);

--- a/packages/squad-cli/src/cli/commands/doctor.ts
+++ b/packages/squad-cli/src/cli/commands/doctor.ts
@@ -435,6 +435,24 @@ function checkSquadAgentMd(cwd: string): DoctorCheck {
   };
 }
 
+// ── provider checks ────────────────────────────────────────────────
+
+function checkApiKey(envVar: string, providerLabel: string): DoctorCheck {
+  const value = process.env[envVar];
+  if (value && value.trim().length > 0) {
+    return {
+      name: `${providerLabel} API key (${envVar})`,
+      status: 'pass',
+      message: 'environment variable set',
+    };
+  }
+  return {
+    name: `${providerLabel} API key (${envVar})`,
+    status: 'fail',
+    message: `${envVar} not set — required for ${providerLabel} provider`,
+  };
+}
+
 // ── public API ──────────────────────────────────────────────────────
 
 /**
@@ -473,15 +491,43 @@ export async function runDoctor(cwd?: string): Promise<DoctorCheck[]> {
     if (rateLimitCheck) checks.push(rateLimitCheck);
   }
 
-  // 10. Copilot agent discovery file (relative to cwd, not squadDir)
-  checks.push(checkSquadAgentMd(resolvedCwd));
+  // Determine active provider for conditional checks
+  const activeProvider = process.env['SQUAD_PROVIDER']?.toLowerCase().trim() ?? 'copilot';
 
-  // 11. Node.js version (node:sqlite availability)
-  checks.push(checkNodeVersion());
+  // 10. Copilot agent discovery file (only relevant for copilot provider)
+  if (activeProvider === 'copilot') {
+    checks.push(checkSquadAgentMd(resolvedCwd));
+  }
 
-  // 11-12. ESM compatibility (Node 22/24+)
-  checks.push(checkVscodeJsonrpcExports(resolvedCwd));
-  checks.push(checkCopilotSdkSessionPatch(resolvedCwd));
+  // 11. Node.js version (node:sqlite availability — copilot provider only)
+  if (activeProvider === 'copilot') {
+    checks.push(checkNodeVersion());
+  }
+
+  // 12-13. ESM compatibility (Node 22/24+ — copilot provider only)
+  if (activeProvider === 'copilot') {
+    checks.push(checkVscodeJsonrpcExports(resolvedCwd));
+    checks.push(checkCopilotSdkSessionPatch(resolvedCwd));
+  }
+
+  // Provider-specific checks
+  if (activeProvider === 'anthropic') {
+    checks.push(checkApiKey('ANTHROPIC_API_KEY', 'Anthropic'));
+  } else if (activeProvider === 'anthropic-vertex') {
+    checks.push(checkApiKey('GOOGLE_CLOUD_PROJECT', 'Google Cloud Project'));
+  } else if (activeProvider === 'google') {
+    checks.push(checkApiKey('GOOGLE_AI_API_KEY', 'Google AI'));
+  } else if (activeProvider === 'google-vertex') {
+    checks.push(checkApiKey('GOOGLE_CLOUD_PROJECT', 'Google Cloud Project'));
+  }
+
+  // Active provider info
+  checks.push({
+    name: 'LLM provider',
+    status: 'pass',
+    message: `active provider: ${activeProvider}`,
+    severity: 'info',
+  });
 
   return checks;
 }

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -976,7 +976,7 @@ prompt: |
 
   Tasks (in order):
   {% if STATE_BACKEND == "orphan" or STATE_BACKEND == "git-notes" or STATE_BACKEND == "two-layer" %}
-  0. STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
+  0. PRE-CHECK — STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
      (.squad/decisions.md, agents/*/history.md, log/*, orchestration-log/*, decisions/inbox/*)
      to the working branch. If found: unstage with `git reset HEAD -- {file}`, restore with
      `git checkout HEAD -- {file}`. If leaked in last commit, amend to remove. Log count.

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -110,6 +110,14 @@
       "types": "./dist/adapter/errors.d.ts",
       "import": "./dist/adapter/errors.js"
     },
+    "./adapter/provider": {
+      "types": "./dist/adapter/provider.d.ts",
+      "import": "./dist/adapter/provider.js"
+    },
+    "./adapter/provider-factory": {
+      "types": "./dist/adapter/provider-factory.d.ts",
+      "import": "./dist/adapter/provider-factory.js"
+    },
     "./config/migrations": {
       "types": "./dist/config/migrations/index.d.ts",
       "import": "./dist/config/migrations/index.js"
@@ -245,6 +253,7 @@
     "@opentelemetry/sdk-trace-base": "^1.30.0",
     "@opentelemetry/sdk-trace-node": "^1.30.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
+    "google-auth-library": "^9.0.0",
     "sql.js": "^1.14.1",
     "ws": "^8.18.0"
   },

--- a/packages/squad-sdk/src/adapter/agentic-loop.ts
+++ b/packages/squad-sdk/src/adapter/agentic-loop.ts
@@ -1,0 +1,408 @@
+/**
+ * Agentic Tool-Use Loop Engine
+ *
+ * Implements the think → tool-call → execute → feed-result loop that the
+ * Copilot SDK handles internally. All direct API providers (Anthropic,
+ * Google) share this engine via their LLMApiAdapter implementations.
+ *
+ * @module adapter/agentic-loop
+ */
+
+import type {
+  SquadTool,
+  SquadToolResultObject,
+  SquadSessionEvent,
+  SquadSessionHooks,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// LLM API Adapter — provider-specific API surface
+// ---------------------------------------------------------------------------
+
+export interface LLMMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: LLMContentBlock[];
+}
+
+export type LLMContentBlock =
+  | LLMTextBlock
+  | LLMToolUseBlock
+  | LLMToolResultBlock
+  | LLMReasoningBlock;
+
+export interface LLMTextBlock {
+  type: 'text';
+  text: string;
+}
+
+export interface LLMToolUseBlock {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface LLMToolResultBlock {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string;
+  is_error?: boolean;
+}
+
+export interface LLMReasoningBlock {
+  type: 'reasoning';
+  text: string;
+}
+
+export interface LLMToolDefinition {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+export interface LLMRequest {
+  model: string;
+  systemPrompt?: string;
+  messages: LLMMessage[];
+  tools: LLMToolDefinition[];
+  stream: boolean;
+  maxTokens?: number;
+  reasoningEffort?: string;
+}
+
+export type LLMChunk =
+  | { type: 'text_delta'; text: string }
+  | { type: 'reasoning_delta'; text: string }
+  | { type: 'tool_use_start'; id: string; name: string }
+  | { type: 'tool_use_delta'; id: string; partialJson: string }
+  | { type: 'tool_use_end'; id: string }
+  | { type: 'usage'; inputTokens: number; outputTokens: number; model: string }
+  | { type: 'end'; stopReason: 'end_turn' | 'tool_use' | 'max_tokens' | 'stop' };
+
+/**
+ * Adapter interface that provider-specific API implementations must fulfill.
+ * Each provider converts its native streaming format to the normalized
+ * LLMChunk stream consumed by the AgenticLoop.
+ */
+export interface LLMApiAdapter {
+  call(request: LLMRequest): AsyncIterable<LLMChunk>;
+}
+
+// ---------------------------------------------------------------------------
+// AgenticLoop
+// ---------------------------------------------------------------------------
+
+export interface AgenticLoopOptions {
+  adapter: LLMApiAdapter;
+  tools: SquadTool<any>[];
+  model: string;
+  systemPrompt?: string;
+  maxIterations?: number;
+  maxTokens?: number;
+  reasoningEffort?: string;
+  hooks?: SquadSessionHooks;
+  sessionId?: string;
+  signal?: AbortSignal;
+}
+
+export interface AgenticLoopResult {
+  messages: LLMMessage[];
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  iterations: number;
+}
+
+/**
+ * Convert SquadTool[] to the LLM tool definition format.
+ */
+function toToolDefinitions(tools: SquadTool<any>[]): LLMToolDefinition[] {
+  return tools.map((t) => {
+    let inputSchema: Record<string, unknown>;
+    if (t.parameters && 'toJSONSchema' in t.parameters && typeof t.parameters.toJSONSchema === 'function') {
+      inputSchema = t.parameters.toJSONSchema() as Record<string, unknown>;
+    } else {
+      inputSchema = (t.parameters as Record<string, unknown>) ?? { type: 'object', properties: {} };
+    }
+    return {
+      name: t.name,
+      description: t.description ?? '',
+      input_schema: inputSchema,
+    };
+  });
+}
+
+/**
+ * Execute a tool and return a normalized result.
+ */
+async function executeTool(
+  tool: SquadTool<any>,
+  args: Record<string, unknown>,
+  toolCallId: string,
+  sessionId: string,
+  hooks?: SquadSessionHooks,
+): Promise<{ content: string; isError: boolean }> {
+  // Pre-tool-use hook
+  let finalArgs = args;
+  if (hooks?.onPreToolUse) {
+    const hookResult = await hooks.onPreToolUse(
+      { timestamp: Date.now(), cwd: process.cwd(), toolName: tool.name, toolArgs: args },
+      { sessionId },
+    );
+    if (hookResult?.permissionDecision === 'deny') {
+      return {
+        content: hookResult.permissionDecisionReason ?? 'Tool execution denied by hook',
+        isError: true,
+      };
+    }
+    if (hookResult?.modifiedArgs) {
+      finalArgs = hookResult.modifiedArgs as Record<string, unknown>;
+    }
+  }
+
+  try {
+    const raw = await tool.handler(finalArgs, {
+      sessionId,
+      toolCallId,
+      toolName: tool.name,
+      arguments: finalArgs,
+    });
+
+    let resultObj: SquadToolResultObject;
+    if (typeof raw === 'string') {
+      resultObj = { textResultForLlm: raw, resultType: 'success' };
+    } else if (raw && typeof raw === 'object' && 'textResultForLlm' in raw) {
+      resultObj = raw as SquadToolResultObject;
+    } else {
+      resultObj = { textResultForLlm: JSON.stringify(raw), resultType: 'success' };
+    }
+
+    // Post-tool-use hook
+    if (hooks?.onPostToolUse) {
+      const postResult = await hooks.onPostToolUse(
+        { timestamp: Date.now(), cwd: process.cwd(), toolName: tool.name, toolArgs: finalArgs, toolResult: resultObj },
+        { sessionId },
+      );
+      if (postResult?.modifiedResult) {
+        resultObj = postResult.modifiedResult;
+      }
+    }
+
+    return {
+      content: resultObj.textResultForLlm,
+      isError: resultObj.resultType === 'failure',
+    };
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    return { content: `Tool error: ${errorMsg}`, isError: true };
+  }
+}
+
+/**
+ * Run the agentic tool-use loop.
+ *
+ * Streams LLM responses, detects tool_use blocks, executes tools, feeds
+ * results back, and repeats until the LLM produces a final text response
+ * (stopReason !== 'tool_use') or the iteration limit is reached.
+ */
+export async function runAgenticLoop(
+  options: AgenticLoopOptions,
+  emit: (event: SquadSessionEvent) => void,
+): Promise<AgenticLoopResult> {
+  const {
+    adapter,
+    tools,
+    model,
+    systemPrompt,
+    maxIterations = 25,
+    maxTokens,
+    reasoningEffort,
+    hooks,
+    sessionId = 'direct-session',
+    signal,
+  } = options;
+
+  const toolDefs = toToolDefinitions(tools);
+  const toolMap = new Map(tools.map((t) => [t.name, t]));
+
+  const messages: LLMMessage[] = [];
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  let iterations = 0;
+
+  // The caller is responsible for pushing the initial user message into
+  // `messages` before calling this function — see DirectApiSession.
+
+  for (let i = 0; i < maxIterations; i++) {
+    if (signal?.aborted) {
+      throw new Error('Agentic loop aborted');
+    }
+
+    iterations++;
+    emit({ type: 'turn_start', iteration: i + 1 });
+
+    const request: LLMRequest = {
+      model,
+      systemPrompt,
+      messages,
+      tools: toolDefs,
+      stream: true,
+      maxTokens,
+      reasoningEffort,
+    };
+
+    // Collect the assistant's response from the streamed chunks
+    const contentBlocks: LLMContentBlock[] = [];
+    let currentText = '';
+    let currentReasoning = '';
+    const pendingToolUses = new Map<string, { name: string; jsonParts: string[] }>();
+    let stopReason: string = 'end_turn';
+
+    for await (const chunk of adapter.call(request)) {
+      if (signal?.aborted) {
+        throw new Error('Agentic loop aborted');
+      }
+
+      switch (chunk.type) {
+        case 'text_delta':
+          currentText += chunk.text;
+          emit({ type: 'message_delta', content: chunk.text });
+          break;
+
+        case 'reasoning_delta':
+          currentReasoning += chunk.text;
+          emit({ type: 'reasoning_delta', content: chunk.text });
+          break;
+
+        case 'tool_use_start':
+          // Flush accumulated text before tool use
+          if (currentText) {
+            contentBlocks.push({ type: 'text', text: currentText });
+            currentText = '';
+          }
+          if (currentReasoning) {
+            contentBlocks.push({ type: 'reasoning', text: currentReasoning });
+            currentReasoning = '';
+          }
+          pendingToolUses.set(chunk.id, { name: chunk.name, jsonParts: [] });
+          break;
+
+        case 'tool_use_delta':
+          pendingToolUses.get(chunk.id)?.jsonParts.push(chunk.partialJson);
+          break;
+
+        case 'tool_use_end': {
+          const pending = pendingToolUses.get(chunk.id);
+          if (pending) {
+            let input: Record<string, unknown> = {};
+            try {
+              const jsonStr = pending.jsonParts.join('');
+              if (jsonStr) {
+                input = JSON.parse(jsonStr);
+              }
+            } catch {
+              input = {};
+            }
+            contentBlocks.push({
+              type: 'tool_use',
+              id: chunk.id,
+              name: pending.name,
+              input,
+            });
+            pendingToolUses.delete(chunk.id);
+          }
+          break;
+        }
+
+        case 'usage':
+          totalInputTokens += chunk.inputTokens;
+          totalOutputTokens += chunk.outputTokens;
+          emit({
+            type: 'usage',
+            inputTokens: chunk.inputTokens,
+            outputTokens: chunk.outputTokens,
+            model: chunk.model,
+          });
+          break;
+
+        case 'end':
+          stopReason = chunk.stopReason;
+          break;
+      }
+    }
+
+    // Flush remaining text/reasoning
+    if (currentText) {
+      contentBlocks.push({ type: 'text', text: currentText });
+    }
+    if (currentReasoning) {
+      contentBlocks.push({ type: 'reasoning', text: currentReasoning });
+    }
+
+    // Add the assistant's response to the conversation
+    messages.push({ role: 'assistant', content: contentBlocks });
+
+    // Emit the full message
+    const fullText = contentBlocks
+      .filter((b): b is LLMTextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join('');
+    if (fullText) {
+      emit({ type: 'message', content: fullText, role: 'assistant' });
+    }
+
+    const fullReasoning = contentBlocks
+      .filter((b): b is LLMReasoningBlock => b.type === 'reasoning')
+      .map((b) => b.text)
+      .join('');
+    if (fullReasoning) {
+      emit({ type: 'reasoning', content: fullReasoning });
+    }
+
+    // If the LLM didn't request tool use, we're done
+    const toolUseBlocks = contentBlocks.filter(
+      (b): b is LLMToolUseBlock => b.type === 'tool_use',
+    );
+
+    if (toolUseBlocks.length === 0 || stopReason !== 'tool_use') {
+      emit({ type: 'turn_end', iteration: i + 1, reason: stopReason });
+      break;
+    }
+
+    // Execute all requested tools
+    const toolResults: LLMContentBlock[] = [];
+    for (const toolUse of toolUseBlocks) {
+      const tool = toolMap.get(toolUse.name);
+      if (!tool) {
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: toolUse.id,
+          content: `Unknown tool: ${toolUse.name}`,
+          is_error: true,
+        });
+        continue;
+      }
+
+      const result = await executeTool(
+        tool,
+        toolUse.input,
+        toolUse.id,
+        sessionId,
+        hooks,
+      );
+
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: toolUse.id,
+        content: result.content,
+        is_error: result.isError,
+      });
+    }
+
+    // Add tool results as the next user message
+    messages.push({ role: 'user', content: toolResults });
+
+    emit({ type: 'turn_end', iteration: i + 1, reason: 'tool_use' });
+  }
+
+  return { messages, totalInputTokens, totalOutputTokens, iterations };
+}

--- a/packages/squad-sdk/src/adapter/client.ts
+++ b/packages/squad-sdk/src/adapter/client.ts
@@ -1,20 +1,25 @@
 /**
  * Squad SDK Client Adapter
- * 
- * Wraps CopilotClient to provide connection lifecycle management, error recovery,
- * automatic reconnection, and protocol version validation.
- * 
+ *
+ * Wraps a SquadProvider to provide connection lifecycle management, error
+ * recovery, automatic reconnection, OTel instrumentation, and EventBus
+ * integration.
+ *
+ * The provider is pluggable: by default a CopilotProvider is constructed
+ * (preserving backward compatibility), but callers can inject any
+ * SquadProvider implementation.
+ *
  * @module adapter/client
  */
 
-import { CopilotClient } from "@github/copilot-sdk";
 import { trace, SpanStatusCode } from '../runtime/otel-api.js';
 import { recordSessionCreated, recordSessionClosed, recordSessionError, recordTokenUsage } from '../runtime/otel-metrics.js';
 import { estimateCost } from '../config/models.js';
 import type { EventBus } from '../runtime/event-bus.js';
 import type { UsageEvent } from '../runtime/streaming.js';
-import type { 
-  SquadSessionConfig, 
+import type { SquadProvider } from './provider.js';
+import type {
+  SquadSessionConfig,
   SquadSession,
   SquadSessionEvent,
   SquadSessionEventHandler,
@@ -27,137 +32,33 @@ import type {
   SquadClientEventType,
   SquadClientEvent,
   SquadClientEventHandler,
-} from "./types.js";
+} from './types.js';
 
 const tracer = trace.getTracer('squad-sdk');
 
 /**
- * Adapts @github/copilot-sdk CopilotSession to our SquadSession interface.
- * Maps sendMessage() → send(), off() via unsubscribe tracking, close() → destroy().
- *
- * Bug reported by @spboyer (Shayne Boyer) — Codespace environment exposed
- * the unsafe `as unknown as` cast that skipped runtime method mapping.
- */
-class CopilotSessionAdapter implements SquadSession {
-  /**
-   * Maps Squad short event names → @github/copilot-sdk dotted event names.
-   * SDK uses dotted-namespace prefixes (e.g., `assistant.message_delta`),
-   * while Squad uses short names (e.g., `message_delta`).
-   * Names already in dotted form pass through via the fallback.
-   */
-  private static readonly EVENT_MAP: Record<string, string> = {
-    'message_delta': 'assistant.message_delta',
-    'message': 'assistant.message',
-    'usage': 'assistant.usage',
-    'reasoning_delta': 'assistant.reasoning_delta',
-    'reasoning': 'assistant.reasoning',
-    'turn_start': 'assistant.turn_start',
-    'turn_end': 'assistant.turn_end',
-    'intent': 'assistant.intent',
-    'idle': 'session.idle',
-    'error': 'session.error',
-  };
-
-  /** Reverse map: SDK dotted names → Squad short names. */
-  private static readonly REVERSE_EVENT_MAP: Record<string, string> = Object.fromEntries(
-    Object.entries(CopilotSessionAdapter.EVENT_MAP).map(([k, v]) => [v, k])
-  );
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readonly inner: any;
-  private readonly unsubscribers = new Map<SquadSessionEventHandler, Map<string, () => void>>();
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(copilotSession: any) {
-    this.inner = copilotSession;
-  }
-
-  get sessionId(): string {
-    return this.inner.sessionId ?? 'unknown';
-  }
-
-  async sendMessage(options: SquadMessageOptions): Promise<void> {
-    await this.inner.send(options);
-  }
-
-  async sendAndWait(options: SquadMessageOptions, timeout?: number): Promise<unknown> {
-    return await this.inner.sendAndWait(options, timeout);
-  }
-
-  async abort(): Promise<void> {
-    await this.inner.abort();
-  }
-
-  async getMessages(): Promise<unknown[]> {
-    return await this.inner.getMessages();
-  }
-
-  /**
-   * Normalizes an SDK event into a SquadSessionEvent.
-   * Maps the dotted type back to the Squad short name and
-   * flattens `event.data` onto the top-level object so callers
-   * can access fields directly (e.g., `event.inputTokens`).
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private static normalizeEvent(sdkEvent: any): SquadSessionEvent {
-    const squadType = CopilotSessionAdapter.REVERSE_EVENT_MAP[sdkEvent.type] ?? sdkEvent.type;
-    return {
-      type: squadType,
-      ...(sdkEvent.data ?? {}),
-    };
-  }
-
-  on(eventType: SquadSessionEventType, handler: SquadSessionEventHandler): void {
-    const sdkType = CopilotSessionAdapter.EVENT_MAP[eventType] ?? eventType;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const wrappedHandler = (sdkEvent: any) => {
-      handler(CopilotSessionAdapter.normalizeEvent(sdkEvent));
-    };
-    const unsubscribe = this.inner.on(sdkType, wrappedHandler);
-    if (!this.unsubscribers.has(handler)) {
-      this.unsubscribers.set(handler, new Map());
-    }
-    this.unsubscribers.get(handler)!.set(eventType, unsubscribe);
-  }
-
-  off(eventType: SquadSessionEventType, handler: SquadSessionEventHandler): void {
-    const handlerMap = this.unsubscribers.get(handler);
-    if (handlerMap) {
-      const unsubscribe = handlerMap.get(eventType);
-      if (unsubscribe) {
-        unsubscribe();
-        handlerMap.delete(eventType);
-      }
-      if (handlerMap.size === 0) {
-        this.unsubscribers.delete(handler);
-      }
-    }
-  }
-
-  async close(): Promise<void> {
-    await this.inner.destroy();
-    this.unsubscribers.clear();
-  }
-}
-
-/**
  * Connection state for SquadClient.
  */
-export type SquadConnectionState = "disconnected" | "connecting" | "connected" | "reconnecting" | "error";
+export type SquadConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting' | 'error';
 
 /**
  * Options for creating a SquadClient.
  */
 export interface SquadClientOptions {
   /**
+   * Pre-built provider instance. When supplied, the client delegates to
+   * this provider directly and Copilot-specific options are ignored.
+   */
+  provider?: SquadProvider;
+
+  /**
    * Path to the Copilot CLI executable.
    * Defaults to bundled CLI from @github/copilot package.
+   * Only used when no `provider` is supplied (CopilotProvider default).
    */
   cliPath?: string;
 
-  /**
-   * Additional arguments to pass to the CLI process.
-   */
+  /** Additional arguments to pass to the CLI process. */
   cliArgs?: string[];
 
   /**
@@ -188,7 +89,7 @@ export interface SquadClientOptions {
    * Log level for the CLI process.
    * @default "debug"
    */
-  logLevel?: "error" | "warning" | "info" | "debug" | "all" | "none";
+  logLevel?: 'error' | 'warning' | 'info' | 'debug' | 'all' | 'none';
 
   /**
    * Automatically start the connection when creating a session.
@@ -242,133 +143,124 @@ export interface SquadClientOptions {
 }
 
 /**
- * SquadClient wraps CopilotClient with enhanced lifecycle management.
- * 
+ * SquadClient wraps a SquadProvider with enhanced lifecycle management.
+ *
  * Features:
  * - Connection state tracking
  * - Automatic reconnection with exponential backoff
- * - Protocol version validation
+ * - OTel instrumentation
  * - Error recovery
  * - Session lifecycle event handling
- * 
+ *
  * @example
  * ```typescript
  * const client = new SquadClient();
  * await client.connect();
- * 
+ *
  * const session = await client.createSession({
  *   model: "claude-sonnet-4.5"
  * });
- * 
+ *
  * await client.disconnect();
  * ```
  */
 export class SquadClient {
-  private client: CopilotClient;
-  private state: SquadConnectionState = "disconnected";
+  private provider: SquadProvider;
+  private state: SquadConnectionState = 'disconnected';
   private connectPromise: Promise<void> | null = null;
   private reconnectAttempts: number = 0;
   private reconnectTimer: NodeJS.Timeout | null = null;
-  private options: Required<Omit<SquadClientOptions, "cliUrl" | "githubToken" | "useLoggedInUser" | "cliPath" | "cliArgs" | "eventBus">> & {
-    cliUrl?: string;
-    githubToken?: string;
-    useLoggedInUser?: boolean;
-    cliPath?: string;
-    cliArgs: string[];
+  private options: {
+    autoStart: boolean;
+    autoReconnect: boolean;
+    maxReconnectAttempts: number;
+    reconnectDelayMs: number;
     eventBus?: EventBus;
+    useStdio?: boolean;
   };
   private manualDisconnect: boolean = false;
 
   /**
    * Creates a new SquadClient instance.
-   * 
-   * @param options - Configuration options
-   * @throws Error if mutually exclusive options are provided
+   *
+   * When `options.provider` is supplied, the client delegates to it directly.
+   * Otherwise, a CopilotProvider is lazily constructed from the remaining
+   * options (backward-compatible default).
    */
   constructor(options: SquadClientOptions = {}) {
     this.options = {
-      cliPath: options.cliPath,
-      cliArgs: options.cliArgs ?? [],
-      cwd: options.cwd ?? process.cwd(),
-      port: options.port ?? 0,
-      useStdio: options.useStdio ?? true,
-      cliUrl: options.cliUrl,
-      logLevel: options.logLevel ?? "debug",
       autoStart: options.autoStart ?? true,
       autoReconnect: options.autoReconnect ?? true,
-      env: options.env ?? (process.env as Record<string, string>),
-      githubToken: options.githubToken,
-      useLoggedInUser: options.useLoggedInUser ?? (options.githubToken ? false : true),
       maxReconnectAttempts: options.maxReconnectAttempts ?? 3,
       reconnectDelayMs: options.reconnectDelayMs ?? 1000,
       eventBus: options.eventBus,
+      useStdio: options.useStdio ?? true,
     };
 
-    this.client = new CopilotClient({
-      cliPath: this.options.cliPath,
-      cliArgs: this.options.cliArgs,
-      cwd: this.options.cwd,
-      port: this.options.port,
-      useStdio: this.options.useStdio,
-      cliUrl: this.options.cliUrl,
-      logLevel: this.options.logLevel,
-      autoStart: false, // We manage connection lifecycle
-      autoRestart: false, // We handle reconnection ourselves
-      env: this.options.env,
-      githubToken: this.options.githubToken,
-      useLoggedInUser: this.options.useLoggedInUser,
-    });
+    if (options.provider) {
+      this.provider = options.provider;
+    } else {
+      // Lazy-import CopilotProvider to avoid pulling in @github/copilot-sdk
+      // when a different provider is supplied.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { CopilotProvider } = require('./providers/copilot-provider.js');
+      this.provider = new CopilotProvider({
+        cliPath: options.cliPath,
+        cliArgs: options.cliArgs,
+        cwd: options.cwd,
+        port: options.port,
+        useStdio: options.useStdio,
+        cliUrl: options.cliUrl,
+        logLevel: options.logLevel,
+        env: options.env,
+        githubToken: options.githubToken,
+        useLoggedInUser: options.useLoggedInUser,
+      });
+    }
   }
 
-  /**
-   * Get the current connection state.
-   */
+  /** Get the current connection state. */
   getState(): SquadConnectionState {
     return this.state;
   }
 
-  /**
-   * Check if the client is connected.
-   */
+  /** Check if the client is connected. */
   isConnected(): boolean {
-    return this.state === "connected";
+    return this.state === 'connected';
+  }
+
+  /** Get the underlying provider. */
+  getProvider(): SquadProvider {
+    return this.provider;
   }
 
   /**
-   * Establish connection to the Copilot CLI server.
-   * 
-   * This method:
-   * 1. Spawns or connects to the CLI server
-   * 2. Validates protocol version compatibility
-   * 3. Sets up automatic reconnection handlers
-   * 
-   * @returns Promise that resolves when connection is established
-   * @throws Error if connection fails or protocol version is incompatible
+   * Establish connection to the LLM provider.
    */
   async connect(): Promise<void> {
-    if (this.state === "connected") {
+    if (this.state === 'connected') {
       return;
     }
 
-    // Dedup: if a connection is already in progress, piggyback on it
-    if (this.state === "connecting" && this.connectPromise) {
+    if (this.state === 'connecting' && this.connectPromise) {
       return this.connectPromise;
     }
 
     const span = tracer.startSpan('squad.client.connect');
+    span.setAttribute('provider', this.provider.name);
     span.setAttribute('connection.transport', this.options.useStdio ? 'stdio' : 'tcp');
 
-    this.state = "connecting";
+    this.state = 'connecting';
     this.manualDisconnect = false;
 
     this.connectPromise = (async () => {
       const startTime = Date.now();
 
       try {
-        await this.client.start();
+        await this.provider.connect();
         const elapsed = Date.now() - startTime;
-        
-        this.state = "connected";
+
+        this.state = 'connected';
         this.reconnectAttempts = 0;
 
         span.setAttribute('connection.duration_ms', elapsed);
@@ -377,9 +269,9 @@ export class SquadClient {
           console.warn(`SquadClient connection took ${elapsed}ms (> 2s threshold)`);
         }
       } catch (error) {
-        this.state = "error";
+        this.state = 'error';
         const wrapped = new Error(
-          `Failed to connect to Copilot CLI: ${error instanceof Error ? error.message : String(error)}`
+          `Failed to connect to ${this.provider.name} provider: ${error instanceof Error ? error.message : String(error)}`,
         );
         span.setStatus({ code: SpanStatusCode.ERROR, message: wrapped.message });
         span.recordException(wrapped);
@@ -394,14 +286,7 @@ export class SquadClient {
   }
 
   /**
-   * Disconnect from the Copilot CLI server.
-   * 
-   * Performs graceful cleanup:
-   * 1. Destroys all active sessions
-   * 2. Closes the connection
-   * 3. Terminates the CLI process (if spawned)
-   * 
-   * @returns Promise that resolves with any errors encountered during cleanup
+   * Disconnect from the LLM provider.
    */
   async disconnect(): Promise<Error[]> {
     const span = tracer.startSpan('squad.client.disconnect');
@@ -413,8 +298,8 @@ export class SquadClient {
         this.reconnectTimer = null;
       }
 
-      const errors = await this.client.stop();
-      this.state = "disconnected";
+      const errors = await this.provider.disconnect();
+      this.state = 'disconnected';
       this.reconnectAttempts = 0;
       this.connectPromise = null;
 
@@ -440,20 +325,18 @@ export class SquadClient {
       this.reconnectTimer = null;
     }
 
-    await this.client.forceStop();
-    this.state = "disconnected";
+    if (this.provider.forceDisconnect) {
+      await this.provider.forceDisconnect();
+    } else {
+      await this.provider.disconnect();
+    }
+    this.state = 'disconnected';
     this.reconnectAttempts = 0;
     this.connectPromise = null;
   }
 
   /**
    * Create a new Squad session.
-   * 
-   * If autoStart is enabled and the client is not connected, this will
-   * automatically establish the connection.
-   * 
-   * @param config - Session configuration
-   * @returns Promise that resolves with the created session
    */
   async createSession(config: SquadSessionConfig = {}): Promise<SquadSession> {
     const span = tracer.startSpan('squad.session.create');
@@ -464,19 +347,16 @@ export class SquadClient {
       }
 
       if (!this.isConnected()) {
-        throw new Error("Client not connected. Call connect() first.");
+        throw new Error('Client not connected. Call connect() first.');
       }
 
       try {
-        // Cast config to handle SDK version differences in SessionConfig type
-        const session = await this.client.createSession(config as Parameters<typeof this.client.createSession>[0]);
-        const result = new CopilotSessionAdapter(session);
+        const result = await this.provider.createSession(config);
         if (result.sessionId) {
           span.setAttribute('session.id', result.sessionId);
         }
         recordSessionCreated();
 
-        // Auto-forward usage events to EventBus when one is configured
         if (this.options.eventBus) {
           const bus = this.options.eventBus;
           const sid = result.sessionId;
@@ -488,12 +368,7 @@ export class SquadClient {
             void bus.emit({
               type: 'session:message',
               sessionId: sid,
-              payload: {
-                inputTokens,
-                outputTokens,
-                model,
-                estimatedCost: cost,
-              },
+              payload: { inputTokens, outputTokens, model, estimatedCost: cost },
               timestamp: new Date(),
             });
           });
@@ -505,8 +380,8 @@ export class SquadClient {
         if (msg.includes('onPermissionRequest')) {
           throw new Error(
             'Session creation failed: an onPermissionRequest handler is required. ' +
-            'Pass { onPermissionRequest: () => ({ kind: "approved" }) } in your session config ' +
-            'to approve all permissions, or provide a custom handler.'
+              'Pass { onPermissionRequest: () => ({ kind: "approved" }) } in your session config ' +
+              'to approve all permissions, or provide a custom handler.',
           );
         }
         recordSessionError();
@@ -527,10 +402,6 @@ export class SquadClient {
 
   /**
    * Resume an existing Squad session by ID.
-   * 
-   * @param sessionId - ID of the session to resume
-   * @param config - Optional configuration overrides
-   * @returns Promise that resolves with the resumed session
    */
   async resumeSession(sessionId: string, config: SquadSessionConfig = {}): Promise<SquadSession> {
     const span = tracer.startSpan('squad.session.resume');
@@ -541,13 +412,14 @@ export class SquadClient {
       }
 
       if (!this.isConnected()) {
-        throw new Error("Client not connected. Call connect() first.");
+        throw new Error('Client not connected. Call connect() first.');
       }
 
       try {
-        // Cast config to handle SDK version differences in ResumeSessionConfig type
-        const session = await this.client.resumeSession(sessionId, config as Parameters<typeof this.client.resumeSession>[1]);
-        return new CopilotSessionAdapter(session);
+        if (!this.provider.resumeSession) {
+          throw new Error(`Provider ${this.provider.name} does not support session resumption`);
+        }
+        return await this.provider.resumeSession(sessionId, config);
       } catch (error) {
         if (this.shouldAttemptReconnect(error)) {
           await this.attemptReconnection();
@@ -571,19 +443,14 @@ export class SquadClient {
     const span = tracer.startSpan('squad.session.list');
     try {
       if (!this.isConnected()) {
-        throw new Error("Client not connected");
+        throw new Error('Client not connected');
       }
 
       try {
-        const sessions = await this.client.listSessions();
-        const result = sessions.map((s): SquadSessionMetadata => ({
-          sessionId: s.sessionId,
-          startTime: s.startTime,
-          modifiedTime: s.modifiedTime,
-          summary: s.summary,
-          isRemote: s.isRemote,
-          context: s.context as Record<string, unknown> | undefined,
-        }));
+        if (!this.provider.listSessions) {
+          return [];
+        }
+        const result = await this.provider.listSessions();
         span.setAttribute('sessions.count', result.length);
         return result;
       } catch (error) {
@@ -610,11 +477,13 @@ export class SquadClient {
     span.setAttribute('session.id', sessionId);
     try {
       if (!this.isConnected()) {
-        throw new Error("Client not connected");
+        throw new Error('Client not connected');
       }
 
       try {
-        await this.client.deleteSession(sessionId);
+        if (this.provider.deleteSession) {
+          await this.provider.deleteSession(sessionId);
+        }
         recordSessionClosed();
       } catch (error) {
         recordSessionError();
@@ -638,11 +507,12 @@ export class SquadClient {
    */
   async getLastSessionId(): Promise<string | undefined> {
     if (!this.isConnected()) {
-      throw new Error("Client not connected");
+      throw new Error('Client not connected');
     }
 
     try {
-      return await this.client.getLastSessionId();
+      if (!this.provider.getLastSessionId) return undefined;
+      return await this.provider.getLastSessionId();
     } catch (error) {
       if (this.shouldAttemptReconnect(error)) {
         await this.attemptReconnection();
@@ -657,11 +527,14 @@ export class SquadClient {
    */
   async ping(message?: string): Promise<{ message: string; timestamp: number; protocolVersion?: number }> {
     if (!this.isConnected()) {
-      throw new Error("Client not connected");
+      throw new Error('Client not connected');
     }
 
     try {
-      return await this.client.ping(message);
+      if (!this.provider.ping) {
+        return { message: message ?? 'pong', timestamp: Date.now() };
+      }
+      return await this.provider.ping(message);
     } catch (error) {
       if (this.shouldAttemptReconnect(error)) {
         await this.attemptReconnection();
@@ -672,19 +545,18 @@ export class SquadClient {
   }
 
   /**
-   * Get CLI status information.
+   * Get provider status information.
    */
   async getStatus(): Promise<SquadGetStatusResponse> {
     if (!this.isConnected()) {
-      throw new Error("Client not connected");
+      throw new Error('Client not connected');
     }
 
     try {
-      const raw = await this.client.getStatus();
-      return {
-        version: raw.version,
-        protocolVersion: raw.protocolVersion,
-      };
+      if (!this.provider.getStatus) {
+        return { version: '0.0.0', protocolVersion: 0 };
+      }
+      return await this.provider.getStatus();
     } catch (error) {
       if (this.shouldAttemptReconnect(error)) {
         await this.attemptReconnection();
@@ -699,18 +571,14 @@ export class SquadClient {
    */
   async getAuthStatus(): Promise<SquadGetAuthStatusResponse> {
     if (!this.isConnected()) {
-      throw new Error("Client not connected");
+      throw new Error('Client not connected');
     }
 
     try {
-      const raw = await this.client.getAuthStatus();
-      return {
-        isAuthenticated: raw.isAuthenticated,
-        authType: raw.authType,
-        host: raw.host,
-        login: raw.login,
-        statusMessage: raw.statusMessage,
-      };
+      if (!this.provider.getAuthStatus) {
+        return { isAuthenticated: true };
+      }
+      return await this.provider.getAuthStatus();
     } catch (error) {
       if (this.shouldAttemptReconnect(error)) {
         await this.attemptReconnection();
@@ -725,20 +593,14 @@ export class SquadClient {
    */
   async listModels(): Promise<SquadModelInfo[]> {
     if (!this.isConnected()) {
-      throw new Error("Client not connected");
+      throw new Error('Client not connected');
     }
 
     try {
-      const models = await this.client.listModels();
-      return models.map((m): SquadModelInfo => ({
-        id: m.id,
-        name: m.name,
-        capabilities: m.capabilities,
-        policy: m.policy,
-        billing: m.billing,
-        supportedReasoningEfforts: m.supportedReasoningEfforts,
-        defaultReasoningEffort: m.defaultReasoningEffort,
-      }));
+      if (!this.provider.listModels) {
+        return [];
+      }
+      return await this.provider.listModels();
     } catch (error) {
       if (this.shouldAttemptReconnect(error)) {
         await this.attemptReconnection();
@@ -750,14 +612,6 @@ export class SquadClient {
 
   /**
    * Send a message to a session, wrapped with OTel tracing.
-   *
-   * Creates a `squad.session.message` span for the full call and a
-   * child `squad.session.stream` span that tracks streaming duration
-   * with `first_token`, `last_token`, and `stream_error` events.
-   *
-   * @param session - The session to send the message to
-   * @param options - Message content and delivery options
-   * @returns Promise that resolves when the message is processed
    */
   async sendMessage(session: SquadSession, options: SquadMessageOptions): Promise<void> {
     const messageSpan = tracer.startSpan('squad.session.message');
@@ -772,12 +626,10 @@ export class SquadClient {
     let firstTokenRecorded = false;
     let outputTokens = 0;
     let inputTokens = 0;
-
     let model = 'unknown';
 
     const origOn = session.on.bind(session);
 
-    // Wire temporary event listener for stream tracking
     const streamListener = (event: SquadSessionEvent) => {
       if (event.type === 'message_delta' && !firstTokenRecorded) {
         firstTokenRecorded = true;
@@ -802,7 +654,6 @@ export class SquadClient {
       streamSpan.setAttribute('tokens.output', outputTokens);
       streamSpan.setAttribute('duration_ms', durationMs);
 
-      // Record token usage in OTel metrics (not just span attributes)
       if (inputTokens > 0 || outputTokens > 0) {
         const usageEvent: UsageEvent = {
           type: 'usage',
@@ -825,7 +676,6 @@ export class SquadClient {
     } finally {
       streamSpan.end();
       messageSpan.end();
-      // Clean up listeners
       try {
         session.off('message_delta', streamListener);
         session.off('usage', streamListener);
@@ -837,8 +687,6 @@ export class SquadClient {
 
   /**
    * Close a session (alias for deleteSession with `squad.session.close` span).
-   *
-   * @param sessionId - ID of the session to close
    */
   async closeSession(sessionId: string): Promise<void> {
     const span = tracer.startSpan('squad.session.close');
@@ -855,13 +703,7 @@ export class SquadClient {
   }
 
   /**
-   * Send a message and wait for the response, wrapped with OTel tracing
-   * and token metric recording.
-   *
-   * @param session - The session to send the message to
-   * @param options - Message content and delivery options
-   * @param timeout - Optional timeout in milliseconds
-   * @returns Promise that resolves with the session response
+   * Send a message and wait for the response, wrapped with OTel tracing.
    */
   async sendAndWait(session: SquadSession, options: SquadMessageOptions, timeout?: number): Promise<unknown> {
     const span = tracer.startSpan('squad.session.sendAndWait');
@@ -891,7 +733,6 @@ export class SquadClient {
       span.setAttribute('tokens.input', inputTokens);
       span.setAttribute('tokens.output', outputTokens);
 
-      // Record token usage in OTel metrics
       if (inputTokens > 0 || outputTokens > 0) {
         const usageEvent: UsageEvent = {
           type: 'usage',
@@ -927,40 +768,34 @@ export class SquadClient {
   on(handler: SquadClientEventHandler): () => void;
   on(
     eventTypeOrHandler: SquadClientEventType | SquadClientEventHandler,
-    handler?: (event: SquadClientEvent) => void
+    handler?: (event: SquadClientEvent) => void,
   ): () => void {
-    if (typeof eventTypeOrHandler === "string" && handler) {
-      return this.client.on(eventTypeOrHandler, handler);
-    } else {
-      return this.client.on(eventTypeOrHandler as SquadClientEventHandler);
+    if (this.provider.on) {
+      if (typeof eventTypeOrHandler === 'string' && handler) {
+        return this.provider.on(eventTypeOrHandler, handler);
+      }
+      return this.provider.on(eventTypeOrHandler as SquadClientEventHandler);
     }
+    // Provider does not support lifecycle events — return no-op unsubscribe
+    return () => {};
   }
 
   /**
    * Determine if an error is recoverable via reconnection.
    */
   private shouldAttemptReconnect(error: unknown): boolean {
-    if (!this.options.autoReconnect) {
-      return false;
-    }
-
-    if (this.manualDisconnect) {
-      return false;
-    }
-
-    if (this.reconnectAttempts >= this.options.maxReconnectAttempts) {
-      return false;
-    }
+    if (!this.options.autoReconnect) return false;
+    if (this.manualDisconnect) return false;
+    if (this.reconnectAttempts >= this.options.maxReconnectAttempts) return false;
 
     const message = error instanceof Error ? error.message : String(error);
-    
-    // Transient connection errors
+
     if (
-      message.includes("ECONNREFUSED") ||
-      message.includes("ECONNRESET") ||
-      message.includes("EPIPE") ||
-      message.includes("Client not connected") ||
-      message.includes("Connection closed")
+      message.includes('ECONNREFUSED') ||
+      message.includes('ECONNRESET') ||
+      message.includes('EPIPE') ||
+      message.includes('Client not connected') ||
+      message.includes('Connection closed')
     ) {
       return true;
     }
@@ -972,11 +807,11 @@ export class SquadClient {
    * Attempt to reconnect with exponential backoff.
    */
   private async attemptReconnection(): Promise<void> {
-    if (this.state === "reconnecting") {
-      throw new Error("Reconnection already in progress");
+    if (this.state === 'reconnecting') {
+      throw new Error('Reconnection already in progress');
     }
 
-    this.state = "reconnecting";
+    this.state = 'reconnecting';
     this.reconnectAttempts++;
 
     const delay = this.options.reconnectDelayMs * Math.pow(2, this.reconnectAttempts - 1);
@@ -986,14 +821,14 @@ export class SquadClient {
     });
 
     try {
-      await this.client.stop();
-      await this.client.start();
-      this.state = "connected";
+      await this.provider.disconnect();
+      await this.provider.connect();
+      this.state = 'connected';
       this.reconnectAttempts = 0;
     } catch (error) {
-      this.state = "error";
+      this.state = 'error';
       throw new Error(
-        `Reconnection attempt ${this.reconnectAttempts} failed: ${error instanceof Error ? error.message : String(error)}`
+        `Reconnection attempt ${this.reconnectAttempts} failed: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }

--- a/packages/squad-sdk/src/adapter/direct-session.ts
+++ b/packages/squad-sdk/src/adapter/direct-session.ts
@@ -1,0 +1,207 @@
+/**
+ * Direct API Session
+ *
+ * Implements SquadSession for providers that call LLM APIs directly
+ * (Anthropic, Google) rather than delegating to an SDK that manages
+ * the agentic loop internally (Copilot SDK).
+ *
+ * Manages in-memory conversation history and drives the AgenticLoop.
+ *
+ * @module adapter/direct-session
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  SquadSession,
+  SquadSessionEvent,
+  SquadSessionEventHandler,
+  SquadSessionEventType,
+  SquadMessageOptions,
+  SquadTool,
+  SquadSessionHooks,
+  SquadSystemMessageConfig,
+} from './types.js';
+import {
+  runAgenticLoop,
+  type LLMApiAdapter,
+  type LLMMessage,
+  type LLMContentBlock,
+} from './agentic-loop.js';
+
+// ---------------------------------------------------------------------------
+// DirectApiSession
+// ---------------------------------------------------------------------------
+
+export interface DirectApiSessionOptions {
+  adapter: LLMApiAdapter;
+  model: string;
+  tools: SquadTool<any>[];
+  systemMessage?: SquadSystemMessageConfig;
+  sessionId?: string;
+  maxIterations?: number;
+  maxTokens?: number;
+  reasoningEffort?: string;
+  hooks?: SquadSessionHooks;
+}
+
+export class DirectApiSession implements SquadSession {
+  readonly sessionId: string;
+
+  private adapter: LLMApiAdapter;
+  private model: string;
+  private tools: SquadTool<any>[];
+  private systemPrompt: string | undefined;
+  private maxIterations: number;
+  private maxTokens: number | undefined;
+  private reasoningEffort: string | undefined;
+  private hooks: SquadSessionHooks | undefined;
+  private messages: LLMMessage[] = [];
+  private abortController: AbortController | null = null;
+  private listeners = new Map<string, Set<SquadSessionEventHandler>>();
+  private closed = false;
+
+  constructor(options: DirectApiSessionOptions) {
+    this.sessionId = options.sessionId ?? randomUUID();
+    this.adapter = options.adapter;
+    this.model = options.model;
+    this.tools = options.tools;
+    this.maxIterations = options.maxIterations ?? 25;
+    this.maxTokens = options.maxTokens;
+    this.reasoningEffort = options.reasoningEffort;
+    this.hooks = options.hooks;
+
+    if (options.systemMessage) {
+      if (options.systemMessage.mode === 'replace') {
+        this.systemPrompt = options.systemMessage.content;
+      } else {
+        this.systemPrompt = options.systemMessage.content;
+      }
+    }
+  }
+
+  async sendMessage(options: SquadMessageOptions): Promise<void> {
+    if (this.closed) throw new Error('Session is closed');
+
+    this.abortController = new AbortController();
+
+    // Build user message content
+    let userContent = options.prompt;
+    if (options.attachments?.length) {
+      const attachmentText = options.attachments
+        .map((a) => {
+          if (a.type === 'selection' && a.text) {
+            return `\n[Selection from ${a.filePath}${a.displayName ? ` (${a.displayName})` : ''}]:\n${a.text}`;
+          }
+          if (a.type === 'file' || a.type === 'directory') {
+            return `\n[Attached ${a.type}: ${a.path}]`;
+          }
+          return '';
+        })
+        .join('');
+      userContent += attachmentText;
+    }
+
+    // Append user message to conversation
+    this.messages.push({
+      role: 'user',
+      content: [{ type: 'text', text: userContent }],
+    });
+
+    const result = await runAgenticLoop(
+      {
+        adapter: this.adapter,
+        tools: this.tools,
+        model: this.model,
+        systemPrompt: this.systemPrompt,
+        maxIterations: this.maxIterations,
+        maxTokens: this.maxTokens,
+        reasoningEffort: this.reasoningEffort,
+        hooks: this.hooks,
+        sessionId: this.sessionId,
+        signal: this.abortController.signal,
+      },
+      (event) => this.emit(event),
+    );
+
+    // Replace local messages with the full conversation from the loop
+    // (includes the user message we pushed plus all assistant/tool turns)
+    this.messages = result.messages;
+    this.abortController = null;
+
+    this.emit({ type: 'idle' });
+  }
+
+  async sendAndWait(options: SquadMessageOptions, timeout?: number): Promise<unknown> {
+    const timeoutMs = timeout ?? 60000;
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error(`sendAndWait timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      let lastMessage = '';
+
+      const messageHandler: SquadSessionEventHandler = (event) => {
+        if (event.type === 'message' && typeof event['content'] === 'string') {
+          lastMessage = event['content'];
+        }
+      };
+
+      const idleHandler: SquadSessionEventHandler = () => {
+        clearTimeout(timer);
+        this.off('message', messageHandler);
+        this.off('idle', idleHandler);
+        resolve(lastMessage || undefined);
+      };
+
+      this.on('message', messageHandler);
+      this.on('idle', idleHandler);
+
+      this.sendMessage(options).catch((err) => {
+        clearTimeout(timer);
+        this.off('message', messageHandler);
+        this.off('idle', idleHandler);
+        reject(err);
+      });
+    });
+  }
+
+  async abort(): Promise<void> {
+    this.abortController?.abort();
+  }
+
+  async getMessages(): Promise<unknown[]> {
+    return this.messages;
+  }
+
+  on(eventType: SquadSessionEventType, handler: SquadSessionEventHandler): void {
+    if (!this.listeners.has(eventType)) {
+      this.listeners.set(eventType, new Set());
+    }
+    this.listeners.get(eventType)!.add(handler);
+  }
+
+  off(eventType: SquadSessionEventType, handler: SquadSessionEventHandler): void {
+    this.listeners.get(eventType)?.delete(handler);
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    this.abortController?.abort();
+    this.listeners.clear();
+    this.messages = [];
+  }
+
+  private emit(event: SquadSessionEvent): void {
+    const handlers = this.listeners.get(event.type);
+    if (handlers) {
+      for (const handler of handlers) {
+        try {
+          handler(event);
+        } catch {
+          // swallow handler errors
+        }
+      }
+    }
+  }
+}

--- a/packages/squad-sdk/src/adapter/errors.ts
+++ b/packages/squad-sdk/src/adapter/errors.ts
@@ -164,7 +164,7 @@ export class SquadError extends Error {
 // ============================================================================
 
 /**
- * SDK connection error — failed to connect to Copilot SDK.
+ * Connection error — failed to connect to LLM provider.
  */
 export class SDKConnectionError extends SquadError {
   constructor(message: string, context: ErrorContext, originalError?: Error) {
@@ -306,7 +306,7 @@ export class ErrorFactory {
     // Pattern matching on error message to categorize
     if (message.includes('connection') || message.includes('ECONNREFUSED') || message.includes('ETIMEDOUT')) {
       return new SDKConnectionError(
-        `Failed to connect to Copilot SDK: ${message}`,
+        `Failed to connect to LLM provider: ${message}`,
         fullContext,
         originalError
       );
@@ -317,6 +317,42 @@ export class ErrorFactory {
         `Session lifecycle error: ${message}`,
         fullContext,
         true,
+        originalError
+      );
+    }
+
+    // Anthropic-specific error patterns
+    if (message.includes('overloaded_error') || message.includes('Anthropic API error (529)')) {
+      return new RateLimitError(
+        `Anthropic API overloaded: ${message}`,
+        fullContext,
+        30,
+        originalError
+      );
+    }
+
+    if (message.includes('invalid_api_key') || message.includes('Anthropic API error (401)')) {
+      return new AuthenticationError(
+        `Anthropic API key invalid: ${message}`,
+        fullContext,
+        originalError
+      );
+    }
+
+    // Google-specific error patterns
+    if (message.includes('PERMISSION_DENIED') || message.includes('Google') && message.includes('403')) {
+      return new AuthenticationError(
+        `Google API permission denied: ${message}`,
+        fullContext,
+        originalError
+      );
+    }
+
+    if (message.includes('RESOURCE_EXHAUSTED') || message.includes('Google') && message.includes('429')) {
+      return new RateLimitError(
+        `Google API quota exceeded: ${message}`,
+        fullContext,
+        60,
         originalError
       );
     }

--- a/packages/squad-sdk/src/adapter/provider-factory.ts
+++ b/packages/squad-sdk/src/adapter/provider-factory.ts
@@ -1,0 +1,101 @@
+/**
+ * Provider Factory
+ *
+ * Resolves the correct SquadProvider implementation based on configuration,
+ * environment variables, or model name heuristics.
+ *
+ * @module adapter/provider-factory
+ */
+
+import type { SquadProviderConfig } from './types.js';
+import type { SquadProvider, ProviderType } from './provider.js';
+import type { SquadClientOptions } from './client.js';
+
+/**
+ * Resolve which provider type to use.
+ *
+ * Priority:
+ *  1. Explicit `config.type`
+ *  2. `SQUAD_PROVIDER` environment variable
+ *  3. Presence of provider-specific API key env vars
+ *  4. Model name prefix heuristic
+ *  5. Default to 'copilot'
+ */
+export function resolveProviderType(
+  config?: SquadProviderConfig,
+  model?: string,
+): ProviderType {
+  if (config?.type) {
+    const mapped = mapConfigType(config.type);
+    if (mapped) return mapped;
+  }
+
+  const envProvider = process.env['SQUAD_PROVIDER'];
+  if (envProvider) {
+    const mapped = mapConfigType(envProvider);
+    if (mapped) return mapped;
+  }
+
+  if (process.env['ANTHROPIC_API_KEY']) return 'anthropic';
+  if (process.env['GOOGLE_AI_API_KEY']) return 'google';
+
+  if (model) {
+    if (model.startsWith('claude-')) return 'anthropic';
+    if (model.startsWith('gemini-')) return 'google';
+  }
+
+  return 'copilot';
+}
+
+function mapConfigType(raw: string): ProviderType | undefined {
+  const normalized = raw.toLowerCase().trim();
+  const valid: ProviderType[] = [
+    'copilot',
+    'anthropic',
+    'anthropic-vertex',
+    'google',
+    'google-vertex',
+  ];
+  if (valid.includes(normalized as ProviderType)) {
+    return normalized as ProviderType;
+  }
+  return undefined;
+}
+
+/**
+ * Create a SquadProvider for the given configuration.
+ *
+ * Provider modules are loaded lazily so that unused SDKs are never imported.
+ */
+export async function createProvider(
+  providerType: ProviderType,
+  providerConfig?: SquadProviderConfig,
+  clientOptions?: SquadClientOptions,
+): Promise<SquadProvider> {
+  switch (providerType) {
+    case 'copilot': {
+      const { CopilotProvider } = await import('./providers/copilot-provider.js');
+      return new CopilotProvider(clientOptions);
+    }
+    case 'anthropic': {
+      const { AnthropicProvider } = await import('./providers/anthropic-provider.js');
+      return new AnthropicProvider(providerConfig);
+    }
+    case 'anthropic-vertex': {
+      const { AnthropicVertexProvider } = await import('./providers/anthropic-vertex-provider.js');
+      return new AnthropicVertexProvider(providerConfig);
+    }
+    case 'google': {
+      const { GoogleProvider } = await import('./providers/google-provider.js');
+      return new GoogleProvider(providerConfig);
+    }
+    case 'google-vertex': {
+      const { GoogleVertexProvider } = await import('./providers/google-vertex-provider.js');
+      return new GoogleVertexProvider(providerConfig);
+    }
+    default: {
+      const _exhaustive: never = providerType;
+      throw new Error(`Unknown provider type: ${_exhaustive}`);
+    }
+  }
+}

--- a/packages/squad-sdk/src/adapter/provider.ts
+++ b/packages/squad-sdk/src/adapter/provider.ts
@@ -1,0 +1,104 @@
+/**
+ * Squad Provider Interface
+ *
+ * Defines the contract that all LLM backend providers must implement.
+ * Providers handle connection lifecycle and session creation; the
+ * SquadClient delegates to the active provider.
+ *
+ * @module adapter/provider
+ */
+
+import type {
+  SquadSessionConfig,
+  SquadSession,
+  SquadSessionMetadata,
+  SquadGetAuthStatusResponse,
+  SquadGetStatusResponse,
+  SquadModelInfo,
+  SquadClientEventType,
+  SquadClientEvent,
+  SquadClientEventHandler,
+} from './types.js';
+
+/**
+ * Supported provider backends.
+ *
+ * - copilot: GitHub Copilot SDK (default, full feature set)
+ * - anthropic: Claude via Anthropic Messages API
+ * - anthropic-vertex: Claude via Google Cloud Vertex AI
+ * - google: Gemini via Google AI API
+ * - google-vertex: Gemini via Google Cloud Vertex AI
+ */
+export type ProviderType =
+  | 'copilot'
+  | 'anthropic'
+  | 'anthropic-vertex'
+  | 'google'
+  | 'google-vertex';
+
+/**
+ * Provider interface that all LLM backends implement.
+ *
+ * Required methods cover the minimum surface: connect, disconnect,
+ * session creation, and connection state. Optional methods are
+ * capabilities that only some backends support (e.g., the Copilot SDK
+ * supports session listing and model enumeration; direct API providers
+ * generally do not).
+ */
+export interface SquadProvider {
+  /** Provider identifier. */
+  readonly name: ProviderType;
+
+  // -- Lifecycle ---------------------------------------------------------------
+
+  /** Establish connection to the backend. */
+  connect(): Promise<void>;
+
+  /** Graceful shutdown. Returns any errors encountered during cleanup. */
+  disconnect(): Promise<Error[]>;
+
+  /** Force disconnect without graceful cleanup. */
+  forceDisconnect?(): Promise<void>;
+
+  /** Whether the provider is ready to create sessions. */
+  isConnected(): boolean;
+
+  // -- Session management (required) ------------------------------------------
+
+  /** Create a new agent session. */
+  createSession(config: SquadSessionConfig): Promise<SquadSession>;
+
+  // -- Session management (optional) ------------------------------------------
+
+  /** Resume an existing session by ID. */
+  resumeSession?(sessionId: string, config: SquadSessionConfig): Promise<SquadSession>;
+
+  /** List all sessions managed by this provider. */
+  listSessions?(): Promise<SquadSessionMetadata[]>;
+
+  /** Delete a session by ID. */
+  deleteSession?(sessionId: string): Promise<void>;
+
+  /** Get the ID of the most recently updated session. */
+  getLastSessionId?(): Promise<string | undefined>;
+
+  // -- Informational (optional) -----------------------------------------------
+
+  /** List available models from this provider. */
+  listModels?(): Promise<SquadModelInfo[]>;
+
+  /** Check authentication status. */
+  getAuthStatus?(): Promise<SquadGetAuthStatusResponse>;
+
+  /** Get provider/server status. */
+  getStatus?(): Promise<SquadGetStatusResponse>;
+
+  /** Connectivity check. */
+  ping?(message?: string): Promise<{ message: string; timestamp: number; protocolVersion?: number }>;
+
+  // -- Events (optional) ------------------------------------------------------
+
+  /** Subscribe to provider-level lifecycle events. */
+  on?(eventType: SquadClientEventType, handler: (event: SquadClientEvent) => void): () => void;
+  on?(handler: SquadClientEventHandler): () => void;
+}

--- a/packages/squad-sdk/src/adapter/providers/anthropic-api.ts
+++ b/packages/squad-sdk/src/adapter/providers/anthropic-api.ts
@@ -1,0 +1,292 @@
+/**
+ * Anthropic Messages API Adapter
+ *
+ * Implements LLMApiAdapter for the Anthropic Messages API using native
+ * fetch(). No SDK dependency — only requires an API key.
+ *
+ * @module adapter/providers/anthropic-api
+ */
+
+import type {
+  LLMApiAdapter,
+  LLMRequest,
+  LLMChunk,
+  LLMMessage,
+  LLMToolDefinition,
+} from '../agentic-loop.js';
+
+// ---------------------------------------------------------------------------
+// Types for the Anthropic Messages API request/response
+// ---------------------------------------------------------------------------
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: AnthropicContentBlock[];
+}
+
+type AnthropicContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'tool_result'; tool_use_id: string; content: string; is_error?: boolean }
+  | { type: 'thinking'; thinking: string };
+
+interface AnthropicTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// AnthropicApi
+// ---------------------------------------------------------------------------
+
+export interface AnthropicApiOptions {
+  apiKey: string;
+  baseUrl?: string;
+  apiVersion?: string;
+}
+
+export class AnthropicApi implements LLMApiAdapter {
+  protected apiKey: string;
+  protected baseUrl: string;
+  protected apiVersion: string;
+
+  constructor(options: AnthropicApiOptions) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl ?? 'https://api.anthropic.com';
+    this.apiVersion = options.apiVersion ?? '2023-06-01';
+  }
+
+  protected getEndpoint(): string {
+    return `${this.baseUrl}/v1/messages`;
+  }
+
+  protected getHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      'x-api-key': this.apiKey,
+      'anthropic-version': this.apiVersion,
+    };
+  }
+
+  async *call(request: LLMRequest): AsyncIterable<LLMChunk> {
+    const body = this.buildRequestBody(request);
+    const headers = this.getHeaders();
+    const endpoint = this.getEndpoint();
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Anthropic API error (${response.status}): ${errorText}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Anthropic API returned no response body');
+    }
+
+    yield* this.parseSSEStream(response.body, request.model);
+  }
+
+  protected buildRequestBody(request: LLMRequest): Record<string, unknown> {
+    const messages = this.convertMessages(request.messages);
+    const tools = this.convertTools(request.tools);
+
+    const body: Record<string, unknown> = {
+      model: request.model,
+      messages,
+      max_tokens: request.maxTokens ?? 8192,
+      stream: true,
+    };
+
+    if (request.systemPrompt) {
+      body.system = request.systemPrompt;
+    }
+
+    if (tools.length > 0) {
+      body.tools = tools;
+    }
+
+    if (request.reasoningEffort) {
+      body.thinking = {
+        type: 'enabled',
+        budget_tokens: this.reasoningEffortToBudget(request.reasoningEffort),
+      };
+    }
+
+    return body;
+  }
+
+  private reasoningEffortToBudget(effort: string): number {
+    switch (effort) {
+      case 'low': return 2048;
+      case 'medium': return 8192;
+      case 'high': return 16384;
+      case 'xhigh': return 32768;
+      default: return 8192;
+    }
+  }
+
+  private convertMessages(messages: LLMMessage[]): AnthropicMessage[] {
+    const result: AnthropicMessage[] = [];
+
+    for (const msg of messages) {
+      if (msg.role === 'system') continue;
+
+      const role = msg.role === 'tool' ? 'user' : msg.role;
+      const content: AnthropicContentBlock[] = [];
+
+      for (const block of msg.content) {
+        switch (block.type) {
+          case 'text':
+            content.push({ type: 'text', text: block.text });
+            break;
+          case 'tool_use':
+            content.push({
+              type: 'tool_use',
+              id: block.id,
+              name: block.name,
+              input: block.input,
+            });
+            break;
+          case 'tool_result':
+            content.push({
+              type: 'tool_result',
+              tool_use_id: block.tool_use_id,
+              content: block.content,
+              is_error: block.is_error,
+            });
+            break;
+          case 'reasoning':
+            content.push({ type: 'thinking', thinking: block.text });
+            break;
+        }
+      }
+
+      if (content.length > 0) {
+        result.push({ role: role as 'user' | 'assistant', content });
+      }
+    }
+
+    return result;
+  }
+
+  private convertTools(tools: LLMToolDefinition[]): AnthropicTool[] {
+    return tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      input_schema: t.input_schema,
+    }));
+  }
+
+  protected async *parseSSEStream(
+    body: ReadableStream<Uint8Array>,
+    model: string,
+  ): AsyncIterable<LLMChunk> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let currentToolId = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6).trim();
+          if (data === '[DONE]') continue;
+
+          let event: any;
+          try {
+            event = JSON.parse(data);
+          } catch {
+            continue;
+          }
+
+          yield* this.handleSSEEvent(event, model, currentToolId, (id) => {
+            currentToolId = id;
+          });
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private *handleSSEEvent(
+    event: any,
+    model: string,
+    currentToolId: string,
+    setToolId: (id: string) => void,
+  ): Iterable<LLMChunk> {
+    switch (event.type) {
+      case 'content_block_start': {
+        const block = event.content_block;
+        if (block?.type === 'tool_use') {
+          setToolId(block.id);
+          yield { type: 'tool_use_start', id: block.id, name: block.name };
+        }
+        break;
+      }
+
+      case 'content_block_delta': {
+        const delta = event.delta;
+        if (delta?.type === 'text_delta') {
+          yield { type: 'text_delta', text: delta.text };
+        } else if (delta?.type === 'input_json_delta') {
+          yield { type: 'tool_use_delta', id: currentToolId, partialJson: delta.partial_json };
+        } else if (delta?.type === 'thinking_delta') {
+          yield { type: 'reasoning_delta', text: delta.thinking };
+        }
+        break;
+      }
+
+      case 'content_block_stop': {
+        if (currentToolId) {
+          yield { type: 'tool_use_end', id: currentToolId };
+          setToolId('');
+        }
+        break;
+      }
+
+      case 'message_delta': {
+        const stopReason = event.delta?.stop_reason;
+        if (stopReason) {
+          const mapped = stopReason === 'tool_use' ? 'tool_use' : stopReason === 'max_tokens' ? 'max_tokens' : 'end_turn';
+          yield { type: 'end', stopReason: mapped as LLMChunk & { type: 'end' } extends { stopReason: infer R } ? R : never };
+        }
+        if (event.usage) {
+          yield {
+            type: 'usage',
+            inputTokens: event.usage.input_tokens ?? 0,
+            outputTokens: event.usage.output_tokens ?? 0,
+            model,
+          };
+        }
+        break;
+      }
+
+      case 'message_start': {
+        if (event.message?.usage) {
+          yield {
+            type: 'usage',
+            inputTokens: event.message.usage.input_tokens ?? 0,
+            outputTokens: event.message.usage.output_tokens ?? 0,
+            model: event.message.model ?? model,
+          };
+        }
+        break;
+      }
+    }
+  }
+}

--- a/packages/squad-sdk/src/adapter/providers/anthropic-provider.ts
+++ b/packages/squad-sdk/src/adapter/providers/anthropic-provider.ts
@@ -1,0 +1,65 @@
+/**
+ * Anthropic Provider
+ *
+ * SquadProvider implementation for Claude via the Anthropic Messages API.
+ * Uses native fetch() — no Anthropic SDK dependency.
+ *
+ * @module adapter/providers/anthropic-provider
+ */
+
+import type { SquadProvider } from '../provider.js';
+import type {
+  SquadSessionConfig,
+  SquadSession,
+  SquadProviderConfig,
+} from '../types.js';
+import { AnthropicApi } from './anthropic-api.js';
+import { DirectApiSession } from '../direct-session.js';
+
+export class AnthropicProvider implements SquadProvider {
+  readonly name = 'anthropic' as const;
+
+  private apiKey: string;
+  private baseUrl: string;
+  private connected = false;
+
+  constructor(providerConfig?: SquadProviderConfig) {
+    this.apiKey = providerConfig?.apiKey ?? process.env['ANTHROPIC_API_KEY'] ?? '';
+    this.baseUrl = providerConfig?.baseUrl ?? 'https://api.anthropic.com';
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(): Promise<void> {
+    if (!this.apiKey) {
+      throw new Error(
+        'Anthropic API key not found. Set ANTHROPIC_API_KEY environment variable or pass apiKey in provider config.',
+      );
+    }
+    this.connected = true;
+  }
+
+  async disconnect(): Promise<Error[]> {
+    this.connected = false;
+    return [];
+  }
+
+  async createSession(config: SquadSessionConfig): Promise<SquadSession> {
+    const adapter = new AnthropicApi({
+      apiKey: this.apiKey,
+      baseUrl: this.baseUrl,
+    });
+
+    return new DirectApiSession({
+      adapter,
+      model: config.model ?? 'claude-sonnet-4-5-20250514',
+      tools: config.tools ?? [],
+      systemMessage: config.systemMessage,
+      sessionId: config.sessionId,
+      reasoningEffort: config.reasoningEffort,
+      hooks: config.hooks,
+    });
+  }
+}

--- a/packages/squad-sdk/src/adapter/providers/anthropic-vertex-api.ts
+++ b/packages/squad-sdk/src/adapter/providers/anthropic-vertex-api.ts
@@ -1,0 +1,115 @@
+/**
+ * Anthropic Vertex AI API Adapter
+ *
+ * Extends AnthropicApi to route requests through Google Cloud Vertex AI
+ * instead of the Anthropic API directly. Uses Google Cloud ADC for auth.
+ *
+ * @module adapter/providers/anthropic-vertex-api
+ */
+
+import { AnthropicApi } from './anthropic-api.js';
+import type { LLMRequest } from '../agentic-loop.js';
+
+export interface AnthropicVertexApiOptions {
+  projectId: string;
+  region: string;
+}
+
+export class AnthropicVertexApi extends AnthropicApi {
+  private projectId: string;
+  private region: string;
+  private cachedToken: { token: string; expiresAt: number } | null = null;
+
+  constructor(options: AnthropicVertexApiOptions) {
+    // Parent requires an apiKey but Vertex uses ADC tokens instead
+    super({ apiKey: 'vertex-ai' });
+    this.projectId = options.projectId;
+    this.region = options.region;
+  }
+
+  protected getEndpoint(): string {
+    // Vertex AI does not use the /v1/messages path — the model is in the URL
+    // and we override buildRequestBody to set the model there.
+    // We'll construct the full URL in call() instead.
+    return '';
+  }
+
+  protected getHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      'anthropic-version': this.apiVersion,
+    };
+  }
+
+  private getModelEndpoint(model: string): string {
+    return `https://${this.region}-aiplatform.googleapis.com/v1/projects/${this.projectId}/locations/${this.region}/publishers/anthropic/models/${model}:streamRawPredict`;
+  }
+
+  private async getAccessToken(): Promise<string> {
+    if (this.cachedToken && Date.now() < this.cachedToken.expiresAt) {
+      return this.cachedToken.token;
+    }
+
+    // Try google-auth-library first
+    try {
+      const { GoogleAuth } = await import('google-auth-library');
+      const auth = new GoogleAuth({
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      });
+      const client = await auth.getClient();
+      const tokenResponse = await client.getAccessToken();
+      const token = typeof tokenResponse === 'string' ? tokenResponse : tokenResponse.token;
+      if (token) {
+        this.cachedToken = { token, expiresAt: Date.now() + 3300_000 };
+        return token;
+      }
+    } catch {
+      // google-auth-library not installed — fall through to gcloud CLI
+    }
+
+    // Fallback: gcloud CLI
+    try {
+      const { execSync } = await import('node:child_process');
+      const token = execSync('gcloud auth application-default print-access-token', {
+        encoding: 'utf-8',
+        timeout: 10_000,
+      }).trim();
+      if (token) {
+        this.cachedToken = { token, expiresAt: Date.now() + 3300_000 };
+        return token;
+      }
+    } catch {
+      // gcloud not available
+    }
+
+    throw new Error(
+      'Could not obtain Google Cloud access token. Install google-auth-library, ' +
+      'run "gcloud auth application-default login", or set GOOGLE_APPLICATION_CREDENTIALS.',
+    );
+  }
+
+  async *call(request: LLMRequest): AsyncIterable<import('../agentic-loop.js').LLMChunk> {
+    const body = this.buildRequestBody(request);
+    const headers = this.getHeaders();
+    const endpoint = this.getModelEndpoint(request.model);
+    const accessToken = await this.getAccessToken();
+    headers['Authorization'] = `Bearer ${accessToken}`;
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Anthropic Vertex AI error (${response.status}): ${errorText}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Anthropic Vertex AI returned no response body');
+    }
+
+    yield* this.parseSSEStream(response.body, request.model);
+  }
+}

--- a/packages/squad-sdk/src/adapter/providers/anthropic-vertex-provider.ts
+++ b/packages/squad-sdk/src/adapter/providers/anthropic-vertex-provider.ts
@@ -1,0 +1,72 @@
+/**
+ * Anthropic Vertex AI Provider
+ *
+ * SquadProvider implementation for Claude via Google Cloud Vertex AI.
+ * Uses Google Cloud ADC for authentication.
+ *
+ * @module adapter/providers/anthropic-vertex-provider
+ */
+
+import type { SquadProvider } from '../provider.js';
+import type {
+  SquadSessionConfig,
+  SquadSession,
+  SquadProviderConfig,
+} from '../types.js';
+import { AnthropicVertexApi } from './anthropic-vertex-api.js';
+import { DirectApiSession } from '../direct-session.js';
+
+export class AnthropicVertexProvider implements SquadProvider {
+  readonly name = 'anthropic-vertex' as const;
+
+  private projectId: string;
+  private region: string;
+  private connected = false;
+
+  constructor(providerConfig?: SquadProviderConfig) {
+    this.projectId =
+      providerConfig?.anthropicVertex?.projectId ??
+      process.env['GOOGLE_CLOUD_PROJECT'] ??
+      '';
+    this.region =
+      providerConfig?.anthropicVertex?.region ??
+      process.env['GOOGLE_CLOUD_REGION'] ??
+      'us-east5';
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(): Promise<void> {
+    if (!this.projectId) {
+      throw new Error(
+        'Google Cloud project ID not found. Set GOOGLE_CLOUD_PROJECT environment variable ' +
+        'or pass projectId in provider.anthropicVertex config.',
+      );
+    }
+    this.connected = true;
+  }
+
+  async disconnect(): Promise<Error[]> {
+    this.connected = false;
+    return [];
+  }
+
+  async createSession(config: SquadSessionConfig): Promise<SquadSession> {
+    const adapter = new AnthropicVertexApi({
+      projectId: this.projectId,
+      region: this.region,
+    });
+
+    return new DirectApiSession({
+      adapter,
+      model: config.model ?? 'claude-sonnet-4-5-20250514',
+      tools: config.tools ?? [],
+      systemMessage: config.systemMessage,
+      sessionId: config.sessionId,
+      reasoningEffort: config.reasoningEffort,
+      hooks: config.hooks,
+    });
+  }
+}

--- a/packages/squad-sdk/src/adapter/providers/copilot-provider.ts
+++ b/packages/squad-sdk/src/adapter/providers/copilot-provider.ts
@@ -1,0 +1,262 @@
+/**
+ * Copilot Provider
+ *
+ * Wraps @github/copilot-sdk CopilotClient as a SquadProvider implementation.
+ * This is the sole file in the codebase that imports from the Copilot SDK.
+ *
+ * @module adapter/providers/copilot-provider
+ */
+
+import { CopilotClient } from '@github/copilot-sdk';
+import type { SquadProvider } from '../provider.js';
+import type {
+  SquadSessionConfig,
+  SquadSession,
+  SquadSessionEvent,
+  SquadSessionEventHandler,
+  SquadSessionEventType,
+  SquadSessionMetadata,
+  SquadGetAuthStatusResponse,
+  SquadGetStatusResponse,
+  SquadModelInfo,
+  SquadMessageOptions,
+  SquadClientEventType,
+  SquadClientEvent,
+  SquadClientEventHandler,
+} from '../types.js';
+
+// ---------------------------------------------------------------------------
+// CopilotSessionAdapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Adapts @github/copilot-sdk CopilotSession to the SquadSession interface.
+ * Maps sendMessage() → send(), off() via unsubscribe tracking, close() → destroy().
+ */
+class CopilotSessionAdapter implements SquadSession {
+  private static readonly EVENT_MAP: Record<string, string> = {
+    'message_delta': 'assistant.message_delta',
+    'message': 'assistant.message',
+    'usage': 'assistant.usage',
+    'reasoning_delta': 'assistant.reasoning_delta',
+    'reasoning': 'assistant.reasoning',
+    'turn_start': 'assistant.turn_start',
+    'turn_end': 'assistant.turn_end',
+    'intent': 'assistant.intent',
+    'idle': 'session.idle',
+    'error': 'session.error',
+  };
+
+  private static readonly REVERSE_EVENT_MAP: Record<string, string> = Object.fromEntries(
+    Object.entries(CopilotSessionAdapter.EVENT_MAP).map(([k, v]) => [v, k]),
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly inner: any;
+  private readonly unsubscribers = new Map<SquadSessionEventHandler, Map<string, () => void>>();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(copilotSession: any) {
+    this.inner = copilotSession;
+  }
+
+  get sessionId(): string {
+    return this.inner.sessionId ?? 'unknown';
+  }
+
+  async sendMessage(options: SquadMessageOptions): Promise<void> {
+    await this.inner.send(options);
+  }
+
+  async sendAndWait(options: SquadMessageOptions, timeout?: number): Promise<unknown> {
+    return await this.inner.sendAndWait(options, timeout);
+  }
+
+  async abort(): Promise<void> {
+    await this.inner.abort();
+  }
+
+  async getMessages(): Promise<unknown[]> {
+    return await this.inner.getMessages();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private static normalizeEvent(sdkEvent: any): SquadSessionEvent {
+    const squadType = CopilotSessionAdapter.REVERSE_EVENT_MAP[sdkEvent.type] ?? sdkEvent.type;
+    return { type: squadType, ...(sdkEvent.data ?? {}) };
+  }
+
+  on(eventType: SquadSessionEventType, handler: SquadSessionEventHandler): void {
+    const sdkType = CopilotSessionAdapter.EVENT_MAP[eventType] ?? eventType;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wrappedHandler = (sdkEvent: any) => {
+      handler(CopilotSessionAdapter.normalizeEvent(sdkEvent));
+    };
+    const unsubscribe = this.inner.on(sdkType, wrappedHandler);
+    if (!this.unsubscribers.has(handler)) {
+      this.unsubscribers.set(handler, new Map());
+    }
+    this.unsubscribers.get(handler)!.set(eventType, unsubscribe);
+  }
+
+  off(eventType: SquadSessionEventType, handler: SquadSessionEventHandler): void {
+    const handlerMap = this.unsubscribers.get(handler);
+    if (handlerMap) {
+      const unsubscribe = handlerMap.get(eventType);
+      if (unsubscribe) {
+        unsubscribe();
+        handlerMap.delete(eventType);
+      }
+      if (handlerMap.size === 0) {
+        this.unsubscribers.delete(handler);
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.inner.destroy();
+    this.unsubscribers.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CopilotProvider
+// ---------------------------------------------------------------------------
+
+export interface CopilotProviderOptions {
+  cliPath?: string;
+  cliArgs?: string[];
+  cwd?: string;
+  port?: number;
+  useStdio?: boolean;
+  cliUrl?: string;
+  logLevel?: 'error' | 'warning' | 'info' | 'debug' | 'all' | 'none';
+  env?: Record<string, string>;
+  githubToken?: string;
+  useLoggedInUser?: boolean;
+}
+
+export class CopilotProvider implements SquadProvider {
+  readonly name = 'copilot' as const;
+
+  private client: CopilotClient;
+  private connected = false;
+  private options: CopilotProviderOptions;
+
+  constructor(options?: CopilotProviderOptions) {
+    this.options = options ?? {};
+    this.client = new CopilotClient({
+      cliPath: this.options.cliPath,
+      cliArgs: this.options.cliArgs ?? [],
+      cwd: this.options.cwd ?? process.cwd(),
+      port: this.options.port ?? 0,
+      useStdio: this.options.useStdio ?? true,
+      cliUrl: this.options.cliUrl,
+      logLevel: this.options.logLevel ?? 'debug',
+      autoStart: false,
+      autoRestart: false,
+      env: this.options.env ?? (process.env as Record<string, string>),
+      githubToken: this.options.githubToken,
+      useLoggedInUser: this.options.useLoggedInUser ?? (this.options.githubToken ? false : true),
+    });
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(): Promise<void> {
+    await this.client.start();
+    this.connected = true;
+  }
+
+  async disconnect(): Promise<Error[]> {
+    const errors = await this.client.stop();
+    this.connected = false;
+    return errors;
+  }
+
+  async forceDisconnect(): Promise<void> {
+    await this.client.forceStop();
+    this.connected = false;
+  }
+
+  async createSession(config: SquadSessionConfig): Promise<SquadSession> {
+    const session = await this.client.createSession(
+      config as Parameters<typeof this.client.createSession>[0],
+    );
+    return new CopilotSessionAdapter(session);
+  }
+
+  async resumeSession(sessionId: string, config: SquadSessionConfig): Promise<SquadSession> {
+    const session = await this.client.resumeSession(
+      sessionId,
+      config as Parameters<typeof this.client.resumeSession>[1],
+    );
+    return new CopilotSessionAdapter(session);
+  }
+
+  async listSessions(): Promise<SquadSessionMetadata[]> {
+    const sessions = await this.client.listSessions();
+    return sessions.map(
+      (s): SquadSessionMetadata => ({
+        sessionId: s.sessionId,
+        startTime: s.startTime,
+        modifiedTime: s.modifiedTime,
+        summary: s.summary,
+        isRemote: s.isRemote,
+        context: s.context as Record<string, unknown> | undefined,
+      }),
+    );
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.client.deleteSession(sessionId);
+  }
+
+  async getLastSessionId(): Promise<string | undefined> {
+    return await this.client.getLastSessionId();
+  }
+
+  async listModels(): Promise<SquadModelInfo[]> {
+    const models = await this.client.listModels();
+    return models.map(
+      (m): SquadModelInfo => ({
+        id: m.id,
+        name: m.name,
+        capabilities: m.capabilities,
+        policy: m.policy,
+        billing: m.billing,
+        supportedReasoningEfforts: m.supportedReasoningEfforts,
+        defaultReasoningEffort: m.defaultReasoningEffort,
+      }),
+    );
+  }
+
+  async getAuthStatus(): Promise<SquadGetAuthStatusResponse> {
+    const raw = await this.client.getAuthStatus();
+    return {
+      isAuthenticated: raw.isAuthenticated,
+      authType: raw.authType,
+      host: raw.host,
+      login: raw.login,
+      statusMessage: raw.statusMessage,
+    };
+  }
+
+  async getStatus(): Promise<SquadGetStatusResponse> {
+    const raw = await this.client.getStatus();
+    return { version: raw.version, protocolVersion: raw.protocolVersion };
+  }
+
+  async ping(message?: string): Promise<{ message: string; timestamp: number; protocolVersion?: number }> {
+    return await this.client.ping(message);
+  }
+
+  on(eventTypeOrHandler: SquadClientEventType | SquadClientEventHandler, handler?: (event: SquadClientEvent) => void): () => void {
+    if (typeof eventTypeOrHandler === 'string' && handler) {
+      return this.client.on(eventTypeOrHandler, handler);
+    }
+    return this.client.on(eventTypeOrHandler as SquadClientEventHandler);
+  }
+}

--- a/packages/squad-sdk/src/adapter/providers/google-api.ts
+++ b/packages/squad-sdk/src/adapter/providers/google-api.ts
@@ -1,0 +1,296 @@
+/**
+ * Google Gemini API Adapter
+ *
+ * Implements LLMApiAdapter for the Google Generative Language API using
+ * native fetch(). No SDK dependency — only requires an API key.
+ *
+ * @module adapter/providers/google-api
+ */
+
+import type {
+  LLMApiAdapter,
+  LLMRequest,
+  LLMChunk,
+  LLMMessage,
+  LLMToolDefinition,
+} from '../agentic-loop.js';
+
+// ---------------------------------------------------------------------------
+// Types for the Gemini API request/response
+// ---------------------------------------------------------------------------
+
+interface GeminiContent {
+  role: 'user' | 'model';
+  parts: GeminiPart[];
+}
+
+type GeminiPart =
+  | { text: string }
+  | { functionCall: { name: string; args: Record<string, unknown> } }
+  | { functionResponse: { name: string; response: { content: string } } };
+
+interface GeminiFunctionDeclaration {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// GoogleApi
+// ---------------------------------------------------------------------------
+
+export interface GoogleApiOptions {
+  apiKey: string;
+  baseUrl?: string;
+}
+
+export class GoogleApi implements LLMApiAdapter {
+  protected apiKey: string;
+  protected baseUrl: string;
+
+  constructor(options: GoogleApiOptions) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl ?? 'https://generativelanguage.googleapis.com';
+  }
+
+  protected getEndpoint(model: string): string {
+    return `${this.baseUrl}/v1beta/models/${model}:streamGenerateContent?key=${this.apiKey}&alt=sse`;
+  }
+
+  protected getHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+    };
+  }
+
+  async *call(request: LLMRequest): AsyncIterable<LLMChunk> {
+    const body = this.buildRequestBody(request);
+    const headers = this.getHeaders();
+    const endpoint = this.getEndpoint(request.model);
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Google AI API error (${response.status}): ${errorText}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Google AI API returned no response body');
+    }
+
+    yield* this.parseSSEStream(response.body, request.model);
+  }
+
+  protected buildRequestBody(request: LLMRequest): Record<string, unknown> {
+    const contents = this.convertMessages(request.messages);
+    const tools = this.convertTools(request.tools);
+
+    const body: Record<string, unknown> = {
+      contents,
+      generationConfig: {
+        maxOutputTokens: request.maxTokens ?? 8192,
+      },
+    };
+
+    if (request.systemPrompt) {
+      body.systemInstruction = {
+        parts: [{ text: request.systemPrompt }],
+      };
+    }
+
+    if (tools.length > 0) {
+      body.tools = [{ functionDeclarations: tools }];
+    }
+
+    if (request.reasoningEffort) {
+      (body.generationConfig as Record<string, unknown>).thinkingConfig = {
+        thinkingBudget: this.reasoningEffortToBudget(request.reasoningEffort),
+      };
+    }
+
+    return body;
+  }
+
+  private reasoningEffortToBudget(effort: string): number {
+    switch (effort) {
+      case 'low': return 1024;
+      case 'medium': return 8192;
+      case 'high': return 16384;
+      case 'xhigh': return 32768;
+      default: return 8192;
+    }
+  }
+
+  private convertMessages(messages: LLMMessage[]): GeminiContent[] {
+    const result: GeminiContent[] = [];
+
+    for (const msg of messages) {
+      if (msg.role === 'system') continue;
+
+      const role: 'user' | 'model' = msg.role === 'assistant' ? 'model' : 'user';
+      const parts: GeminiPart[] = [];
+
+      for (const block of msg.content) {
+        switch (block.type) {
+          case 'text':
+            parts.push({ text: block.text });
+            break;
+          case 'tool_use':
+            parts.push({
+              functionCall: { name: block.name, args: block.input },
+            });
+            break;
+          case 'tool_result':
+            parts.push({
+              functionResponse: {
+                name: this.findToolName(messages, block.tool_use_id),
+                response: { content: block.content },
+              },
+            });
+            break;
+          case 'reasoning':
+            parts.push({ text: block.text });
+            break;
+        }
+      }
+
+      if (parts.length > 0) {
+        result.push({ role, parts });
+      }
+    }
+
+    return result;
+  }
+
+  private findToolName(messages: LLMMessage[], toolUseId: string): string {
+    for (const msg of messages) {
+      for (const block of msg.content) {
+        if (block.type === 'tool_use' && block.id === toolUseId) {
+          return block.name;
+        }
+      }
+    }
+    return 'unknown_tool';
+  }
+
+  private convertTools(tools: LLMToolDefinition[]): GeminiFunctionDeclaration[] {
+    return tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      parameters: this.convertToOpenApiSchema(t.input_schema),
+    }));
+  }
+
+  private convertToOpenApiSchema(schema: Record<string, unknown>): Record<string, unknown> {
+    // Gemini expects OpenAPI-style schemas without JSON Schema extensions
+    // like $schema, additionalProperties, etc. Strip those.
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(schema)) {
+      if (key === '$schema' || key === 'additionalProperties') continue;
+      if (key === 'properties' && typeof value === 'object' && value !== null) {
+        const props: Record<string, unknown> = {};
+        for (const [pk, pv] of Object.entries(value as Record<string, unknown>)) {
+          if (typeof pv === 'object' && pv !== null) {
+            props[pk] = this.convertToOpenApiSchema(pv as Record<string, unknown>);
+          } else {
+            props[pk] = pv;
+          }
+        }
+        result[key] = props;
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  protected async *parseSSEStream(
+    body: ReadableStream<Uint8Array>,
+    model: string,
+  ): AsyncIterable<LLMChunk> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let toolCallCounter = 0;
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6).trim();
+          if (!data || data === '[DONE]') continue;
+
+          let chunk: any;
+          try {
+            chunk = JSON.parse(data);
+          } catch {
+            continue;
+          }
+
+          // Track usage from usageMetadata
+          if (chunk.usageMetadata) {
+            const inputTokens = chunk.usageMetadata.promptTokenCount ?? 0;
+            const outputTokens = chunk.usageMetadata.candidatesTokenCount ?? 0;
+            if (inputTokens > totalInputTokens || outputTokens > totalOutputTokens) {
+              totalInputTokens = inputTokens;
+              totalOutputTokens = outputTokens;
+            }
+          }
+
+          const candidate = chunk.candidates?.[0];
+          if (!candidate?.content?.parts) continue;
+
+          let hasToolUse = false;
+
+          for (const part of candidate.content.parts) {
+            if (part.text !== undefined) {
+              yield { type: 'text_delta', text: part.text };
+            }
+
+            if (part.functionCall) {
+              hasToolUse = true;
+              const toolId = `tool_${++toolCallCounter}`;
+              yield { type: 'tool_use_start', id: toolId, name: part.functionCall.name };
+              const argsJson = JSON.stringify(part.functionCall.args ?? {});
+              yield { type: 'tool_use_delta', id: toolId, partialJson: argsJson };
+              yield { type: 'tool_use_end', id: toolId };
+            }
+          }
+
+          // Check finish reason
+          if (candidate.finishReason) {
+            yield {
+              type: 'usage',
+              inputTokens: totalInputTokens,
+              outputTokens: totalOutputTokens,
+              model,
+            };
+
+            const stopReason = hasToolUse || candidate.finishReason === 'TOOL_CALLS'
+              ? 'tool_use'
+              : candidate.finishReason === 'MAX_TOKENS'
+                ? 'max_tokens'
+                : 'end_turn';
+            yield { type: 'end', stopReason: stopReason as any };
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}

--- a/packages/squad-sdk/src/adapter/providers/google-provider.ts
+++ b/packages/squad-sdk/src/adapter/providers/google-provider.ts
@@ -1,0 +1,65 @@
+/**
+ * Google AI Provider
+ *
+ * SquadProvider implementation for Gemini via the Google Generative
+ * Language API. Uses native fetch() — no Google SDK dependency.
+ *
+ * @module adapter/providers/google-provider
+ */
+
+import type { SquadProvider } from '../provider.js';
+import type {
+  SquadSessionConfig,
+  SquadSession,
+  SquadProviderConfig,
+} from '../types.js';
+import { GoogleApi } from './google-api.js';
+import { DirectApiSession } from '../direct-session.js';
+
+export class GoogleProvider implements SquadProvider {
+  readonly name = 'google' as const;
+
+  private apiKey: string;
+  private baseUrl: string;
+  private connected = false;
+
+  constructor(providerConfig?: SquadProviderConfig) {
+    this.apiKey = providerConfig?.apiKey ?? process.env['GOOGLE_AI_API_KEY'] ?? '';
+    this.baseUrl = providerConfig?.baseUrl ?? 'https://generativelanguage.googleapis.com';
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(): Promise<void> {
+    if (!this.apiKey) {
+      throw new Error(
+        'Google AI API key not found. Set GOOGLE_AI_API_KEY environment variable or pass apiKey in provider config.',
+      );
+    }
+    this.connected = true;
+  }
+
+  async disconnect(): Promise<Error[]> {
+    this.connected = false;
+    return [];
+  }
+
+  async createSession(config: SquadSessionConfig): Promise<SquadSession> {
+    const adapter = new GoogleApi({
+      apiKey: this.apiKey,
+      baseUrl: this.baseUrl,
+    });
+
+    return new DirectApiSession({
+      adapter,
+      model: config.model ?? 'gemini-2.5-pro',
+      tools: config.tools ?? [],
+      systemMessage: config.systemMessage,
+      sessionId: config.sessionId,
+      reasoningEffort: config.reasoningEffort,
+      hooks: config.hooks,
+    });
+  }
+}

--- a/packages/squad-sdk/src/adapter/providers/google-vertex-api.ts
+++ b/packages/squad-sdk/src/adapter/providers/google-vertex-api.ts
@@ -1,0 +1,110 @@
+/**
+ * Google Vertex AI API Adapter
+ *
+ * Extends GoogleApi to route requests through Google Cloud Vertex AI
+ * instead of the public Google AI API. Uses Google Cloud ADC for auth.
+ *
+ * @module adapter/providers/google-vertex-api
+ */
+
+import { GoogleApi } from './google-api.js';
+import type { LLMRequest, LLMChunk } from '../agentic-loop.js';
+
+export interface GoogleVertexApiOptions {
+  projectId: string;
+  location: string;
+}
+
+export class GoogleVertexApi extends GoogleApi {
+  private projectId: string;
+  private location: string;
+  private cachedToken: { token: string; expiresAt: number } | null = null;
+
+  constructor(options: GoogleVertexApiOptions) {
+    // Parent requires an apiKey but Vertex uses ADC tokens instead
+    super({ apiKey: 'vertex-ai' });
+    this.projectId = options.projectId;
+    this.location = options.location;
+  }
+
+  protected getEndpoint(model: string): string {
+    return `https://${this.location}-aiplatform.googleapis.com/v1/projects/${this.projectId}/locations/${this.location}/publishers/google/models/${model}:streamGenerateContent?alt=sse`;
+  }
+
+  protected getHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private async getAccessToken(): Promise<string> {
+    if (this.cachedToken && Date.now() < this.cachedToken.expiresAt) {
+      return this.cachedToken.token;
+    }
+
+    // Try google-auth-library first
+    try {
+      const { GoogleAuth } = await import('google-auth-library');
+      const auth = new GoogleAuth({
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      });
+      const client = await auth.getClient();
+      const tokenResponse = await client.getAccessToken();
+      const token = typeof tokenResponse === 'string' ? tokenResponse : tokenResponse.token;
+      if (token) {
+        this.cachedToken = { token, expiresAt: Date.now() + 3300_000 };
+        return token;
+      }
+    } catch {
+      // google-auth-library not installed — fall through to gcloud CLI
+    }
+
+    // Fallback: gcloud CLI
+    try {
+      const { execSync } = await import('node:child_process');
+      const token = execSync('gcloud auth application-default print-access-token', {
+        encoding: 'utf-8',
+        timeout: 10_000,
+      }).trim();
+      if (token) {
+        this.cachedToken = { token, expiresAt: Date.now() + 3300_000 };
+        return token;
+      }
+    } catch {
+      // gcloud not available
+    }
+
+    throw new Error(
+      'Could not obtain Google Cloud access token. Install google-auth-library, ' +
+      'run "gcloud auth application-default login", or set GOOGLE_APPLICATION_CREDENTIALS.',
+    );
+  }
+
+  async *call(request: LLMRequest): AsyncIterable<LLMChunk> {
+    const body = this.buildRequestBody(request);
+    const headers = this.getHeaders();
+    const endpoint = this.getEndpoint(request.model);
+    const accessToken = await this.getAccessToken();
+    headers['Authorization'] = `Bearer ${accessToken}`;
+
+    // Vertex AI doesn't use the API key in the URL
+    const cleanEndpoint = endpoint.replace(/[?&]key=[^&]+/, '');
+
+    const response = await fetch(cleanEndpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Google Vertex AI error (${response.status}): ${errorText}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Google Vertex AI returned no response body');
+    }
+
+    yield* this.parseSSEStream(response.body, request.model);
+  }
+}

--- a/packages/squad-sdk/src/adapter/providers/google-vertex-provider.ts
+++ b/packages/squad-sdk/src/adapter/providers/google-vertex-provider.ts
@@ -1,0 +1,72 @@
+/**
+ * Google Vertex AI Provider
+ *
+ * SquadProvider implementation for Gemini via Google Cloud Vertex AI.
+ * Uses Google Cloud ADC for authentication.
+ *
+ * @module adapter/providers/google-vertex-provider
+ */
+
+import type { SquadProvider } from '../provider.js';
+import type {
+  SquadSessionConfig,
+  SquadSession,
+  SquadProviderConfig,
+} from '../types.js';
+import { GoogleVertexApi } from './google-vertex-api.js';
+import { DirectApiSession } from '../direct-session.js';
+
+export class GoogleVertexProvider implements SquadProvider {
+  readonly name = 'google-vertex' as const;
+
+  private projectId: string;
+  private location: string;
+  private connected = false;
+
+  constructor(providerConfig?: SquadProviderConfig) {
+    this.projectId =
+      providerConfig?.google?.projectId ??
+      process.env['GOOGLE_CLOUD_PROJECT'] ??
+      '';
+    this.location =
+      providerConfig?.google?.location ??
+      process.env['GOOGLE_CLOUD_REGION'] ??
+      'us-central1';
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  async connect(): Promise<void> {
+    if (!this.projectId) {
+      throw new Error(
+        'Google Cloud project ID not found. Set GOOGLE_CLOUD_PROJECT environment variable ' +
+        'or pass projectId in provider.google config.',
+      );
+    }
+    this.connected = true;
+  }
+
+  async disconnect(): Promise<Error[]> {
+    this.connected = false;
+    return [];
+  }
+
+  async createSession(config: SquadSessionConfig): Promise<SquadSession> {
+    const adapter = new GoogleVertexApi({
+      projectId: this.projectId,
+      location: this.location,
+    });
+
+    return new DirectApiSession({
+      adapter,
+      model: config.model ?? 'gemini-2.5-pro',
+      tools: config.tools ?? [],
+      systemMessage: config.systemMessage,
+      sessionId: config.sessionId,
+      reasoningEffort: config.reasoningEffort,
+      hooks: config.hooks,
+    });
+  }
+}

--- a/packages/squad-sdk/src/adapter/types.ts
+++ b/packages/squad-sdk/src/adapter/types.ts
@@ -657,14 +657,14 @@ export interface SquadProviderConfig {
    * Provider type.
    * @default "openai"
    */
-  type?: "openai" | "azure" | "anthropic";
+  type?: "openai" | "azure" | "anthropic" | "anthropic-vertex" | "google" | "google-vertex" | "copilot";
   /**
    * API format (openai/azure only).
    * @default "completions"
    */
   wireApi?: "completions" | "responses";
   /** API endpoint URL */
-  baseUrl: string;
+  baseUrl?: string;
   /** API key (optional for local providers like Ollama) */
   apiKey?: string;
   /**
@@ -679,6 +679,20 @@ export interface SquadProviderConfig {
      * @default "2024-10-21"
      */
     apiVersion?: string;
+  };
+  /** Google Cloud / Vertex AI options (for anthropic-vertex and google-vertex) */
+  google?: {
+    /** Google Cloud project ID */
+    projectId?: string;
+    /** Google Cloud region (e.g., "us-central1") */
+    location?: string;
+  };
+  /** Anthropic on Vertex AI options */
+  anthropicVertex?: {
+    /** Google Cloud project ID */
+    projectId?: string;
+    /** Google Cloud region (e.g., "us-east5") */
+    region?: string;
   };
 }
 

--- a/packages/squad-sdk/src/agents/model-selector.ts
+++ b/packages/squad-sdk/src/agents/model-selector.ts
@@ -150,16 +150,16 @@ function selectModelForTask(taskType: TaskType, economyMode?: boolean): Resolved
 
 export function inferTierFromModel(model: string): ModelTier {
   const lowerModel = model.toLowerCase();
-  
+
   if (lowerModel.includes('opus')) {
     return 'premium';
   }
-  
-  if (lowerModel.includes('haiku') || lowerModel.includes('mini')) {
+
+  if (lowerModel.includes('haiku') || lowerModel.includes('mini') || lowerModel.includes('flash')) {
     return 'fast';
   }
-  
-  // Default to standard for sonnet, gpt-5.x, etc.
+
+  // Default to standard for sonnet, gpt-5.x, gemini-*-pro, etc.
   return 'standard';
 }
 

--- a/packages/squad-sdk/src/build/bundle.ts
+++ b/packages/squad-sdk/src/build/bundle.ts
@@ -33,6 +33,7 @@ const DEFAULT_ENTRY_POINTS = [
 
 const DEFAULT_EXTERNAL = [
   '@github/copilot-sdk',
+  'google-auth-library',
 ];
 
 const DEFAULT_CONFIG: BundleConfig = {

--- a/packages/squad-sdk/src/config/models.ts
+++ b/packages/squad-sdk/src/config/models.ts
@@ -216,7 +216,18 @@ export const MODEL_CATALOG: ModelInfo[] = [
     speed: 7,
     pricing: { inputPerToken: 0.00000125, outputPerToken: 0.00001 },
   },
-  
+  {
+    id: 'gemini-2.5-pro',
+    tier: 'standard',
+    provider: 'google',
+    family: 'gemini',
+    vision: true,
+    useCases: ['code generation', 'analysis', 'multi-file refactors'],
+    cost: 4,
+    speed: 7,
+    pricing: { inputPerToken: 0.00000125, outputPerToken: 0.00001 },
+  },
+
   // Fast tier - lowest cost, fastest, good enough quality
   {
     id: 'claude-haiku-4.5',
@@ -257,7 +268,18 @@ export const MODEL_CATALOG: ModelInfo[] = [
     cost: 2,
     speed: 9,
     pricing: { inputPerToken: 0.0000002, outputPerToken: 0.0000008 },
-  }
+  },
+  {
+    id: 'gemini-2.5-flash',
+    tier: 'fast',
+    provider: 'google',
+    family: 'gemini',
+    vision: true,
+    useCases: ['boilerplate', 'simple fixes', 'triage'],
+    cost: 1,
+    speed: 10,
+    pricing: { inputPerToken: 0.00000015, outputPerToken: 0.0000006 },
+  },
 ];
 
 /**
@@ -265,8 +287,8 @@ export const MODEL_CATALOG: ModelInfo[] = [
  */
 export const DEFAULT_FALLBACK_CHAINS: Record<ModelTier, ModelId[]> = {
   premium: ['claude-opus-4.6', 'claude-opus-4.6-fast', 'claude-opus-4.5', 'claude-sonnet-4.6'],
-  standard: ['claude-sonnet-4.6', 'gpt-5.4', 'claude-sonnet-4.5', 'gpt-5.3-codex', 'claude-sonnet-4', 'gpt-5.2'],
-  fast: ['claude-haiku-4.5', 'gpt-5.1-codex-mini', 'gpt-4.1', 'gpt-5-mini']
+  standard: ['claude-sonnet-4.6', 'gpt-5.4', 'gemini-2.5-pro', 'claude-sonnet-4.5', 'gpt-5.3-codex', 'claude-sonnet-4', 'gpt-5.2'],
+  fast: ['claude-haiku-4.5', 'gemini-2.5-flash', 'gpt-5.1-codex-mini', 'gpt-4.1', 'gpt-5-mini']
 };
 
 /**
@@ -531,6 +553,8 @@ export const ECONOMY_MODEL_MAP: Record<string, string> = {
   'claude-sonnet-4.5':    'gpt-4.1',
   // Fast → cheapest fast (scribe/mechanical, docs)
   'claude-haiku-4.5':     'gpt-4.1',
+  // Gemini economy downgrades
+  'gemini-2.5-pro':       'gemini-2.5-flash',
 };
 
 /**

--- a/packages/squad-sdk/src/runtime/constants.ts
+++ b/packages/squad-sdk/src/runtime/constants.ts
@@ -30,6 +30,7 @@ export const MODELS = {
     standard: [
       'claude-sonnet-4.6',
       'gpt-5.4',
+      'gemini-2.5-pro',
       'claude-sonnet-4.5',
       'gpt-5.3-codex',
       'claude-sonnet-4',
@@ -37,6 +38,7 @@ export const MODELS = {
     ],
     fast: [
       'claude-haiku-4.5',
+      'gemini-2.5-flash',
       'gpt-5.1-codex-mini',
       'gpt-4.1',
       'gpt-5-mini',

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -976,7 +976,7 @@ prompt: |
 
   Tasks (in order):
   {% if STATE_BACKEND == "orphan" or STATE_BACKEND == "git-notes" or STATE_BACKEND == "two-layer" %}
-  0. STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
+  0. PRE-CHECK — STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
      (.squad/decisions.md, agents/*/history.md, log/*, orchestration-log/*, decisions/inbox/*)
      to the working branch. If found: unstage with `git reset HEAD -- {file}`, restore with
      `git checkout HEAD -- {file}`. If leaked in last commit, amend to remove. Log count.

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -976,7 +976,7 @@ prompt: |
 
   Tasks (in order):
   {% if STATE_BACKEND == "orphan" or STATE_BACKEND == "git-notes" or STATE_BACKEND == "two-layer" %}
-  0. STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
+  0. PRE-CHECK — STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
      (.squad/decisions.md, agents/*/history.md, log/*, orchestration-log/*, decisions/inbox/*)
      to the working branch. If found: unstage with `git reset HEAD -- {file}`, restore with
      `git checkout HEAD -- {file}`. If leaked in last commit, amend to remove. Log count.

--- a/test-fixtures/init-test/.gitignore
+++ b/test-fixtures/init-test/.gitignore
@@ -1,2 +1,0 @@
-# Squad: SubSquad activation file (local to this machine)
-.squad-workstream

--- a/test/adapter-client.test.ts
+++ b/test/adapter-client.test.ts
@@ -1,64 +1,67 @@
 /**
  * Integration tests for SquadClient adapter (M0-9, Issue #85)
- * 
+ *
  * Tests connection lifecycle, session CRUD, and error recovery.
- * Uses vi.mock to stub CopilotClient since it requires a real CLI server.
+ * Uses a mock SquadProvider injected via options.provider.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { SquadClient, type SquadClientOptions } from '@bradygaster/squad-sdk/client';
-import { CopilotClient } from '@github/copilot-sdk';
+import type { SquadProvider } from '@bradygaster/squad-sdk/adapter/provider';
 
-// Mock CopilotClient
-vi.mock('@github/copilot-sdk', () => {
-  return {
-    CopilotClient: vi.fn().mockImplementation(() => {
-      return {
-        start: vi.fn().mockResolvedValue(undefined),
-        stop: vi.fn().mockResolvedValue([]),
-        forceStop: vi.fn().mockResolvedValue(undefined),
-        createSession: vi.fn().mockResolvedValue({
-          sessionId: 'session-1',
-          send: vi.fn().mockResolvedValue('msg-1'),
-          on: vi.fn().mockReturnValue(() => {}),
-          destroy: vi.fn().mockResolvedValue(undefined),
-        }),
-        resumeSession: vi.fn().mockResolvedValue({
-          sessionId: 'session-1',
-          send: vi.fn().mockResolvedValue('msg-1'),
-          on: vi.fn().mockReturnValue(() => {}),
-          destroy: vi.fn().mockResolvedValue(undefined),
-        }),
-        listSessions: vi.fn().mockResolvedValue([]),
-        deleteSession: vi.fn().mockResolvedValue(undefined),
-        getLastSessionId: vi.fn().mockResolvedValue(undefined),
-        ping: vi.fn().mockResolvedValue({ message: 'pong', timestamp: Date.now() }),
-        getStatus: vi.fn().mockResolvedValue({ version: '1.0.0' }),
-        getAuthStatus: vi.fn().mockResolvedValue({ authenticated: true }),
-        listModels: vi.fn().mockResolvedValue([]),
-        on: vi.fn().mockReturnValue(() => {}),
-      };
-    }),
+function createMockProvider(): SquadProvider & { _mocks: Record<string, ReturnType<typeof vi.fn>> } {
+  const mockSession = {
+    sessionId: 'session-1',
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendAndWait: vi.fn().mockResolvedValue('result'),
+    abort: vi.fn().mockResolvedValue(undefined),
+    getMessages: vi.fn().mockResolvedValue([]),
+    on: vi.fn(),
+    off: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
   };
-});
+
+  const mocks = {
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue([]),
+    forceDisconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(false),
+    createSession: vi.fn().mockResolvedValue(mockSession),
+    resumeSession: vi.fn().mockResolvedValue(mockSession),
+    listSessions: vi.fn().mockResolvedValue([]),
+    deleteSession: vi.fn().mockResolvedValue(undefined),
+    getLastSessionId: vi.fn().mockResolvedValue(undefined),
+    ping: vi.fn().mockResolvedValue({ message: 'pong', timestamp: Date.now() }),
+    getStatus: vi.fn().mockResolvedValue({ version: '1.0.0', protocolVersion: 1 }),
+    getAuthStatus: vi.fn().mockResolvedValue({ isAuthenticated: true }),
+    listModels: vi.fn().mockResolvedValue([]),
+    on: vi.fn().mockReturnValue(() => {}),
+  };
+
+  return {
+    name: 'copilot' as const,
+    ...mocks,
+    _mocks: mocks,
+  };
+}
 
 describe('SquadClient — Connection Lifecycle', () => {
+  let mockProvider: ReturnType<typeof createMockProvider>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProvider = createMockProvider();
   });
 
   it('should construct with minimal options', () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     expect(client).toBeDefined();
     expect(client.getState()).toBe('disconnected');
   });
 
   it('should construct with custom options', () => {
     const options: SquadClientOptions = {
-      cwd: '/tmp/test',
-      port: 8080,
-      useStdio: false,
-      logLevel: 'error',
+      provider: mockProvider,
       autoStart: false,
       autoReconnect: false,
       maxReconnectAttempts: 5,
@@ -70,7 +73,7 @@ describe('SquadClient — Connection Lifecycle', () => {
   });
 
   it('should connect and transition to connected state', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     expect(client.isConnected()).toBe(false);
 
     await client.connect();
@@ -80,24 +83,19 @@ describe('SquadClient — Connection Lifecycle', () => {
   });
 
   it('should not connect twice when already connected', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
     expect(client.getState()).toBe('connected');
 
-    // Second connect should be no-op
     await client.connect();
     expect(client.getState()).toBe('connected');
   });
 
   it('should deduplicate concurrent connect calls', async () => {
-    const client = new SquadClient();
-    
-    // Make start() slow so both calls overlap
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    instance.start.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100)));
+    mockProvider._mocks.connect.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100)));
 
-    // Fire two concurrent connect calls — second should wait, not throw
+    const client = new SquadClient({ provider: mockProvider });
+
     const [result1, result2] = await Promise.all([
       client.connect(),
       client.connect(),
@@ -106,17 +104,14 @@ describe('SquadClient — Connection Lifecycle', () => {
     expect(result1).toBeUndefined();
     expect(result2).toBeUndefined();
     expect(client.getState()).toBe('connected');
-    // start() should only be called once — the second call piggybacked
-    expect(instance.start).toHaveBeenCalledTimes(1);
+    expect(mockProvider._mocks.connect).toHaveBeenCalledTimes(1);
   });
 
   it('should handle concurrent createSession calls that trigger auto-connect', async () => {
-    const client = new SquadClient({ autoStart: true });
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    instance.start.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 50)));
+    mockProvider._mocks.connect.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 50)));
 
-    // Both createSession calls should succeed — second waits for connect
+    const client = new SquadClient({ provider: mockProvider, autoStart: true });
+
     const [session1, session2] = await Promise.all([
       client.createSession({ model: 'claude-sonnet-4.5' }),
       client.createSession({ model: 'claude-sonnet-4.5' }),
@@ -125,16 +120,15 @@ describe('SquadClient — Connection Lifecycle', () => {
     expect(session1.sessionId).toBe('session-1');
     expect(session2.sessionId).toBe('session-1');
     expect(client.isConnected()).toBe(true);
-    expect(instance.start).toHaveBeenCalledTimes(1);
+    expect(mockProvider._mocks.connect).toHaveBeenCalledTimes(1);
   });
 
   it('should propagate connect failure to concurrent callers', async () => {
-    const client = new SquadClient();
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    instance.start.mockImplementation(
+    mockProvider._mocks.connect.mockImplementation(
       () => new Promise((_, reject) => setTimeout(() => reject(new Error('server down')), 50))
     );
+
+    const client = new SquadClient({ provider: mockProvider });
 
     const results = await Promise.allSettled([
       client.connect(),
@@ -149,29 +143,24 @@ describe('SquadClient — Connection Lifecycle', () => {
   });
 
   it('should start fresh connect after failed concurrent connect', async () => {
-    const client = new SquadClient();
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-
-    // First connect attempt fails
-    instance.start.mockImplementationOnce(
+    mockProvider._mocks.connect.mockImplementationOnce(
       () => new Promise((_, reject) => setTimeout(() => reject(new Error('server down')), 50))
     );
+
+    const client = new SquadClient({ provider: mockProvider });
 
     await Promise.allSettled([client.connect(), client.connect()]);
     expect(client.getState()).toBe('error');
 
-    // Restore start to succeed
-    instance.start.mockResolvedValue(undefined);
+    mockProvider._mocks.connect.mockResolvedValue(undefined);
 
-    // New connect should start fresh (connectPromise was cleared on failure)
     await client.connect();
     expect(client.getState()).toBe('connected');
-    expect(instance.start).toHaveBeenCalledTimes(2); // 1 failed + 1 fresh
+    expect(mockProvider._mocks.connect).toHaveBeenCalledTimes(2);
   });
 
   it('should disconnect gracefully', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
     const errors = await client.disconnect();
@@ -182,7 +171,7 @@ describe('SquadClient — Connection Lifecycle', () => {
   });
 
   it('should force disconnect without graceful cleanup', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
     await client.forceDisconnect();
@@ -191,103 +180,89 @@ describe('SquadClient — Connection Lifecycle', () => {
   });
 
   it('should reset reconnect attempts on successful connect', async () => {
-    const client = new SquadClient({ maxReconnectAttempts: 3 });
-    
+    const client = new SquadClient({ provider: mockProvider, maxReconnectAttempts: 3 });
+
     await client.connect();
     expect(client.getState()).toBe('connected');
-    
+
     await client.disconnect();
     await client.connect();
-    
+
     expect(client.getState()).toBe('connected');
   });
 });
 
 describe('SquadClient — Auto-Reconnection', () => {
+  let mockProvider: ReturnType<typeof createMockProvider>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProvider = createMockProvider();
   });
 
   it('should auto-reconnect on ECONNREFUSED', async () => {
-    const client = new SquadClient({ autoReconnect: true, reconnectDelayMs: 10 });
+    const client = new SquadClient({ provider: mockProvider, autoReconnect: true, reconnectDelayMs: 10 });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-
-    // First call fails with ECONNREFUSED, second succeeds
-    instance.createSession
+    mockProvider._mocks.createSession
       .mockRejectedValueOnce(new Error('ECONNREFUSED'))
-      .mockResolvedValueOnce({ sessionId: 'session-1', send: vi.fn().mockResolvedValue('msg-1'), on: vi.fn().mockReturnValue(() => {}), destroy: vi.fn().mockResolvedValue(undefined) });
+      .mockResolvedValueOnce({ sessionId: 'session-1', sendMessage: vi.fn(), on: vi.fn(), off: vi.fn(), close: vi.fn() });
 
     const session = await client.createSession({ model: 'claude-sonnet-4.5' });
-    
+
     expect(session).toBeDefined();
     expect(session.sessionId).toBe('session-1');
-    expect(instance.stop).toHaveBeenCalled();
-    expect(instance.start).toHaveBeenCalledTimes(2); // initial + reconnect
+    expect(mockProvider._mocks.disconnect).toHaveBeenCalled();
+    expect(mockProvider._mocks.connect).toHaveBeenCalledTimes(2);
   });
 
   it('should auto-reconnect on ECONNRESET', async () => {
-    const client = new SquadClient({ autoReconnect: true, reconnectDelayMs: 10 });
+    const client = new SquadClient({ provider: mockProvider, autoReconnect: true, reconnectDelayMs: 10 });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-
-    instance.listSessions
+    mockProvider._mocks.listSessions
       .mockRejectedValueOnce(new Error('Connection error: ECONNRESET'))
       .mockResolvedValueOnce([]);
 
     const sessions = await client.listSessions();
-    
+
     expect(sessions).toEqual([]);
   });
 
   it('should auto-reconnect on EPIPE', async () => {
-    const client = new SquadClient({ autoReconnect: true, reconnectDelayMs: 10 });
+    const client = new SquadClient({ provider: mockProvider, autoReconnect: true, reconnectDelayMs: 10 });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-
-    instance.ping
+    mockProvider._mocks.ping
       .mockRejectedValueOnce(new Error('EPIPE'))
       .mockResolvedValueOnce({ message: 'pong', timestamp: Date.now() });
 
     const result = await client.ping();
-    
+
     expect(result.message).toBe('pong');
   });
 
   it('should exhaust max reconnect attempts', async () => {
-    const client = new SquadClient({ autoReconnect: true, maxReconnectAttempts: 2, reconnectDelayMs: 10 });
+    const client = new SquadClient({ provider: mockProvider, autoReconnect: true, maxReconnectAttempts: 2, reconnectDelayMs: 10 });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-
-    // Always fail
-    instance.createSession.mockRejectedValue(new Error('ECONNREFUSED'));
-    instance.start.mockRejectedValue(new Error('Connection failed'));
+    mockProvider._mocks.createSession.mockRejectedValue(new Error('ECONNREFUSED'));
+    mockProvider._mocks.connect.mockRejectedValue(new Error('Connection failed'));
 
     await expect(client.createSession()).rejects.toThrow();
   });
 
   it('should not auto-reconnect when autoReconnect is false', async () => {
-    const client = new SquadClient({ autoReconnect: false });
+    const client = new SquadClient({ provider: mockProvider, autoReconnect: false });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-
-    instance.createSession.mockRejectedValue(new Error('ECONNREFUSED'));
+    mockProvider._mocks.createSession.mockRejectedValue(new Error('ECONNREFUSED'));
 
     await expect(client.createSession()).rejects.toThrow('ECONNREFUSED');
   });
 
   it('should not auto-reconnect after manual disconnect', async () => {
-    const client = new SquadClient({ autoReconnect: true, autoStart: false });
+    const client = new SquadClient({ provider: mockProvider, autoReconnect: true, autoStart: false });
     await client.connect();
     await client.disconnect();
 
@@ -295,38 +270,35 @@ describe('SquadClient — Auto-Reconnection', () => {
   });
 
   it('should use exponential backoff for reconnect delays', async () => {
-    const client = new SquadClient({ autoReconnect: true, maxReconnectAttempts: 3, reconnectDelayMs: 100 });
+    const client = new SquadClient({ provider: mockProvider, autoReconnect: true, maxReconnectAttempts: 3, reconnectDelayMs: 100 });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-
-    // Fail on first attempt, succeed on second
-    instance.createSession
+    mockProvider._mocks.createSession
       .mockRejectedValueOnce(new Error('ECONNREFUSED'))
-      .mockResolvedValueOnce({ sessionId: 'session-1', send: vi.fn().mockResolvedValue('msg-1'), on: vi.fn().mockReturnValue(() => {}), destroy: vi.fn().mockResolvedValue(undefined) });
+      .mockResolvedValueOnce({ sessionId: 'session-1', sendMessage: vi.fn(), on: vi.fn(), off: vi.fn(), close: vi.fn() });
 
-    // First reconnect succeeds
-    instance.stop.mockResolvedValue([]);
-    instance.start.mockResolvedValue(undefined);
+    mockProvider._mocks.disconnect.mockResolvedValue([]);
+    mockProvider._mocks.connect.mockResolvedValue(undefined);
 
     const startTime = Date.now();
     const session = await client.createSession();
     const elapsed = Date.now() - startTime;
 
-    // First delay: 100ms minimum
     expect(elapsed).toBeGreaterThan(90);
     expect(session.sessionId).toBe('session-1');
   });
 });
 
 describe('SquadClient — Session CRUD', () => {
+  let mockProvider: ReturnType<typeof createMockProvider>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProvider = createMockProvider();
   });
 
   it('should create session when connected', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
     const session = await client.createSession({ model: 'claude-sonnet-4.5' });
@@ -336,7 +308,7 @@ describe('SquadClient — Session CRUD', () => {
   });
 
   it('should auto-connect when creating session with autoStart enabled', async () => {
-    const client = new SquadClient({ autoStart: true });
+    const client = new SquadClient({ provider: mockProvider, autoStart: true });
     expect(client.isConnected()).toBe(false);
 
     const session = await client.createSession({ model: 'claude-sonnet-4.5' });
@@ -346,13 +318,13 @@ describe('SquadClient — Session CRUD', () => {
   });
 
   it('should throw when creating session without connection and autoStart disabled', async () => {
-    const client = new SquadClient({ autoStart: false });
+    const client = new SquadClient({ provider: mockProvider, autoStart: false });
 
     await expect(client.createSession()).rejects.toThrow('Client not connected');
   });
 
   it('should resume existing session', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
     const session = await client.resumeSession('session-1', { model: 'claude-opus-4.6' });
@@ -362,12 +334,10 @@ describe('SquadClient — Session CRUD', () => {
   });
 
   it('should list sessions', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    instance.listSessions.mockResolvedValue([
+    mockProvider._mocks.listSessions.mockResolvedValue([
       { sessionId: 'session-1', startTime: new Date(), modifiedTime: new Date(), isRemote: false },
       { sessionId: 'session-2', startTime: new Date(), modifiedTime: new Date(), isRemote: false },
     ]);
@@ -380,23 +350,19 @@ describe('SquadClient — Session CRUD', () => {
   });
 
   it('should delete session', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
     await client.deleteSession('session-1');
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    expect(instance.deleteSession).toHaveBeenCalledWith('session-1');
+    expect(mockProvider._mocks.deleteSession).toHaveBeenCalledWith('session-1');
   });
 
   it('should get last session ID', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    instance.getLastSessionId.mockResolvedValue('session-42');
+    mockProvider._mocks.getLastSessionId.mockResolvedValue('session-42');
 
     const lastId = await client.getLastSessionId();
 
@@ -405,12 +371,15 @@ describe('SquadClient — Session CRUD', () => {
 });
 
 describe('SquadClient — Status Operations', () => {
+  let mockProvider: ReturnType<typeof createMockProvider>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProvider = createMockProvider();
   });
 
   it('should ping server', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
     const result = await client.ping('hello');
@@ -420,13 +389,11 @@ describe('SquadClient — Status Operations', () => {
   });
 
   it('should get status', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    instance.getStatus.mockResolvedValue({ 
-      version: '1.0.0', 
+    mockProvider._mocks.getStatus.mockResolvedValue({
+      version: '1.0.0',
       protocolVersion: 2,
     });
 
@@ -437,12 +404,10 @@ describe('SquadClient — Status Operations', () => {
   });
 
   it('should get auth status', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    instance.getAuthStatus.mockResolvedValue({ 
+    mockProvider._mocks.getAuthStatus.mockResolvedValue({
       isAuthenticated: true,
       login: 'testuser'
     });
@@ -454,12 +419,10 @@ describe('SquadClient — Status Operations', () => {
   });
 
   it('should list models', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    instance.listModels.mockResolvedValue([
+    mockProvider._mocks.listModels.mockResolvedValue([
       { id: 'claude-sonnet-4.5', name: 'Claude Sonnet 4.5' },
       { id: 'claude-opus-4.6', name: 'Claude Opus 4.6' },
     ]);
@@ -471,7 +434,7 @@ describe('SquadClient — Status Operations', () => {
   });
 
   it('should throw when calling operations while disconnected', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
 
     await expect(client.ping()).rejects.toThrow('Client not connected');
     await expect(client.getStatus()).rejects.toThrow('Client not connected');
@@ -483,12 +446,15 @@ describe('SquadClient — Status Operations', () => {
 });
 
 describe('SquadClient — Event Subscriptions', () => {
+  let mockProvider: ReturnType<typeof createMockProvider>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProvider = createMockProvider();
   });
 
   it('should subscribe to typed events', () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     const handler = vi.fn();
 
     const unsubscribe = client.on('session.created', handler);
@@ -497,7 +463,7 @@ describe('SquadClient — Event Subscriptions', () => {
   });
 
   it('should subscribe to all events', () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     const handler = vi.fn();
 
     const unsubscribe = client.on(handler);

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -342,6 +342,7 @@ describe('Per-Agent Model Selection (M1-9)', () => {
       expect(result.fallbackChain).toEqual([
         'claude-sonnet-4.6',
         'gpt-5.4',
+        'gemini-2.5-pro',
         'claude-sonnet-4.5',
         'gpt-5.3-codex',
         'claude-sonnet-4',
@@ -358,6 +359,7 @@ describe('Per-Agent Model Selection (M1-9)', () => {
 
       expect(result.fallbackChain).toEqual([
         'claude-haiku-4.5',
+        'gemini-2.5-flash',
         'gpt-5.1-codex-mini',
         'gpt-4.1',
         'gpt-5-mini',

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -68,8 +68,8 @@ describe('squad doctor', () => {
 
     const squadDirCheck = checks.find((c: DoctorCheck) => c.name === '.squad/ directory exists');
     expect(squadDirCheck?.status).toBe('fail');
-    // When .squad/ is missing the file checks are skipped — .squad/ + squad.agent.md + Node version + 2 ESM checks
-    expect(checks.length).toBe(5);
+    // When .squad/ is missing the file checks are skipped — .squad/ + squad.agent.md + Node version + 2 ESM checks + provider info
+    expect(checks.length).toBe(6);
   });
 
   it('detects remote mode from config.json with teamRoot', async () => {

--- a/test/session-adapter.test.ts
+++ b/test/session-adapter.test.ts
@@ -55,9 +55,9 @@ describe('CopilotSessionAdapter (via SquadClient)', () => {
     // Force connected state
     (client as any).state = 'connected';
 
-    // Inject mock CopilotSession via the inner CopilotClient
+    // Inject mock CopilotSession via the CopilotProvider's inner CopilotClient
     const mockSession = createMockCopilotSession();
-    (client as any).client.createSession = vi.fn().mockResolvedValue(mockSession);
+    (client as any).provider.client.createSession = vi.fn().mockResolvedValue(mockSession);
 
     const session = await client.createSession();
     return { session, mockSession };
@@ -286,7 +286,7 @@ describe('CopilotSessionAdapter via resumeSession', () => {
     (client as any).state = 'connected';
 
     const mockSession = createMockCopilotSession('resumed-session-99');
-    (client as any).client.resumeSession = vi.fn().mockResolvedValue(mockSession);
+    (client as any).provider.client.resumeSession = vi.fn().mockResolvedValue(mockSession);
 
     const session = await client.resumeSession('resumed-session-99');
 
@@ -301,7 +301,7 @@ describe('CopilotSessionAdapter optional methods', () => {
     const client = new SquadClient({ autoStart: false });
     (client as any).state = 'connected';
     const mockSession = createMockCopilotSession();
-    (client as any).client.createSession = vi.fn().mockResolvedValue(mockSession);
+    (client as any).provider.client.createSession = vi.fn().mockResolvedValue(mockSession);
     const session = await client.createSession();
     return { session, mockSession };
   }

--- a/test/session-traces.test.ts
+++ b/test/session-traces.test.ts
@@ -9,45 +9,12 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { SquadClient } from '@bradygaster/squad-sdk/client';
-import { CopilotClient } from '@github/copilot-sdk';
+import type { SquadProvider } from '@bradygaster/squad-sdk/adapter/provider';
 import {
   StreamingPipeline,
   type StreamDelta,
   type UsageEvent,
 } from '@bradygaster/squad-sdk/runtime/streaming';
-
-// Mock CopilotClient
-vi.mock('@github/copilot-sdk', () => {
-  return {
-    CopilotClient: vi.fn().mockImplementation(() => {
-      return {
-        start: vi.fn().mockResolvedValue(undefined),
-        stop: vi.fn().mockResolvedValue([]),
-        forceStop: vi.fn().mockResolvedValue(undefined),
-        createSession: vi.fn().mockResolvedValue({
-          sessionId: 'session-1',
-          send: vi.fn().mockResolvedValue('msg-1'),
-          on: vi.fn().mockReturnValue(() => {}),
-          destroy: vi.fn().mockResolvedValue(undefined),
-        }),
-        resumeSession: vi.fn().mockResolvedValue({
-          sessionId: 'session-1',
-          send: vi.fn().mockResolvedValue('msg-1'),
-          on: vi.fn().mockReturnValue(() => {}),
-          destroy: vi.fn().mockResolvedValue(undefined),
-        }),
-        listSessions: vi.fn().mockResolvedValue([]),
-        deleteSession: vi.fn().mockResolvedValue(undefined),
-        getLastSessionId: vi.fn().mockResolvedValue(undefined),
-        ping: vi.fn().mockResolvedValue({ message: 'pong', timestamp: Date.now() }),
-        getStatus: vi.fn().mockResolvedValue({ version: '1.0.0' }),
-        getAuthStatus: vi.fn().mockResolvedValue({ authenticated: true }),
-        listModels: vi.fn().mockResolvedValue([]),
-        on: vi.fn().mockReturnValue(() => {}),
-      };
-    }),
-  };
-});
 
 // Mock otel-metrics to verify they're called
 vi.mock('@bradygaster/squad-sdk/runtime/otel-metrics', async (importOriginal) => {
@@ -67,17 +34,60 @@ import {
   recordTokensPerSecond,
 } from '@bradygaster/squad-sdk/runtime/otel-metrics';
 
+// ---------------------------------------------------------------------------
+// Mock provider helper (replaces vi.mock of @github/copilot-sdk)
+// ---------------------------------------------------------------------------
+
+function createMockProvider(): SquadProvider & { _mocks: Record<string, ReturnType<typeof vi.fn>> } {
+  const mockSession = {
+    sessionId: 'session-1',
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendAndWait: vi.fn().mockResolvedValue('result'),
+    abort: vi.fn().mockResolvedValue(undefined),
+    getMessages: vi.fn().mockResolvedValue([]),
+    on: vi.fn(),
+    off: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const mocks = {
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue([]),
+    forceDisconnect: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(false),
+    createSession: vi.fn().mockResolvedValue(mockSession),
+    resumeSession: vi.fn().mockResolvedValue(mockSession),
+    listSessions: vi.fn().mockResolvedValue([]),
+    deleteSession: vi.fn().mockResolvedValue(undefined),
+    getLastSessionId: vi.fn().mockResolvedValue(undefined),
+    ping: vi.fn().mockResolvedValue({ message: 'pong', timestamp: Date.now() }),
+    getStatus: vi.fn().mockResolvedValue({ version: '1.0.0', protocolVersion: 1 }),
+    getAuthStatus: vi.fn().mockResolvedValue({ isAuthenticated: true }),
+    listModels: vi.fn().mockResolvedValue([]),
+    on: vi.fn().mockReturnValue(() => {}),
+  };
+
+  return {
+    name: 'copilot' as const,
+    ...mocks,
+    _mocks: mocks,
+  };
+}
+
 // ============================================================================
 // #259 — SquadClient.sendMessage()
 // ============================================================================
 
 describe('SquadClient.sendMessage() — squad.session.message span', () => {
+  let mockProvider: ReturnType<typeof createMockProvider>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProvider = createMockProvider();
   });
 
   it('should call session.sendMessage with options', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
     const session = await client.createSession();
     const spy = vi.spyOn(session, 'sendMessage');
@@ -88,7 +98,7 @@ describe('SquadClient.sendMessage() — squad.session.message span', () => {
   });
 
   it('should propagate errors from session.sendMessage', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
     const session = await client.createSession();
     vi.spyOn(session, 'sendMessage').mockRejectedValueOnce(new Error('stream failed'));
@@ -99,7 +109,7 @@ describe('SquadClient.sendMessage() — squad.session.message span', () => {
   });
 
   it('should register event listeners on session', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
     const session = await client.createSession();
     const onSpy = vi.spyOn(session, 'on');
@@ -112,7 +122,7 @@ describe('SquadClient.sendMessage() — squad.session.message span', () => {
   });
 
   it('should clean up event listeners after completion', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
     const session = await client.createSession();
     const offSpy = vi.spyOn(session, 'off');
@@ -129,28 +139,27 @@ describe('SquadClient.sendMessage() — squad.session.message span', () => {
 // ============================================================================
 
 describe('SquadClient.closeSession() — squad.session.close span', () => {
+  let mockProvider: ReturnType<typeof createMockProvider>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProvider = createMockProvider();
   });
 
   it('should delete the session', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
     await client.closeSession('session-42');
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    expect(instance.deleteSession).toHaveBeenCalledWith('session-42');
+    expect(mockProvider._mocks.deleteSession).toHaveBeenCalledWith('session-42');
   });
 
   it('should propagate errors from deleteSession', async () => {
-    const client = new SquadClient();
+    const client = new SquadClient({ provider: mockProvider });
     await client.connect();
 
-    const MockedCopilotClient = CopilotClient as unknown as ReturnType<typeof vi.fn>;
-    const instance = MockedCopilotClient.mock.results[0].value;
-    instance.deleteSession.mockRejectedValueOnce(new Error('not found'));
+    mockProvider._mocks.deleteSession.mockRejectedValueOnce(new Error('not found'));
 
     await expect(client.closeSession('session-99')).rejects.toThrow('not found');
   });


### PR DESCRIPTION
Add pluggable provider architecture enabling Squad to use Anthropic API, Google AI, and both Vertex AI variants as alternatives to the Copilot SDK.

- Provider abstraction layer (SquadProvider interface + factory)
- Agentic tool-use loop engine for direct API providers
- Anthropic provider (API key + Vertex AI with ADC auth)
- Google provider (API key + Vertex AI with ADC auth)
- Extract Copilot SDK into CopilotProvider (sole SDK import point)
- CLI --provider flag and SQUAD_PROVIDER env var
- Provider-aware doctor checks and error handling
- Gemini models added to fallback chains and cost tracking
- All tests updated for provider injection pattern

### What
<!-- One paragraph: what does this PR change? -->

### Why
<!-- Problem being solved. Link to the issue: Closes #N -->

### How
<!-- Approach taken. Key design decisions and trade-offs. -->

---

### ⚠️ Quick Check
- [ ] If SDK/CLI source files changed: completed the applicable Changeset step below (`npx changeset add` / `.changeset/*.md`, direct `CHANGELOG.md` entry for maintainers, or `skip-changelog` label for no user-facing changes)

### PR Readiness Checklist

> The PR readiness bot will validate these automatically after push.
> Check each item before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for full details.

#### Branch & Commit
- [ ] Branch created from `dev` (not `main`)
- [ ] Branch is up to date with `dev` (`git fetch upstream && git rebase upstream/dev`)
- [ ] Verified diff contains only intended changes (`git diff --cached --stat`)
- [ ] PR is **not** in draft mode (mark ready when checks pass)
- [ ] Commit history is clean (squash fixups before review)

#### Build & Test
- [ ] `npm run build` passes
- [ ] `npm test` passes (all tests green)
- [ ] `npm run lint` passes (type check clean)
- [ ] `npm run lint:eslint` passes
- [ ] For migration PRs (>20 files): include test output summary in PR description

#### Changeset
- [ ] Changeset added via `npx changeset add` (if `packages/squad-sdk/src/` or `packages/squad-cli/src/` changed)
- [ ] Or direct `CHANGELOG.md` entry (maintainers only — write-protected for external contributors)
- [ ] Or `skip-changelog` label applied (if no user-facing changes)

#### Docs
<!-- "N/A" only if truly no user-facing change. -->
- [ ] README section updated (if new feature/module)
- [ ] Docs feature page (if new user-facing capability)

#### Exports
<!-- For SDK changes only. "N/A" if no new modules. -->
- [ ] package.json subpath exports updated (if new module)

---

### Breaking Changes
<!-- Any backward-incompatible changes. "None" if clean. -->

### Waivers
<!-- If skipping any REQUIRED item: 1) Request waiver in this section, 2) Named reviewer must approve in PR comments BEFORE merge. Format: "Waived: {item}, reason: {why}, approved by: {Flight|FIDO}" -->
