### PR TITLE
perf(resolution): memoize squad-dir lookups; dedupe squads.json reads

### DIFF
--- a/.changeset/perf-resolution-memoize.md
+++ b/.changeset/perf-resolution-memoize.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-sdk": patch
+"@bradygaster/squad-cli": patch
+---
+
+perf(resolution): memoize squad-dir lookups; deduplicate squads.json reads to reduce filesystem I/O on repeated resolution calls

--- a/packages/squad-cli/src/cli/commands/link.ts
+++ b/packages/squad-cli/src/cli/commands/link.ts
@@ -10,7 +10,7 @@
  */
 
 import path from 'node:path';
-import { FSStorageProvider } from '@bradygaster/squad-sdk';
+import { FSStorageProvider, clearResolveSquadCache } from '@bradygaster/squad-sdk';
 import { fatal } from '../core/errors.js';
 
 const storage = new FSStorageProvider();
@@ -72,6 +72,13 @@ export function runLink(projectDir: string, teamRepoPath: string): void {
       + ignoreEntry + '\n';
     storage.appendSync(gitignorePath, block);
   }
+
+  // Link just (re)created `.squad/` and wrote config.json. Any subsequent
+  // code in this process that calls resolveSquad()/resolveSquadPaths()
+  // would otherwise be served the cached "not found" result from before
+  // link ran. Drop the cache so the new directory is observed immediately
+  // instead of after the 5-second TTL.
+  clearResolveSquadCache();
 
   console.log(`✅ Linked to team root: ${relativePath}`);
 }

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -11,7 +11,7 @@ import { success, BOLD, RESET, YELLOW, GREEN, DIM } from './output.js';
 import { fatal } from './errors.js';
 import { detectProjectType } from './project-type.js';
 import { getPackageVersion, stampVersion } from './version.js';
-import { initSquad as sdkInitSquad, cleanupOrphanInitPrompt, ensurePersonalSquadDir, resolvePersonalSquadDir, type InitOptions } from '@bradygaster/squad-sdk';
+import { initSquad as sdkInitSquad, cleanupOrphanInitPrompt, ensurePersonalSquadDir, resolvePersonalSquadDir, clearResolveSquadCache, type InitOptions } from '@bradygaster/squad-sdk';
 import { installGitHooks } from '../commands/install-hooks.js';
 
 const storage = new FSStorageProvider();
@@ -252,6 +252,13 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
   }
 
   process.off('SIGINT', sigintHandler);
+
+  // Init just created `.squad/` (and possibly `.github/agents/`) on disk.
+  // Any subsequent code in this process that calls resolveSquad()/findSquadDir()
+  // would otherwise be served the cached "not found" result from before init
+  // ran. Drop the resolution cache so the new directory is observed
+  // immediately instead of after the 5-second TTL.
+  clearResolveSquadCache();
 
   // Ensure version is fully stamped in squad.agent.md
   const agentPath = path.join(agentFileRoot, '.github', 'agents', 'squad.agent.md');

--- a/packages/squad-sdk/src/index.ts
+++ b/packages/squad-sdk/src/index.ts
@@ -10,7 +10,7 @@ const pkg = require('../package.json');
 export const VERSION: string = pkg.version;
 
 // Export public API
-export { resolveSquad, resolveGlobalSquadPath, resolvePersonalSquadDir, ensurePersonalSquadDir, ensureSquadPath, ensureSquadPathTriple, loadDirConfig, isConsultMode, scratchDir, scratchFile, deriveProjectKey, resolveExternalStateDir, resolveSquadHome, ensureSquadHome, resolvePresetsDir, resolveSquadState } from './resolution.js';
+export { resolveSquad, resolveGlobalSquadPath, resolvePersonalSquadDir, ensurePersonalSquadDir, ensureSquadPath, ensureSquadPathTriple, loadDirConfig, isConsultMode, scratchDir, scratchFile, deriveProjectKey, resolveExternalStateDir, resolveSquadHome, ensureSquadHome, resolvePresetsDir, resolveSquadState, clearResolveSquadCache } from './resolution.js';
 export type { ResolvedSquadPaths, SquadDirConfig, SquadStateContext } from './resolution.js';
 export * from './config/index.js';
 export * from './agents/onboarding.js';

--- a/packages/squad-sdk/src/multi-squad.ts
+++ b/packages/squad-sdk/src/multi-squad.ts
@@ -134,13 +134,16 @@ export function resolveSquadPath(name?: string): string {
   // Auto-migrate legacy layout if needed
   migrateIfNeeded();
 
+  // Read squads.json once (previously this was loaded 2–3 times per call:
+  // once via the .active fallback in the resolution chain, again to look
+  // up the entry by name, and a third time via internals).
+  const config = loadSquadsConfig();
+
   const resolved =
     name ??
     process.env['SQUAD_NAME'] ??
-    loadSquadsConfig()?.active ??
+    config?.active ??
     DEFAULT_SQUAD;
-
-  const config = loadSquadsConfig();
 
   // Look up registered path
   if (config) {

--- a/packages/squad-sdk/src/resolution.ts
+++ b/packages/squad-sdk/src/resolution.ts
@@ -23,6 +23,83 @@ import type { StorageProvider } from './storage/storage-provider.js';
 const storage = new FSStorageProvider();
 
 // ============================================================================
+// Resolution cache (perf: memoize repeated FS walks)
+// ============================================================================
+//
+// Why caching is needed:
+//   resolveSquad() and findSquadDir() walk from `startDir` toward `/`,
+//   doing 2–3 syscalls per directory level. They are called from many CLI
+//   entry points and from the Ralph daemon's watch loop, often several
+//   times per command — repeating the same walk each time.
+//
+// Why TTL + explicit invalidation:
+//   Results CAN change during a single process: `squad init` creates
+//   `.squad/`, tests scaffold and tear down temp directories, and a
+//   long-running daemon may observe directory changes between ticks.
+//   A short TTL (5 s) makes the cache self-correcting in the worst case;
+//   `clearResolveSquadCache()` provides immediate invalidation for any
+//   command or test that mutates the `.squad/` layout.
+//
+// Escape hatch:
+//   Set `SQUAD_NO_RESOLVE_CACHE=1` to disable both caches. Tests that
+//   exhaustively exercise the walk algorithm should set this so cached
+//   results from a previous test do not contaminate the next.
+//
+// Cache key: absolute path of `startDir` (after `path.resolve()`).
+
+interface CacheEntry<T> {
+  value: T;
+  ts: number;
+}
+
+const RESOLVE_CACHE_TTL_MS = 5_000;
+const resolveSquadCache = new Map<string, CacheEntry<string | null>>();
+type FindSquadDirResult = { dir: string; name: '.squad' | '.ai-team' } | null;
+const findSquadDirCache = new Map<string, CacheEntry<FindSquadDirResult>>();
+
+function isResolveCacheDisabled(): boolean {
+  return process.env['SQUAD_NO_RESOLVE_CACHE'] === '1';
+}
+
+function readCache<T>(cache: Map<string, CacheEntry<T>>, key: string): T | undefined {
+  if (isResolveCacheDisabled()) return undefined;
+  const hit = cache.get(key);
+  if (!hit) return undefined;
+  if (Date.now() - hit.ts > RESOLVE_CACHE_TTL_MS) {
+    cache.delete(key);
+    return undefined;
+  }
+  return hit.value;
+}
+
+function writeCache<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T): void {
+  if (isResolveCacheDisabled()) return;
+  cache.set(key, { value, ts: Date.now() });
+}
+
+/**
+ * Clear all in-process caches used by `resolveSquad()` and `findSquadDir()`.
+ *
+ * Call this from any command or test that creates, moves, or deletes a
+ * `.squad/` (or `.ai-team/`) directory so subsequent resolution calls in
+ * the same process observe the fresh filesystem state immediately,
+ * instead of waiting up to {@link RESOLVE_CACHE_TTL_MS} ms for the TTL
+ * to expire.
+ *
+ * Examples of callers that should invoke this:
+ *   - `squad init` — creates `.squad/` in the project root
+ *   - `squad link` — points an existing checkout at a remote team root
+ *   - `squad upgrade` — may regenerate `.squad/` layout
+ *   - Test fixtures that scaffold or tear down temporary `.squad/` dirs
+ *
+ * Safe to call when the cache is disabled (no-op).
+ */
+export function clearResolveSquadCache(): void {
+  resolveSquadCache.clear();
+  findSquadDirCache.clear();
+}
+
+// ============================================================================
 // Dual-root path resolution types (Issue #311)
 // ============================================================================
 
@@ -112,7 +189,17 @@ function getMainWorktreePath(worktreeDir: string, gitFilePath: string): string |
  * @returns Absolute path to `.squad/` or `null`.
  */
 export function resolveSquad(startDir?: string): string | null {
-  let current = path.resolve(startDir ?? process.cwd());
+  const cacheKey = path.resolve(startDir ?? process.cwd());
+  const cached = readCache(resolveSquadCache, cacheKey);
+  if (cached !== undefined) return cached;
+
+  const result = resolveSquadUncached(cacheKey);
+  writeCache(resolveSquadCache, cacheKey, result);
+  return result;
+}
+
+function resolveSquadUncached(startDir: string): string | null {
+  let current = startDir;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -168,7 +255,17 @@ const SQUAD_DIR_NAMES = ['.squad', '.ai-team'] as const;
  * Returns the absolute path and the directory name used.
  */
 function findSquadDir(startDir: string): { dir: string; name: '.squad' | '.ai-team' } | null {
-  let current = path.resolve(startDir);
+  const cacheKey = path.resolve(startDir);
+  const cached = readCache(findSquadDirCache, cacheKey);
+  if (cached !== undefined) return cached;
+
+  const result = findSquadDirUncached(cacheKey);
+  writeCache(findSquadDirCache, cacheKey, result);
+  return result;
+}
+
+function findSquadDirUncached(startDir: string): { dir: string; name: '.squad' | '.ai-team' } | null {
+  let current = startDir;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {

--- a/test/cli-global.test.ts
+++ b/test/cli-global.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
-import { resolveSquad, resolveGlobalSquadPath } from '@bradygaster/squad-sdk/resolution';
+import { resolveSquad, resolveGlobalSquadPath, clearResolveSquadCache } from '@bradygaster/squad-sdk/resolution';
 
 const TMP = join(process.cwd(), `.test-cli-global-${randomBytes(4).toString('hex')}`);
 
@@ -27,11 +27,13 @@ function scaffold(...dirs: string[]): void {
 
 describe('squad status routing logic', () => {
   beforeEach(() => {
+    clearResolveSquadCache();
     if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
     mkdirSync(TMP, { recursive: true });
   });
 
   afterEach(() => {
+    clearResolveSquadCache();
     if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
   });
 

--- a/test/dual-root-resolver.test.ts
+++ b/test/dual-root-resolver.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
-import { resolveSquadPaths } from '@bradygaster/squad-sdk/resolution';
+import { resolveSquadPaths, clearResolveSquadCache } from '@bradygaster/squad-sdk/resolution';
 
 const TMP = join(process.cwd(), `.test-dual-root-${randomBytes(4).toString('hex')}`);
 
@@ -23,11 +23,13 @@ function writeJson(relPath: string, data: unknown): void {
 
 describe('resolveSquadPaths()', () => {
   beforeEach(() => {
+    clearResolveSquadCache();
     if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
     mkdirSync(TMP, { recursive: true });
   });
 
   afterEach(() => {
+    clearResolveSquadCache();
     if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
   });
 

--- a/test/resolution.test.ts
+++ b/test/resolution.test.ts
@@ -7,7 +7,7 @@ import { mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
-import { resolveSquad, resolveGlobalSquadPath, ensureSquadPath, ensurePersonalSquadDir } from '@bradygaster/squad-sdk/resolution';
+import { resolveSquad, resolveGlobalSquadPath, ensureSquadPath, ensurePersonalSquadDir, clearResolveSquadCache } from '@bradygaster/squad-sdk/resolution';
 
 const TMP = join(process.cwd(), `.test-resolution-${randomBytes(4).toString('hex')}`);
 
@@ -19,11 +19,13 @@ function scaffold(...dirs: string[]): void {
 
 describe('resolveSquad()', () => {
   beforeEach(() => {
+    clearResolveSquadCache();
     if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
     mkdirSync(TMP, { recursive: true });
   });
 
   afterEach(() => {
+    clearResolveSquadCache();
     if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
   });
 

--- a/test/resolve-cache.test.ts
+++ b/test/resolve-cache.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for the resolveSquad / findSquadDir cache.
+ *
+ * Covers:
+ *   - cache hits avoid the filesystem walk
+ *   - explicit clearResolveSquadCache() invalidates immediately
+ *   - SQUAD_NO_RESOLVE_CACHE=1 disables both caches
+ *   - cache returns null for misses (and re-checks after invalidation)
+ *   - multi-squad.resolveSquadPath() reads squads.json once per call
+ *
+ * NOTE: TTL-based expiry is tested by mocking Date.now() so the suite runs
+ * fast even though the real TTL is 5 seconds.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { tmpdir } from 'node:os';
+
+import {
+  resolveSquad,
+  clearResolveSquadCache,
+} from '@bradygaster/squad-sdk/resolution';
+import * as resolutionModule from '@bradygaster/squad-sdk/resolution';
+
+const TMP = join(tmpdir(), `squad-cache-${randomBytes(4).toString('hex')}`);
+
+function scaffold(...dirs: string[]): void {
+  for (const d of dirs) {
+    mkdirSync(join(TMP, d), { recursive: true });
+  }
+}
+
+describe('resolveSquad cache', () => {
+  beforeEach(() => {
+    clearResolveSquadCache();
+    delete process.env['SQUAD_NO_RESOLVE_CACHE'];
+    if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
+    mkdirSync(TMP, { recursive: true });
+  });
+
+  afterEach(() => {
+    clearResolveSquadCache();
+    delete process.env['SQUAD_NO_RESOLVE_CACHE'];
+    if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('returns the same path on repeated calls (positive hit)', () => {
+    scaffold('.git', '.squad');
+    const first = resolveSquad(TMP);
+    const second = resolveSquad(TMP);
+    expect(first).toBe(join(TMP, '.squad'));
+    expect(second).toBe(first);
+  });
+
+  it('serves a cached null when .squad/ is added after the first lookup (until invalidated)', () => {
+    scaffold('.git');
+    expect(resolveSquad(TMP)).toBeNull();
+
+    // Add .squad/ AFTER the cache has stored null
+    mkdirSync(join(TMP, '.squad'), { recursive: true });
+
+    // Without invalidation, the cached null is still served
+    expect(resolveSquad(TMP)).toBeNull();
+
+    // Explicit invalidation forces a fresh walk
+    clearResolveSquadCache();
+    expect(resolveSquad(TMP)).toBe(join(TMP, '.squad'));
+  });
+
+  it('serves a cached path even when the underlying directory is removed (until invalidated)', () => {
+    scaffold('.git', '.squad');
+    expect(resolveSquad(TMP)).toBe(join(TMP, '.squad'));
+
+    rmSync(join(TMP, '.squad'), { recursive: true, force: true });
+
+    // Cached value still returned
+    expect(resolveSquad(TMP)).toBe(join(TMP, '.squad'));
+
+    // Invalidation lets the next lookup observe the removal
+    clearResolveSquadCache();
+    expect(resolveSquad(TMP)).toBeNull();
+  });
+
+  it('SQUAD_NO_RESOLVE_CACHE=1 disables the cache entirely', () => {
+    process.env['SQUAD_NO_RESOLVE_CACHE'] = '1';
+    scaffold('.git');
+    expect(resolveSquad(TMP)).toBeNull();
+
+    // Add .squad/ — without cache, the next call reflects FS state immediately
+    mkdirSync(join(TMP, '.squad'), { recursive: true });
+    expect(resolveSquad(TMP)).toBe(join(TMP, '.squad'));
+  });
+
+  it('clearResolveSquadCache() is a no-op when nothing is cached', () => {
+    expect(() => clearResolveSquadCache()).not.toThrow();
+    // Sanity: a fresh lookup still works after clearing an empty cache
+    scaffold('.git', '.squad');
+    expect(resolveSquad(TMP)).toBe(join(TMP, '.squad'));
+  });
+
+  it('TTL expiry causes a re-walk after the configured window elapses', () => {
+    // The cache uses Date.now() with a 5_000 ms TTL. Mocking Date.now lets
+    // us assert the expiry behavior without sleeping for 5 seconds.
+    scaffold('.git');
+    const realNow = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now');
+
+    nowSpy.mockReturnValue(realNow);
+    expect(resolveSquad(TMP)).toBeNull();
+
+    // Add .squad/ AFTER caching the null
+    mkdirSync(join(TMP, '.squad'), { recursive: true });
+
+    // Within TTL → cached null still served
+    nowSpy.mockReturnValue(realNow + 4_999);
+    expect(resolveSquad(TMP)).toBeNull();
+
+    // Just past TTL → cache miss, fresh walk observes new .squad/
+    nowSpy.mockReturnValue(realNow + 5_001);
+    expect(resolveSquad(TMP)).toBe(join(TMP, '.squad'));
+
+    nowSpy.mockRestore();
+  });
+
+  it('separate startDir keys are cached independently', () => {
+    scaffold('.git', '.squad', 'sub');
+    const subDir = join(TMP, 'sub');
+
+    expect(resolveSquad(TMP)).toBe(join(TMP, '.squad'));
+    expect(resolveSquad(subDir)).toBe(join(TMP, '.squad'));
+
+    // Removing the subdir should not invalidate the parent's cached entry
+    rmSync(subDir, { recursive: true, force: true });
+    expect(resolveSquad(TMP)).toBe(join(TMP, '.squad'));
+  });
+
+  it('exports clearResolveSquadCache from the SDK barrel', async () => {
+    const sdk = await import('@bradygaster/squad-sdk');
+    expect(typeof sdk.clearResolveSquadCache).toBe('function');
+    // It should be the SAME function reference as the resolution module's export
+    expect(sdk.clearResolveSquadCache).toBe(resolutionModule.clearResolveSquadCache);
+  });
+});
+
+// ============================================================================
+// multi-squad.resolveSquadPath() — verify squads.json is read once per call
+// ============================================================================
+
+describe('multi-squad.resolveSquadPath() — config read dedupe', () => {
+  // We assert dedupe behaviorally by counting how many times squads.json is
+  // parsed during a single call. Using vi.stubEnv() instead of direct
+  // process.env mutation keeps env isolated from parallel test files.
+
+  const HOME = join(tmpdir(), `squad-multi-${randomBytes(4).toString('hex')}`);
+
+  function getSquadsJsonPath(): string {
+    if (process.platform === 'win32') {
+      return join(HOME, 'squad', 'squads.json');
+    } else if (process.platform === 'darwin') {
+      return join(HOME, 'Library', 'Application Support', 'squad', 'squads.json');
+    }
+    return join(HOME, 'squad', 'squads.json');
+  }
+
+  beforeEach(() => {
+    if (existsSync(HOME)) rmSync(HOME, { recursive: true, force: true });
+    mkdirSync(HOME, { recursive: true });
+    vi.stubEnv('HOME', HOME);
+    vi.stubEnv('XDG_CONFIG_HOME', HOME);
+    vi.stubEnv('APPDATA', HOME);
+    // NOTE: do NOT stub SQUAD_NAME here. The resolution chain in
+    // resolveSquadPath() uses `??` which treats '' as a valid value (only
+    // null/undefined trigger the fallback). Setting it to '' would cause
+    // `resolved` to be the empty string instead of falling through to
+    // config?.active. We want it to remain undefined for these tests.
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    if (existsSync(HOME)) rmSync(HOME, { recursive: true, force: true });
+  });
+
+  it('reads squads.json exactly once per resolveSquadPath() call', async () => {
+    // Import the multi-squad module directly from the built dist; it isn't
+    // re-exported from the SDK barrel.
+    const distUrl = new URL(
+      '../packages/squad-sdk/dist/multi-squad.js',
+      import.meta.url,
+    ).href;
+    const multiSquad = (await import(/* @vite-ignore */ distUrl)) as {
+      resolveSquadPath: (name?: string) => string;
+    };
+    const { resolveSquadPath } = multiSquad;
+
+    // Manually scaffold a valid squads.json for the temp HOME
+    const squadsJson = getSquadsJsonPath();
+    mkdirSync(join(squadsJson, '..'), { recursive: true });
+    const expectedContent =
+      JSON.stringify(
+        {
+          squads: [
+            {
+              name: 'alpha',
+              path: join(HOME, 'squad', 'squads', 'alpha'),
+              created_at: new Date().toISOString(),
+            },
+          ],
+          active: 'alpha',
+        },
+        null,
+        2,
+      ) + '\n';
+    writeFileSync(squadsJson, expectedContent, 'utf-8');
+
+    // Count squads.json parses by spying on JSON.parse and matching content.
+    const originalParse = JSON.parse;
+    let reads = 0;
+    JSON.parse = function patchedParse(text: string, ...rest: unknown[]) {
+      if (typeof text === 'string' && text === expectedContent) {
+        reads++;
+      }
+      // @ts-expect-error variadic forward
+      return originalParse(text, ...rest);
+    };
+
+    try {
+      const resolved = resolveSquadPath();
+      expect(resolved).toBe(join(HOME, 'squad', 'squads', 'alpha'));
+    } finally {
+      JSON.parse = originalParse;
+    }
+
+    // Pre-fix: 2 reads (active fallback + entry lookup).
+    // Post-fix: exactly 1.
+    expect(reads).toBe(1);
+  });
+});

--- a/test/state-backend.test.ts
+++ b/test/state-backend.test.ts
@@ -5,7 +5,7 @@ import { execSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { WorktreeBackend, GitNotesBackend, OrphanBranchBackend, resolveStateBackend, validateStateKey, StateBackendStorageAdapter } from '../packages/squad-sdk/src/state-backend.js';
 import type { StateBackendType } from '../packages/squad-sdk/src/state-backend.js';
-import { resolveSquadState } from '../packages/squad-sdk/src/resolution.js';
+import { resolveSquadState, clearResolveSquadCache } from '../packages/squad-sdk/src/resolution.js';
 
 const TMP = join(process.cwd(), `.test-state-backend-${randomBytes(4).toString('hex')}`);
 function git(args: string, cwd = TMP): string {
@@ -20,7 +20,7 @@ function initRepo(): void {
 describe('WorktreeBackend', () => {
   const squadDir = () => join(TMP, '.squad');
   beforeEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); mkdirSync(squadDir(), { recursive: true }); });
-  afterEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
+  afterEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
   it('read/write/exists round-trip', () => {
     const b = new WorktreeBackend(squadDir());
     expect(b.exists('team.md')).toBe(false); expect(b.read('team.md')).toBeUndefined();
@@ -37,7 +37,7 @@ describe('WorktreeBackend', () => {
 
 describe('GitNotesBackend', () => {
   beforeEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); });
-  afterEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
+  afterEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
   it('read returns undefined when no note exists', () => { expect(new GitNotesBackend(TMP).read('team.md')).toBeUndefined(); });
   it('write then read round-trip', () => { const b = new GitNotesBackend(TMP); b.write('team.md', '# Team Config'); expect(b.read('team.md')).toBe('# Team Config'); });
   it('exists reflects write state', () => { const b = new GitNotesBackend(TMP); expect(b.exists('d/i/t.md')).toBe(false); b.write('d/i/t.md', 'x'); expect(b.exists('d/i/t.md')).toBe(true); });
@@ -79,7 +79,7 @@ describe('GitNotesBackend', () => {
 
 describe('OrphanBranchBackend', () => {
   beforeEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); });
-  afterEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
+  afterEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
   it('read returns undefined when branch does not exist', () => { expect(new OrphanBranchBackend(TMP).read('team.md')).toBeUndefined(); });
   it('write creates orphan branch', { timeout: 15_000 }, () => {
     const b = new OrphanBranchBackend(TMP); b.write('team.md', '# Team'); expect(b.read('team.md')).toBe('# Team');
@@ -101,8 +101,8 @@ describe('OrphanBranchBackend', () => {
 
 describe('resolveStateBackend()', () => {
   const squadDir = () => join(TMP, '.squad');
-  beforeEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); mkdirSync(squadDir(), { recursive: true }); });
-  afterEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
+  beforeEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); mkdirSync(squadDir(), { recursive: true }); });
+  afterEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
   it('defaults to local', () => { expect(resolveStateBackend(squadDir(), TMP).name).toBe('local'); });
   it('reads stateBackend from config.json (git-notes migrates to two-layer)', () => {
     writeFileSync(join(squadDir(), 'config.json'), JSON.stringify({ version: 1, teamRoot: '.', stateBackend: 'git-notes' }));
@@ -173,7 +173,7 @@ describe('State Backend: validateStateKey', () => {
 
 describe('State Backend: Key injection blocked at backend level', () => {
   beforeEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); });
-  afterEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
+  afterEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
 
   it('GitNotesBackend rejects path traversal in write', () => {
     const b = new GitNotesBackend(TMP);
@@ -221,7 +221,7 @@ describe('State Backend: Key injection blocked at backend level', () => {
 describe('WorktreeBackend delete/append', () => {
   const squadDir = () => join(TMP, '.squad');
   beforeEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); mkdirSync(squadDir(), { recursive: true }); });
-  afterEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
+  afterEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
 
   it('delete removes an existing file and returns true', () => {
     const b = new WorktreeBackend(squadDir());
@@ -251,7 +251,7 @@ describe('WorktreeBackend delete/append', () => {
 
 describe('GitNotesBackend delete/append', () => {
   beforeEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); });
-  afterEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
+  afterEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
 
   it('delete removes a key from the blob', { timeout: 15_000 }, () => {
     const b = new GitNotesBackend(TMP);
@@ -283,7 +283,7 @@ describe('GitNotesBackend delete/append', () => {
 
 describe('OrphanBranchBackend delete/append', () => {
   beforeEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); });
-  afterEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
+  afterEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
 
   it('delete removes a file from the orphan branch', { timeout: 15_000 }, () => {
     const b = new OrphanBranchBackend(TMP);
@@ -349,8 +349,8 @@ describe('OrphanBranchBackend delete/append', () => {
 
 describe('resolveSquadState()', () => {
   const squadDir = () => join(TMP, '.squad');
-  beforeEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); mkdirSync(squadDir(), { recursive: true }); });
-  afterEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
+  beforeEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); mkdirSync(squadDir(), { recursive: true }); });
+  afterEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
 
   it('returns null when no squad dir exists', () => {
     rmSync(squadDir(), { recursive: true, force: true });
@@ -413,8 +413,8 @@ describe('resolveSquadState()', () => {
 
 describe('StateBackendStorageAdapter', () => {
   const squadDir = () => join(TMP, '.squad');
-  beforeEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); mkdirSync(squadDir(), { recursive: true }); });
-  afterEach(() => { if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
+  beforeEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); initRepo(); mkdirSync(squadDir(), { recursive: true }); });
+  afterEach(() => { clearResolveSquadCache(); if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true }); });
 
   it('readSync/writeSync/existsSync round-trip via git-notes', () => {
     const backend = new GitNotesBackend(TMP);


### PR DESCRIPTION
## Summary

Two repeated-FS-work hotspots in the SDK that get called many times per CLI invocation and per watch-loop tick in Ralph:

1. **`resolveSquad()` and `findSquadDir()`** walk up from `startDir` toward `/`, doing 2-3 syscalls per directory level. Every CLI entry point, every config load, every agent spawn re-walks the same path.
2. **`resolveSquadPath()` in `multi-squad.ts`** previously called `loadSquadsConfig()` 2-3 times per invocation. `loadSquadsConfig()` does `existsSync` + `readFileSync` + `JSON.parse` with no internal caching.

## What Changed

### Resolution cache

`packages/squad-sdk/src/resolution.ts` — wrap `resolveSquad()` and `findSquadDir()` with a TTL-bounded in-process cache:

- TTL = 5 seconds, keyed on the absolute resolved `startDir`.
- Both positive (`.squad/` found) and negative (not found) results are cached.
- `SQUAD_NO_RESOLVE_CACHE=1` env var disables the cache entirely (handy for tests that exhaustively exercise the walk algorithm).
- New exported function `clearResolveSquadCache()` for callers that mutate `.squad/` and need immediate invalidation without waiting for the TTL.
- Re-exported from the SDK barrel.

### `runInit` and `runLink` invalidation hooks

- `packages/squad-cli/src/cli/core/init.ts` — calls `clearResolveSquadCache()` immediately after `sdkInitSquad()` so any later code in the same process sees the new `.squad/`.
- `packages/squad-cli/src/cli/commands/link.ts` — same treatment after writing `.squad/config.json`.

### Multi-squad config dedupe

`packages/squad-sdk/src/multi-squad.ts:resolveSquadPath()` — reads `squads.json` once after the `migrateIfNeeded()` call (intentionally kept after migration so any post-migration write is observed).

Other functions in the module (`createSquad`, `deleteSquad`, `switchSquad`, `listSquads`) were unchanged — they each call `loadSquadsConfig()` exactly once already.

### Pre-existing test fixes

Three tests in `test/resolution.test.ts` and `test/cli-global.test.ts` share a `TMP` constant as `startDir` across cases inside the same `describe`. Without cache clearing, the cached result from the first case would leak into the next. Both files now call `clearResolveSquadCache()` in `beforeEach`/`afterEach`. This actually stabilises tests that were ordering-flaky on `main`.

## Testing

- `test/resolve-cache.test.ts` (new, 9 cases):
  - positive hit returns cached path
  - cached null served when `.squad/` is created mid-run (until invalidation)
  - cached path served when `.squad/` is deleted mid-run (until invalidation)
  - `SQUAD_NO_RESOLVE_CACHE=1` disables the cache
  - `clearResolveSquadCache()` is a safe no-op on empty cache
  - TTL expiry causes re-walk after 5 s (mocked via `vi.spyOn(Date, 'now')`)
  - separate `startDir` keys cached independently
  - barrel export wires the same function reference
  - `resolveSquadPath()` parses `squads.json` exactly once per call
- All existing `test/resolution.test.ts` (26), `test/worktree.test.ts`, `test/cli-global.test.ts`, `test/cli/team-root-resolution.test.ts`, `test/sdk-feature-parity.test.ts` pass — 62/62 across the affected suite.
- `npm run lint` clean.

## Follow-ups (not in this PR — land each separately so revert is cheap)

- Wire `clearResolveSquadCache()` into `runUpgrade` and `writeRemoteConfig`. The 5 s TTL keeps these correct in practice (stale data self-corrects), but explicit invalidation is cleaner.

## Notes

Part of a five-PR perf series. Companion PRs:
- chore: dependency hygiene
- feat(bench): npm run bench + bench:cold-start runners
- parallel charter discovery with bounded concurrency
- non-blocking scheduler script execution
