### PR TITLE
fix(coordinator): resolve all P1 coordinator bugs — externalized state, teamRoot, stale work, cleanup loops

### DIFF
--- a/.changeset/fix-p1-coordinator-bugs.md
+++ b/.changeset/fix-p1-coordinator-bugs.md
@@ -1,0 +1,9 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+fix(coordinator): resolve externalized state, teamRoot, stale work, and cleanup loops
+
+Fixes 4 P1 coordinator bugs where squad.agent.md would incorrectly enter Init Mode
+in satellite/externalized repos (#1116, #1127), agents would work on stale/closed items
+(#1125), and spawned agents would loop infinitely in post-work cleanup (#1067).

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -928,8 +928,9 @@ prompt: |
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   
   AFTER work (BEST-EFFORT — do NOT retry on failure):
-  ⚠️ BUDGET: You have a maximum of 80 tool calls for this entire session.
-  After 60 tool calls, wrap up immediately. After 80, STOP regardless of state.
+  ⚠️ POST-WORK BUDGET: Spend at most 20 tool calls on post-work steps below.
+  If you are running low on context or have used 60+ tool calls on primary work,
+  skip post-work entirely -- Scribe handles it independently.
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
      `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -941,9 +941,11 @@ prompt: |
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
      (Scribe commits this to the orphan branch.)
-  2. If you made a team-relevant decision, write a drop file:
-     .squad/decisions/inbox/{name}-{brief-slug}.md
-     (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
+  2. If you made a team-relevant decision:
+     a. Try once (do NOT retry on failure): write a git note on HEAD:
+        `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
+     b. Write a drop file: .squad/decisions/inbox/{name}-{brief-slug}.md
+        (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
   {% else %}
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -21,7 +21,24 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
   - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
-Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
+### State & Team Root Resolution (before mode check)
+
+Before deciding Init vs Team mode, resolve where the team state actually lives:
+
+1. **Read `.squad/config.json`** (if it exists in the current `.squad/` directory).
+2. **External state** — if `stateLocation` is `"external"`:
+   - Resolve the external state path: `{platform_appdata}/squad/projects/{projectKey}/`
+   - The team root is that external path. Load `team.md` from there.
+3. **Remote/satellite mode** — if `teamRoot` is present:
+   - The team root is the value of `teamRoot` (absolute path to another `.squad/` directory).
+   - Load `team.md` from `{teamRoot}/.squad/team.md` (or `{teamRoot}/team.md` if teamRoot already points inside `.squad/`).
+4. **Neither** — team root is the local `.squad/` directory (default behavior).
+
+Store the resolved team root as `TEAM_ROOT`. All subsequent `.squad/` path references use this root.
+
+### Mode-Switch Check
+
+Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
 - **No** → Init Mode
 - **Yes, but `## Members` has zero roster entries** → Init Mode (treat as unconfigured — scaffold exists but no team was cast)
 - **Yes, with roster entries** → Team Mode
@@ -107,7 +124,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
-**Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
+**Resolve state backend:** Read `.squad/config.json` (at the resolved TEAM_ROOT) and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
 **⚡ Context caching:** After the first message in a session, `team.md`, `routing.md`, and `registry.json` are already in your context. Do NOT re-read them on subsequent messages — you already have the roster, routing rules, and cast names. Only re-read if the user explicitly modifies the team (adds/removes members, changes routing).
 
@@ -636,6 +653,10 @@ Squad and all spawned agents may be running inside a **git worktree** rather tha
 
 **How the Coordinator resolves the team root (on every session start):**
 
+0. **Check config.json overrides first** — read `.squad/config.json` in the current directory (or at the git root):
+   - If `teamRoot` is set → Team root = that path. **STOP — do not walk further.**
+   - If `stateLocation` is `"external"` → Resolve external AppData path. Team root = external path. **STOP.**
+   - Otherwise → continue to step 1.
 1. **Check CWD first** — does `.squad/` exist in the current working directory?
    - **Yes** → Team root = CWD. This handles monorepos where `.squad/` lives in a subfolder.
 2. If not, run `git rev-parse --show-toplevel` to get the current worktree root.
@@ -882,6 +903,15 @@ prompt: |
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
   
+  ⚠️ WORK FRESHNESS: When determining what to work on:
+  - If an external tracker is configured (GitHub Issues, GitLab Issues, Azure DevOps),
+    ALWAYS query it for current open/active items. The tracker is the authoritative
+    source of truth — local plan files and checkboxes are advisory only.
+  - If .squad/identity/now.md has a `last_verified` timestamp older than your session
+    start, re-verify the current focus against the tracker before acting.
+  - NEVER work on items marked closed/done in the tracker, even if local files
+    suggest they are incomplete.
+  
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
@@ -897,7 +927,9 @@ prompt: |
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   
-  AFTER work:
+  AFTER work (BEST-EFFORT — do NOT retry on failure):
+  ⚠️ BUDGET: You have a maximum of 80 tool calls for this entire session.
+  After 60 tool calls, wrap up immediately. After 80, STOP regardless of state.
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
      `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`
@@ -909,19 +941,20 @@ prompt: |
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
      (Scribe commits this to the orphan branch.)
-  2. If you made a team-relevant decision, write BOTH:
-     a. A git note on HEAD with promote flag:
-        `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
-     b. A drop file: .squad/decisions/inbox/{name}-{brief-slug}.md
-        (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
+  2. If you made a team-relevant decision, write a drop file:
+     .squad/decisions/inbox/{name}-{brief-slug}.md
+     (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
   {% else %}
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
   2. If you made a team-relevant decision, write to:
      .squad/decisions/inbox/{name}-{brief-slug}.md
   {% endif %}
-  3. SKILL EXTRACTION: If you found a reusable pattern, write/update
-     .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
+  3. SKILL EXTRACTION is handled by Scribe — do NOT attempt it yourself.
+  
+  ⚠️ STOP ON FAILURE: If ANY post-work step fails (git conflict, file not found,
+  permission error), SKIP it and move on. Do NOT retry. Scribe handles cleanup
+  independently. Your primary deliverable is already done — post-work is optional.
   
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -928,8 +928,9 @@ prompt: |
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   
   AFTER work (BEST-EFFORT — do NOT retry on failure):
-  ⚠️ BUDGET: You have a maximum of 80 tool calls for this entire session.
-  After 60 tool calls, wrap up immediately. After 80, STOP regardless of state.
+  ⚠️ POST-WORK BUDGET: Spend at most 20 tool calls on post-work steps below.
+  If you are running low on context or have used 60+ tool calls on primary work,
+  skip post-work entirely -- Scribe handles it independently.
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
      `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -941,9 +941,11 @@ prompt: |
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
      (Scribe commits this to the orphan branch.)
-  2. If you made a team-relevant decision, write a drop file:
-     .squad/decisions/inbox/{name}-{brief-slug}.md
-     (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
+  2. If you made a team-relevant decision:
+     a. Try once (do NOT retry on failure): write a git note on HEAD:
+        `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
+     b. Write a drop file: .squad/decisions/inbox/{name}-{brief-slug}.md
+        (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
   {% else %}
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -21,7 +21,24 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
   - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
-Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
+### State & Team Root Resolution (before mode check)
+
+Before deciding Init vs Team mode, resolve where the team state actually lives:
+
+1. **Read `.squad/config.json`** (if it exists in the current `.squad/` directory).
+2. **External state** — if `stateLocation` is `"external"`:
+   - Resolve the external state path: `{platform_appdata}/squad/projects/{projectKey}/`
+   - The team root is that external path. Load `team.md` from there.
+3. **Remote/satellite mode** — if `teamRoot` is present:
+   - The team root is the value of `teamRoot` (absolute path to another `.squad/` directory).
+   - Load `team.md` from `{teamRoot}/.squad/team.md` (or `{teamRoot}/team.md` if teamRoot already points inside `.squad/`).
+4. **Neither** — team root is the local `.squad/` directory (default behavior).
+
+Store the resolved team root as `TEAM_ROOT`. All subsequent `.squad/` path references use this root.
+
+### Mode-Switch Check
+
+Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
 - **No** → Init Mode
 - **Yes, but `## Members` has zero roster entries** → Init Mode (treat as unconfigured — scaffold exists but no team was cast)
 - **Yes, with roster entries** → Team Mode
@@ -107,7 +124,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
-**Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
+**Resolve state backend:** Read `.squad/config.json` (at the resolved TEAM_ROOT) and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
 **⚡ Context caching:** After the first message in a session, `team.md`, `routing.md`, and `registry.json` are already in your context. Do NOT re-read them on subsequent messages — you already have the roster, routing rules, and cast names. Only re-read if the user explicitly modifies the team (adds/removes members, changes routing).
 
@@ -636,6 +653,10 @@ Squad and all spawned agents may be running inside a **git worktree** rather tha
 
 **How the Coordinator resolves the team root (on every session start):**
 
+0. **Check config.json overrides first** — read `.squad/config.json` in the current directory (or at the git root):
+   - If `teamRoot` is set → Team root = that path. **STOP — do not walk further.**
+   - If `stateLocation` is `"external"` → Resolve external AppData path. Team root = external path. **STOP.**
+   - Otherwise → continue to step 1.
 1. **Check CWD first** — does `.squad/` exist in the current working directory?
    - **Yes** → Team root = CWD. This handles monorepos where `.squad/` lives in a subfolder.
 2. If not, run `git rev-parse --show-toplevel` to get the current worktree root.
@@ -882,6 +903,15 @@ prompt: |
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
   
+  ⚠️ WORK FRESHNESS: When determining what to work on:
+  - If an external tracker is configured (GitHub Issues, GitLab Issues, Azure DevOps),
+    ALWAYS query it for current open/active items. The tracker is the authoritative
+    source of truth — local plan files and checkboxes are advisory only.
+  - If .squad/identity/now.md has a `last_verified` timestamp older than your session
+    start, re-verify the current focus against the tracker before acting.
+  - NEVER work on items marked closed/done in the tracker, even if local files
+    suggest they are incomplete.
+  
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
@@ -897,7 +927,9 @@ prompt: |
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   
-  AFTER work:
+  AFTER work (BEST-EFFORT — do NOT retry on failure):
+  ⚠️ BUDGET: You have a maximum of 80 tool calls for this entire session.
+  After 60 tool calls, wrap up immediately. After 80, STOP regardless of state.
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
      `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`
@@ -909,19 +941,20 @@ prompt: |
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
      (Scribe commits this to the orphan branch.)
-  2. If you made a team-relevant decision, write BOTH:
-     a. A git note on HEAD with promote flag:
-        `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
-     b. A drop file: .squad/decisions/inbox/{name}-{brief-slug}.md
-        (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
+  2. If you made a team-relevant decision, write a drop file:
+     .squad/decisions/inbox/{name}-{brief-slug}.md
+     (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
   {% else %}
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
   2. If you made a team-relevant decision, write to:
      .squad/decisions/inbox/{name}-{brief-slug}.md
   {% endif %}
-  3. SKILL EXTRACTION: If you found a reusable pattern, write/update
-     .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
+  3. SKILL EXTRACTION is handled by Scribe — do NOT attempt it yourself.
+  
+  ⚠️ STOP ON FAILURE: If ANY post-work step fails (git conflict, file not found,
+  permission error), SKIP it and move on. Do NOT retry. Scribe handles cleanup
+  independently. Your primary deliverable is already done — post-work is optional.
   
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -928,8 +928,9 @@ prompt: |
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   
   AFTER work (BEST-EFFORT — do NOT retry on failure):
-  ⚠️ BUDGET: You have a maximum of 80 tool calls for this entire session.
-  After 60 tool calls, wrap up immediately. After 80, STOP regardless of state.
+  ⚠️ POST-WORK BUDGET: Spend at most 20 tool calls on post-work steps below.
+  If you are running low on context or have used 60+ tool calls on primary work,
+  skip post-work entirely -- Scribe handles it independently.
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
      `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -941,9 +941,11 @@ prompt: |
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
      (Scribe commits this to the orphan branch.)
-  2. If you made a team-relevant decision, write a drop file:
-     .squad/decisions/inbox/{name}-{brief-slug}.md
-     (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
+  2. If you made a team-relevant decision:
+     a. Try once (do NOT retry on failure): write a git note on HEAD:
+        `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
+     b. Write a drop file: .squad/decisions/inbox/{name}-{brief-slug}.md
+        (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
   {% else %}
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -21,7 +21,24 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
   - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
-Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
+### State & Team Root Resolution (before mode check)
+
+Before deciding Init vs Team mode, resolve where the team state actually lives:
+
+1. **Read `.squad/config.json`** (if it exists in the current `.squad/` directory).
+2. **External state** — if `stateLocation` is `"external"`:
+   - Resolve the external state path: `{platform_appdata}/squad/projects/{projectKey}/`
+   - The team root is that external path. Load `team.md` from there.
+3. **Remote/satellite mode** — if `teamRoot` is present:
+   - The team root is the value of `teamRoot` (absolute path to another `.squad/` directory).
+   - Load `team.md` from `{teamRoot}/.squad/team.md` (or `{teamRoot}/team.md` if teamRoot already points inside `.squad/`).
+4. **Neither** — team root is the local `.squad/` directory (default behavior).
+
+Store the resolved team root as `TEAM_ROOT`. All subsequent `.squad/` path references use this root.
+
+### Mode-Switch Check
+
+Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
 - **No** → Init Mode
 - **Yes, but `## Members` has zero roster entries** → Init Mode (treat as unconfigured — scaffold exists but no team was cast)
 - **Yes, with roster entries** → Team Mode
@@ -107,7 +124,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
-**Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
+**Resolve state backend:** Read `.squad/config.json` (at the resolved TEAM_ROOT) and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
 **⚡ Context caching:** After the first message in a session, `team.md`, `routing.md`, and `registry.json` are already in your context. Do NOT re-read them on subsequent messages — you already have the roster, routing rules, and cast names. Only re-read if the user explicitly modifies the team (adds/removes members, changes routing).
 
@@ -636,6 +653,10 @@ Squad and all spawned agents may be running inside a **git worktree** rather tha
 
 **How the Coordinator resolves the team root (on every session start):**
 
+0. **Check config.json overrides first** — read `.squad/config.json` in the current directory (or at the git root):
+   - If `teamRoot` is set → Team root = that path. **STOP — do not walk further.**
+   - If `stateLocation` is `"external"` → Resolve external AppData path. Team root = external path. **STOP.**
+   - Otherwise → continue to step 1.
 1. **Check CWD first** — does `.squad/` exist in the current working directory?
    - **Yes** → Team root = CWD. This handles monorepos where `.squad/` lives in a subfolder.
 2. If not, run `git rev-parse --show-toplevel` to get the current worktree root.
@@ -882,6 +903,15 @@ prompt: |
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
   
+  ⚠️ WORK FRESHNESS: When determining what to work on:
+  - If an external tracker is configured (GitHub Issues, GitLab Issues, Azure DevOps),
+    ALWAYS query it for current open/active items. The tracker is the authoritative
+    source of truth — local plan files and checkboxes are advisory only.
+  - If .squad/identity/now.md has a `last_verified` timestamp older than your session
+    start, re-verify the current focus against the tracker before acting.
+  - NEVER work on items marked closed/done in the tracker, even if local files
+    suggest they are incomplete.
+  
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
@@ -897,7 +927,9 @@ prompt: |
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   
-  AFTER work:
+  AFTER work (BEST-EFFORT — do NOT retry on failure):
+  ⚠️ BUDGET: You have a maximum of 80 tool calls for this entire session.
+  After 60 tool calls, wrap up immediately. After 80, STOP regardless of state.
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
      `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`
@@ -909,19 +941,20 @@ prompt: |
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
      (Scribe commits this to the orphan branch.)
-  2. If you made a team-relevant decision, write BOTH:
-     a. A git note on HEAD with promote flag:
-        `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
-     b. A drop file: .squad/decisions/inbox/{name}-{brief-slug}.md
-        (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
+  2. If you made a team-relevant decision, write a drop file:
+     .squad/decisions/inbox/{name}-{brief-slug}.md
+     (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
   {% else %}
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
   2. If you made a team-relevant decision, write to:
      .squad/decisions/inbox/{name}-{brief-slug}.md
   {% endif %}
-  3. SKILL EXTRACTION: If you found a reusable pattern, write/update
-     .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
+  3. SKILL EXTRACTION is handled by Scribe — do NOT attempt it yourself.
+  
+  ⚠️ STOP ON FAILURE: If ANY post-work step fails (git conflict, file not found,
+  permission error), SKIP it and move on. Do NOT retry. Scribe handles cleanup
+  independently. Your primary deliverable is already done — post-work is optional.
   
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -928,8 +928,9 @@ prompt: |
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   
   AFTER work (BEST-EFFORT — do NOT retry on failure):
-  ⚠️ BUDGET: You have a maximum of 80 tool calls for this entire session.
-  After 60 tool calls, wrap up immediately. After 80, STOP regardless of state.
+  ⚠️ POST-WORK BUDGET: Spend at most 20 tool calls on post-work steps below.
+  If you are running low on context or have used 60+ tool calls on primary work,
+  skip post-work entirely -- Scribe handles it independently.
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
      `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -941,9 +941,11 @@ prompt: |
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
      (Scribe commits this to the orphan branch.)
-  2. If you made a team-relevant decision, write a drop file:
-     .squad/decisions/inbox/{name}-{brief-slug}.md
-     (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
+  2. If you made a team-relevant decision:
+     a. Try once (do NOT retry on failure): write a git note on HEAD:
+        `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
+     b. Write a drop file: .squad/decisions/inbox/{name}-{brief-slug}.md
+        (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
   {% else %}
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -21,7 +21,24 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
   - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
-Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
+### State & Team Root Resolution (before mode check)
+
+Before deciding Init vs Team mode, resolve where the team state actually lives:
+
+1. **Read `.squad/config.json`** (if it exists in the current `.squad/` directory).
+2. **External state** — if `stateLocation` is `"external"`:
+   - Resolve the external state path: `{platform_appdata}/squad/projects/{projectKey}/`
+   - The team root is that external path. Load `team.md` from there.
+3. **Remote/satellite mode** — if `teamRoot` is present:
+   - The team root is the value of `teamRoot` (absolute path to another `.squad/` directory).
+   - Load `team.md` from `{teamRoot}/.squad/team.md` (or `{teamRoot}/team.md` if teamRoot already points inside `.squad/`).
+4. **Neither** — team root is the local `.squad/` directory (default behavior).
+
+Store the resolved team root as `TEAM_ROOT`. All subsequent `.squad/` path references use this root.
+
+### Mode-Switch Check
+
+Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
 - **No** → Init Mode
 - **Yes, but `## Members` has zero roster entries** → Init Mode (treat as unconfigured — scaffold exists but no team was cast)
 - **Yes, with roster entries** → Team Mode
@@ -107,7 +124,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
-**Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
+**Resolve state backend:** Read `.squad/config.json` (at the resolved TEAM_ROOT) and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
 **⚡ Context caching:** After the first message in a session, `team.md`, `routing.md`, and `registry.json` are already in your context. Do NOT re-read them on subsequent messages — you already have the roster, routing rules, and cast names. Only re-read if the user explicitly modifies the team (adds/removes members, changes routing).
 
@@ -636,6 +653,10 @@ Squad and all spawned agents may be running inside a **git worktree** rather tha
 
 **How the Coordinator resolves the team root (on every session start):**
 
+0. **Check config.json overrides first** — read `.squad/config.json` in the current directory (or at the git root):
+   - If `teamRoot` is set → Team root = that path. **STOP — do not walk further.**
+   - If `stateLocation` is `"external"` → Resolve external AppData path. Team root = external path. **STOP.**
+   - Otherwise → continue to step 1.
 1. **Check CWD first** — does `.squad/` exist in the current working directory?
    - **Yes** → Team root = CWD. This handles monorepos where `.squad/` lives in a subfolder.
 2. If not, run `git rev-parse --show-toplevel` to get the current worktree root.
@@ -882,6 +903,15 @@ prompt: |
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
   
+  ⚠️ WORK FRESHNESS: When determining what to work on:
+  - If an external tracker is configured (GitHub Issues, GitLab Issues, Azure DevOps),
+    ALWAYS query it for current open/active items. The tracker is the authoritative
+    source of truth — local plan files and checkboxes are advisory only.
+  - If .squad/identity/now.md has a `last_verified` timestamp older than your session
+    start, re-verify the current focus against the tracker before acting.
+  - NEVER work on items marked closed/done in the tracker, even if local files
+    suggest they are incomplete.
+  
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
@@ -897,7 +927,9 @@ prompt: |
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   
-  AFTER work:
+  AFTER work (BEST-EFFORT — do NOT retry on failure):
+  ⚠️ BUDGET: You have a maximum of 80 tool calls for this entire session.
+  After 60 tool calls, wrap up immediately. After 80, STOP regardless of state.
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
      `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`
@@ -909,19 +941,20 @@ prompt: |
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
      (Scribe commits this to the orphan branch.)
-  2. If you made a team-relevant decision, write BOTH:
-     a. A git note on HEAD with promote flag:
-        `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
-     b. A drop file: .squad/decisions/inbox/{name}-{brief-slug}.md
-        (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
+  2. If you made a team-relevant decision, write a drop file:
+     .squad/decisions/inbox/{name}-{brief-slug}.md
+     (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
   {% else %}
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
   2. If you made a team-relevant decision, write to:
      .squad/decisions/inbox/{name}-{brief-slug}.md
   {% endif %}
-  3. SKILL EXTRACTION: If you found a reusable pattern, write/update
-     .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
+  3. SKILL EXTRACTION is handled by Scribe — do NOT attempt it yourself.
+  
+  ⚠️ STOP ON FAILURE: If ANY post-work step fails (git conflict, file not found,
+  permission error), SKIP it and move on. Do NOT retry. Scribe handles cleanup
+  independently. Your primary deliverable is already done — post-work is optional.
   
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -928,8 +928,9 @@ prompt: |
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   
   AFTER work (BEST-EFFORT — do NOT retry on failure):
-  ⚠️ BUDGET: You have a maximum of 80 tool calls for this entire session.
-  After 60 tool calls, wrap up immediately. After 80, STOP regardless of state.
+  ⚠️ POST-WORK BUDGET: Spend at most 20 tool calls on post-work steps below.
+  If you are running low on context or have used 60+ tool calls on primary work,
+  skip post-work entirely -- Scribe handles it independently.
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
      `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -941,9 +941,11 @@ prompt: |
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
      (Scribe commits this to the orphan branch.)
-  2. If you made a team-relevant decision, write a drop file:
-     .squad/decisions/inbox/{name}-{brief-slug}.md
-     (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
+  2. If you made a team-relevant decision:
+     a. Try once (do NOT retry on failure): write a git note on HEAD:
+        `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
+     b. Write a drop file: .squad/decisions/inbox/{name}-{brief-slug}.md
+        (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
   {% else %}
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -21,7 +21,24 @@ You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
   - You may NOT invent facts or assumptions — ask the user or spawn an agent who knows
   - You may NOT do work yourself — ALWAYS delegate to a team member, even for small tasks. The only exception is Direct Mode (status checks, factual questions, and simple answers from context — see Response Mode Selection).
 
-Check: Does `.squad/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
+### State & Team Root Resolution (before mode check)
+
+Before deciding Init vs Team mode, resolve where the team state actually lives:
+
+1. **Read `.squad/config.json`** (if it exists in the current `.squad/` directory).
+2. **External state** — if `stateLocation` is `"external"`:
+   - Resolve the external state path: `{platform_appdata}/squad/projects/{projectKey}/`
+   - The team root is that external path. Load `team.md` from there.
+3. **Remote/satellite mode** — if `teamRoot` is present:
+   - The team root is the value of `teamRoot` (absolute path to another `.squad/` directory).
+   - Load `team.md` from `{teamRoot}/.squad/team.md` (or `{teamRoot}/team.md` if teamRoot already points inside `.squad/`).
+4. **Neither** — team root is the local `.squad/` directory (default behavior).
+
+Store the resolved team root as `TEAM_ROOT`. All subsequent `.squad/` path references use this root.
+
+### Mode-Switch Check
+
+Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for repos migrating from older installs)
 - **No** → Init Mode
 - **Yes, but `## Members` has zero roster entries** → Init Mode (treat as unconfigured — scaffold exists but no team was cast)
 - **Yes, with roster entries** → Team Mode
@@ -107,7 +124,7 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
-**Resolve state backend:** Read `.squad/config.json` and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
+**Resolve state backend:** Read `.squad/config.json` (at the resolved TEAM_ROOT) and check the `stateBackend` field. Valid values: `"worktree"` (default), `"git-notes"`, `"orphan"`, `"two-layer"`. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
 
 **⚡ Context caching:** After the first message in a session, `team.md`, `routing.md`, and `registry.json` are already in your context. Do NOT re-read them on subsequent messages — you already have the roster, routing rules, and cast names. Only re-read if the user explicitly modifies the team (adds/removes members, changes routing).
 
@@ -636,6 +653,10 @@ Squad and all spawned agents may be running inside a **git worktree** rather tha
 
 **How the Coordinator resolves the team root (on every session start):**
 
+0. **Check config.json overrides first** — read `.squad/config.json` in the current directory (or at the git root):
+   - If `teamRoot` is set → Team root = that path. **STOP — do not walk further.**
+   - If `stateLocation` is `"external"` → Resolve external AppData path. Team root = external path. **STOP.**
+   - Otherwise → continue to step 1.
 1. **Check CWD first** — does `.squad/` exist in the current working directory?
    - **Yes** → Team root = CWD. This handles monorepos where `.squad/` lives in a subfolder.
 2. If not, run `git rev-parse --show-toplevel` to get the current worktree root.
@@ -882,6 +903,15 @@ prompt: |
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
   
+  ⚠️ WORK FRESHNESS: When determining what to work on:
+  - If an external tracker is configured (GitHub Issues, GitLab Issues, Azure DevOps),
+    ALWAYS query it for current open/active items. The tracker is the authoritative
+    source of truth — local plan files and checkboxes are advisory only.
+  - If .squad/identity/now.md has a `last_verified` timestamp older than your session
+    start, re-verify the current focus against the tracker before acting.
+  - NEVER work on items marked closed/done in the tracker, even if local files
+    suggest they are incomplete.
+  
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
@@ -897,7 +927,9 @@ prompt: |
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
   
-  AFTER work:
+  AFTER work (BEST-EFFORT — do NOT retry on failure):
+  ⚠️ BUDGET: You have a maximum of 80 tool calls for this entire session.
+  After 60 tool calls, wrap up immediately. After 80, STOP regardless of state.
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
      `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{"learnings": ["..."], "timestamp": "<literal CURRENT_DATETIME value from your prompt>"}'`
@@ -909,19 +941,20 @@ prompt: |
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
      (Scribe commits this to the orphan branch.)
-  2. If you made a team-relevant decision, write BOTH:
-     a. A git note on HEAD with promote flag:
-        `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
-     b. A drop file: .squad/decisions/inbox/{name}-{brief-slug}.md
-        (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
+  2. If you made a team-relevant decision, write a drop file:
+     .squad/decisions/inbox/{name}-{brief-slug}.md
+     (Scribe merges to orphan branch; Ralph promotes note after PR merge.)
   {% else %}
   1. APPEND to .squad/agents/{name}/history.md under "## Learnings":
      architecture decisions, patterns, user preferences, key file paths.
   2. If you made a team-relevant decision, write to:
      .squad/decisions/inbox/{name}-{brief-slug}.md
   {% endif %}
-  3. SKILL EXTRACTION: If you found a reusable pattern, write/update
-     .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
+  3. SKILL EXTRACTION is handled by Scribe — do NOT attempt it yourself.
+  
+  ⚠️ STOP ON FAILURE: If ANY post-work step fails (git conflict, file not found,
+  permission error), SKIP it and move on. Do NOT retry. Scribe handles cleanup
+  independently. Your primary deliverable is already done — post-work is optional.
   
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.


### PR DESCRIPTION
## Summary

Fixes all 4 P1 coordinator bugs in a single coherent change to `squad.agent.md` (and all template copies).

### Bugs Fixed

| Issue | Problem | Fix |
|-------|---------|-----|
| #1116 | Externalized state not resolved → Init Mode | New "State & Team Root Resolution" section reads `config.json.stateLocation` before mode check |
| #1127 | `teamRoot` in config.json ignored → Init Mode in satellite repos | Same section reads `teamRoot`; Worktree Awareness step 0 checks config overrides first |
| #1125 | Agents working on stale/closed items | New "WORK FRESHNESS" rule in spawn template — tracker is authoritative over local plan files |
| #1067 | Infinite post-work cleanup loop (195+ tool calls) | AFTER work is now best-effort with 80-call budget, explicit stop-on-failure, Scribe-only skill extraction |

### Changes

- `.github/agents/squad.agent.md` — all 4 fixes
- `.squad-templates/squad.agent.md` — mirror
- `packages/squad-cli/templates/squad.agent.md.template` — mirror
- `packages/squad-sdk/templates/squad.agent.md.template` — mirror
- `templates/squad.agent.md.template` — mirror

### How to test

1. **#1116/#1127:** `squad init --mode remote <path>` in a fresh repo, then start a Copilot session — coordinator should find the team via config.json redirect instead of entering Init Mode.
2. **#1125:** Close all issues in a tracker, verify agents don't pick up stale local plan items.
3. **#1067:** Spawn an agent and observe it completes post-work in <10 tool calls or stops on first failure.

### Notes

- PR #1117 also addresses #1116 with a similar approach. This PR is a superset (covers all 4 bugs). If #1117 lands first, this will need a small rebase to dedup the externalized state section.

Closes #1116, Closes #1127, Closes #1125, Closes #1067