### PR TITLE
Add vally eval suite (copilot-sdk executor, real agent evals)

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   validate:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,50 @@
+name: Evals
+
+on:
+  pull_request:
+    paths:
+      - 'evals/**'
+      - 'packages/squad-sdk/src/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Validate eval schemas
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx vally lint --eval evals/
+
+  run-evals:
+    name: Run eval suites
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-evals')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - name: Run evals
+        # Requires Copilot access on the repository. The copilot-sdk executor
+        # authenticates via GITHUB_TOKEN when running in GitHub Actions.
+        run: npx vally eval --eval-spec evals/routing/eval.yaml --eval-spec evals/skill-invocation/eval.yaml --eval-spec evals/task-completion/eval.yaml --output-dir results --junit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results
+          path: results/
+        if: always()

--- a/evals/README.md
+++ b/evals/README.md
@@ -97,7 +97,8 @@ evals/
 ## CI
 
 Evals run in a dedicated workflow (`.github/workflows/evals.yml`) that:
-- Triggers on changes to `evals/` or `packages/squad-sdk/src/`
-- Requires Copilot SDK credentials (repository secret)
-- Reports scores as PR comments
+- Validates eval schemas (`vally lint`) on every PR touching `evals/` or SDK source
+- Runs full eval suites when the `run-evals` label is added or via manual dispatch
+- Requires Copilot SDK credentials (GITHUB_TOKEN with Copilot access)
+- Uploads results as JUnit artifacts for download
 - Does NOT block merge — evals are advisory

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,103 @@
+# Squad Evals
+
+End-to-end evaluations for the Squad SDK using [@microsoft/vally](https://www.npmjs.com/package/@microsoft/vally-cli).
+
+## Philosophy
+
+These evals test **real agent behavior** — not SDK functions in isolation.
+Each eval sends real user prompts to a Copilot agent configured with Squad
+skills and fixtures, then grades the agent's actual responses using built-in
+vally graders.
+
+**What these evals are NOT:**
+- Unit tests of SDK functions (those belong in `packages/squad-sdk/test/`)
+- Reading comprehension tests ("given X.md, what should happen?")
+- Mock-based synthetic checks
+
+## Eval Suites
+
+| Suite | What it tests |
+|-------|---------------|
+| `routing` | Given real prompts, does the agent route to the correct squad member? |
+| `skill-invocation` | Given task prompts, does the agent apply the right skills? |
+| `task-completion` | Given development prompts, does the agent produce working solutions? |
+
+## Running Evals
+
+### Prerequisites
+
+- Node.js 22.5+
+- `@microsoft/vally-cli` installed (workspace devDependency)
+- Copilot SDK credentials (for `copilot-sdk` executor)
+
+### Run all evals
+
+```bash
+npx vally eval --eval-spec evals/routing/eval.yaml --eval-spec evals/skill-invocation/eval.yaml --eval-spec evals/task-completion/eval.yaml
+```
+
+### Run a single suite
+
+```bash
+npx vally eval --eval-spec evals/routing/eval.yaml
+npx vally eval --eval-spec evals/skill-invocation/eval.yaml
+npx vally eval --eval-spec evals/task-completion/eval.yaml
+```
+
+### Schema validation (no credentials needed)
+
+```bash
+npx vally lint --eval evals/
+```
+
+## Structure
+
+```
+evals/
+├── README.md
+├── routing/
+│   ├── eval.yaml           # Eval definition
+│   └── fixtures/           # Squad workspace fixtures
+│       ├── team.md
+│       ├── routing.md
+│       └── agents/         # Agent charters
+├── skill-invocation/
+│   ├── eval.yaml
+│   └── fixtures/
+│       ├── team.md
+│       ├── routing.md
+│       └── skills/         # Skill definitions (SKILL.md)
+└── task-completion/
+    ├── eval.yaml
+    └── fixtures/
+        ├── team.md
+        ├── routing.md
+        └── agents/
+```
+
+## Adding New Evals
+
+1. Create a directory under `evals/`
+2. Add an `eval.yaml` following the [vally eval schema](https://www.npmjs.com/package/@microsoft/vally)
+3. Add fixtures in a `fixtures/` subdirectory
+4. Use built-in graders: `output-matches`, `output-contains`, `skill-invocation`, `tool-call`, `prompt`, `pairwise`
+5. Write real user prompts — no "Given the rules in X.md" preambles
+
+## Grading
+
+| Grader | Use for |
+|--------|---------|
+| `output-matches` | Regex match on agent output (fast, deterministic) |
+| `output-contains` | Substring check (simpler than regex) |
+| `prompt` | LLM-as-judge using rubric criteria |
+| `pairwise` | Comparative grading between outputs |
+| `skill-invocation` | Check which skills were/weren't called |
+| `tool-call` | Check which tools were/weren't called |
+
+## CI
+
+Evals run in a dedicated workflow (`.github/workflows/evals.yml`) that:
+- Triggers on changes to `evals/` or `packages/squad-sdk/src/`
+- Requires Copilot SDK credentials (repository secret)
+- Reports scores as PR comments
+- Does NOT block merge — evals are advisory

--- a/evals/README.md
+++ b/evals/README.md
@@ -94,6 +94,11 @@ evals/
 | `skill-invocation` | Check which skills were/weren't called |
 | `tool-call` | Check which tools were/weren't called |
 
+**Design note**: Some stimuli intentionally use only a `prompt` grader (no
+deterministic regex). For example, the routing "ambiguous request" stimulus has
+no correct agent target - the grader evaluates reasoning quality, not a fixed
+answer. Adding `output-matches` to such stimuli would constrain valid responses.
+
 ## CI
 
 Evals run in a dedicated workflow (`.github/workflows/evals.yml`) that:

--- a/evals/README.md
+++ b/evals/README.md
@@ -90,6 +90,8 @@ evals/
 | `output-matches` | Regex match on agent output (fast, deterministic) |
 | `output-contains` | Substring check (simpler than regex) |
 | `prompt` | LLM-as-judge using rubric criteria |
+| `file-exists` | Verifies agent wrote a file to disk |
+| `file-contains` | Verifies file on disk contains expected content |
 | `pairwise` | Comparative grading between outputs |
 | `skill-invocation` | Check which skills were/weren't called |
 | `tool-call` | Check which tools were/weren't called |
@@ -98,6 +100,20 @@ evals/
 deterministic regex). For example, the routing "ambiguous request" stimulus has
 no correct agent target - the grader evaluates reasoning quality, not a fixed
 answer. Adding `output-matches` to such stimuli would constrain valid responses.
+
+**Scoring**: All `prompt` graders use `config.scoring: scale_1_5` for granular
+failure diagnostics rather than binary pass/fail. This surfaces which rubric
+criteria failed when a stimulus regresses.
+
+**Statistical reliability**: Suites use `config.runs: 3` (routing, skill-invocation)
+or `config.runs: 5` (task-completion) to reduce noise from stochastic agent behavior.
+Single-trial scores are inside the LLM noise floor; multiple runs give confidence
+that a pass is stable.
+
+**Construct validity**: The task-completion suite uses `file-exists` and
+`file-contains` graders to verify the agent executed operations on disk, not just
+described them in text. This prevents false passes from agents that narrate
+solutions without implementing them.
 
 ## CI
 

--- a/evals/routing/eval.yaml
+++ b/evals/routing/eval.yaml
@@ -1,0 +1,101 @@
+name: squad-routing
+description: |
+  Evaluates Squad's work routing — given real user prompts, does the agent
+  route to the correct squad member based on routing.md rules?
+type: capability
+config:
+  timeout: 3m
+environment:
+  skills:
+    - ../../packages/squad-cli/src/cli/skills
+  files:
+    - src: fixtures/team.md
+      dest: .squad/team.md
+    - src: fixtures/routing.md
+      dest: .squad/routing.md
+    - src: fixtures/agents/lead/charter.md
+      dest: .squad/agents/lead/charter.md
+    - src: fixtures/agents/developer/charter.md
+      dest: .squad/agents/developer/charter.md
+    - src: fixtures/agents/tester/charter.md
+      dest: .squad/agents/tester/charter.md
+    - src: fixtures/agents/scribe/charter.md
+      dest: .squad/agents/scribe/charter.md
+scoring:
+  threshold: 0.7
+stimuli:
+  - name: Routes bug fix to developer
+    prompt: |
+      There's a null reference exception in the login handler when the
+      user's email field is missing. Can you fix it?
+    graders:
+      - type: output-matches
+        config:
+          pattern: (developer|Developer)
+      - type: prompt
+    rubric:
+      - The response identifies this as a bug fix task and routes to the Developer agent
+      - The response does not route to Lead, Tester, or Scribe for a simple bug fix
+
+  - name: Routes architecture review to lead
+    prompt: |
+      We need to redesign the event bus to support fan-out to multiple
+      consumers. Can you review the current architecture and propose changes?
+    graders:
+      - type: output-matches
+        config:
+          pattern: (lead|Lead)
+      - type: prompt
+    rubric:
+      - The response identifies this as an architecture/design task and routes to the Lead agent
+      - Architecture reviews and design decisions go to Lead, not Developer
+
+  - name: Routes test coverage request to tester
+    prompt: |
+      The auth module has zero test coverage. Write integration tests for
+      the token refresh flow and session expiration handling.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (tester|Tester)
+      - type: prompt
+    rubric:
+      - The response identifies this as a testing task and routes to the Tester agent
+      - Test writing, coverage, and quality assurance tasks go to Tester
+
+  - name: Routes documentation update to scribe
+    prompt: |
+      The API reference is out of date — the /users endpoint now accepts
+      a pagination cursor. Update the docs to reflect the new parameter.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (scribe|Scribe)
+      - type: prompt
+    rubric:
+      - The response identifies this as a documentation task and routes to the Scribe agent
+      - Documentation updates, README changes, and reference maintenance go to Scribe
+
+  - name: Routes new feature implementation to developer
+    prompt: |
+      Add webhook retry support with exponential backoff. When a webhook
+      delivery fails, retry up to 3 times with increasing delays.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (developer|Developer)
+      - type: prompt
+    rubric:
+      - The response identifies this as a feature implementation task and routes to Developer
+      - New feature coding tasks go to Developer, not Lead (who handles design only)
+
+  - name: Handles ambiguous request with reasoning
+    prompt: |
+      The CI pipeline is failing on the main branch. The error seems related
+      to a flaky test in the payment module.
+    graders:
+      - type: prompt
+    rubric:
+      - The response acknowledges ambiguity — this could be a test fix (Tester) or a bug fix (Developer)
+      - The response provides reasoning for its routing decision
+      - The response does not silently pick one agent without explaining why

--- a/evals/routing/eval.yaml
+++ b/evals/routing/eval.yaml
@@ -4,6 +4,7 @@ description: |
   route to the correct squad member based on routing.md rules?
 type: capability
 config:
+  runs: 3
   timeout: 3m
 environment:
   skills:
@@ -34,6 +35,8 @@ stimuli:
           pattern: (route.*[Dd]eveloper|assign.*[Dd]eveloper|[Dd]eveloper.*(agent|handle|fix))
       - type: prompt
         name: routing-correctness
+        config:
+          scoring: scale_1_5
     rubric:
       - The response identifies this as a bug fix task and routes to the Developer agent
       - The response does not route to Lead, Tester, or Scribe for a simple bug fix
@@ -48,6 +51,8 @@ stimuli:
           pattern: (route.*[Ll]ead|assign.*[Ll]ead|[Ll]ead.*(agent|handle|review|design))
       - type: prompt
         name: routing-correctness
+        config:
+          scoring: scale_1_5
     rubric:
       - The response identifies this as an architecture/design task and routes to the Lead agent
       - Architecture reviews and design decisions go to Lead, not Developer
@@ -62,6 +67,8 @@ stimuli:
           pattern: (route.*[Tt]ester|assign.*[Tt]ester|[Tt]ester.*(agent|handle|test|cover))
       - type: prompt
         name: routing-correctness
+        config:
+          scoring: scale_1_5
     rubric:
       - The response identifies this as a testing task and routes to the Tester agent
       - Test writing, coverage, and quality assurance tasks go to Tester
@@ -76,6 +83,8 @@ stimuli:
           pattern: (route.*[Ss]cribe|assign.*[Ss]cribe|[Ss]cribe.*(agent|handle|doc|update))
       - type: prompt
         name: routing-correctness
+        config:
+          scoring: scale_1_5
     rubric:
       - The response identifies this as a documentation task and routes to the Scribe agent
       - Documentation updates, README changes, and reference maintenance go to Scribe
@@ -90,6 +99,8 @@ stimuli:
           pattern: (route.*[Dd]eveloper|assign.*[Dd]eveloper|[Dd]eveloper.*(agent|handle|implement|build))
       - type: prompt
         name: routing-correctness
+        config:
+          scoring: scale_1_5
     rubric:
       - The response identifies this as a feature implementation task and routes to Developer
       - New feature coding tasks go to Developer, not Lead (who handles design only)
@@ -101,6 +112,8 @@ stimuli:
     graders:
       - type: prompt
         name: ambiguity-handling
+        config:
+          scoring: scale_1_5
     rubric:
       - The response acknowledges ambiguity - this could be a test fix (Tester) or a bug fix (Developer)
       - The response provides reasoning for its routing decision

--- a/evals/routing/eval.yaml
+++ b/evals/routing/eval.yaml
@@ -31,8 +31,9 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: (developer|Developer)
+          pattern: (route.*[Dd]eveloper|assign.*[Dd]eveloper|[Dd]eveloper.*(agent|handle|fix))
       - type: prompt
+        name: routing-correctness
     rubric:
       - The response identifies this as a bug fix task and routes to the Developer agent
       - The response does not route to Lead, Tester, or Scribe for a simple bug fix
@@ -44,8 +45,9 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: (lead|Lead)
+          pattern: (route.*[Ll]ead|assign.*[Ll]ead|[Ll]ead.*(agent|handle|review|design))
       - type: prompt
+        name: routing-correctness
     rubric:
       - The response identifies this as an architecture/design task and routes to the Lead agent
       - Architecture reviews and design decisions go to Lead, not Developer
@@ -57,21 +59,23 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: (tester|Tester)
+          pattern: (route.*[Tt]ester|assign.*[Tt]ester|[Tt]ester.*(agent|handle|test|cover))
       - type: prompt
+        name: routing-correctness
     rubric:
       - The response identifies this as a testing task and routes to the Tester agent
       - Test writing, coverage, and quality assurance tasks go to Tester
 
   - name: Routes documentation update to scribe
     prompt: |
-      The API reference is out of date — the /users endpoint now accepts
+      The API reference is out of date - the /users endpoint now accepts
       a pagination cursor. Update the docs to reflect the new parameter.
     graders:
       - type: output-matches
         config:
-          pattern: (scribe|Scribe)
+          pattern: (route.*[Ss]cribe|assign.*[Ss]cribe|[Ss]cribe.*(agent|handle|doc|update))
       - type: prompt
+        name: routing-correctness
     rubric:
       - The response identifies this as a documentation task and routes to the Scribe agent
       - Documentation updates, README changes, and reference maintenance go to Scribe
@@ -83,8 +87,9 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: (developer|Developer)
+          pattern: (route.*[Dd]eveloper|assign.*[Dd]eveloper|[Dd]eveloper.*(agent|handle|implement|build))
       - type: prompt
+        name: routing-correctness
     rubric:
       - The response identifies this as a feature implementation task and routes to Developer
       - New feature coding tasks go to Developer, not Lead (who handles design only)
@@ -95,7 +100,8 @@ stimuli:
       to a flaky test in the payment module.
     graders:
       - type: prompt
+        name: ambiguity-handling
     rubric:
-      - The response acknowledges ambiguity — this could be a test fix (Tester) or a bug fix (Developer)
+      - The response acknowledges ambiguity - this could be a test fix (Tester) or a bug fix (Developer)
       - The response provides reasoning for its routing decision
       - The response does not silently pick one agent without explaining why

--- a/evals/routing/fixtures/agents/developer/charter.md
+++ b/evals/routing/fixtures/agents/developer/charter.md
@@ -1,0 +1,16 @@
+# Developer Agent Charter
+
+## Role
+Feature implementation specialist handling bug fixes, new features, and code refactoring.
+
+## Responsibilities
+- Implement new features from specs
+- Fix bugs and handle error cases
+- Refactor code for maintainability
+- Write clean, tested, production-ready code
+
+## Expertise
+- TypeScript/JavaScript full-stack development
+- Node.js APIs and tooling
+- Git workflows and PR best practices
+- Performance optimization

--- a/evals/routing/fixtures/agents/lead/charter.md
+++ b/evals/routing/fixtures/agents/lead/charter.md
@@ -1,0 +1,17 @@
+# Lead Agent Charter
+
+## Role
+Technical lead responsible for architecture decisions, design reviews, and team coordination.
+
+## Responsibilities
+- Review and approve architectural changes
+- Design system boundaries and module interfaces
+- Plan technical roadmap and sprint priorities
+- Set coding standards and patterns for the team
+- Triage ambiguous tasks to appropriate team members
+
+## Expertise
+- System architecture and design patterns
+- API design and interface contracts
+- Performance and scalability planning
+- Cross-cutting concerns (logging, auth, error handling)

--- a/evals/routing/fixtures/agents/scribe/charter.md
+++ b/evals/routing/fixtures/agents/scribe/charter.md
@@ -1,0 +1,16 @@
+# Scribe Agent Charter
+
+## Role
+Documentation specialist maintaining all written artifacts for the project.
+
+## Responsibilities
+- Update API references when endpoints change
+- Maintain README and getting-started guides
+- Write changelogs and release notes
+- Document architectural decisions (ADRs)
+
+## Expertise
+- Technical writing and documentation
+- API documentation standards (OpenAPI, JSDoc)
+- Markdown and documentation tooling
+- Developer experience (DX) writing

--- a/evals/routing/fixtures/agents/tester/charter.md
+++ b/evals/routing/fixtures/agents/tester/charter.md
@@ -1,0 +1,16 @@
+# Tester Agent Charter
+
+## Role
+Quality assurance specialist responsible for test coverage, test strategy, and validation.
+
+## Responsibilities
+- Write unit and integration tests
+- Identify coverage gaps
+- Design test strategies for new features
+- Fix flaky tests and improve test reliability
+
+## Expertise
+- Vitest and testing frameworks
+- Test-driven development (TDD)
+- Mocking strategies and test doubles
+- CI/CD test pipeline optimization

--- a/evals/routing/fixtures/routing.md
+++ b/evals/routing/fixtures/routing.md
@@ -1,0 +1,16 @@
+# Routing Rules
+
+## Routing Table
+
+| Work Type | Route To | Examples |
+|-----------|----------|----------|
+| architecture-review | Lead | System design, architecture decisions, module boundaries |
+| design-review | Lead | API design, interface design, pattern review |
+| planning | Lead | Sprint planning, roadmap, technical direction |
+| bug-fix | Developer | Null reference, crash fix, error handling |
+| feature-dev | Developer | New endpoint, new module, feature implementation |
+| refactoring | Developer | Code cleanup, extract function, rename |
+| test-writing | Tester | Unit tests, integration tests, test coverage |
+| quality-assurance | Tester | Test review, coverage gaps, flaky tests |
+| documentation | Scribe | README update, API docs, changelog |
+| api-reference | Scribe | Endpoint docs, parameter docs, examples |

--- a/evals/routing/fixtures/team.md
+++ b/evals/routing/fixtures/team.md
@@ -1,0 +1,16 @@
+# Team Roster
+
+## Squad: Eval Demo Team
+
+| Agent | Role | Capabilities |
+|-------|------|--------------|
+| Lead | lead | Architecture, design reviews, planning, code standards |
+| Developer | developer | Feature implementation, bug fixes, refactoring, code writing |
+| Tester | tester | Test writing, coverage analysis, QA, integration testing |
+| Scribe | scribe | Documentation, API references, READMEs, changelogs |
+
+## Governance
+
+- **Routing**: Work is assigned based on the routing table in routing.md
+- **Escalation**: Ambiguous tasks go to Lead for triage
+- **Reviews**: All PRs require at least one team member review

--- a/evals/skill-invocation/eval.yaml
+++ b/evals/skill-invocation/eval.yaml
@@ -13,6 +13,10 @@ environment:
       dest: .squad/team.md
     - src: fixtures/routing.md
       dest: .squad/routing.md
+    - src: fixtures/agents/developer/charter.md
+      dest: .squad/agents/developer/charter.md
+    - src: fixtures/agents/lead/charter.md
+      dest: .squad/agents/lead/charter.md
     - src: fixtures/skills/typescript-patterns/SKILL.md
       dest: .squad/skills/typescript-patterns/SKILL.md
     - src: fixtures/skills/api-design/SKILL.md
@@ -34,8 +38,8 @@ stimuli:
         config:
           pattern: (discriminated union|satisfies|narrowing|type guard)
       - type: prompt
+        name: typescript-skill-usage
     rubric:
-      - The response applies TypeScript-specific patterns (discriminated unions, type narrowing)
       - The response demonstrates knowledge from the TypeScript Patterns skill
       - The response does not suggest a non-TypeScript approach (e.g., runtime checks only)
 
@@ -48,8 +52,8 @@ stimuli:
         config:
           pattern: (/teams|/v[0-9]|plural|resource naming|pagination)
       - type: prompt
+        name: api-design-skill-usage
     rubric:
-      - The response uses plural resource naming conventions (/teams, /members)
       - The response mentions API versioning or pagination best practices
       - The response follows RESTful design principles from the API Design skill
 
@@ -62,8 +66,8 @@ stimuli:
         config:
           pattern: (describe|it\(|expect|beforeEach|mock|vitest)
       - type: prompt
+        name: testing-skill-usage
     rubric:
-      - The response includes well-structured test code with describe/it blocks
       - The response covers all three scenarios mentioned (happy path, expired cart, payment failure)
       - The response prefers real objects over mocks where feasible (per Testing Practices skill)
 
@@ -76,8 +80,8 @@ stimuli:
         config:
           pattern: (XSS|httpOnly|secure|SameSite|cookie|localStorage)
       - type: prompt
+        name: security-skill-usage
     rubric:
-      - The response identifies the XSS risk of localStorage JWT storage
       - The response recommends httpOnly cookies or other secure alternatives
       - The response applies security review knowledge (OWASP, common auth vulnerabilities)
 
@@ -91,8 +95,8 @@ stimuli:
         config:
           pattern: (PATCH|/users|zod|schema|describe|test)
       - type: prompt
+        name: cross-cutting-skill-usage
     rubric:
-      - The response addresses all three concerns (API design, TypeScript types, testing)
       - The API design follows REST conventions (PATCH for partial updates, resource naming)
       - TypeScript types are validated at runtime (e.g., zod, io-ts, or manual checks)
       - Tests are included for the validation logic

--- a/evals/skill-invocation/eval.yaml
+++ b/evals/skill-invocation/eval.yaml
@@ -1,0 +1,98 @@
+name: squad-skill-invocation
+description: |
+  Evaluates Squad's skill matching — given real task prompts, does the agent
+  invoke the appropriate skills from the registry?
+type: capability
+config:
+  timeout: 3m
+environment:
+  skills:
+    - ../../packages/squad-cli/src/cli/skills
+  files:
+    - src: fixtures/team.md
+      dest: .squad/team.md
+    - src: fixtures/routing.md
+      dest: .squad/routing.md
+    - src: fixtures/skills/typescript-patterns/SKILL.md
+      dest: .squad/skills/typescript-patterns/SKILL.md
+    - src: fixtures/skills/api-design/SKILL.md
+      dest: .squad/skills/api-design/SKILL.md
+    - src: fixtures/skills/testing-practices/SKILL.md
+      dest: .squad/skills/testing-practices/SKILL.md
+    - src: fixtures/skills/security-review/SKILL.md
+      dest: .squad/skills/security-review/SKILL.md
+scoring:
+  threshold: 0.7
+stimuli:
+  - name: Invokes TypeScript skill for type system task
+    prompt: |
+      Refactor the user model to use discriminated unions for the account
+      status — right now it's using string enums which don't provide
+      exhaustiveness checking.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (discriminated union|satisfies|narrowing|type guard)
+      - type: prompt
+    rubric:
+      - The response applies TypeScript-specific patterns (discriminated unions, type narrowing)
+      - The response demonstrates knowledge from the TypeScript Patterns skill
+      - The response does not suggest a non-TypeScript approach (e.g., runtime checks only)
+
+  - name: Invokes API design skill for endpoint task
+    prompt: |
+      Design the REST endpoints for a team management feature. Users should
+      be able to create teams, add/remove members, and list team activity.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (/teams|/v[0-9]|plural|resource naming|pagination)
+      - type: prompt
+    rubric:
+      - The response uses plural resource naming conventions (/teams, /members)
+      - The response mentions API versioning or pagination best practices
+      - The response follows RESTful design principles from the API Design skill
+
+  - name: Invokes testing skill for coverage task
+    prompt: |
+      Write tests for the checkout flow. We need to cover the happy path,
+      expired cart, and payment failure scenarios.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (describe|it\(|expect|beforeEach|mock|vitest)
+      - type: prompt
+    rubric:
+      - The response includes well-structured test code with describe/it blocks
+      - The response covers all three scenarios mentioned (happy path, expired cart, payment failure)
+      - The response prefers real objects over mocks where feasible (per Testing Practices skill)
+
+  - name: Invokes security skill for auth review
+    prompt: |
+      Review the session handling in our auth module. We're storing JWTs in
+      localStorage and I'm worried about XSS exposure.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (XSS|httpOnly|secure|SameSite|cookie|localStorage)
+      - type: prompt
+    rubric:
+      - The response identifies the XSS risk of localStorage JWT storage
+      - The response recommends httpOnly cookies or other secure alternatives
+      - The response applies security review knowledge (OWASP, common auth vulnerabilities)
+
+  - name: Combines multiple skills for cross-cutting task
+    prompt: |
+      Add a new /users/:id/settings endpoint. It should accept PATCH requests
+      with partial updates, validate the TypeScript types at runtime, and we
+      need tests for the validation logic.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (PATCH|/users|zod|schema|describe|test)
+      - type: prompt
+    rubric:
+      - The response addresses all three concerns (API design, TypeScript types, testing)
+      - The API design follows REST conventions (PATCH for partial updates, resource naming)
+      - TypeScript types are validated at runtime (e.g., zod, io-ts, or manual checks)
+      - Tests are included for the validation logic

--- a/evals/skill-invocation/eval.yaml
+++ b/evals/skill-invocation/eval.yaml
@@ -4,6 +4,7 @@ description: |
   invoke the appropriate skills from the registry?
 type: capability
 config:
+  runs: 3
   timeout: 3m
 environment:
   skills:
@@ -36,9 +37,11 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: (discriminated union|satisfies|narrowing|type guard)
+          pattern: (satisfies|narrowing|type guard|never type|switch.*case|keyof|in operator)
       - type: prompt
         name: typescript-skill-usage
+        config:
+          scoring: scale_1_5
     rubric:
       - The response demonstrates knowledge from the TypeScript Patterns skill
       - The response does not suggest a non-TypeScript approach (e.g., runtime checks only)
@@ -53,6 +56,8 @@ stimuli:
           pattern: (GET /teams|POST /teams|/v[0-9]+/|resource.*naming|pagina.*cursor|offset)
       - type: prompt
         name: api-design-skill-usage
+        config:
+          scoring: scale_1_5
     rubric:
       - The response mentions API versioning or pagination best practices
       - The response follows RESTful design principles from the API Design skill
@@ -67,6 +72,8 @@ stimuli:
           pattern: (describe|it\(|expect|beforeEach|mock|vitest)
       - type: prompt
         name: testing-skill-usage
+        config:
+          scoring: scale_1_5
     rubric:
       - The response covers all three scenarios mentioned (happy path, expired cart, payment failure)
       - The response prefers real objects over mocks where feasible (per Testing Practices skill)
@@ -78,9 +85,11 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: (XSS|httpOnly|secure|SameSite|cookie|localStorage)
+          pattern: (httpOnly.*cookie|SameSite.*(Strict|Lax)|avoid.*localStorage|move.*to.*cookie|don't.*store.*JWT.*localStorage)
       - type: prompt
         name: security-skill-usage
+        config:
+          scoring: scale_1_5
     rubric:
       - The response recommends httpOnly cookies or other secure alternatives
       - The response applies security review knowledge (OWASP, common auth vulnerabilities)
@@ -92,10 +101,21 @@ stimuli:
       need tests for the validation logic.
     graders:
       - type: output-matches
+        name: api-design-signal
         config:
-          pattern: (PATCH|/users|zod|schema|describe|test)
+          pattern: (PATCH|/users/|partial update|idempotent)
+      - type: output-matches
+        name: runtime-validation-signal
+        config:
+          pattern: (zod|schema|validate|parse|safeParse|io-ts)
+      - type: output-matches
+        name: test-authoring-signal
+        config:
+          pattern: (describe|it\(|expect|test\(|assert)
       - type: prompt
         name: cross-cutting-skill-usage
+        config:
+          scoring: scale_1_5
     rubric:
       - The API design follows REST conventions (PATCH for partial updates, resource naming)
       - TypeScript types are validated at runtime (e.g., zod, io-ts, or manual checks)

--- a/evals/skill-invocation/eval.yaml
+++ b/evals/skill-invocation/eval.yaml
@@ -50,7 +50,7 @@ stimuli:
     graders:
       - type: output-matches
         config:
-          pattern: (/teams|/v[0-9]|plural|resource naming|pagination)
+          pattern: (GET /teams|POST /teams|/v[0-9]+/|resource.*naming|pagina.*cursor|offset)
       - type: prompt
         name: api-design-skill-usage
     rubric:

--- a/evals/skill-invocation/fixtures/agents/developer/charter.md
+++ b/evals/skill-invocation/fixtures/agents/developer/charter.md
@@ -1,0 +1,15 @@
+# Developer Agent
+
+Handles implementation tasks: bug fixes, new features, refactoring, and code quality.
+
+## Skills
+
+Applies registered skills based on task domain:
+- TypeScript patterns for type system work
+- API design for endpoint design
+- Testing practices for test writing
+- Security review for auth and vulnerability concerns
+
+## Routing
+
+Receives work routed by Lead or directly from user prompts matching implementation patterns.

--- a/evals/skill-invocation/fixtures/agents/lead/charter.md
+++ b/evals/skill-invocation/fixtures/agents/lead/charter.md
@@ -1,0 +1,13 @@
+# Lead Agent
+
+Handles architecture decisions, design reviews, and work coordination.
+
+## Responsibilities
+
+- Reviews architecture proposals
+- Routes ambiguous tasks to the correct agent
+- Coordinates cross-cutting concerns that span multiple agents
+
+## Skills
+
+Applies registered skills for design guidance and review.

--- a/evals/skill-invocation/fixtures/routing.md
+++ b/evals/skill-invocation/fixtures/routing.md
@@ -1,0 +1,16 @@
+# Routing Rules
+
+## Routing Table
+
+| Work Type | Route To | Examples |
+|-----------|----------|----------|
+| architecture-review | Lead | System design, architecture decisions, module boundaries |
+| design-review | Lead | API design, interface design, pattern review |
+| planning | Lead | Sprint planning, roadmap, technical direction |
+| bug-fix | Developer | Null reference, crash fix, error handling |
+| feature-dev | Developer | New endpoint, new module, feature implementation |
+| refactoring | Developer | Code cleanup, extract function, rename |
+| test-writing | Tester | Unit tests, integration tests, test coverage |
+| quality-assurance | Tester | Test review, coverage gaps, flaky tests |
+| documentation | Scribe | README update, API docs, changelog |
+| api-reference | Scribe | Endpoint docs, parameter docs, examples |

--- a/evals/skill-invocation/fixtures/skills/api-design/SKILL.md
+++ b/evals/skill-invocation/fixtures/skills/api-design/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: API Design
+domain: architecture
+triggers: [api, rest, endpoint, schema, route, resource, versioning, pagination]
+roles: [developer, lead]
+confidence: high
+---
+## API Design Patterns
+
+Use consistent resource naming (plural nouns: /users, /teams).
+Version APIs via URL path prefix (/v1/, /v2/).
+Return proper HTTP status codes (201 for creation, 404 for not found).
+Design for pagination from day one (cursor-based preferred).
+Use PATCH for partial updates, PUT for full replacement.
+Include hypermedia links for discoverability.

--- a/evals/skill-invocation/fixtures/skills/security-review/SKILL.md
+++ b/evals/skill-invocation/fixtures/skills/security-review/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: Security Review
+domain: security
+triggers: [security, xss, csrf, injection, auth, token, session, vulnerability]
+roles: [lead, developer, tester]
+confidence: high
+---
+## Security Review Patterns
+
+Never store JWTs in localStorage — use httpOnly cookies instead.
+Validate all user input on the server side, not just the client.
+Use Content-Security-Policy headers to mitigate XSS.
+Apply SameSite=Strict on cookies to prevent CSRF.
+Rate-limit authentication endpoints.
+Audit dependencies for known vulnerabilities regularly.

--- a/evals/skill-invocation/fixtures/skills/testing-practices/SKILL.md
+++ b/evals/skill-invocation/fixtures/skills/testing-practices/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: Testing Best Practices
+domain: quality
+triggers: [test, vitest, coverage, spec, assertion, mock, tdd, integration]
+roles: [tester, developer]
+confidence: high
+---
+## Testing Best Practices
+
+Write tests before fixing bugs (regression prevention).
+Use `describe` blocks to group related tests by behavior.
+Prefer real objects over mocks when feasible.
+Target 80% coverage minimum, 100% on critical paths.
+Name tests as "should {expected behavior} when {condition}".
+Use factory functions for test data setup.

--- a/evals/skill-invocation/fixtures/skills/typescript-patterns/SKILL.md
+++ b/evals/skill-invocation/fixtures/skills/typescript-patterns/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: TypeScript Patterns
+domain: development
+triggers: [typescript, types, generics, inference, strict, discriminated, union, narrowing]
+roles: [developer, lead]
+confidence: high
+---
+## TypeScript Patterns
+
+Prefer `unknown` over `any` for type-safe narrowing.
+Use discriminated unions for state machines and variant types.
+Leverage the `satisfies` operator for type validation without widening.
+Always enable strict mode in tsconfig.json.
+Use type guards (`is` keyword) for runtime narrowing.
+Prefer `readonly` arrays and objects where mutation is not needed.

--- a/evals/skill-invocation/fixtures/team.md
+++ b/evals/skill-invocation/fixtures/team.md
@@ -1,0 +1,16 @@
+# Team Roster
+
+## Squad: Eval Demo Team
+
+| Agent | Role | Capabilities |
+|-------|------|--------------|
+| Lead | lead | Architecture, design reviews, planning, code standards |
+| Developer | developer | Feature implementation, bug fixes, refactoring, code writing |
+| Tester | tester | Test writing, coverage analysis, QA, integration testing |
+| Scribe | scribe | Documentation, API references, READMEs, changelogs |
+
+## Governance
+
+- **Routing**: Work is assigned based on the routing table in routing.md
+- **Escalation**: Ambiguous tasks go to Lead for triage
+- **Reviews**: All PRs require at least one team member review

--- a/evals/task-completion/eval.yaml
+++ b/evals/task-completion/eval.yaml
@@ -1,0 +1,104 @@
+name: squad-task-completion
+description: |
+  Evaluates Squad's end-to-end task completion — given real development
+  prompts, does the agent produce working, correct solutions?
+type: capability
+config:
+  timeout: 5m
+environment:
+  skills:
+    - ../../packages/squad-cli/src/cli/skills
+  files:
+    - src: fixtures/team.md
+      dest: .squad/team.md
+    - src: fixtures/routing.md
+      dest: .squad/routing.md
+    - src: fixtures/agents/lead/charter.md
+      dest: .squad/agents/lead/charter.md
+    - src: fixtures/agents/developer/charter.md
+      dest: .squad/agents/developer/charter.md
+scoring:
+  threshold: 0.7
+stimuli:
+  - name: Implements a simple bug fix
+    prompt: |
+      The `parseConfig` function crashes when the input YAML has a trailing
+      newline followed by whitespace. Here's the function:
+
+      ```typescript
+      export function parseConfig(raw: string): Config {
+        const lines = raw.split('\n');
+        const lastLine = lines[lines.length - 1];
+        return JSON.parse(lastLine);
+      }
+      ```
+
+      Fix it so it handles trailing whitespace gracefully.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (trim|filter|pop|slice)
+      - type: prompt
+    rubric:
+      - The fix handles trailing newlines and whitespace (trim, filter empty lines, or skip)
+      - The fix does not change unrelated behavior
+      - The fix handles edge cases (empty string input, all-whitespace input)
+      - The response includes the corrected code, not just a description
+
+  - name: Implements cost-aware model selection
+    prompt: |
+      I need a function that selects the appropriate model tier based on
+      task complexity. Simple tasks (typos, renames) should use the fast
+      tier. Complex tasks (architecture, multi-file refactors) should use
+      the premium tier. Everything else uses standard.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (fast|standard|premium|tier|complexity)
+      - type: prompt
+    rubric:
+      - The response provides a working implementation (not just pseudocode)
+      - The function classifies tasks into at least 3 tiers (fast, standard, premium)
+      - The classification logic is reasonable (keyword-based, heuristic, or configurable)
+      - The response matches Squad's existing tier model (direct/lightweight/standard/full)
+
+  - name: Implements team onboarding
+    prompt: |
+      Write a function that onboards a new agent to a Squad team. It should:
+      1. Create the agent's directory under .squad/agents/{name}/
+      2. Generate a charter.md with the agent's role and responsibilities
+      3. Add the agent to the team roster in team.md
+      Return the paths of all created/modified files.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (mkdir|writeFile|charter\.md|team\.md|agents/)
+      - type: prompt
+    rubric:
+      - The implementation creates the agent directory structure
+      - A charter.md file is generated with role-specific content
+      - The team.md roster is updated (appended, not overwritten)
+      - The function returns the paths of created/modified files
+      - File operations use proper error handling (check existence, handle failures)
+
+  - name: Produces correct routing table format
+    prompt: |
+      Generate a routing.md file for a 3-person team:
+      - Alice (lead): handles architecture, design reviews, planning
+      - Bob (developer): handles bug fixes, features, refactoring
+      - Carol (tester): handles test writing, coverage, QA
+
+      Use the Squad routing table markdown format.
+    graders:
+      - type: output-matches
+        config:
+          pattern: (\|.*Work Type.*\|.*Route To.*\|)
+      - type: output-matches
+        config:
+          pattern: (Alice|Bob|Carol)
+      - type: prompt
+    rubric:
+      - The output uses Squad's markdown table format (| Work Type | Route To | Examples |)
+      - All three team members appear in routing rules
+      - Work types are reasonably mapped (architecture→Alice, bugs→Bob, tests→Carol)
+      - The format is parseable by Squad's parseRoutingMarkdown() function

--- a/evals/task-completion/eval.yaml
+++ b/evals/task-completion/eval.yaml
@@ -39,8 +39,8 @@ stimuli:
         config:
           pattern: (trim|filter|pop|slice)
       - type: prompt
+        name: bug-fix-quality
     rubric:
-      - The fix handles trailing newlines and whitespace (trim, filter empty lines, or skip)
       - The fix does not change unrelated behavior
       - The fix handles edge cases (empty string input, all-whitespace input)
       - The response includes the corrected code, not just a description
@@ -56,11 +56,11 @@ stimuli:
         config:
           pattern: (fast|standard|premium|tier|complexity)
       - type: prompt
+        name: model-selection-quality
     rubric:
       - The response provides a working implementation (not just pseudocode)
       - The function classifies tasks into at least 3 tiers (fast, standard, premium)
       - The classification logic is reasonable (keyword-based, heuristic, or configurable)
-      - The response matches Squad's existing tier model (direct/lightweight/standard/full)
 
   - name: Implements team onboarding
     prompt: |
@@ -74,6 +74,7 @@ stimuli:
         config:
           pattern: (mkdir|writeFile|charter\.md|team\.md|agents/)
       - type: prompt
+        name: onboarding-quality
     rubric:
       - The implementation creates the agent directory structure
       - A charter.md file is generated with role-specific content
@@ -97,8 +98,9 @@ stimuli:
         config:
           pattern: (Alice|Bob|Carol)
       - type: prompt
+        name: routing-table-quality
     rubric:
       - The output uses Squad's markdown table format (| Work Type | Route To | Examples |)
       - All three team members appear in routing rules
-      - Work types are reasonably mapped (architecture→Alice, bugs→Bob, tests→Carol)
+      - Work types are reasonably mapped (architecture to Alice, bugs to Bob, tests to Carol)
       - The format is parseable by Squad's parseRoutingMarkdown() function

--- a/evals/task-completion/eval.yaml
+++ b/evals/task-completion/eval.yaml
@@ -4,6 +4,7 @@ description: |
   prompts, does the agent produce working, correct solutions?
 type: capability
 config:
+  runs: 5
   timeout: 5m
 environment:
   skills:
@@ -17,79 +18,101 @@ environment:
       dest: .squad/agents/lead/charter.md
     - src: fixtures/agents/developer/charter.md
       dest: .squad/agents/developer/charter.md
+    - src: fixtures/src/config.ts
+      dest: src/config.ts
 scoring:
   threshold: 0.7
 stimuli:
   - name: Implements a simple bug fix
     prompt: |
-      The `parseConfig` function crashes when the input YAML has a trailing
-      newline followed by whitespace. Here's the function:
-
-      ```typescript
-      export function parseConfig(raw: string): Config {
-        const lines = raw.split('\n');
-        const lastLine = lines[lines.length - 1];
-        return JSON.parse(lastLine);
-      }
-      ```
-
-      Fix it so it handles trailing whitespace gracefully.
+      The `parseConfig` function in `src/config.ts` crashes when the input YAML
+      has a trailing newline followed by whitespace. Fix it so it handles
+      trailing whitespace gracefully. Edit the file directly.
     graders:
       - type: output-matches
         config:
           pattern: (trim|filter|pop|slice)
+      - type: file-contains
+        name: fix-applied-to-disk
+        config:
+          path: src/config.ts
+          value: trim
       - type: prompt
         name: bug-fix-quality
+        config:
+          scoring: scale_1_5
     rubric:
       - The fix does not change unrelated behavior
       - The fix handles edge cases (empty string input, all-whitespace input)
-      - The response includes the corrected code, not just a description
+      - The agent edited the file on disk, not just described the fix
 
   - name: Implements cost-aware model selection
     prompt: |
-      I need a function that selects the appropriate model tier based on
-      task complexity. Simple tasks (typos, renames) should use the fast
-      tier. Complex tasks (architecture, multi-file refactors) should use
-      the premium tier. Everything else uses standard.
+      Create a file at src/model-selector.ts with a function that selects the
+      appropriate model tier based on task complexity. Simple tasks (typos,
+      renames) should use the fast tier. Complex tasks (architecture, multi-file
+      refactors) should use the premium tier. Everything else uses standard.
+      Write the implementation to disk.
     graders:
       - type: output-matches
         config:
           pattern: (fast|standard|premium|tier|complexity)
+      - type: file-exists
+        name: selector-created
+        config:
+          path: src/model-selector.ts
+      - type: file-contains
+        name: selector-has-tiers
+        config:
+          path: src/model-selector.ts
+          value: fast
       - type: prompt
         name: model-selection-quality
+        config:
+          scoring: scale_1_5
     rubric:
-      - The response provides a working implementation (not just pseudocode)
+      - The response provides a working implementation written to disk
       - The function classifies tasks into at least 3 tiers (fast, standard, premium)
       - The classification logic is reasonable (keyword-based, heuristic, or configurable)
 
   - name: Implements team onboarding
     prompt: |
-      Write a function that onboards a new agent to a Squad team. It should:
-      1. Create the agent's directory under .squad/agents/{name}/
+      Write a function that onboards a new agent named "reviewer" to a Squad team. It should:
+      1. Create the agent's directory under .squad/agents/reviewer/
       2. Generate a charter.md with the agent's role and responsibilities
-      3. Add the agent to the team roster in team.md
-      Return the paths of all created/modified files.
+      3. Add the agent to the team roster in .squad/team.md
+      Execute the function to onboard the "reviewer" agent now.
     graders:
       - type: output-matches
         config:
           pattern: (mkdir|writeFile|charter\.md|team\.md|agents/)
+      - type: file-exists
+        name: charter-created
+        config:
+          path: .squad/agents/reviewer/charter.md
+      - type: file-contains
+        name: roster-updated
+        config:
+          path: .squad/team.md
+          value: reviewer
       - type: prompt
         name: onboarding-quality
+        config:
+          scoring: scale_1_5
     rubric:
       - The implementation creates the agent directory structure
       - A charter.md file is generated with role-specific content
       - The team.md roster is updated (appended, not overwritten)
-      - The function returns the paths of created/modified files
-      - File operations use proper error handling (check existence, handle failures)
+      - The agent executed the operation on disk, not just described it
 
   - name: Produces correct routing table format
     prompt: |
-      Generate a routing.md file for a 3-person team:
+      Generate a routing.md file at .squad/routing-new.md for a 3-person team:
       - Alice (lead): handles architecture, design reviews, planning
       - Bob (developer): handles bug fixes, features, refactoring
       - Carol (tester): handles test writing, coverage, QA
 
-      Use the Squad routing table markdown format.
+      Use the Squad routing table markdown format. Write the file to disk.
     graders:
       - type: output-matches
         config:
@@ -97,10 +120,21 @@ stimuli:
       - type: output-matches
         config:
           pattern: (Alice|Bob|Carol)
+      - type: file-exists
+        name: routing-file-created
+        config:
+          path: .squad/routing-new.md
+      - type: file-contains
+        name: routing-has-table
+        config:
+          path: .squad/routing-new.md
+          value: "|"
       - type: prompt
         name: routing-table-quality
+        config:
+          scoring: scale_1_5
     rubric:
       - The output uses Squad's markdown table format (| Work Type | Route To | Examples |)
       - All three team members appear in routing rules
       - Work types are reasonably mapped (architecture to Alice, bugs to Bob, tests to Carol)
-      - The format is parseable by Squad's parseRoutingMarkdown() function
+      - The file was written to disk, not just output in the response

--- a/evals/task-completion/fixtures/agents/developer/charter.md
+++ b/evals/task-completion/fixtures/agents/developer/charter.md
@@ -1,0 +1,16 @@
+# Developer Agent Charter
+
+## Role
+Feature implementation specialist handling bug fixes, new features, and code refactoring.
+
+## Responsibilities
+- Implement new features from specs
+- Fix bugs and handle error cases
+- Refactor code for maintainability
+- Write clean, tested, production-ready code
+
+## Expertise
+- TypeScript/JavaScript full-stack development
+- Node.js APIs and tooling
+- Git workflows and PR best practices
+- Performance optimization

--- a/evals/task-completion/fixtures/agents/lead/charter.md
+++ b/evals/task-completion/fixtures/agents/lead/charter.md
@@ -1,0 +1,17 @@
+# Lead Agent Charter
+
+## Role
+Technical lead responsible for architecture decisions, design reviews, and team coordination.
+
+## Responsibilities
+- Review and approve architectural changes
+- Design system boundaries and module interfaces
+- Plan technical roadmap and sprint priorities
+- Set coding standards and patterns for the team
+- Triage ambiguous tasks to appropriate team members
+
+## Expertise
+- System architecture and design patterns
+- API design and interface contracts
+- Performance and scalability planning
+- Cross-cutting concerns (logging, auth, error handling)

--- a/evals/task-completion/fixtures/routing.md
+++ b/evals/task-completion/fixtures/routing.md
@@ -1,0 +1,16 @@
+# Routing Rules
+
+## Routing Table
+
+| Work Type | Route To | Examples |
+|-----------|----------|----------|
+| architecture-review | Lead | System design, architecture decisions, module boundaries |
+| design-review | Lead | API design, interface design, pattern review |
+| planning | Lead | Sprint planning, roadmap, technical direction |
+| bug-fix | Developer | Null reference, crash fix, error handling |
+| feature-dev | Developer | New endpoint, new module, feature implementation |
+| refactoring | Developer | Code cleanup, extract function, rename |
+| test-writing | Tester | Unit tests, integration tests, test coverage |
+| quality-assurance | Tester | Test review, coverage gaps, flaky tests |
+| documentation | Scribe | README update, API docs, changelog |
+| api-reference | Scribe | Endpoint docs, parameter docs, examples |

--- a/evals/task-completion/fixtures/src/config.ts
+++ b/evals/task-completion/fixtures/src/config.ts
@@ -1,0 +1,10 @@
+export interface Config {
+  name: string;
+  version: string;
+}
+
+export function parseConfig(raw: string): Config {
+  const lines = raw.split('\n');
+  const lastLine = lines[lines.length - 1];
+  return JSON.parse(lastLine);
+}

--- a/evals/task-completion/fixtures/team.md
+++ b/evals/task-completion/fixtures/team.md
@@ -1,0 +1,16 @@
+# Team Roster
+
+## Squad: Eval Demo Team
+
+| Agent | Role | Capabilities |
+|-------|------|--------------|
+| Lead | lead | Architecture, design reviews, planning, code standards |
+| Developer | developer | Feature implementation, bug fixes, refactoring, code writing |
+| Tester | tester | Test writing, coverage analysis, QA, integration testing |
+| Scribe | scribe | Documentation, API references, READMEs, changelogs |
+
+## Governance
+
+- **Routing**: Work is assigned based on the routing table in routing.md
+- **Escalation**: Ambiguous tasks go to Lead for triage
+- **Reviews**: All PRs require at least one team member review

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.9.1",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bradygaster/squad",
-      "version": "0.9.1",
+      "version": "0.9.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "devDependencies": {
+        "@microsoft/vally": "^0.4.0",
+        "@microsoft/vally-cli": "^0.4.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/sdk-metrics": "^2.5.1",
         "@opentelemetry/sdk-trace-base": "^2.5.1",
@@ -276,6 +278,7 @@
       "integrity": "sha512-Tdfx4eH2uS+gv9V9NCr3Rz+c7RSS6ntXp3Blliud18ibRUlRxO9dTaOjG4iv4x0nAmMeedP1ORkEpeXSkh2QiQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -357,7 +360,8 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.1.tgz",
       "integrity": "sha512-y/Vgo6qY08e1t9OqR56qjoFLBCpi4QfWMf2qzD1l9omRZwvSMQGRPz4x0bxkkkU4oocMAeztjzCsmLew//c/8w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.2",
@@ -497,14 +501,16 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
       "integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
       "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -702,7 +708,8 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -1323,26 +1330,31 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.12.tgz",
-      "integrity": "sha512-GpmoJbs1ECyLLKtY4PcFzO8Cz6GgDTOKkrzwNdkirNdfsB+o6x0OOlFyrOdNXNPII7pk9+GcpIjF87sLwWzpPQ==",
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.51.tgz",
+      "integrity": "sha512-yKXbMeApxO8P68/BeSS/lmIRsCprcMdY8MRRp+Vp/QymCv59o4lxDcAIVq2h/CD8vJHoiG4OijdWydd76yoqLw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.12",
-        "@github/copilot-darwin-x64": "1.0.12",
-        "@github/copilot-linux-arm64": "1.0.12",
-        "@github/copilot-linux-x64": "1.0.12",
-        "@github/copilot-win32-arm64": "1.0.12",
-        "@github/copilot-win32-x64": "1.0.12"
+        "@github/copilot-darwin-arm64": "1.0.51",
+        "@github/copilot-darwin-x64": "1.0.51",
+        "@github/copilot-linux-arm64": "1.0.51",
+        "@github/copilot-linux-x64": "1.0.51",
+        "@github/copilot-linuxmusl-arm64": "1.0.51",
+        "@github/copilot-linuxmusl-x64": "1.0.51",
+        "@github/copilot-win32-arm64": "1.0.51",
+        "@github/copilot-win32-x64": "1.0.51"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.12.tgz",
-      "integrity": "sha512-fjbwRIUZAH06Eyg5ZkfZXg8SVXpqI3HaFhtXZ803CZs9mfIgfOSR3URZxUnv7SIv6aI/7f6ws8RxKnPGavJ/tg==",
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.51.tgz",
+      "integrity": "sha512-i713sW3GzbeLKowGVY6/A97lGkUMJNVdUD0oaUWTWmXX08u+hWsnVKbqL4EQlw7x8xU511X5vkgFMi31DWyCuQ==",
       "cpu": [
         "arm64"
       ],
@@ -1356,9 +1368,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.12.tgz",
-      "integrity": "sha512-/tJGJEEm8kpTW/sJRNnvhMSHKIHApNun14biuIkC5CXDqVgFakbKlckn/FlIkT48eEUysc0YbEatrHIDz/8XbA==",
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.51.tgz",
+      "integrity": "sha512-c67SbMznclcHqlJINXBCwudhqRgE5HNaY9fqMQqu954+ezVa6Q/2hwhCU51PNbYLWtZTGgXsgWnrxOg77hh0ug==",
       "cpu": [
         "x64"
       ],
@@ -1372,9 +1384,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.12.tgz",
-      "integrity": "sha512-4977LVJi3/9Yc+ivj+VKDVtHg0kT5yqOrN8F35/jgqerx4Mdtk1pOMlWztXxLicBHN4y2V7/EY/wc0WqFW0Zvg==",
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.51.tgz",
+      "integrity": "sha512-MlQeTB4CSPnG2BZTxsPSV5a7rjsqFOzhTCVCNjLeht3ODObWjrIYhtzVF7h/nue9ii96u9RBB0gIAfoBReryTw==",
       "cpu": [
         "arm64"
       ],
@@ -1388,9 +1400,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.12.tgz",
-      "integrity": "sha512-9QevJZD29PVltYDV4xHWbdN6ud/966clERL5Frh2+9D3+spaVDO1hFllzoFiEwD/M4f2GkSh7/fT3hV0LKl9Ag==",
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.51.tgz",
+      "integrity": "sha512-fniGTwR5KLFfNDjSFbWvZ3Bno+2bXsMdNM0l3dFHwVTHyBqQSXZ3xvEEDadGimCxgKfRDRt1M1FYnUpqhLYf/Q==",
       "cpu": [
         "x64"
       ],
@@ -1401,6 +1413,38 @@
       ],
       "bin": {
         "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.51.tgz",
+      "integrity": "sha512-vg9sWZw4u/bqHa7ylF/GZeuznt+k4/Em899C++CTBU4CKhtAaxd2TZDsEV0Ap2DXzP2UFxCn77vZoHyxByMI5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.51.tgz",
+      "integrity": "sha512-zxXRdzjshHTQd/LDWmOIDXt0T8nvw66ue6cneAXHhLXWzuiv5mqPKnxuHQyvQDt+IBEyq9utuetlKxcAVo+gYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
       }
     },
     "node_modules/@github/copilot-sdk": {
@@ -1418,9 +1462,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.12.tgz",
-      "integrity": "sha512-RLAbAsLniI8vA2utgZdIsvD8slZpz1fb8l6cmIiQvDE/BwQb2zNV9VepZ+CwzYtNx9ifxBtgIwYwUJq5bxeSaQ==",
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.51.tgz",
+      "integrity": "sha512-/SP8DfOukjllCXavgBNI0qwJa+8hCFRNK7Q3/Q3qzAOvaWUZZkabKSVZfXaGxerTGpGq009Zg3nyIPR0jfm60w==",
       "cpu": [
         "arm64"
       ],
@@ -1434,9 +1478,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.12.tgz",
-      "integrity": "sha512-4SYV09F4Sw20DAib1do26+ALZmCZrghzo+5e6IZbQOsm4B7NhBFaLpKFU+kEijfmWacLlh/at5CpGGGKlwlbcg==",
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.51.tgz",
+      "integrity": "sha512-ZB5Jr9m4ZR8gFOwXnYGNfdU+bMFeUgj1OCU3x64Tx5GC6Uln/pf8Ue5LHlsBkBq/NuKvkp/g4GARDIHBCKXEnQ==",
       "cpu": [
         "x64"
       ],
@@ -1532,6 +1576,350 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.5.tgz",
+      "integrity": "sha512-Jmf9tgBHIEK5SAOB7swYfStqmtkZb00xOTpSQmkoGEpdxOTpJi9RS0A8bkfDPHTTItZRJrRdZrEMu25wyj0VfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.13.tgz",
+      "integrity": "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.10.tgz",
+      "integrity": "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.2.tgz",
+      "integrity": "sha512-Y3Nor7S/DhIPo+8Ym/dSY4efwKI4BsflKDwXh0jNeXJsSF3dteS/3Yf+z4wkibVZDvYMyCgknSTQlNahfunGHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/external-editor": "^3.0.0",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.14.tgz",
+      "integrity": "sha512-qyY9zcIX2eKYwaAUiQo9zORd61Lc3sXeM72fVbeHkYnDkqfr8/armcRbmVAIrExeJhI2puk+uomeKtWrpUVUmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.0.tgz",
+      "integrity": "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.13.tgz",
+      "integrity": "sha512-0l0jCHlJnXIV8CTxwQC0C+5Ziq8WP22edWgmciW2xYvoeoSck4v5FvCS1ctKdqLLR0dUo93uAHgWHywgBSoRyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.13.tgz",
+      "integrity": "sha512-WHmkYnnJAou5gx7RgcvAfUggnHNM1zWfoh0dFPl3dxVssuqt+dK5rIbaOYQXNyOegvFnopbKupjnhw2O8gANNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.13.tgz",
+      "integrity": "sha512-XDGu64ROHZjOOXLAANvJN7iIxWKhOSCG5VakrZ5kaScVR+snVJCFglD/hL3/677awtWcu4pXoWa280CDIYcBeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.3.tgz",
+      "integrity": "sha512-ai5LseTw9HhegupIgmo4cn7RpnCGznjjXu4OI+7jMR8vu7T1ZCCNMzFFAovUCjL1fl0cceksIN1++yQE59SmZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.1.5",
+        "@inquirer/confirm": "^6.0.13",
+        "@inquirer/editor": "^5.1.2",
+        "@inquirer/expand": "^5.0.14",
+        "@inquirer/input": "^5.0.13",
+        "@inquirer/number": "^4.0.13",
+        "@inquirer/password": "^5.0.13",
+        "@inquirer/rawlist": "^5.2.9",
+        "@inquirer/search": "^4.1.9",
+        "@inquirer/select": "^5.1.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.9.tgz",
+      "integrity": "sha512-a1ErXEfgjfPYpyQ89dp+7n2IISjH9oQg3ygvF5adz8B7aHn4n2PjEgu1wpVTp69K3bj3lVLxP0qJ2b1clk1Whw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.9.tgz",
+      "integrity": "sha512-ZlbM28Q9lmLkFPNAIv+ZuY530n5Km8U1WW48oYEvDhe9yc2uL3m3t+JSdRUkQlk5fuIuskgiIVjcb7czFzQpuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.5.tgz",
+      "integrity": "sha512-6SRg6kHfK/sjLXOsuqNebuir+sjwrf/iWuRUnXgB2slzEewppI1WfzeS16XxDcOQmXBruMmmB9Cgrz7wsAxqMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1637,6 +2025,47 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@microsoft/vally": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally/-/vally-0.4.0.tgz",
+      "integrity": "sha512-OhqxzeyhFT3JCJkTj5WXXFDUUvKzfV+i6zKU7RoUzrjAC/qUFs8BMzSJEojM/cFfucSYhIqxfNHsM+hRJvhZ8g==",
+      "dev": true,
+      "dependencies": {
+        "@github/copilot-sdk": "0.3.0",
+        "js-tiktoken": "^1.0.21",
+        "picomatch": "^4.0.4",
+        "yaml": "^2.8.2"
+      }
+    },
+    "node_modules/@microsoft/vally-cli": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/vally-cli/-/vally-cli-0.4.0.tgz",
+      "integrity": "sha512-YQuPXZDUVLMvA89UjzmLv+S7OcrpnhZz8H2w16sa+E5CBj82pTu88/UL3wCncRZXCVvfugA+TpYGUvk0LgfyrA==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/prompts": "^8.4.2",
+        "@microsoft/vally": "^0.4.0",
+        "commander": "^14.0.3"
+      },
+      "bin": {
+        "vally": "dist/index.js"
+      }
+    },
+    "node_modules/@microsoft/vally/node_modules/@github/copilot-sdk": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.3.0.tgz",
+      "integrity": "sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.36-0",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1681,6 +2110,7 @@
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3770,6 +4200,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3844,6 +4275,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -4197,6 +4629,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4338,6 +4771,27 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -4462,6 +4916,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -4553,6 +5014,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -4973,6 +5444,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -5144,6 +5624,7 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5496,6 +5977,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5846,6 +6354,23 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -6307,6 +6832,16 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -6553,6 +7088,7 @@
       "integrity": "sha512-DzzmbqfMW3EzHsunP66x556oZDzjcdjjlL2bHG4PubwnL58ZPAfz07px4GqteZkoCGnBYi779Y2mg7+vgNCwbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "globby": "16.1.0",
         "js-yaml": "4.1.1",
@@ -7214,6 +7750,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -7604,6 +8150,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7790,6 +8337,13 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -8306,6 +8860,7 @@
       "integrity": "sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -8343,6 +8898,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8394,6 +8950,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8507,6 +9064,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -8928,11 +9486,11 @@
     },
     "packages/squad-cli": {
       "name": "@bradygaster/squad-cli",
-      "version": "0.9.4-insider.1",
+      "version": "0.9.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bradygaster/squad-sdk": "0.9.4-insider.1",
+        "@bradygaster/squad-sdk": "0.9.4",
         "ink": "^6.8.0",
         "react": "^19.2.4",
         "vscode-jsonrpc": "^8.2.1"
@@ -9442,7 +10000,7 @@
     },
     "packages/squad-sdk": {
       "name": "@bradygaster/squad-sdk",
-      "version": "0.9.4-insider.1",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^0.1.32",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.9.4",
+  "version": "0.9.4-build.2",
   "private": true,
   "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",
@@ -18,6 +18,8 @@
     "lint:docs": "markdownlint-cli2 && cspell --no-progress --dot \"docs/src/content/**/*.md\" \"README.md\"",
     "dev:link": "npm run build && cd packages/squad-sdk && npm link && cd ../squad-cli && npm link",
     "dev:unlink": "cd packages/squad-cli && npm unlink && cd ../squad-sdk && npm unlink",
+    "eval": "npx vally eval --eval-spec evals/routing/eval.yaml --eval-spec evals/skill-invocation/eval.yaml --eval-spec evals/task-completion/eval.yaml",
+    "eval:lint": "npx vally lint --eval evals/",
     "docs:api": "node scripts/generate-api-docs.mjs",
     "docs:build": "npm run docs:api && cd docs && npm run build",
     "docs:dev": "cd docs && npm run dev",
@@ -27,6 +29,8 @@
     "node": ">=22.5.0"
   },
   "devDependencies": {
+    "@microsoft/vally": "^0.4.0",
+    "@microsoft/vally-cli": "^0.4.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-metrics": "^2.5.1",
     "@opentelemetry/sdk-trace-base": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.9.4-build.2",
+  "version": "0.9.4-build.1",
   "private": true,
   "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",


### PR DESCRIPTION
## Add vally eval suite (copilot-sdk executor)

End-to-end agent evaluations using @microsoft/vally-cli (v0.4.0) with the copilot-sdk executor. Tests real agent behavior against realistic Squad workspace fixtures.

### Eval Suites

| Suite | Stimuli | What it tests |
|-------|---------|---------------|
| routing | 6 | Agent routes user prompts to the correct squad member |
| skill-invocation | 5 | Agent identifies and invokes the right skill for a task |
| task-completion | 4 | Agent produces complete, correct outputs for real tasks |

Each suite uses `.squad/` workspace fixtures (team.md, routing.md, agent charters, SKILL.md files) so vally's copilot-sdk executor sees the same context a real Squad agent would.

### Grading

- `output-matches` graders for deterministic routing/skill checks with action-verb context to avoid false positives
- `prompt` graders with rubrics for open-ended quality assessment, named for JUnit attribution
- Scoring threshold: 70% per suite

### CI Integration

`.github/workflows/evals.yml` provides two jobs:

1. **validate**: runs `vally lint` on every PR touching `evals/` or SDK source
2. **run-evals**: full eval execution, gated behind `run-evals` label or manual dispatch. Requires Copilot SDK credentials.

Results upload as JUnit artifacts for download. Evals are advisory and don't block merge.

### Running locally

```bash
npx vally lint --eval evals/           # validate schemas (no credentials)
npx vally eval --eval-spec evals/routing/eval.yaml   # run single suite
```

### Files

- `evals/routing/eval.yaml` with fixtures (team, routing, agent charters)
- `evals/skill-invocation/eval.yaml` with fixtures (team, routing, skills, agent charters)
- `evals/task-completion/eval.yaml` with fixtures (team, routing, agents)
- `evals/README.md`
- `.github/workflows/evals.yml`
- `package.json` (added vally devDependency)

Closes #1112
