### PR TITLE
fix: Squash the Gremlins — 5 bug fixes (#920, #1062, #880, #1107, #905)

### DIFF
--- a/.changeset/squash-the-gremlins-cli.md
+++ b/.changeset/squash-the-gremlins-cli.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-cli': patch
+---
+
+Fix Windows spawn EINVAL in watch capabilities by adding `shell: true` to `execFile()` calls in monitor-teams, monitor-email, retro, and decision-hygiene capabilities. Add Copilot CLI preflight check to `squad doctor` and monitor capabilities so missing `gh copilot` extension is flagged early. Improve team hire confirmation UX to show member names inline with the prompt. (closes #920, closes #880, closes #1107)

--- a/.changeset/squash-the-gremlins-sdk.md
+++ b/.changeset/squash-the-gremlins-sdk.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-sdk': patch
+---
+
+Bump `@github/copilot-sdk` from `^0.1.32` to `^0.3.0` to fix ESM module resolution error (ERR_MODULE_NOT_FOUND for vscode-jsonrpc/node). Add explicit GitHub repo config support in `.squad/config.json` (`{ "github": { "owner": "...", "repo": "..." } }`) so platform adapter prefers user-specified repo over auto-detection from origin remote. (closes #1062, closes #905)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1322,26 +1322,28 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.12.tgz",
-      "integrity": "sha512-GpmoJbs1ECyLLKtY4PcFzO8Cz6GgDTOKkrzwNdkirNdfsB+o6x0OOlFyrOdNXNPII7pk9+GcpIjF87sLwWzpPQ==",
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.50.tgz",
+      "integrity": "sha512-HJFM+LYt5i6shAiTYHolCSQLV9ZzfX/06m7yWht4PiKBE+hO/zxXhqnJFMshqMkFm0Ab3ea0FZDx8CVjdXn5bQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.12",
-        "@github/copilot-darwin-x64": "1.0.12",
-        "@github/copilot-linux-arm64": "1.0.12",
-        "@github/copilot-linux-x64": "1.0.12",
-        "@github/copilot-win32-arm64": "1.0.12",
-        "@github/copilot-win32-x64": "1.0.12"
+        "@github/copilot-darwin-arm64": "1.0.50",
+        "@github/copilot-darwin-x64": "1.0.50",
+        "@github/copilot-linux-arm64": "1.0.50",
+        "@github/copilot-linux-x64": "1.0.50",
+        "@github/copilot-linuxmusl-arm64": "1.0.50",
+        "@github/copilot-linuxmusl-x64": "1.0.50",
+        "@github/copilot-win32-arm64": "1.0.50",
+        "@github/copilot-win32-x64": "1.0.50"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.12.tgz",
-      "integrity": "sha512-fjbwRIUZAH06Eyg5ZkfZXg8SVXpqI3HaFhtXZ803CZs9mfIgfOSR3URZxUnv7SIv6aI/7f6ws8RxKnPGavJ/tg==",
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.50.tgz",
+      "integrity": "sha512-PSqw/QrJelPGa9jHooe9QaTzhLt2DquCj2shyVNgC7bfFKkCFPbY0vBXNAK6TD+REOKaj1vPsGrEt3dYODnzaw==",
       "cpu": [
         "arm64"
       ],
@@ -1355,9 +1357,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.12.tgz",
-      "integrity": "sha512-/tJGJEEm8kpTW/sJRNnvhMSHKIHApNun14biuIkC5CXDqVgFakbKlckn/FlIkT48eEUysc0YbEatrHIDz/8XbA==",
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.50.tgz",
+      "integrity": "sha512-Z/8DEWmkPpPz0H5oT5m1MAnudFxHkykEmCNWPvQYXMBcUuJ2OdYIt9bWr57nGU+KjY2TcnkoN766rnBm2MwKWQ==",
       "cpu": [
         "x64"
       ],
@@ -1371,9 +1373,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.12.tgz",
-      "integrity": "sha512-4977LVJi3/9Yc+ivj+VKDVtHg0kT5yqOrN8F35/jgqerx4Mdtk1pOMlWztXxLicBHN4y2V7/EY/wc0WqFW0Zvg==",
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.50.tgz",
+      "integrity": "sha512-Hp5Bhmur7N63ngiZTECr1oyLg4kz6GSM4LGinRdI7PcDu9qB/6GYZO41MtwP17PyzNgfP8Gs4Lej2vgVqO3/Dw==",
       "cpu": [
         "arm64"
       ],
@@ -1387,9 +1389,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.12.tgz",
-      "integrity": "sha512-9QevJZD29PVltYDV4xHWbdN6ud/966clERL5Frh2+9D3+spaVDO1hFllzoFiEwD/M4f2GkSh7/fT3hV0LKl9Ag==",
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.50.tgz",
+      "integrity": "sha512-acjlW1g0sgAfnsBj/JQCdTODKCHRcadVJiJUT3xv7HKTYLVilIU1iwmQAzQ7r3QwmNCOI48FL7usbNiKouop8A==",
       "cpu": [
         "x64"
       ],
@@ -1402,13 +1404,45 @@
         "copilot-linux-x64": "copilot"
       }
     },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.50.tgz",
+      "integrity": "sha512-GRhiIDVBPdit5QItfEvEn3d9mwT6cVFr2Ms5bvtKBLS4Hs7E419dZX66Z6zB2Wjh4u2l4MLjinxVzggcpEx/HQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.50.tgz",
+      "integrity": "sha512-3G0+/4F6SYaj6AfttLqRzp3HO3/6RIdXEqzCirR0E5l4SMjD8mHmTAE8YKbjPl9XGf/wbhyDmSMcIcxj79Mf7w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.1.32",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.1.32.tgz",
-      "integrity": "sha512-mPWM0fw1Gqc/SW8nl45K8abrFH+92fO7y6tRtRl5imjS5hGapLf/dkX5WDrgPtlsflD0c41lFXVUri5NVJwtoA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.3.0.tgz",
+      "integrity": "sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.2",
+        "@github/copilot": "^1.0.36-0",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -1417,9 +1451,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.12.tgz",
-      "integrity": "sha512-RLAbAsLniI8vA2utgZdIsvD8slZpz1fb8l6cmIiQvDE/BwQb2zNV9VepZ+CwzYtNx9ifxBtgIwYwUJq5bxeSaQ==",
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.50.tgz",
+      "integrity": "sha512-cLSnU+IQ7p0WIdxeaDeTR6rtiSLwHqN+3AkAaOKKBXBsYjmB3Ct6UHqlZf20GtZ5I/K1HH9ZDYRYVKlsA4olJQ==",
       "cpu": [
         "arm64"
       ],
@@ -1433,9 +1467,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.12.tgz",
-      "integrity": "sha512-4SYV09F4Sw20DAib1do26+ALZmCZrghzo+5e6IZbQOsm4B7NhBFaLpKFU+kEijfmWacLlh/at5CpGGGKlwlbcg==",
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.50.tgz",
+      "integrity": "sha512-f5cA798nmOj/E7GXuzX2HnPenx8ddp/y87q6hpoU78nySTasWCTvWhckjuJ+fwzJQmp3fORBbL67pDdELvdajA==",
       "cpu": [
         "x64"
       ],
@@ -8960,7 +8994,7 @@
       "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot-sdk": "^0.1.32",
+        "@github/copilot-sdk": "^0.3.0",
         "vscode-jsonrpc": "^8.2.1"
       },
       "devDependencies": {

--- a/packages/squad-cli/src/cli/commands/doctor.ts
+++ b/packages/squad-cli/src/cli/commands/doctor.ts
@@ -11,6 +11,7 @@
  */
 
 import path from 'node:path';
+import { execFile } from 'node:child_process';
 import { FSStorageProvider } from '@bradygaster/squad-sdk';
 
 const storage = new FSStorageProvider();
@@ -435,6 +436,34 @@ function checkSquadAgentMd(cwd: string): DoctorCheck {
   };
 }
 
+// ── copilot CLI check ───────────────────────────────────────────────
+
+/**
+ * Check that the Copilot CLI is reachable (needed by watch capabilities).
+ * Tests `copilot --version` with shell:true for Windows compatibility.
+ */
+function checkCopilotCli(): Promise<DoctorCheck> {
+  return new Promise((resolve) => {
+    execFile('copilot', ['--version'], { shell: true, timeout: 5000 }, (err) => {
+      if (err) {
+        resolve({
+          name: 'Copilot CLI available',
+          status: 'warn',
+          message:
+            "'copilot --version' failed — watch capabilities (monitor-teams, monitor-email) require the Copilot CLI. " +
+            "Install with: gh extension install github/gh-copilot",
+        });
+      } else {
+        resolve({
+          name: 'Copilot CLI available',
+          status: 'pass',
+          message: 'copilot CLI reachable',
+        });
+      }
+    });
+  });
+}
+
 // ── public API ──────────────────────────────────────────────────────
 
 /**
@@ -482,6 +511,9 @@ export async function runDoctor(cwd?: string): Promise<DoctorCheck[]> {
   // 11-12. ESM compatibility (Node 22/24+)
   checks.push(checkVscodeJsonrpcExports(resolvedCwd));
   checks.push(checkCopilotSdkSessionPatch(resolvedCwd));
+
+  // 13. Copilot CLI availability (needed by watch capabilities)
+  checks.push(await checkCopilotCli());
 
   return checks;
 }

--- a/packages/squad-cli/src/cli/commands/doctor.ts
+++ b/packages/squad-cli/src/cli/commands/doctor.ts
@@ -450,8 +450,8 @@ function checkCopilotCli(): Promise<DoctorCheck> {
           name: 'Copilot CLI available',
           status: 'warn',
           message:
-            "'copilot --version' failed — watch capabilities (monitor-teams, monitor-email) require the Copilot CLI. " +
-            "Install with: gh extension install github/gh-copilot",
+            "'copilot --version' failed — watch capabilities (monitor-teams, monitor-email, retro, decision-hygiene) require the Copilot CLI. " +
+            "If you installed the GitHub CLI extension, ensure 'copilot' is also available on your PATH, or set --agent-cmd to override.",
         });
       } else {
         resolve({

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/decision-hygiene.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/decision-hygiene.ts
@@ -21,7 +21,7 @@ function buildAgentCommand(prompt: string, context: WatchContext): { cmd: string
 
 function spawnWithTimeout(cmd: string, args: string[], cwd: string, timeoutMs: number): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    execFile(cmd, args, { cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024 }, (err) => {
+    execFile(cmd, args, { cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024, shell: true }, (err) => {
       if (err) {
         const execErr = err as Error & { killed?: boolean };
         reject(new Error(execErr.killed ? `Timed out after ${Math.round(timeoutMs / 1000)}s` : execErr.message));

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/monitor-email.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/monitor-email.ts
@@ -43,7 +43,9 @@ export class MonitorEmailCapability implements WatchCapability {
         if (err) {
           resolve({
             ok: false,
-            reason: 'Copilot CLI not found. Install with: gh extension install github/gh-copilot',
+            reason:
+              "Copilot CLI ('copilot') not found on PATH. Watch capabilities (monitor-teams, monitor-email, retro, decision-hygiene) require it. " +
+              "If you installed the GitHub CLI extension, ensure 'copilot' is also available on your PATH, or set --agent-cmd to override.",
           });
         } else {
           resolve({ ok: true });

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/monitor-email.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/monitor-email.ts
@@ -17,7 +17,7 @@ function buildAgentCommand(prompt: string, context: WatchContext): { cmd: string
 
 function spawnWithTimeout(cmd: string, args: string[], cwd: string, timeoutMs: number): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    execFile(cmd, args, { cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024 }, (err) => {
+    execFile(cmd, args, { cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024, shell: true }, (err) => {
       if (err) {
         const execErr = err as Error & { killed?: boolean };
         reject(new Error(execErr.killed ? `Timed out after ${Math.round(timeoutMs / 1000)}s` : execErr.message));
@@ -35,8 +35,21 @@ export class MonitorEmailCapability implements WatchCapability {
   readonly requires = ['gh', 'WorkIQ MCP'];
   readonly phase = 'housekeeping' as const;
 
-  async preflight(_context: WatchContext): Promise<PreflightResult> {
-    return { ok: true };
+  async preflight(context: WatchContext): Promise<PreflightResult> {
+    // If using custom agentCmd, skip copilot check
+    if (context.agentCmd) return { ok: true };
+    return new Promise((resolve) => {
+      execFile('copilot', ['--version'], { shell: true, timeout: 5000 }, (err) => {
+        if (err) {
+          resolve({
+            ok: false,
+            reason: 'Copilot CLI not found. Install with: gh extension install github/gh-copilot',
+          });
+        } else {
+          resolve({ ok: true });
+        }
+      });
+    });
   }
 
   async execute(context: WatchContext): Promise<CapabilityResult> {

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/monitor-teams.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/monitor-teams.ts
@@ -18,7 +18,7 @@ function buildAgentCommand(prompt: string, context: WatchContext): { cmd: string
 
 function spawnWithTimeout(cmd: string, args: string[], cwd: string, timeoutMs: number): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    execFile(cmd, args, { cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024 }, (err) => {
+    execFile(cmd, args, { cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024, shell: true }, (err) => {
       if (err) {
         const execErr = err as Error & { killed?: boolean };
         reject(new Error(execErr.killed ? `Timed out after ${Math.round(timeoutMs / 1000)}s` : execErr.message));
@@ -36,9 +36,21 @@ export class MonitorTeamsCapability implements WatchCapability {
   readonly requires = ['gh', 'WorkIQ MCP'];
   readonly phase = 'housekeeping' as const;
 
-  async preflight(_context: WatchContext): Promise<PreflightResult> {
-    // WorkIQ availability can only be checked at runtime; preflight is optimistic
-    return { ok: true };
+  async preflight(context: WatchContext): Promise<PreflightResult> {
+    // If using custom agentCmd, skip copilot check
+    if (context.agentCmd) return { ok: true };
+    return new Promise((resolve) => {
+      execFile('copilot', ['--version'], { shell: true, timeout: 5000 }, (err) => {
+        if (err) {
+          resolve({
+            ok: false,
+            reason: 'Copilot CLI not found. Install with: gh extension install github/gh-copilot',
+          });
+        } else {
+          resolve({ ok: true });
+        }
+      });
+    });
   }
 
   async execute(context: WatchContext): Promise<CapabilityResult> {

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/monitor-teams.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/monitor-teams.ts
@@ -44,7 +44,9 @@ export class MonitorTeamsCapability implements WatchCapability {
         if (err) {
           resolve({
             ok: false,
-            reason: 'Copilot CLI not found. Install with: gh extension install github/gh-copilot',
+            reason:
+              "Copilot CLI ('copilot') not found on PATH. Watch capabilities (monitor-teams, monitor-email, retro, decision-hygiene) require it. " +
+              "If you installed the GitHub CLI extension, ensure 'copilot' is also available on your PATH, or set --agent-cmd to override.",
           });
         } else {
           resolve({ ok: true });

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/retro.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/retro.ts
@@ -21,7 +21,7 @@ function buildAgentCommand(prompt: string, context: WatchContext): { cmd: string
 
 function spawnWithTimeout(cmd: string, args: string[], cwd: string, timeoutMs: number): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    execFile(cmd, args, { cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024 }, (err) => {
+    execFile(cmd, args, { cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024, shell: true }, (err) => {
       if (err) {
         const execErr = err as Error & { killed?: boolean };
         reject(new Error(execErr.killed ? `Timed out after ${Math.round(timeoutMs / 1000)}s` : execErr.message));

--- a/packages/squad-cli/src/cli/shell/index.ts
+++ b/packages/squad-cli/src/cli/shell/index.ts
@@ -941,9 +941,10 @@ export async function runShell(): Promise<void> {
 
       // P2: Cast confirmation — require user approval for freeform REPL casts
       if (!skipConfirmation) {
+        const memberNames = proposal.members.map(m => `${m.emoji} ${m.name}`).join(', ');
         shellApi?.addMessage({
           role: 'system',
-          content: 'Look good? Type **y** to confirm or **n** to cancel.',
+          content: `Confirm team: ${memberNames} (universe: ${proposal.universe})\n\nType **y** to confirm or **n** to cancel.`,
           timestamp: new Date(),
         });
         pendingCastConfirmation = { proposal, parsed };

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.9.6-build.3",
+  "version": "0.9.6-build.5",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.9.6-build.5",
+  "version": "0.9.6",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.9.6",
+  "version": "0.9.6-build.3",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",
@@ -232,7 +232,7 @@
     "node": ">=22.5.0"
   },
   "dependencies": {
-    "@github/copilot-sdk": "^0.1.32",
+    "@github/copilot-sdk": "^0.3.0",
     "vscode-jsonrpc": "^8.2.1"
   },
   "optionalDependencies": {

--- a/packages/squad-sdk/src/adapter/client.ts
+++ b/packages/squad-sdk/src/adapter/client.ts
@@ -315,7 +315,7 @@ export class SquadClient {
       autoStart: false, // We manage connection lifecycle
       autoRestart: false, // We handle reconnection ourselves
       env: this.options.env,
-      githubToken: this.options.githubToken,
+      gitHubToken: this.options.githubToken,
       useLoggedInUser: this.options.useLoggedInUser,
     });
   }
@@ -469,7 +469,7 @@ export class SquadClient {
 
       try {
         // Cast config to handle SDK version differences in SessionConfig type
-        const session = await this.client.createSession(config as Parameters<typeof this.client.createSession>[0]);
+        const session = await this.client.createSession(config as unknown as Parameters<typeof this.client.createSession>[0]);
         const result = new CopilotSessionAdapter(session);
         if (result.sessionId) {
           span.setAttribute('session.id', result.sessionId);
@@ -546,7 +546,7 @@ export class SquadClient {
 
       try {
         // Cast config to handle SDK version differences in ResumeSessionConfig type
-        const session = await this.client.resumeSession(sessionId, config as Parameters<typeof this.client.resumeSession>[1]);
+        const session = await this.client.resumeSession(sessionId, config as unknown as Parameters<typeof this.client.resumeSession>[1]);
         return new CopilotSessionAdapter(session);
       } catch (error) {
         if (this.shouldAttemptReconnect(error)) {

--- a/packages/squad-sdk/src/platform/index.ts
+++ b/packages/squad-sdk/src/platform/index.ts
@@ -30,6 +30,26 @@ import type { AdoWorkItemConfig } from './azure-devops.js';
 const storage = new FSStorageProvider();
 
 /**
+ * Read explicit GitHub repo override from .squad/config.json if present.
+ * Expected shape: { "github": { "owner": "...", "repo": "..." } }
+ */
+function readGitHubConfig(repoRoot: string): { owner: string; repo: string } | undefined {
+  const configPath = join(repoRoot, '.squad', 'config.json');
+  if (!storage.existsSync(configPath)) return undefined;
+  try {
+    const raw = storage.readSync(configPath) ?? '';
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (parsed.github && typeof parsed.github === 'object') {
+      const gh = parsed.github as Record<string, unknown>;
+      if (typeof gh.owner === 'string' && typeof gh.repo === 'string') {
+        return { owner: gh.owner, repo: gh.repo };
+      }
+    }
+  } catch { /* ignore parse errors */ }
+  return undefined;
+}
+
+/**
  * Read ADO work item config from .squad/config.json if present.
  */
 function readAdoConfig(repoRoot: string): AdoWorkItemConfig | undefined {
@@ -50,6 +70,12 @@ function readAdoConfig(repoRoot: string): AdoWorkItemConfig | undefined {
  * Throws if required remote info cannot be parsed.
  */
 export function createPlatformAdapter(repoRoot: string): PlatformAdapter {
+  // Prefer explicit GitHub config from .squad/config.json
+  const ghConfig = readGitHubConfig(repoRoot);
+  if (ghConfig) {
+    return new GitHubAdapter(ghConfig.owner, ghConfig.repo);
+  }
+
   const platform = detectPlatform(repoRoot);
   const remoteUrl = getRemoteUrl(repoRoot);
 

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -68,8 +68,8 @@ describe('squad doctor', () => {
 
     const squadDirCheck = checks.find((c: DoctorCheck) => c.name === '.squad/ directory exists');
     expect(squadDirCheck?.status).toBe('fail');
-    // When .squad/ is missing the file checks are skipped — .squad/ + squad.agent.md + Node version + 2 ESM checks
-    expect(checks.length).toBe(5);
+    // When .squad/ is missing the file checks are skipped — .squad/ + squad.agent.md + Node version + 2 ESM checks + Copilot CLI
+    expect(checks.length).toBe(6);
   });
 
   it('detects remote mode from config.json with teamRoot', async () => {

--- a/test/platform-adapter.test.ts
+++ b/test/platform-adapter.test.ts
@@ -1071,3 +1071,142 @@ describe('ADO exports from platform index', () => {
     expect(types.length).toBeGreaterThan(0);
   });
 });
+
+// ─── createPlatformAdapter with .squad/config.json GitHub override ─────
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+
+describe('createPlatformAdapter with .squad/config.json github override', () => {
+  let tempDir: string;
+
+  function setupTempRepo(): string {
+    tempDir = mkdtempSync(join(tmpdir(), 'squad-test-'));
+    // Initialize a git repo with a GitHub remote (fallback detection target)
+    execSync('git init', { cwd: tempDir, stdio: 'ignore' });
+    execSync('git remote add origin https://github.com/fallbackowner/fallbackrepo.git', { cwd: tempDir, stdio: 'ignore' });
+    return tempDir;
+  }
+
+  function cleanup(): void {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  it('uses owner/repo from .squad/config.json when present', async () => {
+    const repoRoot = setupTempRepo();
+    try {
+      // Write .squad/config.json with github override
+      const squadDir = join(repoRoot, '.squad');
+      mkdirSync(squadDir, { recursive: true });
+      writeFileSync(join(squadDir, 'config.json'), JSON.stringify({
+        github: { owner: 'testowner', repo: 'testrepo' }
+      }));
+
+      const { createPlatformAdapter } = await import('../packages/squad-sdk/src/platform/index.js');
+      const adapter = createPlatformAdapter(repoRoot);
+
+      // Should be a GitHubAdapter with the config values, not the remote values
+      expect(adapter).toBeDefined();
+      // Access internal state via the adapter's known interface
+      expect((adapter as any).owner).toBe('testowner');
+      expect((adapter as any).repo).toBe('testrepo');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('falls back to git remote when github key is absent', async () => {
+    const repoRoot = setupTempRepo();
+    try {
+      // Write .squad/config.json WITHOUT github key
+      const squadDir = join(repoRoot, '.squad');
+      mkdirSync(squadDir, { recursive: true });
+      writeFileSync(join(squadDir, 'config.json'), JSON.stringify({ version: 1 }));
+
+      const { createPlatformAdapter } = await import('../packages/squad-sdk/src/platform/index.js');
+      const adapter = createPlatformAdapter(repoRoot);
+
+      expect(adapter).toBeDefined();
+      expect((adapter as any).owner).toBe('fallbackowner');
+      expect((adapter as any).repo).toBe('fallbackrepo');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('falls back to git remote when github key is malformed (missing repo)', async () => {
+    const repoRoot = setupTempRepo();
+    try {
+      const squadDir = join(repoRoot, '.squad');
+      mkdirSync(squadDir, { recursive: true });
+      writeFileSync(join(squadDir, 'config.json'), JSON.stringify({
+        github: { owner: 'testowner' } // missing repo
+      }));
+
+      const { createPlatformAdapter } = await import('../packages/squad-sdk/src/platform/index.js');
+      const adapter = createPlatformAdapter(repoRoot);
+
+      expect(adapter).toBeDefined();
+      expect((adapter as any).owner).toBe('fallbackowner');
+      expect((adapter as any).repo).toBe('fallbackrepo');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('falls back to git remote when github key is malformed (non-string values)', async () => {
+    const repoRoot = setupTempRepo();
+    try {
+      const squadDir = join(repoRoot, '.squad');
+      mkdirSync(squadDir, { recursive: true });
+      writeFileSync(join(squadDir, 'config.json'), JSON.stringify({
+        github: { owner: 123, repo: true }
+      }));
+
+      const { createPlatformAdapter } = await import('../packages/squad-sdk/src/platform/index.js');
+      const adapter = createPlatformAdapter(repoRoot);
+
+      expect(adapter).toBeDefined();
+      expect((adapter as any).owner).toBe('fallbackowner');
+      expect((adapter as any).repo).toBe('fallbackrepo');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('falls back to git remote when config.json is invalid JSON', async () => {
+    const repoRoot = setupTempRepo();
+    try {
+      const squadDir = join(repoRoot, '.squad');
+      mkdirSync(squadDir, { recursive: true });
+      writeFileSync(join(squadDir, 'config.json'), '{ not valid json !!!');
+
+      const { createPlatformAdapter } = await import('../packages/squad-sdk/src/platform/index.js');
+      const adapter = createPlatformAdapter(repoRoot);
+
+      expect(adapter).toBeDefined();
+      expect((adapter as any).owner).toBe('fallbackowner');
+      expect((adapter as any).repo).toBe('fallbackrepo');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('falls back to git remote when no .squad/config.json exists', async () => {
+    const repoRoot = setupTempRepo();
+    try {
+      const { createPlatformAdapter } = await import('../packages/squad-sdk/src/platform/index.js');
+      const adapter = createPlatformAdapter(repoRoot);
+
+      expect(adapter).toBeDefined();
+      expect((adapter as any).owner).toBe('fallbackowner');
+      expect((adapter as any).repo).toBe('fallbackrepo');
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Squash the Gremlins

Five bug fixes in one pass:

| Issue | Fix |
|-------|-----|
| #920 | Add `shell: true` to `execFile()` in 4 watch capabilities (Windows spawn EINVAL) |
| #1062 | Bump `@github/copilot-sdk` to `^0.3.0` + adapt client.ts for API changes (ESM resolution error) |
| #880 | Add Copilot CLI check to `squad doctor` + preflight in monitor-teams/email |
| #1107 | Inline team member names in hire confirmation prompt |
| #905 | Support explicit `github.owner`/`github.repo` in `.squad/config.json` for repo override |

### Approach

- **#920**: The watch capabilities invoke `copilot` via `execFile()` which on Windows cannot resolve bare commands through PATH. Adding `shell: true` delegates resolution to the OS shell.
- **#1062**: The SDK's `@github/copilot-sdk` 0.1.32 had a broken ESM import. Bumping to 0.3.0 resolves it, with minor type-cast adjustments in `client.ts` for the renamed `gitHubToken` field.
- **#880**: Added a `checkCopilotCli()` doctor check and preflight guards in monitor-teams/email so users get clear guidance when the `copilot` CLI is missing.
- **#1107**: The confirmation prompt now lists team member names inline so the user doesn't need to scroll up to verify.
- **#905**: `createPlatformAdapter()` now reads `.squad/config.json` for explicit `github.owner`/`github.repo` overrides before falling back to git remote parsing.

### Testing

- `npm run build` passes
- `vitest run test/cli/doctor.test.ts` passes (updated check count assertion)
- `vitest run test/platform-adapter.test.ts` passes (6 new tests for config override)
- Pre-existing scheduler test failures on Windows are unchanged by this PR

Closes #920, Closes #1062, Closes #880, Closes #1107, Closes #905
