### PR TITLE
fix: inject current date into spawned agent prompts

### DIFF
--- a/.changeset/fix-date-hallucination.md
+++ b/.changeset/fix-date-hallucination.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-sdk': patch
+---
+
+Fix date hallucination in spawned agents by injecting current ISO timestamp into prompts. Replace hardcoded 2025 dates in scribe-charter templates with dynamic placeholders.

--- a/packages/squad-cli/templates/scribe-charter.md
+++ b/packages/squad-cli/templates/scribe-charter.md
@@ -211,11 +211,11 @@ After every substantial work session:
 │       ├── river-jwt-auth.md
 │       └── kai-component-lib.md
 ├── orchestration-log/    # Per-spawn log entries
-│   ├── 2025-07-01T10-00-river.md
-│   └── 2025-07-01T10-00-kai.md
+│   ├── {timestamp}-river.md
+│   └── {timestamp}-kai.md
 ├── log/                  # Session history — searchable record
-│   ├── 2025-07-01-setup.md
-│   └── 2025-07-02-api.md
+│   ├── {date}-setup.md
+│   └── {date}-api.md
 └── agents/
     ├── kai/history.md    # Kai's personal knowledge
     ├── river/history.md  # River's personal knowledge

--- a/packages/squad-sdk/src/coordinator/fan-out.ts
+++ b/packages/squad-sdk/src/coordinator/fan-out.ts
@@ -12,6 +12,7 @@ import type { AgentCharter } from '../agents/index.js';
 import type { EventBus } from '../client/event-bus.js';
 import type { SessionPool } from '../client/session-pool.js';
 
+
 // --- Spawn Configuration ---
 
 export interface AgentSpawnConfig {
@@ -184,6 +185,10 @@ async function spawnSingle(
  */
 function buildInitialPrompt(config: AgentSpawnConfig): string {
   const parts: string[] = [];
+
+  // Inject current date so spawned agents know the real date/time.
+  // Without this, LLMs hallucinate dates (especially the year).
+  parts.push(`**Current Date:** ${new Date().toISOString()}`);
 
   if (config.priority && config.priority !== 'normal') {
     parts.push(`**Priority:** ${config.priority.toUpperCase()}`);

--- a/packages/squad-sdk/templates/scribe-charter.md
+++ b/packages/squad-sdk/templates/scribe-charter.md
@@ -211,11 +211,11 @@ After every substantial work session:
 │       ├── river-jwt-auth.md
 │       └── kai-component-lib.md
 ├── orchestration-log/    # Per-spawn log entries
-│   ├── 2025-07-01T10-00-river.md
-│   └── 2025-07-01T10-00-kai.md
+│   ├── {timestamp}-river.md
+│   └── {timestamp}-kai.md
 ├── log/                  # Session history — searchable record
-│   ├── 2025-07-01-setup.md
-│   └── 2025-07-02-api.md
+│   ├── {date}-setup.md
+│   └── {date}-api.md
 └── agents/
     ├── kai/history.md    # Kai's personal knowledge
     ├── river/history.md  # River's personal knowledge

--- a/templates/scribe-charter.md
+++ b/templates/scribe-charter.md
@@ -211,11 +211,11 @@ After every substantial work session:
 │       ├── river-jwt-auth.md
 │       └── kai-component-lib.md
 ├── orchestration-log/    # Per-spawn log entries
-│   ├── 2025-07-01T10-00-river.md
-│   └── 2025-07-01T10-00-kai.md
+│   ├── {timestamp}-river.md
+│   └── {timestamp}-kai.md
 ├── log/                  # Session history — searchable record
-│   ├── 2025-07-01-setup.md
-│   └── 2025-07-02-api.md
+│   ├── {date}-setup.md
+│   └── {date}-api.md
 └── agents/
     ├── kai/history.md    # Kai's personal knowledge
     ├── river/history.md  # River's personal knowledge

--- a/test/fan-out.test.ts
+++ b/test/fan-out.test.ts
@@ -120,6 +120,27 @@ describe('spawnParallel', () => {
     expect(sentPrompt).toContain('Related to PRD-5');
   });
 
+  it('should include current date in prompt', async () => {
+    const configs: AgentSpawnConfig[] = [
+      { agentName: 'fenster', task: 'Build feature' },
+    ];
+
+    const results = await spawnParallel(configs, mockDeps);
+
+    expect(results[0].status).toBe('success');
+
+    const createSessionMock = mockDeps.createSession as any;
+    const mockSession = await createSessionMock.mock.results[0].value;
+    const sentPrompt = mockSession.sendMessage.mock.calls[0][0].prompt;
+
+    // Prompt must contain a Current Date with ISO timestamp
+    expect(sentPrompt).toContain('**Current Date:**');
+    const dateMatch = sentPrompt.match(/\*\*Current Date:\*\*\s*(\S+)/);
+    expect(dateMatch).not.toBeNull();
+    const timestamp = dateMatch![1];
+    expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
   it('should handle model overrides', async () => {
     const configs: AgentSpawnConfig[] = [
       {


### PR DESCRIPTION
## Problem

Spawned squad agents frequently hallucinate dates — especially the year — producing timestamps like `2025-05-09` instead of `2026-05-09`. This causes incorrect dates in commit messages, status reports, orchestration logs, and any time-stamped content agents produce.

## Root Cause

Two contributing factors combine to cause date hallucination in spawned agents:

1. **No date in spawn prompt:** `buildInitialPrompt()` in `fan-out.ts` constructs the initial message sent to sub-agents but includes no date/time information. Copilot CLI injects `<current_datetime>` into the session, but in 80KB+ contexts it gets buried.
2. **Hardcoded 2025 dates in templates:** `scribe-charter.md` contains hardcoded `2025-07-01` dates in the Memory Architecture diagram. These get compiled into agent prompts and prime the LLM to use 2025 as the current year.

## Fix

### 1. Date injection in `buildInitialPrompt()` (fan-out.ts)

Adds `**Current Date:** {ISO 8601 UTC timestamp}` as a line in every spawned agent's prompt. UTC is sufficient — agents only need the current date/year to stop hallucinating.

### 2. Remove hardcoded 2025 dates from scribe-charter.md (3 copies)

Replaced `2025-07-01T10-00-river.md` etc. with `{timestamp}-river.md` placeholders in the Memory Architecture diagram across all 3 copies.

### 3. Test coverage

Added a test in `fan-out.test.ts` that verifies the spawned prompt contains a valid ISO 8601 timestamp.

## Files Changed

| File | Change |
|------|--------|
| `packages/squad-sdk/src/coordinator/fan-out.ts` | Added UTC date injection in `buildInitialPrompt()` |
| `templates/scribe-charter.md` | Replaced hardcoded 2025 dates with `{timestamp}/{date}` placeholders |
| `packages/squad-cli/templates/scribe-charter.md` | Same as above |
| `packages/squad-sdk/templates/scribe-charter.md` | Same as above |
| `test/fan-out.test.ts` | Added test for date injection in spawned prompt |
| `.changeset/fix-date-hallucination.md` | Changeset for squad-sdk patch |

## Notes

- **Minimal change:** 6 files, +43/-12 lines
- **No new dependencies**
- Hardcoded dates also exist in `retro-enforcement/SKILL.md` but are in skill documentation examples, not compiled into spawn prompts — out of scope

Closes #232
