### PR TITLE
feat: add extension-fragments mechanism for coordinator plugins

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -542,7 +542,62 @@ Never crash or halt because an MCP tool is missing. MCP tools are enhancements, 
 2. **Inform the user** — "Trello integration requires the Trello MCP server. Add it to `.copilot/mcp-config.json`."
 3. **Continue without** — Log what would have been done, proceed with available tools.
 
-### Eager Execution Philosophy
+### Extension Fragments
+
+Extension fragments let MCP packages, domain tools, and team-specific plugins extend your Squad coordinator context without forking or editing `squad.agent.md` directly. Changes survive Squad upgrades.
+
+#### Where fragments live
+
+- **User-global:** `~/.squad/extensions/coordinator/*.md` — applies to every project on this machine.
+- **Project-local:** `<repo>/.squad/extensions/coordinator/*.md` — applies only in this repo; takes precedence over the user-global copy of the same filename.
+
+Scan both directories at coordinator boot. Load every `.md` file found. Project-local files with the same name as a user-global file WIN (project-local overrides user-global entirely for that filename).
+
+#### Fragment format
+
+Each fragment is a plain Markdown file with an optional YAML front matter block:
+
+```yaml
+---
+name: squadboard          # unique key; matches filename without .md
+version: 0.1.0
+extends: squad            # must be "squad"
+inject_into:              # where content is appended
+  - after-mcp-detection  # after you scan for MCP tools at task start
+---
+```
+
+Body: plain Markdown instructions, same voice and style as this document. Imperative, coordinator-voice ("You DO / You DO NOT"). Keep it ≤200 lines.
+
+#### Loading rules
+
+1. **Silent skip on missing.** If neither directory exists, continue without error.
+2. **Silent skip on malformed.** If a fragment has no `extends: squad` in its front matter, skip it and log a warning to stderr (never fail the session).
+3. **Append, don't replace.** Fragment content is appended to the coordinator context after the `inject_into` target section. It does not replace any upstream rules.
+4. **Detection-guarded fragments.** Fragments should guard their own tool workflows: "If tools with prefix `{service}_` are present, then…". This ensures fragments degrade gracefully when their MCP server isn't installed.
+5. **Anti-patterns to reject.** Fragments MUST NOT contradict upstream governance rules, dispatch agents (call tools instead), assume repo-specific paths, or fail silently on errors in their own logic.
+
+#### For plugin authors
+
+A minimal squadboard fragment example:
+
+```markdown
+---
+name: squadboard
+version: 0.1.0
+extends: squad
+inject_into: [after-mcp-detection]
+---
+
+## Squadboard Integration
+
+If tools with the `squadboard_` prefix exist, Squadboard is installed. Use:
+- `squadboard_capture` — drop a directive into the board inbox
+- `squadboard_list_issues` — read the backlog
+```
+
+Install the fragment via a postinstall script to `~/.squad/extensions/coordinator/squadboard.md`. See [docs/plugins/squad-coordinator-extensions.md](../../docs/plugins/squad-coordinator-extensions.md) for the full authoring guide and postinstall pattern.
+
 
 > **⚠️ Exception:** Eager Execution does NOT apply during Init Mode Phase 1. Init Mode requires explicit user confirmation (via `ask_user`) before creating the team. Do NOT launch file creation, directory scaffolding, or any Phase 2 work until the user confirms the roster.
 
@@ -1073,6 +1128,7 @@ If the user wants to remove someone:
 | File | Status | Who May Write | Who May Read |
 |------|--------|---------------|--------------|
 | `.github/agents/squad.agent.md` | **Authoritative governance.** All roles, handoffs, gates, and enforcement rules. | Repo maintainer (human) | Squad (Coordinator) |
+| `~/.squad/extensions/coordinator/*.md` | **Extension fragments.** Additive coordinator context from plugins. Project-local (`.squad/extensions/`) overrides user-global (`~/.squad/extensions/`). | Plugin postinstall scripts | Squad (Coordinator) — loaded at boot |
 | `.squad/decisions.md` | **Authoritative decision ledger.** Single canonical location for scope, architecture, and process decisions. | Squad (Coordinator) — append only | All agents |
 | `.squad/team.md` | **Authoritative roster.** Current team composition. | Squad (Coordinator) | All agents |
 | `.squad/routing.md` | **Authoritative routing.** Work assignment rules. | Squad (Coordinator) | Squad (Coordinator) |

--- a/docs/plugins/squad-coordinator-extensions.md
+++ b/docs/plugins/squad-coordinator-extensions.md
@@ -1,0 +1,188 @@
+# Squad Coordinator Extension Fragments — Plugin Author Guide
+
+Any npm package, CLI tool, or internal team script can extend the Squad coordinator's system prompt without forking `squad.agent.md`. Extensions survive Squad upgrades and work for every user who installs your package.
+
+---
+
+## How It Works
+
+When Squad boots, it scans two directories for `.md` files:
+
+| Directory | Scope |
+|-----------|-------|
+| `~/.squad/extensions/coordinator/` | User-global — applies to every project on this machine |
+| `<repo>/.squad/extensions/coordinator/` | Project-local — applies only in this repo |
+
+Every `.md` file in these directories is loaded and its content is appended to the coordinator's context at the location specified by `inject_into`. Project-local files override user-global files **with the same filename**.
+
+---
+
+## Fragment Format
+
+A fragment is a Markdown file with optional YAML front matter:
+
+```markdown
+---
+name: my-plugin           # unique key; must match the filename (without .md)
+version: 0.1.0
+extends: squad            # must be "squad" — other values are silently ignored
+inject_into:
+  - after-mcp-detection   # after the coordinator scans for MCP tools
+---
+
+## My Plugin Integration
+
+If tools with the `myplugin_` prefix are present, My Plugin is installed. You can:
+
+- `myplugin_read` — read data from My Plugin
+- `myplugin_write` — write data to My Plugin
+
+When the user asks to sync with My Plugin, call `myplugin_read` first to check current state.
+
+### Boundaries
+
+**You DO NOT:**
+- Call My Plugin tools when the user has not opted in.
+- Invent My Plugin IDs — always look them up via `myplugin_list`.
+```
+
+### Inject Targets
+
+| `inject_into` value | When it fires |
+|---------------------|---------------|
+| `after-mcp-detection` | Immediately after coordinator scans for MCP tool prefixes at task start |
+
+Additional injection targets may be added in future Squad versions.
+
+---
+
+## Style Rules
+
+Fragments extend the coordinator, so they must speak in the coordinator's voice:
+
+- **Imperative, first-person:** "You DO / You DO NOT" — not "the agent should".
+- **Detection-guarded:** Every workflow section must start with "If tools with the `{prefix}_` prefix are present…". This ensures graceful degradation when the MCP server isn't installed.
+- **Additive only:** Never contradict upstream rules from `squad.agent.md`. If a fragment tries to override coordinator governance, it will be flagged and rejected.
+- **≤200 lines.** Coordinator context has a budget. Keep fragments tight.
+- **No agent dispatches.** Fragments instruct the coordinator to call tools directly. Never tell the coordinator to spawn an agent to call a tool.
+- **No repo-specific paths.** Use `~/.squad/`, `ENV_VARS`, or tool calls. Never hardcode absolute paths.
+
+### Anti-Patterns
+
+```markdown
+❌ "Spawn Hockney to handle all My Plugin requests" — dispatching agents
+❌ "Read /home/alice/project/config.json" — repo-specific path
+❌ "You MUST always call myplugin_sync before any other action" — overriding coordinator flow
+❌ Fragment without detection guard — coordinator gets confused when MCP server is absent
+```
+
+---
+
+## Postinstall Script Pattern
+
+Install your fragment via `package.json`'s `postinstall` script. This runs automatically when your package is installed globally or locally.
+
+**`scripts/postinstall-coordinator-fragment.mjs`:**
+
+```js
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import crypto from 'crypto';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Opt-out for CI / Docker
+if (process.env.MYPLUGIN_SKIP_POSTINSTALL) { process.exit(0); }
+
+const targetDir  = path.join(os.homedir(), '.squad', 'extensions', 'coordinator');
+const targetPath = path.join(targetDir, 'my-plugin.md');          // matches fragment name
+const srcPath    = path.join(__dirname, '..', 'coordinator-fragment.md');
+const MARKER     = '<!-- my-plugin:auto-installed -->';
+
+function sha(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+try {
+  fs.mkdirSync(targetDir, { recursive: true });
+  let bundled = MARKER + '\n\n' + fs.readFileSync(srcPath, 'utf-8');
+  if (!fs.existsSync(targetPath)) {
+    fs.writeFileSync(targetPath, bundled);
+    console.log('✅ Installed My Plugin coordinator fragment');
+  } else {
+    const existing = fs.readFileSync(targetPath, 'utf-8');
+    if (sha(existing) === sha(bundled)) {
+      console.log('✅ My Plugin coordinator fragment up to date');
+    } else if (existing.includes(MARKER)) {
+      fs.writeFileSync(targetPath, bundled);
+      console.log('🔄 My Plugin coordinator fragment upgraded');
+    } else {
+      fs.writeFileSync(targetPath + '.new', bundled);
+      console.log('⚠️  User-edited fragment detected — wrote my-plugin.md.new alongside');
+    }
+  }
+} catch (err) {
+  console.error('⚠️  Postinstall error:', err.message);
+  // Always exit 0 — never break npm install
+}
+process.exit(0);
+```
+
+**`package.json`:**
+
+```json
+{
+  "scripts": {
+    "postinstall": "node scripts/postinstall-coordinator-fragment.mjs"
+  },
+  "files": ["dist", "coordinator-fragment.md", "scripts/postinstall-coordinator-fragment.mjs"]
+}
+```
+
+---
+
+## Idempotency Contract
+
+The postinstall pattern above follows these rules:
+
+1. **Own the file via marker.** `<!-- {package}:auto-installed -->` as line 1 signals "this postinstall manages the file". On upgrade, overwrite silently.
+2. **Back off if marker absent.** User removed the marker = "I'm customizing". Write `.new` alongside and warn — never overwrite.
+3. **SHA dedup.** If SHA matches, do nothing. Avoids filesystem churn on repeated `npm install`.
+4. **Exit 0 always.** Postinstall failures must never break `npm install`.
+5. **Respect skip var.** `{PACKAGE}_SKIP_POSTINSTALL` env var for CI and Docker environments.
+
+---
+
+## User Override
+
+Users can customise their fragment by:
+
+1. Editing `~/.squad/extensions/coordinator/my-plugin.md` and removing the auto-installed marker.
+2. The next `npm install` will write a `.new` file alongside; the user's version is preserved.
+
+For project-specific overrides, copy the fragment to `<repo>/.squad/extensions/coordinator/my-plugin.md` — project-local always wins.
+
+---
+
+## Upgrade Story
+
+When you release a new version:
+- Bump `version` in the fragment's front matter.
+- The postinstall script runs on `npm install`; it detects the marker → upgrades silently.
+- Users who removed the marker see the `.new` file and can merge manually.
+
+---
+
+## Example: Squadboard Fragment
+
+`@sabbour/squadboard` ships a coordinator fragment that activates when Squadboard MCP tools are detected. The fragment tells the coordinator to:
+- Capture directives to the board inbox alongside the `.squad/decisions/inbox/` flow.
+- Query the board when the user asks for status.
+- Record close-outs when agent work completes.
+
+Install: `npm install -g @sabbour/squadboard` → fragment auto-installs to `~/.squad/extensions/coordinator/squadboard.md`.
+
+See [`packages/server/coordinator-fragment.md`](https://github.com/asabbour/squadboard/blob/main/packages/server/coordinator-fragment.md) for the full source.


### PR DESCRIPTION
## Summary

This PR adds a **generic, repeatable extension mechanism** so MCP packages and domain tools can extend the Squad coordinator's context without forking `squad.agent.md` or having their knowledge wiped on every Squad upgrade.

## Why

`@sabbour/squadboard` (and any Trello, Aspire, Azure, Notion plugin) needs a stable way to tell Squad how to use its MCP tools. Right now, users either hand-edit `squad.agent.md` (overwritten on upgrade) or lose the integration entirely. This mechanism fixes that.

## What changed

### `.github/agents/squad.agent.md`

Added **`### Extension Fragments`** section after the existing MCP Integration section:

- **Scan dirs:** `~/.squad/extensions/coordinator/*.md` (user-global) and `<repo>/.squad/extensions/coordinator/*.md` (project-local, overrides same-filename user-global).
- **Fragment shape:** YAML front matter with `name`, `version`, `extends: squad`, `inject_into` directives.
- **Loading rules:** Silent skip on missing dirs; silent skip + stderr warning on malformed fragments; append-only (never replaces upstream rules); detection-guarded by convention.
- **Anti-patterns documented:** no agent dispatches, no repo-specific paths, no contradiction of upstream governance.

Updated **Source of Truth Hierarchy** table to include the extension-fragments row.

### `docs/plugins/squad-coordinator-extensions.md` (new)

Full plugin-author guide:
- Fragment format + inject targets
- Style rules (coordinator voice, detection guards, ≤200 lines, additive only)
- Postinstall script pattern (idempotent, SHA-aware, always exits 0)
- User override contract (marker → auto-managed; no marker → back off)
- Upgrade story
- Example using `@sabbour/squadboard` as reference implementation

## Example fragment

```markdown
---
name: squadboard
version: 0.1.0
extends: squad
inject_into: [after-mcp-detection]
---

## Squadboard Integration

If tools with the `squadboard_` prefix exist, Squadboard is installed. You can:
- `squadboard_capture` — drop a directive into the board inbox
- `squadboard_list_issues` — read the backlog
```

Installed by `@sabbour/squadboard` postinstall to `~/.squad/extensions/coordinator/squadboard.md`.

## Contract version

This establishes **Squad extension contract v1**. Future Squad releases should treat `~/.squad/extensions/coordinator/` as a stable install target and not remove or ignore it during upgrades.

---

*Filed by Kobayashi (Squadboard SDK Integrator) — Wave 18, 2026-05-15.*