### PR TITLE
fix: replace datetime derivation with mandatory shell command

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -105,7 +105,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 
-**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Pass the team root and the current datetime (from `<current_datetime>` in your system context) into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
+**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve the current datetime by running `Get-Date -Format "dddd, yyyy-MM-ddTHH:mm:ssK"` (PowerShell) or `date +"%A, %Y-%m-%dT%H:%M:%S%z"` (Bash). Parse the output to extract `CURRENT_DATETIME`, `DAY_OF_WEEK`, and `TIMEZONE`. Pass the team root, `CURRENT_DATETIME`, `DAY_OF_WEEK`, and `TIMEZONE` into every spawn prompt. Never derive `DAY_OF_WEEK` from a date string — LLMs miscalculate day-of-week. Always use the shell command output directly. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
 **Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
@@ -337,6 +337,8 @@ prompt: |
   You are {Name}, the {Role} on this project.
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
+  TIMEZONE: {timezone}
+  DAY_OF_WEEK: {day_of_week}
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
@@ -356,11 +358,12 @@ prompt: |
   If you made a meaningful decision, write to .squad/decisions/inbox/{name}-{brief-slug}.md
   {% endif %}
 
+  ⚠️ DATES: When writing dates in any file, use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
 ```
 
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: {current_datetime} — {question} TEAM ROOT: {team_root}"`
+For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: {current_datetime} DAY_OF_WEEK: {day_of_week} TIMEZONE: {timezone} Requested by: {current user name} — {question} TEAM ROOT: {team_root}"`
 
 ### Per-Agent Model Selection
 
@@ -785,6 +788,8 @@ prompt: |
   
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
+  TIMEZONE: {timezone}
+  DAY_OF_WEEK: {day_of_week}
   All `.squad/` paths are relative to this root.
   
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
@@ -970,6 +975,9 @@ prompt: |
   You are the Scribe. Read .squad/agents/scribe/charter.md.
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
+  TIMEZONE: {timezone}
+  DAY_OF_WEEK: {day_of_week}
+  **Requested by:** {current user name}
   STATE_BACKEND: {state_backend}
 
   SPAWN MANIFEST: {spawn_manifest}

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -363,7 +363,7 @@ prompt: |
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
 ```
 
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: {current_datetime} DAY_OF_WEEK: {day_of_week} TIMEZONE: {timezone} Requested by: {current user name} — {question} TEAM ROOT: {team_root}"`
+For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: {current_datetime} — {question} TEAM ROOT: {team_root}"`
 
 ### Per-Agent Model Selection
 
@@ -975,9 +975,6 @@ prompt: |
   You are the Scribe. Read .squad/agents/scribe/charter.md.
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
-  TIMEZONE: {timezone}
-  DAY_OF_WEEK: {day_of_week}
-  **Requested by:** {current user name}
   STATE_BACKEND: {state_backend}
 
   SPAWN MANIFEST: {spawn_manifest}

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -105,7 +105,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 
-**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Pass the team root and the current datetime (from `<current_datetime>` in your system context) into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
+**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve the current datetime by running `Get-Date -Format "dddd, yyyy-MM-ddTHH:mm:ssK"` (PowerShell) or `date +"%A, %Y-%m-%dT%H:%M:%S%z"` (Bash). Parse the output to extract `CURRENT_DATETIME`, `DAY_OF_WEEK`, and `TIMEZONE`. Pass the team root, `CURRENT_DATETIME`, `DAY_OF_WEEK`, and `TIMEZONE` into every spawn prompt. Never derive `DAY_OF_WEEK` from a date string — LLMs miscalculate day-of-week. Always use the shell command output directly. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
 **Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
@@ -337,6 +337,8 @@ prompt: |
   You are {Name}, the {Role} on this project.
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
+  TIMEZONE: {timezone}
+  DAY_OF_WEEK: {day_of_week}
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
@@ -356,6 +358,7 @@ prompt: |
   If you made a meaningful decision, write to .squad/decisions/inbox/{name}-{brief-slug}.md
   {% endif %}
 
+  ⚠️ DATES: When writing dates in any file, use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
 ```
@@ -785,6 +788,8 @@ prompt: |
   
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
+  TIMEZONE: {timezone}
+  DAY_OF_WEEK: {day_of_week}
   All `.squad/` paths are relative to this root.
   
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent


### PR DESCRIPTION
## Summary

Fixes datetime awareness in the coordinator's session-start instructions. The upstream `squad.agent.md` tells the coordinator to "derive `DAY_OF_WEEK` from `<current_datetime>`" — but since the coordinator IS an LLM, "derive" means asking the model to do day-of-week math from an ISO date string, which is unreliable.

## Symptom

I have a skill that provides status information across a range of tools. On Monday, its the complete list.  On tuesday and thursday, its an abbreviated list. On Wed and Fri, its summarizing accomplishments and what's left to do. 

If I run this skill in copilot, it works regardless of day of week. If I run in squad, its always a day off. 

## The Bug

Session-start says:
> Derive `DAY_OF_WEEK` from the `<current_datetime>` system value (e.g., "Monday").

The coordinator reads `<current_datetime>` (e.g., `2026-05-12T11:45:50-07:00`) and tries to compute "Monday" from it. LLMs frequently get this wrong — they hallucinate day names.

## The Fix

Replace "derive" with a shell command that includes the day name directly:

```powershell
Get-Date -Format "dddd, yyyy-MM-ddTHH:mm:ssK"
# Output: "Monday, 2026-05-12T11:45:50-07:00"
```

The shell output already contains the day of week -- no LLM derivation needed.

## Spawn Template Parameter Analysis

The spawn templates have intentionally different parameter sets based on their purpose:

| Param | Full/Standard | Lightweight | Scribe | Explore Inline | Rationale |
|-------|:---:|:---:|:---:|:---:|-----|
| TEAM_ROOT | Yes | Yes | Yes | Yes | All agents need `.squad/` path resolution |
| CURRENT_DATETIME | Yes | Yes | Yes | Yes | Temporal context for all |
| TIMEZONE | Yes | Yes | No | No | Only needed when **writing** user-facing dates |
| DAY_OF_WEEK | Yes | Yes | No | No | Only needed for scheduling/date-stamped writes |
| Username | Yes | Yes | No | No | Attribution for file writes; Scribe gets from manifest |
| WORKTREE | Yes | Yes | No | No | Only file-writing agents operate in worktrees |

### Design logic

The rule is: **if an agent writes files with dates or user attribution, it gets the full param set. If it only reads, it gets the minimum.**

- **Full/Standard/Lightweight** -- write files (code, docs, decisions) so they need TIMEZONE, DAY_OF_WEEK, username for correct formatting and attribution
- **Explore inline** -- read-only research; never writes files so it only needs CURRENT_DATETIME for temporal awareness ("is this info recent?")
- **Scribe** -- writes to `.squad/` but uses UTC per its own instructions so it does not need TIMEZONE/DAY_OF_WEEK; gets username from the spawn manifest metadata

### Session-start prose vs template reality

The session-start section says "pass into EVERY spawn prompt" but the templates correctly implement "only where needed for writes." The prose overstates; the templates are the authoritative behavior.

## Changes

- Session-start: replaced "derive DAY_OF_WEEK" with shell command approach
- Added "NEVER derive DAY_OF_WEEK" warning
- Added `DAY_OF_WEEK` + `TIMEZONE` to **Lightweight** and **Full** templates (writing agents)
- Added `DATES` hygiene rule to Lightweight template
- Did NOT add extra params to Explore inline (read-only by design)