### PR TITLE
fix: preserve decisions.md and team.md content during export/import

### DIFF
--- a/.changeset/fix-export-import-blank-files.md
+++ b/.changeset/fix-export-import-blank-files.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+Fix export/import producing blank decisions.md and team.md files. Export now includes these files in the manifest, and import restores their content.

--- a/index.cjs
+++ b/index.cjs
@@ -1099,7 +1099,7 @@ if (cmd === 'export') {
 
   const displayPath = path.relative(dest, outPath) || path.basename(outPath);
   console.log(`${GREEN}✓${RESET} Exported squad to ${displayPath}`);
-  console.log(`${DIM}⚠ Review agent histories before sharing — they may contain project-specific information${RESET}`);
+  console.log(`${DIM}⚠ Review agent histories, decisions, and team content before sharing — they may contain project-specific information${RESET}`);
   process.exit(0);
 }
 
@@ -1155,6 +1155,14 @@ if (cmd === 'import') {
   fs.mkdirSync(path.join(aiTeamDir, 'orchestration-log'), { recursive: true });
   fs.mkdirSync(path.join(aiTeamDir, 'log'), { recursive: true });
   fs.mkdirSync(path.join(aiTeamDir, 'skills'), { recursive: true });
+
+  // Validate optional string fields
+  if (manifest.decisions !== undefined && typeof manifest.decisions !== 'string') {
+    fatal('Invalid export file: "decisions" field must be a string');
+  }
+  if (manifest.team !== undefined && typeof manifest.team !== 'string') {
+    fatal('Invalid export file: "team" field must be a string');
+  }
 
   // Write project-specific files from manifest (fall back to empty if not present)
   fs.writeFileSync(path.join(aiTeamDir, 'decisions.md'), manifest.decisions || '');

--- a/index.cjs
+++ b/index.cjs
@@ -1027,6 +1027,15 @@ if (cmd === 'export') {
     skills: []
   };
 
+  // Read top-level squad files (decisions.md, team.md)
+  const decisionsMd = path.join(dest, '.ai-team', 'decisions.md');
+  if (fs.existsSync(decisionsMd)) {
+    manifest.decisions = fs.readFileSync(decisionsMd, 'utf8');
+  }
+  if (fs.existsSync(teamMd)) {
+    manifest.team = fs.readFileSync(teamMd, 'utf8');
+  }
+
   // Read casting state
   const castingDir = path.join(dest, '.ai-team', 'casting');
   for (const file of ['registry.json', 'policy.json', 'history.json']) {
@@ -1147,9 +1156,9 @@ if (cmd === 'import') {
   fs.mkdirSync(path.join(aiTeamDir, 'log'), { recursive: true });
   fs.mkdirSync(path.join(aiTeamDir, 'skills'), { recursive: true });
 
-  // Write empty project-specific files
-  fs.writeFileSync(path.join(aiTeamDir, 'decisions.md'), '');
-  fs.writeFileSync(path.join(aiTeamDir, 'team.md'), '');
+  // Write project-specific files from manifest (fall back to empty if not present)
+  fs.writeFileSync(path.join(aiTeamDir, 'decisions.md'), manifest.decisions || '');
+  fs.writeFileSync(path.join(aiTeamDir, 'team.md'), manifest.team || '');
 
   // Write casting state
   for (const [key, value] of Object.entries(manifest.casting)) {
@@ -1189,7 +1198,6 @@ if (cmd === 'import') {
       : `skill-${index}`;
     return { skillContent, skillName };
   });
-  const hasForce = typeof force !== 'undefined' && force;
 
   if (fs.existsSync(copilotSkillsImportDir)) {
     if (hasForce) {

--- a/packages/squad-cli/src/cli/commands/export.ts
+++ b/packages/squad-cli/src/cli/commands/export.ts
@@ -8,6 +8,7 @@ import { FSStorageProvider } from '@bradygaster/squad-sdk';
 import { detectSquadDir } from '../core/detect-squad-dir.js';
 import { success, warn } from '../core/output.js';
 import { fatal } from '../core/errors.js';
+import { getPackageVersion } from '../core/version.js';
 
 interface ExportManifest {
   version: string;
@@ -35,7 +36,7 @@ export async function runExport(dest: string, outPath?: string): Promise<void> {
   const manifest: ExportManifest = {
     version: '1.0',
     exported_at: new Date().toISOString(),
-    squad_version: '0.6.0',
+    squad_version: getPackageVersion(),
     casting: {},
     agents: {},
     skills: [],
@@ -122,5 +123,5 @@ export async function runExport(dest: string, outPath?: string): Promise<void> {
 
   const displayPath = path.relative(dest, finalOutPath) || path.basename(finalOutPath);
   success(`Exported squad to ${displayPath}`);
-  warn('Review agent histories before sharing — they may contain project-specific information');
+  warn('Review agent histories, decisions, and team content before sharing — they may contain project-specific information');
 }

--- a/packages/squad-cli/src/cli/commands/export.ts
+++ b/packages/squad-cli/src/cli/commands/export.ts
@@ -16,6 +16,8 @@ interface ExportManifest {
   casting: Record<string, unknown>;
   agents: Record<string, { charter?: string; history?: string }>;
   skills: string[];
+  decisions?: string;
+  team?: string;
 }
 
 /**
@@ -36,8 +38,19 @@ export async function runExport(dest: string, outPath?: string): Promise<void> {
     squad_version: '0.6.0',
     casting: {},
     agents: {},
-    skills: []
+    skills: [],
   };
+
+  // Read top-level squad files (decisions.md, team.md)
+  const decisionsMd = path.join(squadInfo.path, 'decisions.md');
+  const decisionsContent = storage.readSync(decisionsMd);
+  if (decisionsContent !== undefined) {
+    manifest.decisions = decisionsContent;
+  }
+  const teamContent = storage.readSync(teamMd);
+  if (teamContent !== undefined) {
+    manifest.team = teamContent;
+  }
 
   // Read casting state
   const castingDir = path.join(squadInfo.path, 'casting');

--- a/packages/squad-cli/src/cli/commands/import.ts
+++ b/packages/squad-cli/src/cli/commands/import.ts
@@ -79,6 +79,14 @@ export async function runImport(dest: string, importPath: string, force: boolean
   storage.mkdirSync(path.join(squadDir, 'log'), { recursive: true });
   storage.mkdirSync(path.join(dest, '.copilot', 'skills'), { recursive: true });
 
+  // Validate optional string fields
+  if (manifest.decisions !== undefined && typeof manifest.decisions !== 'string') {
+    fatal('Invalid export file: "decisions" field must be a string');
+  }
+  if (manifest.team !== undefined && typeof manifest.team !== 'string') {
+    fatal('Invalid export file: "team" field must be a string');
+  }
+
   // Write project-specific files from manifest (fall back to empty if not present)
   storage.writeSync(path.join(squadDir, 'decisions.md'), manifest.decisions || '');
   storage.writeSync(path.join(squadDir, 'team.md'), manifest.team || '');

--- a/packages/squad-cli/src/cli/commands/import.ts
+++ b/packages/squad-cli/src/cli/commands/import.ts
@@ -17,6 +17,8 @@ interface ImportManifest {
   casting: Record<string, unknown>;
   agents: Record<string, { charter?: string; history?: string }>;
   skills: string[];
+  decisions?: string;
+  team?: string;
 }
 
 /**
@@ -77,9 +79,9 @@ export async function runImport(dest: string, importPath: string, force: boolean
   storage.mkdirSync(path.join(squadDir, 'log'), { recursive: true });
   storage.mkdirSync(path.join(dest, '.copilot', 'skills'), { recursive: true });
 
-  // Write empty project-specific files
-  storage.writeSync(path.join(squadDir, 'decisions.md'), '');
-  storage.writeSync(path.join(squadDir, 'team.md'), '');
+  // Write project-specific files from manifest (fall back to empty if not present)
+  storage.writeSync(path.join(squadDir, 'decisions.md'), manifest.decisions || '');
+  storage.writeSync(path.join(squadDir, 'team.md'), manifest.team || '');
 
   // Write casting state
   for (const [key, value] of Object.entries(manifest.casting)) {

--- a/test/skills-export-import.test.cjs
+++ b/test/skills-export-import.test.cjs
@@ -262,3 +262,88 @@ name: report-test
     assert.ok(importResult.stdout.includes('skill'), 'import output should mention skills');
   });
 });
+
+describe('decisions.md and team.md survive export/import round-trip (#1122)', () => {
+  let tmpDir1;
+  let tmpDir2;
+
+  beforeEach(() => {
+    tmpDir1 = makeTempDir();
+    tmpDir2 = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanDir(tmpDir1);
+    cleanDir(tmpDir2);
+  });
+
+  it('exports decisions.md and team.md content in manifest', () => {
+    initSquad(tmpDir1);
+
+    // Write content to decisions.md and team.md
+    const aiTeamDir = path.join(tmpDir1, '.ai-team');
+    fs.writeFileSync(path.join(aiTeamDir, 'decisions.md'), '# Decisions\n\n## Use TypeScript\nWe chose TypeScript for type safety.\n');
+    fs.writeFileSync(path.join(aiTeamDir, 'team.md'), '# Team Roster\n\n## Lead Architect\nDesigns systems.\n');
+
+    // Export
+    const exportPath = path.join(tmpDir1, 'squad-export.json');
+    const exportResult = runSquad(['export'], tmpDir1);
+    assert.equal(exportResult.exitCode, 0, `export should succeed: ${exportResult.stdout}`);
+
+    // Verify manifest contains decisions and team fields
+    const manifest = JSON.parse(fs.readFileSync(exportPath, 'utf8'));
+    assert.equal(manifest.decisions, '# Decisions\n\n## Use TypeScript\nWe chose TypeScript for type safety.\n', 'manifest should contain decisions.md content');
+    assert.equal(manifest.team, '# Team Roster\n\n## Lead Architect\nDesigns systems.\n', 'manifest should contain team.md content');
+  });
+
+  it('imports decisions.md and team.md content from manifest', () => {
+    initSquad(tmpDir1);
+
+    // Write content to decisions.md and team.md
+    const aiTeamDir = path.join(tmpDir1, '.ai-team');
+    fs.writeFileSync(path.join(aiTeamDir, 'decisions.md'), '# Decisions\n\nImportant decision here.\n');
+    fs.writeFileSync(path.join(aiTeamDir, 'team.md'), '# Team\n\nTeam member info here.\n');
+
+    // Export from dir1
+    const exportPath = path.join(tmpDir1, 'squad-export.json');
+    runSquad(['export'], tmpDir1);
+
+    // Init and import into dir2
+    initSquad(tmpDir2);
+    const importResult = runSquad(['import', exportPath, '--force'], tmpDir2);
+    assert.equal(importResult.exitCode, 0, `import should succeed: ${importResult.stdout}`);
+
+    // Verify imported files have the correct content
+    const importedDecisions = fs.readFileSync(path.join(tmpDir2, '.ai-team', 'decisions.md'), 'utf8');
+    const importedTeam = fs.readFileSync(path.join(tmpDir2, '.ai-team', 'team.md'), 'utf8');
+    assert.equal(importedDecisions, '# Decisions\n\nImportant decision here.\n', 'decisions.md should be preserved');
+    assert.equal(importedTeam, '# Team\n\nTeam member info here.\n', 'team.md should be preserved');
+  });
+
+  it('imports older manifests without decisions/team fields successfully', () => {
+    initSquad(tmpDir1);
+
+    // Create a manifest without decisions and team fields (older format)
+    const oldManifest = {
+      version: '1.0',
+      exported_at: new Date().toISOString(),
+      squad_version: '0.6.0',
+      casting: { registry: { agents: [] } },
+      agents: {},
+      skills: []
+    };
+    const exportPath = path.join(tmpDir1, 'old-manifest.json');
+    fs.writeFileSync(exportPath, JSON.stringify(oldManifest, null, 2));
+
+    // Init and import into dir2
+    initSquad(tmpDir2);
+    const importResult = runSquad(['import', exportPath, '--force'], tmpDir2);
+    assert.equal(importResult.exitCode, 0, `import of old manifest should succeed: ${importResult.stdout}`);
+
+    // Verify files exist (empty is fine for old manifests)
+    const importedDecisions = fs.readFileSync(path.join(tmpDir2, '.ai-team', 'decisions.md'), 'utf8');
+    const importedTeam = fs.readFileSync(path.join(tmpDir2, '.ai-team', 'team.md'), 'utf8');
+    assert.equal(importedDecisions, '', 'decisions.md should be empty for old manifest');
+    assert.equal(importedTeam, '', 'team.md should be empty for old manifest');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1122 — Squad export/import was producing blank `decisions.md` and `team.md` files.

## Root Cause

1. **Export** never included `decisions.md` or `team.md` content in the manifest JSON
2. **Import** explicitly wrote empty strings to both files (`storage.writeSync(path.join(squadDir, 'decisions.md'), '')`)

## Fix

- **Export**: Now reads and includes `decisions.md` and `team.md` content in the manifest under `decisions` and `team` fields
- **Import**: Writes manifest content back (falls back to empty string for backward compatibility with older manifests that lack these fields)
- **Validation**: Import validates that `decisions` and `team` fields are strings (if present), emitting a clear fatal error otherwise
- **Version**: Export now uses `getPackageVersion()` instead of hard-coded `'0.6.0'`
- **Warning message**: Updated to mention decisions/team content alongside agent histories
- **Bonus**: Fixed a duplicate `const hasForce` declaration in `index.cjs` that caused a `SyntaxError` at runtime

## Testing

- All 8 `skills-export-import` tests pass (5 existing + 3 new)
- New tests cover:
  - `decisions.md` and `team.md` fields present in exported manifest
  - Content round-trips correctly on import
  - Older manifests without these fields still import successfully