### PR TITLE
Fix current datetime propagation

### DIFF
--- a/.changeset/fix-current-datetime-propagation.md
+++ b/.changeset/fix-current-datetime-propagation.md
@@ -1,0 +1,6 @@
+---
+'@bradygaster/squad-cli': patch
+'@bradygaster/squad-sdk': patch
+---
+
+Fix coordinator and Scribe templates so spawned agents receive and write the resolved current datetime instead of placeholder text.

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -3,14 +3,14 @@ name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
 ---
 
-<!-- version: 0.9.1 -->
+<!-- version: 0.0.0-source -->
 
 You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
 
 ### Coordinator Identity
 
 - **Name:** Squad (Coordinator)
-- **Version:** 0.9.1 (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v0.9.1` in your first response of each session (e.g., in the acknowledgment or greeting).
+- **Version:** 0.0.0-source (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v{version}` in your first response of each session (e.g., in the acknowledgment or greeting).
 - **Role:** Agent orchestration, handoff enforcement, reviewer gating
 - **Inputs:** User request, repository state, `.squad/decisions.md`
 - **Outputs owned:** Final assembled artifacts, orchestration log (via Scribe)
@@ -105,7 +105,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 
-**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Pass the team root and the current datetime (from `<current_datetime>` in your system context) into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
+**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
 **Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
@@ -336,7 +336,7 @@ description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
@@ -360,7 +360,7 @@ prompt: |
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
 ```
 
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: {current_datetime} — {question} TEAM ROOT: {team_root}"`
+For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`
 
 ### Per-Agent Model Selection
 
@@ -784,7 +784,7 @@ prompt: |
   {paste contents of .squad/agents/{name}/charter.md here}
   
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   All `.squad/` paths are relative to this root.
   
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
@@ -900,7 +900,8 @@ prompt: |
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
-     `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "{current_datetime}"}'`
+     `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`
+     Substitute the actual CURRENT_DATETIME value; do not write placeholder text.
   2. If you made a team-relevant decision, include it in the JSON:
      Add a `"decision"` field with `"title"`, `"what"`, and `"why"` keys.
      Scribe will merge decisions into the canonical decisions.md.
@@ -969,7 +970,7 @@ description: "📋 Scribe: Log session & merge decisions"
 prompt: |
   You are the Scribe. Read .squad/agents/scribe/charter.md.
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   STATE_BACKEND: {state_backend}
 
   SPAWN MANIFEST: {spawn_manifest}

--- a/.squad-templates/scribe-charter.md
+++ b/.squad-templates/scribe-charter.md
@@ -96,7 +96,7 @@ After every substantial work session:
    - **Exact duplicates:** If two blocks share the same heading, keep the first and remove the rest.
    - **Overlapping decisions:** Compare block content across all remaining blocks. If two or more blocks cover the same area (same topic, same architectural concern, same component) but were written independently (different dates, different authors), consolidate them:
      a. Synthesize a single merged block that combines the intent and rationale from all overlapping blocks.
-     b. Use the CURRENT_DATETIME value from your spawn prompt and a new heading: `### {CURRENT_DATETIME}: {consolidated topic} (consolidated)`
+     b. Use the literal CURRENT_DATETIME value from your spawn prompt and a new heading: `### <CURRENT_DATETIME value>: {consolidated topic} (consolidated)`. Substitute the actual timestamp; do not write placeholder text.
      c. Credit all original authors: `**By:** {Name1}, {Name2}`
      d. Under **What:**, combine the decisions. Note any differences or evolution.
      e. Under **Why:**, merge the rationale, preserving unique reasoning from each.
@@ -106,7 +106,7 @@ After every substantial work session:
 4. **Propagate cross-agent updates:**
    For any newly merged decision that affects other agents, append to their `history.md`:
    ```
-   📌 Team update ({timestamp}): {summary} — decided by {Name}
+   📌 Team update (<CURRENT_DATETIME value>): {summary} — decided by {Name}
    ```
 
 5. **Commit `.squad/` changes:**

--- a/.squad-templates/scribe-charter.md
+++ b/.squad-templates/scribe-charter.md
@@ -104,7 +104,7 @@ After every substantial work session:
    - Write the updated file back. This handles duplicates and convergent decisions introduced by `merge=union` across branches.
 
 4. **Propagate cross-agent updates:**
-   For any newly merged decision that affects other agents, append to their `history.md`:
+   For any newly merged decision that affects other agents, append to their `history.md`. Replace the parenthetical timestamp with the literal CURRENT_DATETIME value from your spawn prompt; do not write placeholder text.
    ```
    📌 Team update (<CURRENT_DATETIME value>): {summary} — decided by {Name}
    ```

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -105,7 +105,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 
-**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Pass the team root and the current datetime (from `<current_datetime>` in your system context) into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
+**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
 **Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
@@ -336,7 +336,7 @@ description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
@@ -360,7 +360,7 @@ prompt: |
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
 ```
 
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: {current_datetime} — {question} TEAM ROOT: {team_root}"`
+For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`
 
 ### Per-Agent Model Selection
 
@@ -784,7 +784,7 @@ prompt: |
   {paste contents of .squad/agents/{name}/charter.md here}
   
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   All `.squad/` paths are relative to this root.
   
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
@@ -900,7 +900,8 @@ prompt: |
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
-     `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "{current_datetime}"}'`
+     `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`
+     Substitute the actual CURRENT_DATETIME value; do not write placeholder text.
   2. If you made a team-relevant decision, include it in the JSON:
      Add a `"decision"` field with `"title"`, `"what"`, and `"why"` keys.
      Scribe will merge decisions into the canonical decisions.md.
@@ -969,7 +970,7 @@ description: "📋 Scribe: Log session & merge decisions"
 prompt: |
   You are the Scribe. Read .squad/agents/scribe/charter.md.
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   STATE_BACKEND: {state_backend}
 
   SPAWN MANIFEST: {spawn_manifest}

--- a/packages/squad-cli/templates/scribe-charter.md
+++ b/packages/squad-cli/templates/scribe-charter.md
@@ -96,7 +96,7 @@ After every substantial work session:
    - **Exact duplicates:** If two blocks share the same heading, keep the first and remove the rest.
    - **Overlapping decisions:** Compare block content across all remaining blocks. If two or more blocks cover the same area (same topic, same architectural concern, same component) but were written independently (different dates, different authors), consolidate them:
      a. Synthesize a single merged block that combines the intent and rationale from all overlapping blocks.
-     b. Use the CURRENT_DATETIME value from your spawn prompt and a new heading: `### {CURRENT_DATETIME}: {consolidated topic} (consolidated)`
+     b. Use the literal CURRENT_DATETIME value from your spawn prompt and a new heading: `### <CURRENT_DATETIME value>: {consolidated topic} (consolidated)`. Substitute the actual timestamp; do not write placeholder text.
      c. Credit all original authors: `**By:** {Name1}, {Name2}`
      d. Under **What:**, combine the decisions. Note any differences or evolution.
      e. Under **Why:**, merge the rationale, preserving unique reasoning from each.
@@ -106,7 +106,7 @@ After every substantial work session:
 4. **Propagate cross-agent updates:**
    For any newly merged decision that affects other agents, append to their `history.md`:
    ```
-   📌 Team update ({timestamp}): {summary} — decided by {Name}
+   📌 Team update (<CURRENT_DATETIME value>): {summary} — decided by {Name}
    ```
 
 5. **Commit `.squad/` changes:**

--- a/packages/squad-cli/templates/scribe-charter.md
+++ b/packages/squad-cli/templates/scribe-charter.md
@@ -104,7 +104,7 @@ After every substantial work session:
    - Write the updated file back. This handles duplicates and convergent decisions introduced by `merge=union` across branches.
 
 4. **Propagate cross-agent updates:**
-   For any newly merged decision that affects other agents, append to their `history.md`:
+   For any newly merged decision that affects other agents, append to their `history.md`. Replace the parenthetical timestamp with the literal CURRENT_DATETIME value from your spawn prompt; do not write placeholder text.
    ```
    📌 Team update (<CURRENT_DATETIME value>): {summary} — decided by {Name}
    ```

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -105,7 +105,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 
-**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Pass the team root and the current datetime (from `<current_datetime>` in your system context) into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
+**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
 **Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
@@ -336,7 +336,7 @@ description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
@@ -360,7 +360,7 @@ prompt: |
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
 ```
 
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: {current_datetime} — {question} TEAM ROOT: {team_root}"`
+For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`
 
 ### Per-Agent Model Selection
 
@@ -784,7 +784,7 @@ prompt: |
   {paste contents of .squad/agents/{name}/charter.md here}
   
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   All `.squad/` paths are relative to this root.
   
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
@@ -900,7 +900,8 @@ prompt: |
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
-     `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "{current_datetime}"}'`
+     `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`
+     Substitute the actual CURRENT_DATETIME value; do not write placeholder text.
   2. If you made a team-relevant decision, include it in the JSON:
      Add a `"decision"` field with `"title"`, `"what"`, and `"why"` keys.
      Scribe will merge decisions into the canonical decisions.md.
@@ -969,14 +970,14 @@ description: "📋 Scribe: Log session & merge decisions"
 prompt: |
   You are the Scribe. Read .squad/agents/scribe/charter.md.
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   STATE_BACKEND: {state_backend}
 
   SPAWN MANIFEST: {spawn_manifest}
 
   Tasks (in order):
   {% if STATE_BACKEND == "orphan" or STATE_BACKEND == "git-notes" or STATE_BACKEND == "two-layer" %}
-  0. STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
+  0. PRE-CHECK — STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
      (.squad/decisions.md, agents/*/history.md, log/*, orchestration-log/*, decisions/inbox/*)
      to the working branch. If found: unstage with `git reset HEAD -- {file}`, restore with
      `git checkout HEAD -- {file}`. If leaked in last commit, amend to remove. Log count.

--- a/packages/squad-sdk/templates/scribe-charter.md
+++ b/packages/squad-sdk/templates/scribe-charter.md
@@ -96,7 +96,7 @@ After every substantial work session:
    - **Exact duplicates:** If two blocks share the same heading, keep the first and remove the rest.
    - **Overlapping decisions:** Compare block content across all remaining blocks. If two or more blocks cover the same area (same topic, same architectural concern, same component) but were written independently (different dates, different authors), consolidate them:
      a. Synthesize a single merged block that combines the intent and rationale from all overlapping blocks.
-     b. Use the CURRENT_DATETIME value from your spawn prompt and a new heading: `### {CURRENT_DATETIME}: {consolidated topic} (consolidated)`
+     b. Use the literal CURRENT_DATETIME value from your spawn prompt and a new heading: `### <CURRENT_DATETIME value>: {consolidated topic} (consolidated)`. Substitute the actual timestamp; do not write placeholder text.
      c. Credit all original authors: `**By:** {Name1}, {Name2}`
      d. Under **What:**, combine the decisions. Note any differences or evolution.
      e. Under **Why:**, merge the rationale, preserving unique reasoning from each.
@@ -106,7 +106,7 @@ After every substantial work session:
 4. **Propagate cross-agent updates:**
    For any newly merged decision that affects other agents, append to their `history.md`:
    ```
-   📌 Team update ({timestamp}): {summary} — decided by {Name}
+   📌 Team update (<CURRENT_DATETIME value>): {summary} — decided by {Name}
    ```
 
 5. **Commit `.squad/` changes:**

--- a/packages/squad-sdk/templates/scribe-charter.md
+++ b/packages/squad-sdk/templates/scribe-charter.md
@@ -104,7 +104,7 @@ After every substantial work session:
    - Write the updated file back. This handles duplicates and convergent decisions introduced by `merge=union` across branches.
 
 4. **Propagate cross-agent updates:**
-   For any newly merged decision that affects other agents, append to their `history.md`:
+   For any newly merged decision that affects other agents, append to their `history.md`. Replace the parenthetical timestamp with the literal CURRENT_DATETIME value from your spawn prompt; do not write placeholder text.
    ```
    📌 Team update (<CURRENT_DATETIME value>): {summary} — decided by {Name}
    ```

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -105,7 +105,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 
-**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Pass the team root and the current datetime (from `<current_datetime>` in your system context) into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
+**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
 **Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
@@ -336,7 +336,7 @@ description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
@@ -360,7 +360,7 @@ prompt: |
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
 ```
 
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: {current_datetime} — {question} TEAM ROOT: {team_root}"`
+For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`
 
 ### Per-Agent Model Selection
 
@@ -784,7 +784,7 @@ prompt: |
   {paste contents of .squad/agents/{name}/charter.md here}
   
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   All `.squad/` paths are relative to this root.
   
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
@@ -900,7 +900,8 @@ prompt: |
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
-     `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "{current_datetime}"}'`
+     `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`
+     Substitute the actual CURRENT_DATETIME value; do not write placeholder text.
   2. If you made a team-relevant decision, include it in the JSON:
      Add a `"decision"` field with `"title"`, `"what"`, and `"why"` keys.
      Scribe will merge decisions into the canonical decisions.md.
@@ -969,14 +970,14 @@ description: "📋 Scribe: Log session & merge decisions"
 prompt: |
   You are the Scribe. Read .squad/agents/scribe/charter.md.
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   STATE_BACKEND: {state_backend}
 
   SPAWN MANIFEST: {spawn_manifest}
 
   Tasks (in order):
   {% if STATE_BACKEND == "orphan" or STATE_BACKEND == "git-notes" or STATE_BACKEND == "two-layer" %}
-  0. STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
+  0. PRE-CHECK — STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
      (.squad/decisions.md, agents/*/history.md, log/*, orchestration-log/*, decisions/inbox/*)
      to the working branch. If found: unstage with `git reset HEAD -- {file}`, restore with
      `git checkout HEAD -- {file}`. If leaked in last commit, amend to remove. Log count.

--- a/templates/scribe-charter.md
+++ b/templates/scribe-charter.md
@@ -96,7 +96,7 @@ After every substantial work session:
    - **Exact duplicates:** If two blocks share the same heading, keep the first and remove the rest.
    - **Overlapping decisions:** Compare block content across all remaining blocks. If two or more blocks cover the same area (same topic, same architectural concern, same component) but were written independently (different dates, different authors), consolidate them:
      a. Synthesize a single merged block that combines the intent and rationale from all overlapping blocks.
-     b. Use the CURRENT_DATETIME value from your spawn prompt and a new heading: `### {CURRENT_DATETIME}: {consolidated topic} (consolidated)`
+     b. Use the literal CURRENT_DATETIME value from your spawn prompt and a new heading: `### <CURRENT_DATETIME value>: {consolidated topic} (consolidated)`. Substitute the actual timestamp; do not write placeholder text.
      c. Credit all original authors: `**By:** {Name1}, {Name2}`
      d. Under **What:**, combine the decisions. Note any differences or evolution.
      e. Under **Why:**, merge the rationale, preserving unique reasoning from each.
@@ -106,7 +106,7 @@ After every substantial work session:
 4. **Propagate cross-agent updates:**
    For any newly merged decision that affects other agents, append to their `history.md`:
    ```
-   📌 Team update ({timestamp}): {summary} — decided by {Name}
+   📌 Team update (<CURRENT_DATETIME value>): {summary} — decided by {Name}
    ```
 
 5. **Commit `.squad/` changes:**

--- a/templates/scribe-charter.md
+++ b/templates/scribe-charter.md
@@ -104,7 +104,7 @@ After every substantial work session:
    - Write the updated file back. This handles duplicates and convergent decisions introduced by `merge=union` across branches.
 
 4. **Propagate cross-agent updates:**
-   For any newly merged decision that affects other agents, append to their `history.md`:
+   For any newly merged decision that affects other agents, append to their `history.md`. Replace the parenthetical timestamp with the literal CURRENT_DATETIME value from your spawn prompt; do not write placeholder text.
    ```
    📌 Team update (<CURRENT_DATETIME value>): {summary} — decided by {Name}
    ```

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -105,7 +105,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 
-**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Pass the team root and the current datetime (from `<current_datetime>` in your system context) into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
+**On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
 **Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
@@ -336,7 +336,7 @@ description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
@@ -360,7 +360,7 @@ prompt: |
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
 ```
 
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: {current_datetime} — {question} TEAM ROOT: {team_root}"`
+For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`
 
 ### Per-Agent Model Selection
 
@@ -784,7 +784,7 @@ prompt: |
   {paste contents of .squad/agents/{name}/charter.md here}
   
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   All `.squad/` paths are relative to this root.
   
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
@@ -900,7 +900,8 @@ prompt: |
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
-     `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "{current_datetime}"}'`
+     `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`
+     Substitute the actual CURRENT_DATETIME value; do not write placeholder text.
   2. If you made a team-relevant decision, include it in the JSON:
      Add a `"decision"` field with `"title"`, `"what"`, and `"why"` keys.
      Scribe will merge decisions into the canonical decisions.md.
@@ -969,14 +970,14 @@ description: "📋 Scribe: Log session & merge decisions"
 prompt: |
   You are the Scribe. Read .squad/agents/scribe/charter.md.
   TEAM ROOT: {team_root}
-  CURRENT_DATETIME: {current_datetime}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   STATE_BACKEND: {state_backend}
 
   SPAWN MANIFEST: {spawn_manifest}
 
   Tasks (in order):
   {% if STATE_BACKEND == "orphan" or STATE_BACKEND == "git-notes" or STATE_BACKEND == "two-layer" %}
-  0. STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
+  0. PRE-CHECK — STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
      (.squad/decisions.md, agents/*/history.md, log/*, orchestration-log/*, decisions/inbox/*)
      to the working branch. If found: unstage with `git reset HEAD -- {file}`, restore with
      `git checkout HEAD -- {file}`. If leaked in last commit, amend to remove. Log count.

--- a/test/ci/datetime-template.test.ts
+++ b/test/ci/datetime-template.test.ts
@@ -1,0 +1,66 @@
+/**
+ * CI tests for current datetime propagation in Squad templates.
+ *
+ * Canonical source: .squad-templates/
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '../..');
+
+function readTemplate(relPath: string): string {
+  return readFileSync(resolve(ROOT, relPath), 'utf-8');
+}
+
+describe('current datetime template contract', () => {
+  const squadTemplate = readTemplate('.squad-templates/squad.agent.md');
+  const scribeCharter = readTemplate('.squad-templates/scribe-charter.md');
+
+  it('requires resolving and validating the runtime current datetime once per session', () => {
+    const sessionStart = squadTemplate.slice(
+      squadTemplate.indexOf('**On every session start:**'),
+      squadTemplate.indexOf('**Resolve state backend:**'),
+    );
+
+    expect(sessionStart).toContain('<current_datetime>');
+    expect(sessionStart).toContain('Resolve `CURRENT_DATETIME` once');
+    expect(sessionStart).toContain('Sanity-check');
+    expect(sessionStart).toContain('plausible year and timezone');
+    expect(sessionStart).toContain('local date command');
+    expect(sessionStart).toContain('Never pass placeholder text for `CURRENT_DATETIME`');
+  });
+
+  it('does not pass unresolved current_datetime placeholders to spawned agents', () => {
+    expect(squadTemplate).not.toContain('CURRENT_DATETIME: {current_datetime}');
+    expect(squadTemplate).not.toContain('"{current_datetime}"');
+    expect(squadTemplate).not.toContain('CURRENT_DATETIME: {CURRENT_DATETIME}');
+  });
+
+  it('keeps every coordinator spawn template wired with CURRENT_DATETIME', () => {
+    const currentDatetimeLines = squadTemplate
+      .split('\n')
+      .filter(line => line.includes('CURRENT_DATETIME:'));
+
+    expect(currentDatetimeLines.length).toBeGreaterThanOrEqual(4);
+    for (const line of currentDatetimeLines) {
+      expect(line).toContain('<resolved CURRENT_DATETIME literal>');
+    }
+  });
+
+  it('tells agents to substitute the literal datetime in command examples', () => {
+    expect(squadTemplate).toContain('<literal CURRENT_DATETIME value from your prompt>');
+    expect(squadTemplate).toContain('Substitute the actual CURRENT_DATETIME value');
+  });
+
+  it('keeps Scribe from writing placeholder datetime headings', () => {
+    expect(scribeCharter).not.toContain('### {CURRENT_DATETIME}:');
+    expect(scribeCharter).not.toContain('({timestamp})');
+    expect(scribeCharter).toContain('### <CURRENT_DATETIME value>:');
+    expect(scribeCharter).toContain('Substitute the actual timestamp');
+    expect(scribeCharter).toContain('📌 Team update (<CURRENT_DATETIME value>):');
+  });
+});

--- a/test/ci/datetime-template.test.ts
+++ b/test/ci/datetime-template.test.ts
@@ -61,6 +61,7 @@ describe('current datetime template contract', () => {
     expect(scribeCharter).not.toContain('({timestamp})');
     expect(scribeCharter).toContain('### <CURRENT_DATETIME value>:');
     expect(scribeCharter).toContain('Substitute the actual timestamp');
-    expect(scribeCharter).toContain('📌 Team update (<CURRENT_DATETIME value>):');
+    expect(scribeCharter).toContain('Replace the parenthetical timestamp with the literal CURRENT_DATETIME value');
+    expect(scribeCharter).toContain('do not write placeholder text');
   });
 });


### PR DESCRIPTION
### What
Updates the Squad coordinator and Scribe templates so spawned agents receive a resolved `CURRENT_DATETIME` value instead of unresolved placeholder text. Adds regression coverage and a patch changeset for the template behavior.

### Why
Clean/new Squad sessions could carry `{current_datetime}` through spawn examples, leaving agents to infer or write the wrong day/time.

Fixes: #1119

### How
The coordinator now resolves `CURRENT_DATETIME` once from `<current_datetime>`, sanity-checks it, and falls back to a local date command if the system value is missing or implausible. Date-bearing agent and Scribe examples now explicitly require substituting the literal received timestamp, and synced template mirrors keep init/upgrade output aligned.

---

### ⚠️ Quick Check
- [x] If SDK/CLI source files changed: completed the applicable Changeset step below (`npx changeset add` / `.changeset/*.md`, direct `CHANGELOG.md` entry for maintainers, or `skip-changelog` label for no user-facing changes)

### PR Readiness Checklist

> The PR readiness bot will validate these automatically after push.
> Check each item before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for full details.

#### Branch & Commit
- [x] Branch created from `dev` (not `main`)
- [ ] Branch is up to date with `dev` (`git fetch upstream && git rebase upstream/dev`)
- [x] Verified diff contains only intended changes (`git diff --cached --stat`)
- [x] PR is **not** in draft mode (mark ready when checks pass)
- [x] Commit history is clean (squash fixups before review)

#### Build & Test
- [x] `npm run build` passes
- [ ] `npm test` passes (all tests green)
- [x] `npm run lint` passes (type check clean)
- [x] `npm run lint:eslint` passes
- [ ] For migration PRs (>20 files): include test output summary in PR description

#### Changeset
- [x] Changeset added via `npx changeset add` (if `packages/squad-sdk/src/` or `packages/squad-cli/src/` changed)
- [ ] Or direct `CHANGELOG.md` entry (maintainers only — write-protected for external contributors)
- [ ] Or `skip-changelog` label applied (if no user-facing changes)

#### Docs
N/A - this fixes generated coordinator/Scribe template behavior, not a new feature or docs page.
- [ ] README section updated (if new feature/module)
- [ ] Docs feature page (if new user-facing capability)

#### Exports
N/A - no SDK module exports changed.
- [ ] package.json subpath exports updated (if new module)

---

### Breaking Changes
None.

### Waivers
N/A.