### PR TITLE
feat(bench): add npm run bench + bench:cold-start runners

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "sync-templates": "node scripts/sync-templates.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
+    "bench": "node scripts/run-benchmarks.mjs",
+    "bench:cold-start": "node scripts/measure-cold-start.mjs",
     "lint": "tsc --noEmit -p packages/squad-sdk/tsconfig.json && tsc --noEmit -p packages/squad-cli/tsconfig.json",
     "lint:eslint": "eslint packages/ test/",
     "lint:docs": "markdownlint-cli2 && cspell --no-progress --dot \"docs/src/content/**/*.md\" \"README.md\"",

--- a/scripts/measure-cold-start.mjs
+++ b/scripts/measure-cold-start.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * scripts/measure-cold-start.mjs
+ *
+ * Measure CLI cold-start latency for `squad --version` and `squad help`
+ * over N runs.
+ *
+ * Why this script exists
+ * ----------------------
+ * The squad-cli entry point (packages/squad-cli/src/cli-entry.ts, ~28 KB)
+ * has many top-level imports plus postinstall ESM patches that affect
+ * cold-start latency. v0.8.23 added lazy imports for some commands; this
+ * script lets us see whether further deferral helps.
+ *
+ * Usage
+ * -----
+ *   npm run bench:cold-start                       # 5 runs of each command
+ *   npm run bench:cold-start -- --runs=10
+ *   npm run bench:cold-start -- --json
+ *
+ * Exit codes
+ * ----------
+ *   0  success
+ *   1  CLI not built or runtime error
+ */
+
+import { spawn } from 'node:child_process';
+import { argv, exit, stdout, stderr, execPath } from 'node:process';
+import { resolve as resolvePath, dirname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { performance } from 'node:perf_hooks';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolvePath(__dirname, '..');
+const CLI_ENTRY = resolvePath(REPO_ROOT, 'packages/squad-cli/dist/cli-entry.js');
+
+const DEFAULT_COMMANDS = [
+  ['--version'],
+  ['help'],
+];
+
+function parseArgs(args) {
+  const opts = { runs: 5, json: false };
+  for (const arg of args) {
+    if (arg === '--json') opts.json = true;
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+    else if (arg.startsWith('--runs=')) {
+      const n = Number.parseInt(arg.slice('--runs='.length), 10);
+      if (!Number.isFinite(n) || n < 1) {
+        throw new Error(`--runs must be a positive integer, got: ${arg}`);
+      }
+      opts.runs = n;
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function printHelp() {
+  stdout.write(
+    [
+      'Usage: npm run bench:cold-start -- [options]',
+      '',
+      'Options:',
+      '  --runs=N          Number of runs per command (default: 5)',
+      '  --json            Emit JSON instead of a formatted table',
+      '  -h, --help        Show this help',
+      '',
+      'Note: requires `npm run build` to have produced packages/squad-cli/dist/.',
+      '',
+    ].join('\n'),
+  );
+}
+
+/**
+ * Run the CLI once with the given args; resolve with elapsed milliseconds.
+ *
+ * We measure wall-clock from spawn() until the child fully exits. This
+ * captures everything the user perceives as cold start: process spawn,
+ * Node startup, ESM patching, top-level imports, and the actual command.
+ */
+function timeSingleRun(args) {
+  return new Promise((resolveP, rejectP) => {
+    const start = performance.now();
+    const child = spawn(execPath, [CLI_ENTRY, ...args], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      env: { ...process.env, NO_COLOR: '1' },
+    });
+    let stderrBuf = '';
+    child.stderr.on('data', (chunk) => {
+      stderrBuf += chunk.toString();
+    });
+    child.on('error', rejectP);
+    child.on('exit', (code) => {
+      const elapsed = performance.now() - start;
+      if (code !== 0) {
+        // Some help/version paths may exit non-zero on errors; surface stderr
+        // but still record the timing so users see what happened.
+        stderr.write(`(exit ${code} from squad ${args.join(' ')}): ${stderrBuf.trim()}\n`);
+      }
+      resolveP({ elapsed, code });
+    });
+  });
+}
+
+function summarise(timings) {
+  const sorted = [...timings].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const avg = sum / sorted.length;
+  const idx95 = Math.max(0, Math.ceil(0.95 * sorted.length) - 1);
+  return {
+    runs: sorted.length,
+    avg,
+    min: sorted[0],
+    max: sorted[sorted.length - 1],
+    p95: sorted[idx95],
+  };
+}
+
+async function main() {
+  let opts;
+  try {
+    opts = parseArgs(argv.slice(2));
+  } catch (err) {
+    stderr.write(`error: ${err.message}\n`);
+    printHelp();
+    exit(1);
+  }
+
+  if (opts.help) {
+    printHelp();
+    exit(0);
+  }
+
+  if (!existsSync(CLI_ENTRY)) {
+    stderr.write(
+      `error: CLI build output not found at ${CLI_ENTRY}\n` +
+        'Run `npm run build` first.\n',
+    );
+    exit(1);
+  }
+
+  const results = [];
+  let anyFailures = false;
+  for (const args of DEFAULT_COMMANDS) {
+    const label = `squad ${args.join(' ')}`;
+    const timings = [];
+    let failures = 0;
+    for (let i = 0; i < opts.runs; i++) {
+      const { elapsed, code } = await timeSingleRun(args);
+      timings.push(elapsed);
+      if (code !== 0) {
+        failures++;
+        anyFailures = true;
+      }
+    }
+    results.push({ command: label, timings, failures, ...summarise(timings) });
+  }
+
+  if (opts.json) {
+    stdout.write(JSON.stringify({ results, timestamp: new Date().toISOString() }, null, 2) + '\n');
+    exit(anyFailures ? 1 : 0);
+  }
+
+  // Formatted table
+  const COL_CMD = 24;
+  const COL_NUM = 12;
+  const header = [
+    'Command'.padEnd(COL_CMD),
+    'Runs'.padStart(COL_NUM),
+    'Fails'.padStart(COL_NUM),
+    'Avg (ms)'.padStart(COL_NUM),
+    'Min (ms)'.padStart(COL_NUM),
+    'Max (ms)'.padStart(COL_NUM),
+    'P95 (ms)'.padStart(COL_NUM),
+  ].join('  ');
+  const sep = '─'.repeat(header.length);
+  stdout.write(sep + '\n');
+  stdout.write(header + '\n');
+  stdout.write(sep + '\n');
+  for (const r of results) {
+    stdout.write(
+      [
+        r.command.padEnd(COL_CMD),
+        String(r.runs).padStart(COL_NUM),
+        String(r.failures).padStart(COL_NUM),
+        r.avg.toFixed(2).padStart(COL_NUM),
+        r.min.toFixed(2).padStart(COL_NUM),
+        r.max.toFixed(2).padStart(COL_NUM),
+        r.p95.toFixed(2).padStart(COL_NUM),
+      ].join('  ') + '\n',
+    );
+  }
+  stdout.write(sep + '\n');
+  if (anyFailures) {
+    stderr.write(
+      'warning: one or more runs exited with a non-zero status — timings are still reported, but the CLI is broken.\n',
+    );
+  }
+
+  exit(anyFailures ? 1 : 0);
+}
+
+main().catch((err) => {
+  stderr.write(`error: ${err.stack ?? err.message ?? String(err)}\n`);
+  exit(1);
+});

--- a/scripts/run-benchmarks.mjs
+++ b/scripts/run-benchmarks.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * scripts/run-benchmarks.mjs
+ *
+ * Foundation runner for the existing @bradygaster/squad-sdk BenchmarkSuite.
+ *
+ * Why this script exists
+ * ----------------------
+ * The SDK already ships `BenchmarkSuite` (packages/squad-sdk/src/runtime/benchmarks.ts)
+ * with five built-in micro-benchmarks (configLoad, charterCompile, routing,
+ * modelSelection, exportImport). Until now there was no `npm run bench` entry
+ * point, so the suite was only used programmatically and from its own tests.
+ *
+ * This script gives perf-improvement PRs a single command to capture
+ * before/after numbers consistently. It is intentionally tiny — all logic
+ * lives in `BenchmarkSuite`; this is a CLI shim.
+ *
+ * Usage
+ * -----
+ *   npm run bench                      # default 100 iterations, all benches
+ *   npm run bench -- --iterations=50   # custom iteration count
+ *   npm run bench -- --json            # emit JSON (for CI diffing)
+ *   npm run bench -- --filter routing  # only run benches whose name matches
+ *
+ * Exit codes
+ * ----------
+ *   0  success
+ *   1  argument error or runtime failure
+ *
+ * Note: this script imports from the BUILT SDK (`packages/squad-sdk/dist/...`).
+ * Run `npm run build` first if you have not built the workspace.
+ */
+
+import { argv, exit, stdout, stderr } from 'node:process';
+import { pathToFileURL } from 'node:url';
+import { resolve as resolvePath, dirname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolvePath(__dirname, '..');
+const SDK_DIST = resolvePath(REPO_ROOT, 'packages/squad-sdk/dist/runtime/benchmarks.js');
+
+function parseArgs(args) {
+  const opts = { iterations: 100, json: false, filter: null };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--json') {
+      opts.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      opts.help = true;
+    } else if (arg.startsWith('--iterations=')) {
+      const n = Number.parseInt(arg.slice('--iterations='.length), 10);
+      if (!Number.isFinite(n) || n < 1) {
+        throw new Error(`--iterations must be a positive integer, got: ${arg}`);
+      }
+      opts.iterations = n;
+    } else if (arg.startsWith('--filter=')) {
+      opts.filter = arg.slice('--filter='.length);
+    } else if (arg === '--filter') {
+      const next = args[i + 1];
+      if (next === undefined || next.startsWith('-')) {
+        throw new Error('--filter requires a value');
+      }
+      opts.filter = next;
+      i++;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function printHelp() {
+  stdout.write(
+    [
+      'Usage: npm run bench -- [options]',
+      '',
+      'Options:',
+      '  --iterations=N    Number of iterations per benchmark (default: 100)',
+      '  --filter=NAME     Only run benchmarks whose name contains NAME',
+      '  --json            Emit JSON instead of a formatted table',
+      '  -h, --help        Show this help',
+      '',
+      'Note: requires `npm run build` to have produced packages/squad-sdk/dist/.',
+      '',
+    ].join('\n'),
+  );
+}
+
+async function main() {
+  let opts;
+  try {
+    opts = parseArgs(argv.slice(2));
+  } catch (err) {
+    stderr.write(`error: ${err.message}\n`);
+    printHelp();
+    exit(1);
+  }
+
+  if (opts.help) {
+    printHelp();
+    exit(0);
+  }
+
+  if (!existsSync(SDK_DIST)) {
+    stderr.write(
+      `error: SDK build output not found at ${SDK_DIST}\n` +
+        'Run `npm run build` first.\n',
+    );
+    exit(1);
+  }
+
+  const { BenchmarkSuite, formatBenchmarkReport } = await import(
+    pathToFileURL(SDK_DIST).href
+  );
+
+  const suite = new BenchmarkSuite();
+
+  if (opts.filter) {
+    const keep = new Set(suite.list().filter((n) => n.includes(opts.filter)));
+    if (keep.size === 0) {
+      stderr.write(`error: no benchmarks match filter "${opts.filter}"\n`);
+      stderr.write(`available: ${suite.list().join(', ')}\n`);
+      exit(1);
+    }
+    for (const name of suite.list()) {
+      if (!keep.has(name)) suite.unregister(name);
+    }
+  }
+
+  const report = await suite.runAll(opts.iterations);
+
+  if (opts.json) {
+    stdout.write(JSON.stringify(report, null, 2) + '\n');
+  } else {
+    stdout.write(formatBenchmarkReport(report.results) + '\n');
+    stdout.write(`\nTotal time: ${report.totalTime.toFixed(2)} ms\n`);
+    stdout.write(`Timestamp:  ${report.timestamp}\n`);
+  }
+
+  exit(0);
+}
+
+main().catch((err) => {
+  stderr.write(`error: ${err.stack ?? err.message ?? String(err)}\n`);
+  exit(1);
+});

--- a/test/bench-runner.test.ts
+++ b/test/bench-runner.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Smoke test for scripts/run-benchmarks.mjs.
+ *
+ * Why a separate test
+ * -------------------
+ * BenchmarkSuite itself has thorough unit tests in test/benchmarks.test.ts.
+ * This file only verifies that the npm-script-facing shim:
+ *   1. parses CLI flags correctly
+ *   2. emits a usable formatted report
+ *   3. emits valid JSON when --json is used
+ *   4. honours --filter
+ *   5. fails clearly when SDK dist is missing
+ *
+ * The runner intentionally imports from the built SDK at packages/squad-sdk/dist/.
+ * The smoke tests therefore require `npm run build` to have happened. They skip
+ * gracefully (with an informative message) if dist/ is not present, so this
+ * file does not break clean checkouts.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { spawn } from 'node:child_process';
+import { resolve, join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+const REPO_ROOT = resolve(__dirname, '..');
+const RUNNER = join(REPO_ROOT, 'scripts', 'run-benchmarks.mjs');
+const SDK_DIST = join(REPO_ROOT, 'packages', 'squad-sdk', 'dist', 'runtime', 'benchmarks.js');
+
+function runScript(args: string[], extraEnv: NodeJS.ProcessEnv = {}): Promise<{
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolveP, rejectP) => {
+    const child = spawn(process.execPath, [RUNNER, ...args], {
+      env: { ...process.env, NO_COLOR: '1', ...extraEnv },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    child.stdout.on('data', (c) => {
+      stdoutBuf += c.toString();
+    });
+    child.stderr.on('data', (c) => {
+      stderrBuf += c.toString();
+    });
+    child.on('error', rejectP);
+    child.on('exit', (code) => resolveP({ code, stdout: stdoutBuf, stderr: stderrBuf }));
+  });
+}
+
+const SDK_BUILT = existsSync(SDK_DIST);
+// Tiny iteration count keeps these tests under a few hundred ms total.
+const TINY_ITERATIONS = '--iterations=2';
+
+describe('scripts/run-benchmarks.mjs', () => {
+  beforeAll(() => {
+    if (!SDK_BUILT) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[bench smoke] Skipping runtime tests: SDK dist not found at ${SDK_DIST}.\n` +
+          '  Run `npm run build` to enable these tests.',
+      );
+    }
+  });
+
+  it('shows help with --help and exits 0', async () => {
+    const result = await runScript(['--help']);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Usage:');
+    expect(result.stdout).toContain('--iterations');
+    expect(result.stdout).toContain('--json');
+    expect(result.stdout).toContain('--filter');
+  });
+
+  it('rejects unknown arguments with a non-zero exit and a helpful message', async () => {
+    const result = await runScript(['--nope']);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('Unknown argument');
+    // help text should also be printed on stdout to guide the user
+    expect(result.stdout).toContain('Usage:');
+  });
+
+  it('rejects --iterations with a non-integer value', async () => {
+    const result = await runScript(['--iterations=abc']);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('--iterations');
+  });
+
+  it.runIf(SDK_BUILT)(
+    'runs all benchmarks and prints a formatted table by default',
+    async () => {
+      const result = await runScript([TINY_ITERATIONS]);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Avg (ms)');
+      expect(result.stdout).toContain('P95 (ms)');
+      expect(result.stdout).toContain('P99 (ms)');
+      expect(result.stdout).toContain('configLoad');
+      expect(result.stdout).toContain('charterCompile');
+      expect(result.stdout).toContain('routing');
+      expect(result.stdout).toContain('modelSelection');
+      expect(result.stdout).toContain('exportImport');
+      expect(result.stdout).toContain('Total time:');
+      expect(result.stdout).toContain('Timestamp:');
+    },
+    20_000,
+  );
+
+  it.runIf(SDK_BUILT)(
+    'emits valid JSON with --json',
+    async () => {
+      const result = await runScript([TINY_ITERATIONS, '--json']);
+      expect(result.code).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        results: Array<{
+          name: string;
+          iterations: number;
+          avg: number;
+          p95: number;
+          p99: number;
+        }>;
+        totalTime: number;
+        timestamp: string;
+      };
+      expect(parsed.results.length).toBeGreaterThan(0);
+      expect(parsed.results[0]).toHaveProperty('name');
+      expect(parsed.results[0]).toHaveProperty('iterations', 2);
+      expect(parsed.results[0]).toHaveProperty('avg');
+      expect(parsed.results[0]).toHaveProperty('p95');
+      expect(parsed.results[0]).toHaveProperty('p99');
+      expect(typeof parsed.totalTime).toBe('number');
+      expect(typeof parsed.timestamp).toBe('string');
+    },
+    20_000,
+  );
+
+  it.runIf(SDK_BUILT)(
+    '--filter selects matching benchmarks only',
+    async () => {
+      const result = await runScript([TINY_ITERATIONS, '--filter=routing', '--json']);
+      expect(result.code).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        results: Array<{ name: string }>;
+      };
+      expect(parsed.results).toHaveLength(1);
+      expect(parsed.results[0].name).toBe('routing');
+    },
+    20_000,
+  );
+
+  it.runIf(SDK_BUILT)(
+    '--filter with no matches exits 1 and lists available benchmarks',
+    async () => {
+      const result = await runScript([TINY_ITERATIONS, '--filter=NONEXISTENT']);
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain('no benchmarks match');
+      expect(result.stderr).toContain('available:');
+    },
+    10_000,
+  );
+});


### PR DESCRIPTION
## Summary

Foundation PR for the performance-improvement series: adds a thin CLI shim over the existing `BenchmarkSuite` (already shipped in `@bradygaster/squad-sdk/runtime/benchmarks`) plus a wall-clock CLI cold-start timer. Lets every subsequent perf PR include before/after numbers.

No production code changes. Two new npm scripts and two new files under `scripts/`.

## What Changed

- `scripts/run-benchmarks.mjs` — wraps `BenchmarkSuite.runAll()` + `formatBenchmarkReport()`. Flags: `--iterations=N`, `--filter=NAME`, `--json`, `-h`. Fails fast with a helpful message if `packages/squad-sdk/dist/` is missing.
- `scripts/measure-cold-start.mjs` — spawns the built CLI under `node` with `NO_COLOR=1` and times `squad --version` / `squad help` over N runs. Reports avg/min/max/p95 + a `Fails` column. Exits non-zero if any run failed (this is critical so CI catches a broken CLI instead of reporting valid-looking timings for a non-functional binary).
- `package.json`: new scripts `bench` and `bench:cold-start`.
- `test/bench-runner.test.ts` (new, 7 cases) — argument parsing, `--help`, `--json`, `--filter`, missing dist behavior. Runtime tests use `it.runIf(SDK_BUILT)` so the suite skips cleanly on a fresh checkout where `dist/` has not been built.

## Testing

- `npm run bench -- --filter=routing --iterations=3` produces a clean formatted table.
- `npm run bench -- --json --iterations=2` emits parseable JSON with `results / totalTime / timestamp`.
- `npm run bench:cold-start -- --runs=3` produces timing output and exits 0 when the CLI is healthy.
- 7/7 bench-runner smoke tests pass.

## Notes

Part of a five-PR series. Land this first — every subsequent PR's description can then reference before/after numbers from `npm run bench`.

Companion PRs:
- chore: dependency hygiene (zero-risk; deletes redundant playwright/esbuild and stale tarballs)
- resolution cache + multi-squad config dedupe
- parallel charter discovery with bounded concurrency
- non-blocking scheduler script execution
