### PR TITLE
Add governed memory model, provider boundaries, diagnostics, and CLI validation

### DIFF
--- a/.changeset/memory-diagnostics-config.md
+++ b/.changeset/memory-diagnostics-config.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+Allow memory diagnostics log level to be configured from `.squad/config.json`.

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -3,14 +3,14 @@ name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
 ---
 
-<!-- version: 0.9.1 -->
+<!-- version: 0.0.0-source -->
 
 You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
 
 ### Coordinator Identity
 
 - **Name:** Squad (Coordinator)
-- **Version:** 0.9.1 (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v0.9.1` in your first response of each session (e.g., in the acknowledgment or greeting).
+- **Version:** 0.0.0-source (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v{version}` in your first response of each session (e.g., in the acknowledgment or greeting).
 - **Role:** Agent orchestration, handoff enforcement, reviewer gating
 - **Inputs:** User request, repository state, `.squad/decisions.md`
 - **Outputs owned:** Final assembled artifacts, orchestration log (via Scribe)
@@ -340,7 +340,7 @@ prompt: |
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
-  
+
   {% if WORKTREE_MODE %}
   **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
   {% endif %}
@@ -779,17 +779,17 @@ name: "{name}"
 description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
-  
+
   YOUR CHARTER:
   {paste contents of .squad/agents/{name}/charter.md here}
-  
+
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
   All `.squad/` paths are relative to this root.
-  
+
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
-  
+
   {If PERSONAL_AGENT is true, append Ghost Protocol rules:}
   ## Ghost Protocol
   You are a personal agent operating in a project context. You MUST follow these rules:
@@ -798,10 +798,10 @@ prompt: |
   - Transparent origin: Tag all logs with [personal:{name}]
   - Consult mode: Provide recommendations, not direct changes
   {end Ghost Protocol block}
-  
+
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
-  
+
   {% if WORKTREE_MODE %}
   **WORKTREE:** You are working in a dedicated worktree at `{WORKTREE_PATH}`.
   - All file operations should be relative to this path
@@ -809,63 +809,63 @@ prompt: |
   - Build and test in the worktree, not the main repo
   - Commit and push from the worktree
   {% endif %}
-  
+
   STATE_BACKEND: {state_backend}
-  
+
   {% if STATE_BACKEND == "git-notes" %}
   ## State Protocol — Git Notes
   This project uses git-notes for mutable state. **DO NOT write to `.squad/` files for state.**
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-  
+
   **Reading your state:**
   Run: `powershell .squad/scripts/notes/fetch.ps1 -Setup` (first time per session)
   Then: `git notes --ref=squad/{name} show $(git rev-list --max-parents=0 HEAD) 2>$null`
   Falls back to empty if no note exists.
-  
+
   **Writing state (history, decisions, learnings):**
   Run: `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{json}'`
   The helper handles JSON validation, conflict retry, and push.
-  
+
   **Decisions:** Write decisions as JSON via your note ref. Scribe will merge them.
   **Skills:** Skills are static config — write to `.squad/skills/` on disk as normal.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "orphan" %}
   ## State Protocol — Orphan Branch
   This project uses an orphan branch (`squad-state`) for mutable state.
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-  
+
   **Reading state:** Read `.squad/` files on disk — they are synced from the orphan branch.
   **Writing state:** Write to `.squad/` files on disk as normal during your session.
   Scribe will commit your changes to the orphan branch (not the working branch) and
   ensure they persist across branch switches.
-  
+
   **Important:** Do NOT commit `.squad/` state files to the working branch yourself.
   Scribe handles the orphan branch commit workflow.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "two-layer" %}
   ## State Protocol — Two-Layer (Git Notes + Orphan Branch)
   This project uses the two-layer architecture from Tamir's blog:
   - **Layer 1 (git notes):** Commit-scoped "why" annotations — invisible in PRs
   - **Layer 2 (orphan branch):** Permanent state store — decisions, histories, logs
-  
+
   Static config (charters, team.md, routing.md) is on disk as normal.
-  
+
   **During your session:**
   1. Write commit-scoped annotations as git notes on HEAD:
      `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
   2. Write bulk state (history, logs) to `.squad/` files on disk — Scribe moves them to the orphan branch.
-  
+
   **Note flags:**
   - `"promote_to_permanent": true` — Ralph promotes this to decisions.md after PR merge
   - `"archive_on_close": true` — Worth keeping even if PR is rejected (valuable research)
   - Neither flag — silently ignored if PR is rejected (correct for branch-specific decisions)
-  
+
   **Important:** Do NOT commit `.squad/` state files to the working branch.
   Scribe handles orphan commits. Ralph handles note promotion.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "worktree" or STATE_BACKEND is not defined %}
   Read .squad/agents/{name}/history.md (your project knowledge).
   {% endif %}
@@ -881,22 +881,22 @@ prompt: |
   Check .copilot/skills/ for copilot-level skills (process, workflow, protocol).
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
-  
+
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
-  
+
   **Requested by:** {current user name}
-  
+
   INPUT ARTIFACTS: {list exact file paths to review/modify}
-  
+
   The user says: "{message}"
-  
+
   Do the work. Respond as {Name}.
-  
+
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
-  
+
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
@@ -921,7 +921,7 @@ prompt: |
   {% endif %}
   3. SKILL EXTRACTION: If you found a reusable pattern, write/update
      .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
-  
+
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.
 ```

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -238,6 +238,17 @@ The `name` parameter generates the human-readable agent ID shown in the tasks pa
 2. Acknowledge briefly: `"📌 Captured. {one-line summary of the directive}."`
 3. If the message ALSO contains a work request, route that work normally after capturing. If it's directive-only, you're done — no agent spawn needed.
 
+### Memory Governance Tools
+
+When memory tools are available, use them before writing durable memory by hand:
+
+- Classify candidate memories with `memory.classify`.
+- Persist approved durable facts, decisions, and policies with `memory.write`.
+- Search governed memory with `memory.search` before relying only on raw file search.
+- Promote, delete, and audit governed entries with `memory.promote`, `memory.delete`, and `memory.audit`.
+
+If memory tools are not available, keep the prompt-only fallback: write local `.squad/` files directly using the decision inbox, agent histories, and skills. Do not claim provider-backed Copilot Memory, semantic indexing, or remote deletion unless a configured tool or CLI bridge performed the operation. External semantic memory is opt-in; forbidden or transient content must not be persisted.
+
 ### Routing
 
 The routing table determines **WHO** handles work. After routing, use Response Mode Selection to determine **HOW** (Direct/Lightweight/Standard/Full).
@@ -340,7 +351,7 @@ prompt: |
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
-
+  
   {% if WORKTREE_MODE %}
   **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
   {% endif %}
@@ -779,17 +790,17 @@ name: "{name}"
 description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
-
+  
   YOUR CHARTER:
   {paste contents of .squad/agents/{name}/charter.md here}
-
+  
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
   All `.squad/` paths are relative to this root.
-
+  
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
-
+  
   {If PERSONAL_AGENT is true, append Ghost Protocol rules:}
   ## Ghost Protocol
   You are a personal agent operating in a project context. You MUST follow these rules:
@@ -798,10 +809,10 @@ prompt: |
   - Transparent origin: Tag all logs with [personal:{name}]
   - Consult mode: Provide recommendations, not direct changes
   {end Ghost Protocol block}
-
+  
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
-
+  
   {% if WORKTREE_MODE %}
   **WORKTREE:** You are working in a dedicated worktree at `{WORKTREE_PATH}`.
   - All file operations should be relative to this path
@@ -809,63 +820,63 @@ prompt: |
   - Build and test in the worktree, not the main repo
   - Commit and push from the worktree
   {% endif %}
-
+  
   STATE_BACKEND: {state_backend}
-
+  
   {% if STATE_BACKEND == "git-notes" %}
   ## State Protocol — Git Notes
   This project uses git-notes for mutable state. **DO NOT write to `.squad/` files for state.**
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-
+  
   **Reading your state:**
   Run: `powershell .squad/scripts/notes/fetch.ps1 -Setup` (first time per session)
   Then: `git notes --ref=squad/{name} show $(git rev-list --max-parents=0 HEAD) 2>$null`
   Falls back to empty if no note exists.
-
+  
   **Writing state (history, decisions, learnings):**
   Run: `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{json}'`
   The helper handles JSON validation, conflict retry, and push.
-
+  
   **Decisions:** Write decisions as JSON via your note ref. Scribe will merge them.
   **Skills:** Skills are static config — write to `.squad/skills/` on disk as normal.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "orphan" %}
   ## State Protocol — Orphan Branch
   This project uses an orphan branch (`squad-state`) for mutable state.
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-
+  
   **Reading state:** Read `.squad/` files on disk — they are synced from the orphan branch.
   **Writing state:** Write to `.squad/` files on disk as normal during your session.
   Scribe will commit your changes to the orphan branch (not the working branch) and
   ensure they persist across branch switches.
-
+  
   **Important:** Do NOT commit `.squad/` state files to the working branch yourself.
   Scribe handles the orphan branch commit workflow.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "two-layer" %}
   ## State Protocol — Two-Layer (Git Notes + Orphan Branch)
   This project uses the two-layer architecture from Tamir's blog:
   - **Layer 1 (git notes):** Commit-scoped "why" annotations — invisible in PRs
   - **Layer 2 (orphan branch):** Permanent state store — decisions, histories, logs
-
+  
   Static config (charters, team.md, routing.md) is on disk as normal.
-
+  
   **During your session:**
   1. Write commit-scoped annotations as git notes on HEAD:
      `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
   2. Write bulk state (history, logs) to `.squad/` files on disk — Scribe moves them to the orphan branch.
-
+  
   **Note flags:**
   - `"promote_to_permanent": true` — Ralph promotes this to decisions.md after PR merge
   - `"archive_on_close": true` — Worth keeping even if PR is rejected (valuable research)
   - Neither flag — silently ignored if PR is rejected (correct for branch-specific decisions)
-
+  
   **Important:** Do NOT commit `.squad/` state files to the working branch.
   Scribe handles orphan commits. Ralph handles note promotion.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "worktree" or STATE_BACKEND is not defined %}
   Read .squad/agents/{name}/history.md (your project knowledge).
   {% endif %}
@@ -881,22 +892,22 @@ prompt: |
   Check .copilot/skills/ for copilot-level skills (process, workflow, protocol).
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
-
+  
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
-
+  
   **Requested by:** {current user name}
-
+  
   INPUT ARTIFACTS: {list exact file paths to review/modify}
-
+  
   The user says: "{message}"
-
+  
   Do the work. Respond as {Name}.
-
+  
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
-
+  
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
@@ -921,7 +932,7 @@ prompt: |
   {% endif %}
   3. SKILL EXTRACTION: If you found a reusable pattern, write/update
      .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
-
+  
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.
 ```

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -238,6 +238,17 @@ The `name` parameter generates the human-readable agent ID shown in the tasks pa
 2. Acknowledge briefly: `"📌 Captured. {one-line summary of the directive}."`
 3. If the message ALSO contains a work request, route that work normally after capturing. If it's directive-only, you're done — no agent spawn needed.
 
+### Memory Governance Tools
+
+When memory tools are available, use them before writing durable memory by hand:
+
+- Classify candidate memories with `memory.classify`.
+- Persist approved durable facts, decisions, and policies with `memory.write`.
+- Search governed memory with `memory.search` before relying only on raw file search.
+- Promote, delete, and audit governed entries with `memory.promote`, `memory.delete`, and `memory.audit`.
+
+If memory tools are not available, keep the prompt-only fallback: write local `.squad/` files directly using the decision inbox, agent histories, and skills. Do not claim provider-backed Copilot Memory, semantic indexing, or remote deletion unless a configured tool or CLI bridge performed the operation. External semantic memory is opt-in; forbidden or transient content must not be persisted.
+
 ### Routing
 
 The routing table determines **WHO** handles work. After routing, use Response Mode Selection to determine **HOW** (Direct/Lightweight/Standard/Full).

--- a/docs/proposals/memory-governance-provider.md
+++ b/docs/proposals/memory-governance-provider.md
@@ -1,0 +1,391 @@
+# Proposal: Memory Governance Provider
+
+**Issue:** bradygaster/squad#600
+**Author:** tamirdresher
+**Date:** 2026-05-18
+**Status:** Design
+
+---
+
+## Problem Statement
+
+Squad currently treats memory as files under `.squad/` loaded through state and storage
+helpers. That is the right default for local worktrees, but it blurs three different
+concerns:
+
+1. Persisting bytes somewhere.
+2. Deciding which memories are safe and useful to keep.
+3. Retrieving the right memory for a task.
+
+As provider work expands, especially around Copilot Memory and external memory systems,
+Squad needs a higher-level memory governance layer without turning `StorageProvider` into
+a semantic database, policy engine, or agent behavior system.
+
+---
+
+## Design Principles
+
+### StorageProvider stays dumb
+
+`StorageProvider` remains the low-level persistence abstraction. It should read, write,
+list, and delete file/blob-like content. It should not:
+
+- classify memories
+- decide retention policy
+- understand semantic similarity
+- call LLMs
+- enforce durable-memory safety rules
+- know whether content is a decision, directive, policy, or transient note
+
+This keeps the existing storage abstraction portable across local disk, worktree state,
+remote blobs, and future plugin-backed state backends.
+
+### Memory governance sits above state and storage
+
+A new `MemoryGovernanceProvider` / `MemoryStore` should sit above `SquadState` and
+`StorageProvider`.
+
+```text
+Agents / CLI / MCP tools
+        |
+        v
+MemoryStore / MemoryGovernanceProvider
+        |
+        +--> classification, policy, routing, retrieval, promotion
+        |
+        v
+SquadState
+        |
+        v
+StorageProvider
+```
+
+`SquadState` remains the structured state surface for `.squad/` data. The governance
+provider decides what should become memory, where it belongs, and whether it is allowed
+to become durable.
+
+---
+
+## Memory Classes
+
+Every proposed memory write should be classified before persistence.
+
+| Class | Meaning | Default destination |
+|-------|---------|---------------------|
+| `TRANSIENT` | Short-lived task state, CI/PR status, scratch observations, temporary blockers | Do not persist as durable memory |
+| `LOCAL` | Repo-specific context useful in this worktree, such as conventions, file locations, and implementation notes | `.squad/agents/{name}/history.md` or local inbox |
+| `DECISION` | User-approved or team-relevant decision that should guide future work | `.squad/decisions/inbox/` then `decisions.md` |
+| `POLICY` | Durable directive, security rule, workflow rule, or governance constraint | `.squad/decisions.md` / policy section |
+| `COPILOT_MEMORY` | Safe, durable semantic memory intended for Copilot Memory or another semantic provider | Optional external semantic memory provider |
+| `FORBIDDEN` | Secrets, PII, topology, raw logs, credentials, or other disallowed data | Reject and do not persist |
+
+Classification should prefer safety over recall. If content is ambiguous, keep it local
+or transient rather than writing to durable semantic memory.
+
+---
+
+## Provider Roles
+
+### Worktree/local memory remains the default
+
+For `squad init` and Copilot custom agents, local worktree memory remains the default:
+
+- `.squad/decisions.md`
+- `.squad/decisions/inbox/`
+- `.squad/agents/{name}/history.md`
+- `.squad/skills/{name}/SKILL.md`
+
+This keeps Squad usable offline, reviewable in Git, and compatible with existing teams.
+It also preserves the current prompt-only behavior for Copilot custom agents: when no
+tool bridge is available, agents write `.squad/` files directly.
+
+`StorageProvider` participates when Squad is running through SDK or runtime abstractions
+that load state through provider-backed services. It is not automatically exercised by
+`squad init` plus a Copilot CLI custom agent in prompt-only mode; that path relies on the
+agent instructions and local `.squad/` files unless a CLI/MCP bridge is installed.
+
+### Copilot Memory is optional semantic memory
+
+Copilot Memory is not a `StorageProvider`. It is an optional semantic durable memory
+destination behind `MemoryGovernanceProvider`.
+
+The governance layer may route selected `COPILOT_MEMORY` entries to Copilot Memory when:
+
+- the user or team has enabled it
+- classification marks the content safe
+- the entry is stable enough to be useful across sessions
+- the write path supports auditability and deletion
+
+The local `.squad/` files remain the source of truth unless a future configuration
+explicitly selects another governance provider.
+
+Current implementation does not include a real callable Copilot Memory API. Squad does not
+ship, discover, or emulate a Copilot Memory service client, and `provider=copilot` fails
+with an explicit "real Copilot Memory API unavailable" error unless a concrete provider
+module is added. The only current bridge is named `hostInjectedCopilotAdapter`; hosts that
+have access to a real API can inject a `CopilotMemoryProviderClient` into the governed
+memory layer. When `.squad/memory/config.json` enables
+`externalProviders.hostInjectedCopilotAdapter` but no client is supplied, writes, searches,
+and deletes fail closed with clear errors and no fake persistence.
+
+The provider path still goes through governance:
+
+- `COPILOT_MEMORY` writes are classified before the provider is called.
+- forbidden, transient, unapproved, or disabled-provider writes are rejected before any
+  external call.
+- audits record action, class, provider, ids, paths, reasons, and actor, but never raw
+  memory content.
+- deletes call the provider delete operation, mark the governed index entry deleted, and
+  write a local tombstone for auditability.
+- `squad memory provider` reports that real Copilot Memory is unavailable locally, whether
+  `hostInjectedCopilotAdapter` is enabled, and whether the current process has a
+  host-injected client.
+
+### Tool bridge is required for pluggable providers
+
+Copilot custom agents cannot reliably use pluggable memory providers through prompt
+instructions alone. A CLI/MCP/tool bridge is needed so agents can call explicit
+operations such as:
+
+- `memory.classify`
+- `memory.write`
+- `memory.search`
+- `memory.promote`
+- `memory.delete`
+- `memory.audit`
+
+Without that bridge, the fallback is prompt-only local writes to `.squad/` files. That
+fallback is intentionally limited: it preserves current behavior but cannot guarantee
+provider routing, semantic indexing, policy enforcement, or remote deletion.
+
+---
+
+## Agent Responsibilities
+
+Squad should not assume every team has the same named agents. Only the default team
+roles should be required by the memory governance path; richer teams can add specialist
+reviewers by capability.
+
+| Role | Availability | Responsibility |
+|------|--------------|----------------|
+| Scribe | Default | Owns memory stewardship: consolidates inbox entries, summarizes local history, proposes promotions, detects directive conflicts, prepares candidate durable entries, and records audit metadata. |
+| Ralph | Default | Monitors stale work, recurring failures, and backlog signals that may indicate missing or outdated memory. Ralph can suggest memory review, but does not approve policy-sensitive writes. |
+| Domain/research specialist | Optional | Validates sources, retrieves historical context, distinguishes durable facts from transient findings, and identifies when the user should approve promotion. |
+| Safety/review specialist | Optional | Enforces safety boundaries: rejects `FORBIDDEN` writes, reviews security-sensitive memory, and defines redaction requirements. |
+| Framework/architecture specialist | Optional | Owns provider boundaries, schemas, classification taxonomy, tool bridge contracts, and compatibility with state backends. |
+| Team lead/coordinator | Optional | Coordinates team-level policy and final decisions: approves governance defaults, user-facing behavior, and rollout sequencing. |
+
+For example, Tamir's project Squad maps those optional capabilities to agents such as
+Seven, Worf, Data, and Picard. That mapping is an implementation of the capability model,
+not a requirement for every Squad installation.
+
+### Default role decision
+
+The governance model does not require a new always-created memory role at `squad init`
+time. Scribe is already the default durable-record role, so memory governance should extend
+Scribe's responsibilities and give it explicit tools, classification rules, and audit
+obligations. A future `Memory Steward` template may be useful for larger teams, but it
+should be optional unless Scribe's role becomes too broad in practice.
+
+---
+
+## Relationship to Existing Work
+
+### Tiered memory (#600)
+
+This design extends [Tiered Agent Memory](tiered-memory.md). The hot/cold/wiki model
+describes context loading and promotion. Memory governance defines the provider boundary
+and safety rules that decide what may enter those tiers or an external semantic memory.
+
+The two designs are compatible:
+
+- hot memory maps mostly to `TRANSIENT` and recent `LOCAL`
+- cold memory maps to summarized `LOCAL`
+- wiki memory maps to stable `DECISION`, `POLICY`, and selected durable knowledge
+- semantic memory maps only to explicitly safe `COPILOT_MEMORY`
+
+### State backend and plugin work
+
+Provider work for state backends should stay focused on where bytes live. Memory
+governance should decide what bytes are worth writing, how they are classified, and which
+provider receives them.
+
+This avoids coupling the memory policy model to any one runtime plugin, including the
+separate mempalace runtime provider worktree.
+
+---
+
+## Upgrade Story
+
+`squad upgrade` is the user-facing path that makes the new model usable in existing
+repositories. The upgrade must be non-destructive, idempotent, and safe to re-run.
+
+The upgrade should:
+
+- detect the existing `.squad/` version, layout, and any memory/governance config
+- preserve existing `decisions.md`, agent histories, skills, routing, `team.md`, and
+  ceremony files
+- create or migrate `.squad/memory/config.json` or an equivalent policy file with a
+  local-only default
+- add default memory governance policy without overwriting user-authored edits
+- update Scribe's charter responsibilities for memory stewardship through a managed
+  block, patch, or migration note pattern rather than replacing custom charter text
+- preserve Ralph's role as a monitor for stale work and repeated rediscovery, not as the
+  owner of memory policy
+- add CLI/MCP bridge configuration only when the bridge is installed and available
+- leave prompt-only local `.squad/` fallback in place when no bridge exists
+- keep external semantic providers, including Copilot Memory, disabled unless explicitly
+  opted in by the user or repository policy
+- produce a migration report that lists created, changed, skipped, and manually required
+  actions
+
+Before changing existing files, `squad upgrade` should create a rollback point: either a
+timestamped backup of changed `.squad/` files, a reversible migration journal, or a clear
+Git-friendly migration report when the worktree itself is the rollback mechanism. The
+rollback story must cover policy config, managed charter updates, and bridge config.
+
+---
+
+## E2E Validation Story
+
+This model is not complete when the taxonomy, unit tests, or proposal text pass review.
+It is complete only after a real human-style Squad workflow validates upgrade, fallback,
+tool-backed memory, rejection, promotion, deletion, and audit behavior end to end.
+
+The required scenario is:
+
+1. Start with an existing repository that already has a `.squad/` directory from current
+   or older Squad.
+2. Run `squad upgrade`.
+3. Verify the upgrade preserves existing `decisions.md`, agent histories, skills, routing,
+   `team.md`, and ceremonies.
+4. Verify the upgrade adds memory governance config and default local-only policy without
+   overwriting user edits.
+5. Select the Squad custom agent in Copilot CLI.
+6. In prompt-only mode, verify the agent continues to use local `.squad/` memory safely.
+7. With CLI/MCP memory tools installed and enabled, verify the agent uses
+   `memory.classify`, `memory.write`, `memory.search`, `memory.promote`,
+   `memory.delete`, and `memory.audit` rather than relying only on prompt instructions.
+8. Verify Scribe proposes and promotes memory according to policy.
+9. Verify Ralph detects repeated rediscovery or stale work and suggests memory review
+   while leaving policy ownership with Scribe/governance.
+10. Verify optional specialists participate only when configured by the team.
+11. Attempt to store forbidden memory such as secrets, PII, topology, raw logs, or
+    transient CI/PR status; verify the write is rejected and audited.
+12. Attempt to store durable semantic memory; verify Copilot Memory or any external
+    semantic provider is used only after opt-in and required approval.
+13. Verify deletion removes or tombstones governed memory through the configured provider
+    and that `memory.audit` reports writes, promotions, rejections, and deletes.
+
+The E2E test should be run from the user's perspective: clone/open repo, upgrade, select
+the Squad agent, perform normal work, observe what memory is proposed, and inspect the
+resulting local files and audit output.
+
+---
+
+## Security and Retention Rules
+
+The governance provider must not write the following to durable memory:
+
+- secrets, credentials, tokens, keys, connection strings
+- PII or customer data
+- internal network topology or sensitive infrastructure details
+- raw logs, traces, dumps, or telemetry payloads
+- transient CI status, PR status, build output, or one-time task progress
+- unreviewed vulnerability details that would increase risk if retained
+
+Allowed durable memory should be distilled: decisions, policies, stable conventions,
+safe architectural summaries, and reusable workflow knowledge.
+
+### Provider guarantees
+
+Any provider used behind `MemoryGovernanceProvider` must document its operational
+guarantees before it is enabled by default:
+
+- tenant and repository isolation
+- path traversal and namespace confinement
+- encryption expectations for local and remote storage
+- atomic writes or explicit conflict behavior
+- locking/concurrency behavior for concurrent Squad sessions
+- deletion and rollback behavior
+- audit records for durable writes, promotions, rejections, and deletes
+- migration compatibility between provider versions
+
+Prompt instructions are not enough for these guarantees. Prompt-only fallback is useful
+for compatibility, but tool-backed or runtime-backed providers need deterministic checks,
+tests, and audit output.
+
+---
+
+## Implementation Phases
+
+### Phase 0: Documentation and taxonomy
+
+- Document provider boundaries and memory classes.
+- Add public-facing wording that local worktree memory remains the default.
+- Cross-link the tiered memory proposal.
+
+### Phase 1: Local governance shim
+
+- Add a local-only `MemoryStore` facade over `SquadState`.
+- Classify writes before they land in `.squad/`.
+- Keep `StorageProvider` unchanged.
+- Preserve prompt-only fallback for Copilot custom agents.
+
+### Phase 2: CLI/MCP bridge
+
+- Expose memory operations through CLI and MCP tools.
+- Let Copilot custom agents call tool-backed classification, search, and writes.
+- Add audit output so users can inspect what was stored and why.
+
+### Phase 3: Optional semantic provider
+
+- Add an opt-in provider adapter for Copilot Memory or another semantic memory system.
+- Route only `COPILOT_MEMORY` entries after safety checks.
+- Keep local `.squad/` memory as the default and fallback.
+- Implemented only as an explicit `hostInjectedCopilotAdapter` contract; real
+  `provider=copilot` remains blocked until a concrete callable API exists locally, and
+  missing host clients fail closed rather than pretending to persist semantic memory.
+
+### Phase 4: Promotion and lifecycle automation
+
+- Let Scribe propose promotions from local/cold memory to wiki or semantic durable memory.
+- Add retention, expiration, deletion, and conflict resolution flows.
+- Validate behavior against tiered-memory context budgets.
+
+---
+
+## Acceptance Criteria
+
+- `StorageProvider` remains a file/blob persistence interface.
+- A higher-level `MemoryGovernanceProvider` / `MemoryStore` boundary is documented before runtime implementation.
+- `squad init` and Copilot custom agents keep local worktree memory as the default.
+- Copilot Memory is documented as optional semantic durable memory, not as storage.
+- Prompt-only custom agents can still write `.squad/` files when no bridge exists.
+- Tool-backed custom agents have a clear CLI/MCP bridge direction for pluggable providers.
+- `squad upgrade` is non-destructive, idempotent, detects existing `.squad/` state, and
+  preserves decisions, histories, skills, routing, `team.md`, and ceremonies.
+- `squad upgrade` creates or migrates local-only memory governance policy without
+  overwriting user edits and reports changed, skipped, and manual migration actions.
+- Scribe receives memory stewardship responsibilities through managed updates or
+  migration notes, while Ralph remains a monitor rather than policy owner.
+- CLI/MCP bridge config is added only when available; otherwise prompt-only local
+  `.squad/` fallback remains valid.
+- External semantic providers, including Copilot Memory, require explicit opt-in and
+  approval before durable semantic writes.
+- Memory writes are classified as `TRANSIENT`, `LOCAL`, `DECISION`, `POLICY`, `COPILOT_MEMORY`, or `FORBIDDEN`.
+- Durable memory rejects secrets, PII, topology, raw logs, and transient CI/PR status.
+- Providers document isolation, deletion, audit, concurrency, and migration guarantees.
+- Tests cover redaction, denied persistence, provider conformance, rollback/delete, and concurrent-write behavior.
+- E2E validation covers an existing repo upgraded with `squad upgrade`, Copilot CLI
+  custom-agent use, prompt-only fallback, tool-backed memory operations, Scribe/Ralph
+  behavior, forbidden-memory rejection, semantic opt-in/approval, deletion, and audit.
+- The relationship to #600 and state-backend/plugin work is explicit.
+
+---
+
+## References
+
+- Issue: bradygaster/squad#600
+- Related proposal: [Tiered Agent Memory](tiered-memory.md)
+- Internal format: [Squad Entry Markdown Format](../_internal/specs/memory-format.md)

--- a/docs/proposals/tiered-memory.md
+++ b/docs/proposals/tiered-memory.md
@@ -7,6 +7,13 @@
 
 ---
 
+> **Related follow-up:** [Memory Governance Provider](memory-governance-provider.md)
+> extends this tiered-memory proposal with provider boundaries, memory classification,
+> Copilot Memory positioning, and safety rules. This document still describes the
+> hot/cold/wiki context model for bradygaster/squad#600.
+
+---
+
 ## Problem Statement
 
 Squad agents load their full conversation history on every spawn. In production, top agents carry:

--- a/docs/src/content/docs/features/memory.md
+++ b/docs/src/content/docs/features/memory.md
@@ -18,13 +18,78 @@ Always use single quotes in TypeScript
 What does Kane remember about the authentication system?
 ```
 
-Squad remembers everything — decisions, conventions, architecture patterns, and individual agent learnings. Memory grows with every session, making agents smarter over time.
+Squad remembers the durable things that help future work — decisions, conventions,
+architecture patterns, and individual agent learnings. It should not retain secrets, raw
+logs, transient CI/PR status, or other data that is unsafe or too short-lived to become
+memory.
 
 ---
 
 ## Memory Layers
 
 Squad's memory is layered. Each layer serves a different purpose, and knowledge grows with every session.
+
+By default, Squad memory is local worktree memory stored in `.squad/` files. Future
+provider work keeps that local model as the default while adding a governance layer for
+classification, safety, and optional semantic durable memory such as Copilot Memory.
+External semantic memory is opt-in; it is not required for `squad init` or Copilot custom
+agents using the prompt-only `.squad/` fallback.
+
+`squad init` and `squad upgrade` scaffold a local-only governance policy at
+`.squad/memory/config.json`. The default provider is `local`, Copilot Memory is disabled,
+and audit records are written to `.squad/memory/audit.jsonl` without storing memory content.
+
+Tool-backed runtimes can use governed operations:
+
+```text
+memory.classify
+memory.write
+memory.search
+memory.promote
+memory.delete
+memory.audit
+```
+
+Governed memory records include load-guidance metadata so prompts and providers can choose
+what to load without weakening safety gates:
+
+| Tag | Meaning |
+| --- | --- |
+| `[ALWAYS]` | Durable policies and decisions that should be loaded eagerly. |
+| `[ON-DEMAND]` | Stable local or semantic facts retrieved when relevant to a query. |
+| `[ARCHIVE]` | Superseded/deleted entries and tombstones kept for audit/history, not active prompt loading. |
+| `[NEVER]` | Forbidden or transient content that must not be persisted or loaded. |
+
+When an entry is promoted or superseded, the previous index entry is marked `[ARCHIVE]`
+and records `supersededBy` so tooling can follow the forward link to the active successor.
+
+The CLI exposes the same local bridge:
+
+```bash
+squad memory classify "Always run tests before merge"
+squad memory write --content "Use Vitest for SDK regression tests" --class DECISION --author scribe
+squad memory search --query "Vitest"
+squad memory audit
+squad memory provider
+```
+
+Prompt-only Copilot custom agents still fall back to direct `.squad/` file edits. That
+fallback is intentionally local: it does not claim provider-backed semantic memory,
+external indexing, policy enforcement, or remote deletion unless a CLI/MCP/tool bridge is
+installed and used.
+
+Real `provider=copilot` support is unavailable unless a concrete callable Copilot Memory API
+exists in the installed SDK/tooling. Squad does not invent endpoints or fake a remote memory
+service. The only current bridge is explicitly named `hostInjectedCopilotAdapter`; it is
+opt-in and only works when a host supplies a client. Otherwise provider-backed writes fail
+closed after auditing the rejected attempt. Forbidden content is classified and rejected
+before any provider call.
+
+The installed Copilot SDK/CLI currently exposes memory as an agent capability/permission
+concept, not as a documented SDK storage client for write/search/delete. Config files may
+contain `defaultProvider: "copilot"` for forward compatibility, but status reports it as
+configured and unavailable, and governed reads/writes fail closed until a real callable API
+exists.
 
 ---
 
@@ -127,7 +192,9 @@ Skills differ from decisions — decisions are project policies ("use PostgreSQL
 
 ## Tips
 
-- **Commit `.squad/`** — anyone who clones the repo gets the team with all their accumulated knowledge.
+- **Commit intentional `.squad/` state** — anyone who clones the repo gets the team with
+  its accumulated decisions and skills. Never store secrets, credentials, raw logs, or
+  private customer data in Squad memory.
 - Directives ("always...", "never...") are the fastest way to shape team behavior. Use them liberally.
 - If an agent keeps making the same mistake, check `decisions.md` — the relevant convention might be missing.
 - You can edit `decisions.md` and `history.md` files directly. They're plain Markdown.

--- a/docs/src/content/docs/features/memory.md
+++ b/docs/src/content/docs/features/memory.md
@@ -73,6 +73,11 @@ squad memory audit
 squad memory provider
 ```
 
+Use `--log-level info|debug` (or `--verbose`) when troubleshooting memory command
+activity. Diagnostics are written to stderr and include safe metadata such as the command,
+provider, load-guidance, path, result counts, and timing. They do not print raw memory
+content or search text.
+
 Prompt-only Copilot custom agents still fall back to direct `.squad/` file edits. That
 fallback is intentionally local: it does not claim provider-backed semantic memory,
 external indexing, policy enforcement, or remote deletion unless a CLI/MCP/tool bridge is

--- a/docs/src/content/docs/features/memory.md
+++ b/docs/src/content/docs/features/memory.md
@@ -73,10 +73,22 @@ squad memory audit
 squad memory provider
 ```
 
-Use `--log-level info|debug` (or `--verbose`) when troubleshooting memory command
-activity. Diagnostics are written to stderr and include safe metadata such as the command,
-provider, load-guidance, path, result counts, and timing. They do not print raw memory
-content or search text.
+Use `--log-level none|error|info|debug` (or `--verbose`) when troubleshooting memory
+command activity. For persistent project-level diagnostics, set the same level in
+`.squad/config.json`:
+
+```json
+{
+  "memory": {
+    "logLevel": "info"
+  }
+}
+```
+
+Precedence is: explicit CLI switch, then `SQUAD_MEMORY_LOG_LEVEL`, then
+`.squad/config.json` `memory.logLevel`, then the default `none`. Diagnostics are written
+to stderr and include safe metadata such as the command, provider, load-guidance, path,
+result counts, and timing. They do not print raw memory content or search text.
 
 Prompt-only Copilot custom agents still fall back to direct `.squad/` file edits. That
 fallback is intentionally local: it does not claim provider-backed semantic memory,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "bench": "node scripts/run-benchmarks.mjs",
+    "experiment:memory-value": "node scripts/measure-memory-value.mjs",
     "experiment:real-cli-ab": "node scripts/real-cli-ab.js",
     "bench:cold-start": "node scripts/measure-cold-start.mjs",
     "lint": "tsc --noEmit -p packages/squad-sdk/tsconfig.json && tsc --noEmit -p packages/squad-cli/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "bench": "node scripts/run-benchmarks.mjs",
+    "experiment:real-cli-ab": "node scripts/real-cli-ab.js",
     "bench:cold-start": "node scripts/measure-cold-start.mjs",
     "lint": "tsc --noEmit -p packages/squad-sdk/tsconfig.json && tsc --noEmit -p packages/squad-cli/tsconfig.json",
     "lint:eslint": "eslint packages/ test/",

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -149,6 +149,10 @@
       "types": "./dist/cli/commands/copilot.d.ts",
       "import": "./dist/cli/commands/copilot.js"
     },
+    "./commands/memory": {
+      "types": "./dist/cli/commands/memory.d.ts",
+      "import": "./dist/cli/commands/memory.js"
+    },
     "./commands/cost": {
       "types": "./dist/cli/commands/cost.d.ts",
       "import": "./dist/cli/commands/cost.js"

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -222,6 +222,8 @@ async function main(): Promise<void> {
     console.log(`  ${BOLD}nap${RESET}        Context hygiene (compress, prune, archive .squad/ state)`);
     console.log(`             Usage: nap [--deep] [--dry-run]`);
     console.log(`             Flags: --deep (thorough cleanup), --dry-run (preview only)`);
+    console.log(`  ${BOLD}memory${RESET}     Governed memory operations (classify, write, search, promote, delete, audit, provider)`);
+    console.log(`             Usage: memory write --content "..." --class LOCAL`);
     console.log(`  ${BOLD}doctor${RESET}     Validate squad setup (check files, config, health)`);
     console.log(`  ${BOLD}consult${RESET}    Enter consult mode with your personal squad`);
     console.log(`             Flags: --status, --check`);
@@ -410,6 +412,12 @@ async function main(): Promise<void> {
       ensureHooksForBackend(dest);
     }
     
+    return;
+  }
+
+  if (cmd === 'memory') {
+    const { runMemoryCommand } = await import('./cli/commands/memory.js');
+    await runMemoryCommand(getSquadStartDir(), args.slice(1));
     return;
   }
 

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -223,7 +223,6 @@ async function main(): Promise<void> {
     console.log(`             Usage: nap [--deep] [--dry-run]`);
     console.log(`             Flags: --deep (thorough cleanup), --dry-run (preview only)`);
     console.log(`  ${BOLD}memory${RESET}     Governed memory operations`);
-    console.log(`             Actions: classify, write, search, promote, delete, audit, provider`);
     console.log(`             Usage: memory write --content "..." --class LOCAL`);
     console.log(`             Diagnostics: --log-level info|debug or --verbose`);
     console.log(`  ${BOLD}doctor${RESET}     Validate squad setup (check files, config, health)`);

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -224,6 +224,7 @@ async function main(): Promise<void> {
     console.log(`             Flags: --deep (thorough cleanup), --dry-run (preview only)`);
     console.log(`  ${BOLD}memory${RESET}     Governed memory operations (classify, write, search, promote, delete, audit, provider)`);
     console.log(`             Usage: memory write --content "..." --class LOCAL`);
+    console.log(`             Diagnostics: --log-level info|debug or --verbose`);
     console.log(`  ${BOLD}doctor${RESET}     Validate squad setup (check files, config, health)`);
     console.log(`  ${BOLD}consult${RESET}    Enter consult mode with your personal squad`);
     console.log(`             Flags: --status, --check`);

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -222,7 +222,8 @@ async function main(): Promise<void> {
     console.log(`  ${BOLD}nap${RESET}        Context hygiene (compress, prune, archive .squad/ state)`);
     console.log(`             Usage: nap [--deep] [--dry-run]`);
     console.log(`             Flags: --deep (thorough cleanup), --dry-run (preview only)`);
-    console.log(`  ${BOLD}memory${RESET}     Governed memory operations (classify, write, search, promote, delete, audit, provider)`);
+    console.log(`  ${BOLD}memory${RESET}     Governed memory operations`);
+    console.log(`             Actions: classify, write, search, promote, delete, audit, provider`);
     console.log(`             Usage: memory write --content "..." --class LOCAL`);
     console.log(`             Diagnostics: --log-level info|debug or --verbose`);
     console.log(`  ${BOLD}doctor${RESET}     Validate squad setup (check files, config, health)`);

--- a/packages/squad-cli/src/cli/commands/memory.ts
+++ b/packages/squad-cli/src/cli/commands/memory.ts
@@ -1,0 +1,150 @@
+import {
+  FSStorageProvider,
+  LocalMemoryStore,
+  type MemoryClass,
+  type MemoryLoadGuidance,
+} from '@bradygaster/squad-sdk';
+
+const REAL_COPILOT_UNAVAILABLE_REASON =
+  'Real Copilot Memory API unavailable: no concrete callable API was found in installed @github/copilot SDK/tooling. Squad will not fake provider=copilot; use hostInjectedCopilotAdapter only when a host supplies a client.';
+
+function readFlag(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function readContent(args: string[]): string {
+  const content = readFlag(args, '--content');
+  if (content) return content;
+  return args.filter(arg => !arg.startsWith('--')).slice(1).join(' ');
+}
+
+function parseClass(value: string | undefined): MemoryClass | undefined {
+  if (!value) return undefined;
+  const normalized = value.toUpperCase();
+  if (['TRANSIENT', 'LOCAL', 'DECISION', 'POLICY', 'COPILOT_MEMORY', 'FORBIDDEN'].includes(normalized)) {
+    return normalized as MemoryClass;
+  }
+  throw new Error(`Unknown memory class: ${value}`);
+}
+
+function parseLoadGuidance(value: string | undefined): MemoryLoadGuidance | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().replace(/^\[|\]$/g, '').toUpperCase();
+  if (['ALWAYS', 'ON-DEMAND', 'ARCHIVE', 'NEVER'].includes(normalized)) {
+    return normalized as MemoryLoadGuidance;
+  }
+  throw new Error(`Unknown load guidance: ${value}`);
+}
+
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined) return defaultValue;
+  if (['true', '1', 'yes', 'on'].includes(value.toLowerCase())) return true;
+  if (['false', '0', 'no', 'off'].includes(value.toLowerCase())) return false;
+  throw new Error(`Expected boolean value, got: ${value}`);
+}
+
+export async function runMemoryCommand(projectRoot: string, args: string[]): Promise<void> {
+  const operation = args[0] ?? 'help';
+  const store = new LocalMemoryStore(new FSStorageProvider(), projectRoot);
+  const providerStore = store as LocalMemoryStore & {
+    configureHostInjectedCopilotAdapter(options: {
+      enabled: boolean;
+      requireApproval?: boolean;
+      defaultProvider?: 'local' | 'hostInjectedCopilotAdapter';
+      actor?: string;
+    }): Promise<unknown>;
+    providerStatus(): Promise<unknown>;
+  };
+
+  if (operation === 'classify') {
+    const content = readContent(args);
+    const loadGuidance = parseLoadGuidance(readFlag(args, '--load-guidance'));
+    const classification = await store.classify({
+      content,
+      requestedClass: parseClass(readFlag(args, '--class')),
+      metadata: loadGuidance ? { loadGuidance } : undefined,
+    });
+    console.log(JSON.stringify(classification, null, 2));
+    return;
+  }
+
+  if (operation === 'write') {
+    const content = readContent(args);
+    const loadGuidance = parseLoadGuidance(readFlag(args, '--load-guidance'));
+    const result = await store.write({
+      content,
+      title: readFlag(args, '--title'),
+      author: readFlag(args, '--author'),
+      requestedClass: parseClass(readFlag(args, '--class')),
+      approved: args.includes('--approved'),
+      metadata: loadGuidance ? { loadGuidance } : undefined,
+    });
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (operation === 'search') {
+    const query = readFlag(args, '--query') ?? args.slice(1).join(' ');
+    console.log(JSON.stringify(await store.search(query), null, 2));
+    return;
+  }
+
+  if (operation === 'promote') {
+    const id = args[1];
+    const targetClass = parseClass(readFlag(args, '--class'));
+    if (!id || !targetClass || targetClass === 'FORBIDDEN' || targetClass === 'TRANSIENT') {
+      throw new Error('Usage: squad memory promote <id> --class LOCAL|DECISION|POLICY|COPILOT_MEMORY');
+    }
+    console.log(JSON.stringify(await store.promote(id, targetClass, readFlag(args, '--actor')), null, 2));
+    return;
+  }
+
+  if (operation === 'delete') {
+    const id = args[1];
+    if (!id) throw new Error('Usage: squad memory delete <id>');
+    console.log(JSON.stringify({ deleted: await store.delete(id, readFlag(args, '--actor')) }, null, 2));
+    return;
+  }
+
+  if (operation === 'audit') {
+    console.log(JSON.stringify(await store.auditLog(), null, 2));
+    return;
+  }
+
+  if (operation === 'provider' || operation === 'providers' || operation === 'status') {
+    if (readFlag(args, '--provider') === 'copilot' || args.includes('--default-copilot')) {
+      throw new Error(REAL_COPILOT_UNAVAILABLE_REASON);
+    }
+    if (args.includes('--enable-host-injected-copilot-adapter') || args.includes('--enable-copilot')) {
+      console.log(JSON.stringify(await providerStore.configureHostInjectedCopilotAdapter({
+        enabled: true,
+        requireApproval: parseBoolean(readFlag(args, '--require-approval'), true),
+        defaultProvider: args.includes('--default-host-injected-copilot-adapter')
+          ? 'hostInjectedCopilotAdapter'
+          : undefined,
+        actor: readFlag(args, '--actor'),
+      }), null, 2));
+      return;
+    }
+    if (args.includes('--disable-host-injected-copilot-adapter') || args.includes('--disable-copilot')) {
+      console.log(JSON.stringify(await providerStore.configureHostInjectedCopilotAdapter({
+        enabled: false,
+        defaultProvider: 'local',
+        actor: readFlag(args, '--actor'),
+      }), null, 2));
+      return;
+    }
+    console.log(JSON.stringify(await providerStore.providerStatus(), null, 2));
+    return;
+  }
+
+  console.log([
+    'Usage: squad memory <classify|write|search|promote|delete|audit|provider>',
+    '  write --content "..." --class LOCAL --title "..." --author scribe [--load-guidance ALWAYS|ON-DEMAND|ARCHIVE|NEVER]',
+    '  search --query "testing strategy"',
+    '  provider [--enable-host-injected-copilot-adapter|--disable-host-injected-copilot-adapter] [--require-approval true|false]',
+    '  provider --provider copilot fails unless a real Copilot Memory API module is present.',
+    'hostInjectedCopilotAdapter is not real provider=copilot persistence; enabling config alone never fakes remote memory.',
+  ].join('\n'));
+}

--- a/packages/squad-cli/src/cli/commands/memory.ts
+++ b/packages/squad-cli/src/cli/commands/memory.ts
@@ -8,7 +8,35 @@ import {
 const REAL_COPILOT_UNAVAILABLE_REASON =
   'Real Copilot Memory API unavailable: no concrete callable API was found in installed @github/copilot SDK/tooling. Squad will not fake provider=copilot; use hostInjectedCopilotAdapter only when a host supplies a client.';
 
+type MemoryDiagnosticLevel = 'none' | 'error' | 'info' | 'debug';
+
+type MemoryProviderConfig = {
+  defaultProvider: 'local' | 'hostInjectedCopilotAdapter' | 'copilot';
+  externalProviders: {
+    hostInjectedCopilotAdapter: {
+      enabled: boolean;
+      requireApproval: boolean;
+    };
+  };
+};
+
+type MemoryProviderStatus = {
+  defaultProvider: 'local' | 'hostInjectedCopilotAdapter' | 'copilot';
+  realCopilotMemory: { available: false; configured: boolean; reason: string };
+  hostInjectedCopilotAdapter: { enabled: boolean; requireApproval: boolean; clientAvailable: boolean; configured: boolean };
+};
+
+const MEMORY_DIAGNOSTIC_LEVELS: Record<MemoryDiagnosticLevel, number> = {
+  none: 0,
+  error: 1,
+  info: 2,
+  debug: 3,
+};
+
 function readFlag(args: string[], name: string): string | undefined {
+  const equalsPrefix = `${name}=`;
+  const equalsValue = args.find(arg => arg.startsWith(equalsPrefix));
+  if (equalsValue) return equalsValue.slice(equalsPrefix.length);
   const index = args.indexOf(name);
   return index >= 0 ? args[index + 1] : undefined;
 }
@@ -44,8 +72,64 @@ function parseBoolean(value: string | undefined, defaultValue: boolean): boolean
   throw new Error(`Expected boolean value, got: ${value}`);
 }
 
+function parseLogLevel(value: string | undefined): MemoryDiagnosticLevel {
+  if (!value) return 'none';
+  const normalized = value.toLowerCase();
+  if (normalized === 'none' || normalized === 'silent' || normalized === 'off') return 'none';
+  if (normalized === 'error') return 'error';
+  if (normalized === 'info') return 'info';
+  if (normalized === 'debug' || normalized === 'verbose' || normalized === 'all') return 'debug';
+  throw new Error(`Unknown memory log level: ${value}. Expected none|error|info|debug.`);
+}
+
+function parseDiagnostics(args: string[]): { args: string[]; logLevel: MemoryDiagnosticLevel } {
+  const filtered: string[] = [];
+  let logLevel: MemoryDiagnosticLevel | undefined;
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]!;
+    if (arg === '--verbose' || arg === '-v') {
+      logLevel ??= 'debug';
+      continue;
+    }
+    if (arg === '--log-level') {
+      logLevel = parseLogLevel(args[index + 1]);
+      index++;
+      continue;
+    }
+    if (arg.startsWith('--log-level=')) {
+      logLevel = parseLogLevel(arg.slice('--log-level='.length));
+      continue;
+    }
+    filtered.push(arg);
+  }
+
+  return { args: filtered, logLevel: logLevel ?? parseLogLevel(process.env['SQUAD_MEMORY_LOG_LEVEL']) };
+}
+
+function createMemoryDiagnostics(logLevel: MemoryDiagnosticLevel) {
+  const emit = (level: Exclude<MemoryDiagnosticLevel, 'none'>, event: string, data: Record<string, unknown> = {}) => {
+    if (MEMORY_DIAGNOSTIC_LEVELS[logLevel] < MEMORY_DIAGNOSTIC_LEVELS[level]) return;
+    const details = Object.entries(data)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(' ');
+    console.error(`[memory:${level}] ${event}${details ? ` ${details}` : ''}`);
+  };
+
+  return {
+    error: (event: string, data?: Record<string, unknown>) => emit('error', event, data),
+    info: (event: string, data?: Record<string, unknown>) => emit('info', event, data),
+    debug: (event: string, data?: Record<string, unknown>) => emit('debug', event, data),
+  };
+}
+
 export async function runMemoryCommand(projectRoot: string, args: string[]): Promise<void> {
-  const operation = args[0] ?? 'help';
+  const diagnosticsConfig = parseDiagnostics(args);
+  const commandArgs = diagnosticsConfig.args;
+  const diagnostics = createMemoryDiagnostics(diagnosticsConfig.logLevel);
+  const operation = commandArgs[0] ?? 'help';
+  const startedAt = Date.now();
   const store = new LocalMemoryStore(new FSStorageProvider(), projectRoot);
   const providerStore = store as LocalMemoryStore & {
     configureHostInjectedCopilotAdapter(options: {
@@ -53,98 +137,186 @@ export async function runMemoryCommand(projectRoot: string, args: string[]): Pro
       requireApproval?: boolean;
       defaultProvider?: 'local' | 'hostInjectedCopilotAdapter';
       actor?: string;
-    }): Promise<unknown>;
-    providerStatus(): Promise<unknown>;
+    }): Promise<MemoryProviderConfig>;
+    providerStatus(): Promise<MemoryProviderStatus>;
   };
 
-  if (operation === 'classify') {
-    const content = readContent(args);
-    const loadGuidance = parseLoadGuidance(readFlag(args, '--load-guidance'));
-    const classification = await store.classify({
-      content,
-      requestedClass: parseClass(readFlag(args, '--class')),
-      metadata: loadGuidance ? { loadGuidance } : undefined,
-    });
-    console.log(JSON.stringify(classification, null, 2));
-    return;
-  }
+  diagnostics.info('command.start', { command: operation, projectRoot });
 
-  if (operation === 'write') {
-    const content = readContent(args);
-    const loadGuidance = parseLoadGuidance(readFlag(args, '--load-guidance'));
-    const result = await store.write({
-      content,
-      title: readFlag(args, '--title'),
-      author: readFlag(args, '--author'),
-      requestedClass: parseClass(readFlag(args, '--class')),
-      approved: args.includes('--approved'),
-      metadata: loadGuidance ? { loadGuidance } : undefined,
-    });
-    console.log(JSON.stringify(result, null, 2));
-    return;
-  }
-
-  if (operation === 'search') {
-    const query = readFlag(args, '--query') ?? args.slice(1).join(' ');
-    console.log(JSON.stringify(await store.search(query), null, 2));
-    return;
-  }
-
-  if (operation === 'promote') {
-    const id = args[1];
-    const targetClass = parseClass(readFlag(args, '--class'));
-    if (!id || !targetClass || targetClass === 'FORBIDDEN' || targetClass === 'TRANSIENT') {
-      throw new Error('Usage: squad memory promote <id> --class LOCAL|DECISION|POLICY|COPILOT_MEMORY');
-    }
-    console.log(JSON.stringify(await store.promote(id, targetClass, readFlag(args, '--actor')), null, 2));
-    return;
-  }
-
-  if (operation === 'delete') {
-    const id = args[1];
-    if (!id) throw new Error('Usage: squad memory delete <id>');
-    console.log(JSON.stringify({ deleted: await store.delete(id, readFlag(args, '--actor')) }, null, 2));
-    return;
-  }
-
-  if (operation === 'audit') {
-    console.log(JSON.stringify(await store.auditLog(), null, 2));
-    return;
-  }
-
-  if (operation === 'provider' || operation === 'providers' || operation === 'status') {
-    if (readFlag(args, '--provider') === 'copilot' || args.includes('--default-copilot')) {
-      throw new Error(REAL_COPILOT_UNAVAILABLE_REASON);
-    }
-    if (args.includes('--enable-host-injected-copilot-adapter') || args.includes('--enable-copilot')) {
-      console.log(JSON.stringify(await providerStore.configureHostInjectedCopilotAdapter({
-        enabled: true,
-        requireApproval: parseBoolean(readFlag(args, '--require-approval'), true),
-        defaultProvider: args.includes('--default-host-injected-copilot-adapter')
-          ? 'hostInjectedCopilotAdapter'
-          : undefined,
-        actor: readFlag(args, '--actor'),
-      }), null, 2));
+  try {
+    if (operation === 'classify') {
+      const content = readContent(commandArgs);
+      const loadGuidance = parseLoadGuidance(readFlag(commandArgs, '--load-guidance'));
+      const requestedClass = parseClass(readFlag(commandArgs, '--class'));
+      diagnostics.debug('classify.request', { contentLength: content.length, requestedClass, loadGuidance });
+      const classification = await store.classify({
+        content,
+        requestedClass,
+        metadata: loadGuidance ? { loadGuidance } : undefined,
+      });
+      diagnostics.info('classify.complete', {
+        class: classification.class,
+        allowed: classification.allowed,
+        destination: classification.destination,
+        loadGuidance: classification.loadGuidance,
+        elapsedMs: Date.now() - startedAt,
+      });
+      console.log(JSON.stringify(classification, null, 2));
       return;
     }
-    if (args.includes('--disable-host-injected-copilot-adapter') || args.includes('--disable-copilot')) {
-      console.log(JSON.stringify(await providerStore.configureHostInjectedCopilotAdapter({
-        enabled: false,
-        defaultProvider: 'local',
-        actor: readFlag(args, '--actor'),
-      }), null, 2));
+
+    if (operation === 'write') {
+      const content = readContent(commandArgs);
+      const loadGuidance = parseLoadGuidance(readFlag(commandArgs, '--load-guidance'));
+      const requestedClass = parseClass(readFlag(commandArgs, '--class'));
+      diagnostics.debug('write.request', {
+        contentLength: content.length,
+        requestedClass,
+        loadGuidance,
+        titleProvided: readFlag(commandArgs, '--title') !== undefined,
+        authorProvided: readFlag(commandArgs, '--author') !== undefined,
+        approved: commandArgs.includes('--approved'),
+      });
+      const result = await store.write({
+        content,
+        title: readFlag(commandArgs, '--title'),
+        author: readFlag(commandArgs, '--author'),
+        requestedClass,
+        approved: commandArgs.includes('--approved'),
+        metadata: loadGuidance ? { loadGuidance } : undefined,
+      });
+      diagnostics.info('write.complete', {
+        stored: result.stored,
+        class: result.classification.class,
+        provider: result.classification.class === 'COPILOT_MEMORY' ? 'hostInjectedCopilotAdapter' : 'local',
+        loadGuidance: result.classification.loadGuidance,
+        path: result.path,
+        elapsedMs: Date.now() - startedAt,
+      });
+      console.log(JSON.stringify(result, null, 2));
       return;
     }
-    console.log(JSON.stringify(await providerStore.providerStatus(), null, 2));
-    return;
-  }
 
-  console.log([
-    'Usage: squad memory <classify|write|search|promote|delete|audit|provider>',
-    '  write --content "..." --class LOCAL --title "..." --author scribe [--load-guidance ALWAYS|ON-DEMAND|ARCHIVE|NEVER]',
-    '  search --query "testing strategy"',
-    '  provider [--enable-host-injected-copilot-adapter|--disable-host-injected-copilot-adapter] [--require-approval true|false]',
-    '  provider --provider copilot fails unless a real Copilot Memory API module is present.',
-    'hostInjectedCopilotAdapter is not real provider=copilot persistence; enabling config alone never fakes remote memory.',
-  ].join('\n'));
+    if (operation === 'search') {
+      const query = readFlag(commandArgs, '--query') ?? commandArgs.slice(1).join(' ');
+      diagnostics.debug('search.request', { queryLength: query.length });
+      const results = await store.search(query);
+      diagnostics.info('search.complete', {
+        count: results.length,
+        providers: [...new Set(results.map(result => result.provider ?? 'local'))].join(',') || 'none',
+        elapsedMs: Date.now() - startedAt,
+      });
+      console.log(JSON.stringify(results, null, 2));
+      return;
+    }
+
+    if (operation === 'promote') {
+      const id = commandArgs[1];
+      const targetClass = parseClass(readFlag(commandArgs, '--class'));
+      if (!id || !targetClass || targetClass === 'FORBIDDEN' || targetClass === 'TRANSIENT') {
+        throw new Error('Usage: squad memory promote <id> --class LOCAL|DECISION|POLICY|COPILOT_MEMORY');
+      }
+      diagnostics.debug('promote.request', { id, targetClass, actorProvided: readFlag(commandArgs, '--actor') !== undefined });
+      const result = await store.promote(id, targetClass, readFlag(commandArgs, '--actor'));
+      diagnostics.info('promote.complete', {
+        id,
+        stored: result.stored,
+        class: result.classification.class,
+        path: result.path,
+        elapsedMs: Date.now() - startedAt,
+      });
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    if (operation === 'delete') {
+      const id = commandArgs[1];
+      if (!id) throw new Error('Usage: squad memory delete <id>');
+      diagnostics.debug('delete.request', { id, actorProvided: readFlag(commandArgs, '--actor') !== undefined });
+      const deleted = await store.delete(id, readFlag(commandArgs, '--actor'));
+      diagnostics.info('delete.complete', { id, deleted, elapsedMs: Date.now() - startedAt });
+      console.log(JSON.stringify({ deleted }, null, 2));
+      return;
+    }
+
+    if (operation === 'audit') {
+      const audit = await store.auditLog();
+      diagnostics.info('audit.complete', { count: audit.length, elapsedMs: Date.now() - startedAt });
+      console.log(JSON.stringify(audit, null, 2));
+      return;
+    }
+
+    if (operation === 'provider' || operation === 'providers' || operation === 'status') {
+      if (readFlag(commandArgs, '--provider') === 'copilot' || commandArgs.includes('--default-copilot')) {
+        throw new Error(REAL_COPILOT_UNAVAILABLE_REASON);
+      }
+      if (commandArgs.includes('--enable-host-injected-copilot-adapter') || commandArgs.includes('--enable-copilot')) {
+        const requireApproval = parseBoolean(readFlag(commandArgs, '--require-approval'), true);
+        diagnostics.debug('provider.configure.request', {
+          enabled: true,
+          requireApproval,
+          defaultProvider: commandArgs.includes('--default-host-injected-copilot-adapter') ? 'hostInjectedCopilotAdapter' : undefined,
+        });
+        const config = await providerStore.configureHostInjectedCopilotAdapter({
+          enabled: true,
+          requireApproval,
+          defaultProvider: commandArgs.includes('--default-host-injected-copilot-adapter')
+            ? 'hostInjectedCopilotAdapter'
+            : undefined,
+          actor: readFlag(commandArgs, '--actor'),
+        });
+        diagnostics.info('provider.configure.complete', {
+          defaultProvider: config.defaultProvider,
+          hostInjectedCopilotAdapterEnabled: config.externalProviders.hostInjectedCopilotAdapter.enabled,
+          requireApproval: config.externalProviders.hostInjectedCopilotAdapter.requireApproval,
+          elapsedMs: Date.now() - startedAt,
+        });
+        console.log(JSON.stringify(config, null, 2));
+        return;
+      }
+      if (commandArgs.includes('--disable-host-injected-copilot-adapter') || commandArgs.includes('--disable-copilot')) {
+        diagnostics.debug('provider.configure.request', { enabled: false, defaultProvider: 'local' });
+        const config = await providerStore.configureHostInjectedCopilotAdapter({
+          enabled: false,
+          defaultProvider: 'local',
+          actor: readFlag(commandArgs, '--actor'),
+        });
+        diagnostics.info('provider.configure.complete', {
+          defaultProvider: config.defaultProvider,
+          hostInjectedCopilotAdapterEnabled: config.externalProviders.hostInjectedCopilotAdapter.enabled,
+          elapsedMs: Date.now() - startedAt,
+        });
+        console.log(JSON.stringify(config, null, 2));
+        return;
+      }
+      const status = await providerStore.providerStatus();
+      diagnostics.info('provider.status.complete', {
+        defaultProvider: status.defaultProvider,
+        realCopilotConfigured: status.realCopilotMemory.configured,
+        hostInjectedCopilotAdapterConfigured: status.hostInjectedCopilotAdapter.configured,
+        hostInjectedCopilotAdapterClientAvailable: status.hostInjectedCopilotAdapter.clientAvailable,
+        elapsedMs: Date.now() - startedAt,
+      });
+      console.log(JSON.stringify(status, null, 2));
+      return;
+    }
+
+    diagnostics.info('help.complete', { elapsedMs: Date.now() - startedAt });
+    console.log([
+      'Usage: squad memory <classify|write|search|promote|delete|audit|provider>',
+      '  write --content "..." --class LOCAL --title "..." --author scribe [--load-guidance ALWAYS|ON-DEMAND|ARCHIVE|NEVER]',
+      '  search --query "testing strategy"',
+      '  provider [--enable-host-injected-copilot-adapter|--disable-host-injected-copilot-adapter] [--require-approval true|false]',
+      '  provider --provider copilot fails unless a real Copilot Memory API module is present.',
+      '  diagnostics: --log-level none|error|info|debug or --verbose (stderr; never logs raw memory content or search text).',
+      'hostInjectedCopilotAdapter is not real provider=copilot persistence; enabling config alone never fakes remote memory.',
+    ].join('\n'));
+  } catch (error) {
+    diagnostics.error('command.error', {
+      command: operation,
+      message: error instanceof Error ? error.message : String(error),
+      elapsedMs: Date.now() - startedAt,
+    });
+    throw error;
+  }
 }

--- a/packages/squad-cli/src/cli/commands/memory.ts
+++ b/packages/squad-cli/src/cli/commands/memory.ts
@@ -4,6 +4,8 @@ import {
   type MemoryClass,
   type MemoryLoadGuidance,
 } from '@bradygaster/squad-sdk';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const REAL_COPILOT_UNAVAILABLE_REASON =
   'Real Copilot Memory API unavailable: no concrete callable API was found in installed @github/copilot SDK/tooling. Squad will not fake provider=copilot; use hostInjectedCopilotAdapter only when a host supplies a client.';
@@ -24,6 +26,12 @@ type MemoryProviderStatus = {
   defaultProvider: 'local' | 'hostInjectedCopilotAdapter' | 'copilot';
   realCopilotMemory: { available: false; configured: boolean; reason: string };
   hostInjectedCopilotAdapter: { enabled: boolean; requireApproval: boolean; clientAvailable: boolean; configured: boolean };
+};
+
+type SquadConfig = {
+  memory?: {
+    logLevel?: unknown;
+  };
 };
 
 const MEMORY_DIAGNOSTIC_LEVELS: Record<MemoryDiagnosticLevel, number> = {
@@ -82,7 +90,22 @@ function parseLogLevel(value: string | undefined): MemoryDiagnosticLevel {
   throw new Error(`Unknown memory log level: ${value}. Expected none|error|info|debug.`);
 }
 
-function parseDiagnostics(args: string[]): { args: string[]; logLevel: MemoryDiagnosticLevel } {
+function readConfiguredLogLevel(projectRoot: string): MemoryDiagnosticLevel | undefined {
+  const configPath = path.join(projectRoot, '.squad', 'config.json');
+  if (!fs.existsSync(configPath)) return undefined;
+
+  let parsed: SquadConfig;
+  try {
+    parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as SquadConfig;
+  } catch {
+    return undefined;
+  }
+
+  const logLevel = parsed.memory?.logLevel;
+  return typeof logLevel === 'string' ? parseLogLevel(logLevel) : undefined;
+}
+
+function parseDiagnostics(projectRoot: string, args: string[]): { args: string[]; logLevel: MemoryDiagnosticLevel } {
   const filtered: string[] = [];
   let logLevel: MemoryDiagnosticLevel | undefined;
 
@@ -104,7 +127,14 @@ function parseDiagnostics(args: string[]): { args: string[]; logLevel: MemoryDia
     filtered.push(arg);
   }
 
-  return { args: filtered, logLevel: logLevel ?? parseLogLevel(process.env['SQUAD_MEMORY_LOG_LEVEL']) };
+  return {
+    args: filtered,
+    logLevel: logLevel ?? (
+      process.env['SQUAD_MEMORY_LOG_LEVEL'] !== undefined
+        ? parseLogLevel(process.env['SQUAD_MEMORY_LOG_LEVEL'])
+        : readConfiguredLogLevel(projectRoot) ?? 'none'
+    ),
+  };
 }
 
 function createMemoryDiagnostics(logLevel: MemoryDiagnosticLevel) {
@@ -125,7 +155,7 @@ function createMemoryDiagnostics(logLevel: MemoryDiagnosticLevel) {
 }
 
 export async function runMemoryCommand(projectRoot: string, args: string[]): Promise<void> {
-  const diagnosticsConfig = parseDiagnostics(args);
+  const diagnosticsConfig = parseDiagnostics(projectRoot, args);
   const commandArgs = diagnosticsConfig.args;
   const diagnostics = createMemoryDiagnostics(diagnosticsConfig.logLevel);
   const operation = commandArgs[0] ?? 'help';
@@ -308,7 +338,7 @@ export async function runMemoryCommand(projectRoot: string, args: string[]): Pro
       '  search --query "testing strategy"',
       '  provider [--enable-host-injected-copilot-adapter|--disable-host-injected-copilot-adapter] [--require-approval true|false]',
       '  provider --provider copilot fails unless a real Copilot Memory API module is present.',
-      '  diagnostics: --log-level none|error|info|debug or --verbose (stderr; never logs raw memory content or search text).',
+      '  diagnostics: --log-level none|error|info|debug, --verbose, SQUAD_MEMORY_LOG_LEVEL, or .squad/config.json memory.logLevel (stderr; never logs raw memory content or search text).',
       'hostInjectedCopilotAdapter is not real provider=copilot persistence; enabling config alone never fakes remote memory.',
     ].join('\n'));
   } catch (error) {

--- a/packages/squad-cli/src/cli/core/upgrade.ts
+++ b/packages/squad-cli/src/cli/core/upgrade.ts
@@ -52,12 +52,12 @@ function compareSemver(a: string, b: string): number {
   const stripPre = (v: string) => v.split('-')[0]!;
   const pa = stripPre(a).split('.').map(Number);
   const pb = stripPre(b).split('.').map(Number);
-  
+
   for (let i = 0; i < 3; i++) {
     if ((pa[i] || 0) < (pb[i] || 0)) return -1;
     if ((pa[i] || 0) > (pb[i] || 0)) return 1;
   }
-  
+
   // Base versions equal — pre-release is less than release
   const aPre = a.includes('-');
   const bPre = b.includes('-');
@@ -78,14 +78,14 @@ function detectProjectType(dir: string): string {
   if (storage.existsSync(path.join(dir, 'pom.xml')) ||
       storage.existsSync(path.join(dir, 'build.gradle')) ||
       storage.existsSync(path.join(dir, 'build.gradle.kts'))) return 'java';
-  
+
   try {
     const entries = storage.listSync(dir);
-    if (entries.some(e => e.endsWith('.csproj') || e.endsWith('.sln') || 
-                         e.endsWith('.slnx') || e.endsWith('.fsproj') || 
+    if (entries.some(e => e.endsWith('.csproj') || e.endsWith('.sln') ||
+                         e.endsWith('.slnx') || e.endsWith('.fsproj') ||
                          e.endsWith('.vbproj'))) return 'dotnet';
   } catch {}
-  
+
   return 'unknown';
 }
 
@@ -518,6 +518,12 @@ function runEnsureChecks(dest: string, templatesDir: string, filesUpdated: strin
     filesUpdated.push(...castingFiles);
   }
 
+  const memoryFiles = ensureMemoryGovernanceUpgradeDefaults(dest);
+  if (memoryFiles.length > 0) {
+    success(`scaffolded memory governance defaults (${memoryFiles.length} files/directories)`);
+    filesUpdated.push(...memoryFiles);
+  }
+
   const skillCount = syncAllSkills(dest, templatesDir);
   if (skillCount > 0) {
     success(`synced ${skillCount} skills to .copilot/skills/`);
@@ -529,57 +535,97 @@ function runEnsureChecks(dest: string, templatesDir: string, filesUpdated: strin
   filesUpdated.push('.squad/templates/');
 }
 
+export function ensureMemoryGovernanceUpgradeDefaults(dest: string): string[] {
+  const memoryDir = path.join(dest, '.squad', 'memory');
+  const created: string[] = [];
+  for (const dir of ['local', 'policy-inbox', 'semantic-inbox', 'tombstones']) {
+    const fullPath = path.join(memoryDir, dir);
+    if (!storage.existsSync(fullPath)) {
+      storage.mkdirSync(fullPath, { recursive: true });
+      created.push(path.join('.squad', 'memory', dir));
+    }
+  }
+  const defaults = {
+    'config.json': JSON.stringify({
+      version: 1,
+      defaultProvider: 'local',
+      promptOnlyFallback: true,
+      externalProviders: {
+        hostInjectedCopilotAdapter: {
+          enabled: false,
+          requireApproval: true,
+        },
+      },
+      policy: {
+        rejectForbidden: true,
+        rejectTransientDurableWrites: true,
+        auditContent: false,
+      },
+    }, null, 2) + '\n',
+    'index.json': '[]\n',
+    'audit.jsonl': '',
+  };
+  for (const [file, content] of Object.entries(defaults)) {
+    const fullPath = path.join(memoryDir, file);
+    if (!storage.existsSync(fullPath)) {
+      storage.writeSync(fullPath, content);
+      created.push(path.join('.squad', 'memory', file));
+    }
+  }
+  return created;
+}
+
 /**
  * Run the upgrade command
  */
 export async function runUpgrade(dest: string, options: UpgradeOptions = {}): Promise<UpdateInfo> {
   const cliVersion = getPackageVersion();
   const filesUpdated: string[] = [];
-  
+
   // Detect squad directory
   const squadDirInfo = detectSquadDir(dest);
-  
+
   if (squadDirInfo.isLegacy) {
     warn('DEPRECATION: .ai-team/ is deprecated and will be removed in v1.0.0');
     warn("Run 'squad upgrade --migrate-directory' to migrate to .squad/");
     console.log();
   }
-  
+
   // Verify squad exists
   if (!storage.existsSync(squadDirInfo.path)) {
     fatal('No squad found — run init first.');
   }
-  
+
   const agentDest = path.join(dest, '.github', 'agents', 'squad.agent.md');
   const oldVersion = readInstalledVersion(agentDest) ?? '0.0.0';
-  
+
   // Check if already current
   const isAlreadyCurrent = !options.force && oldVersion && oldVersion !== '0.0.0' && compareSemver(oldVersion, cliVersion) === 0;
-  
+
   const projectType = detectProjectType(dest);
-  
+
   if (isAlreadyCurrent) {
     info(`Already up to date (v${cliVersion})`);
-    
+
     // Still run missing migrations
     const migrationsApplied = await runMigrations(squadDirInfo.path, oldVersion, cliVersion);
-    
+
     // Refresh squad-owned files even when version matches
     const templatesDir = getTemplatesDir();
     const workflowsSrc = path.join(templatesDir, 'workflows');
     const workflowsDest = path.join(dest, '.github', 'workflows');
-    
+
     if (storage.existsSync(workflowsSrc)) {
       const wfFiles = storage.listSync(workflowsSrc).filter(f => f.endsWith('.yml'));
       storage.mkdirSync(workflowsDest, { recursive: true });
-      
+
       for (const file of wfFiles) {
         writeWorkflowFile(file, path.join(workflowsSrc, file), path.join(workflowsDest, file), projectType);
       }
       success(`upgraded squad workflows (${wfFiles.length} files)`);
       filesUpdated.push(`workflows (${wfFiles.length} files)`);
     }
-    
+
     // Refresh squad.agent.md
     const agentSrc = path.join(templatesDir, 'squad.agent.md.template');
     if (storage.existsSync(agentSrc)) {
@@ -591,10 +637,10 @@ export async function runUpgrade(dest: string, options: UpgradeOptions = {}): Pr
     } else {
       warn('squad.agent.md.template not found — squad.agent.md was not refreshed. Reinstall or repair the CLI to restore the missing template.');
     }
-    
+
     // Run infrastructure ensure checks even when already current
     runEnsureChecks(dest, templatesDir, filesUpdated);
-    
+
     return {
       fromVersion: oldVersion,
       toVersion: cliVersion,
@@ -602,74 +648,74 @@ export async function runUpgrade(dest: string, options: UpgradeOptions = {}): Pr
       migrationsRun: migrationsApplied,
     };
   }
-  
+
   // Upgrade squad.agent.md
   const templatesDir = getTemplatesDir();
   const agentSrc = path.join(templatesDir, 'squad.agent.md.template');
-  
+
   if (!storage.existsSync(agentSrc)) {
     fatal('squad.agent.md.template not found in templates — installation may be corrupted');
   }
-  
+
   storage.mkdirSync(path.dirname(agentDest), { recursive: true });
   storage.copySync(agentSrc, agentDest);
   stampVersion(agentDest, cliVersion);
-  
+
   const fromLabel = oldVersion === '0.0.0' || !oldVersion ? 'unknown' : oldVersion;
   success(`upgraded coordinator from ${fromLabel} to ${cliVersion}`);
   filesUpdated.push('squad.agent.md');
-  
+
   // Upgrade squad-owned files from template manifest
   // Exclude squad.agent.md — already copied and version-stamped above
   const filesToUpgrade = TEMPLATE_MANIFEST.filter(f => f.overwriteOnUpgrade && f.source !== 'squad.agent.md.template');
-  
+
   for (const file of filesToUpgrade) {
     const srcPath = path.join(templatesDir, file.source);
     const destPath = path.join(squadDirInfo.path, file.destination);
-    
+
     if (!storage.existsSync(srcPath)) continue;
-    
+
     if (file.source.startsWith('skills/')) {
       warnIfSkillCustomized(srcPath, destPath, file.source);
     }
     storage.mkdirSync(path.dirname(destPath), { recursive: true });
     storage.copySync(srcPath, destPath);
-    
+
     filesUpdated.push(file.destination);
   }
-  
+
   if (filesToUpgrade.length > 0) {
     success(`upgraded ${filesToUpgrade.length} squad-owned files`);
   }
-  
+
   // Upgrade workflows
   const workflowsSrc = path.join(templatesDir, 'workflows');
   const workflowsDest = path.join(dest, '.github', 'workflows');
-  
+
   if (storage.existsSync(workflowsSrc)) {
     const wfFiles = storage.listSync(workflowsSrc).filter(f => f.endsWith('.yml'));
     storage.mkdirSync(workflowsDest, { recursive: true });
-    
+
     for (const file of wfFiles) {
       writeWorkflowFile(file, path.join(workflowsSrc, file), path.join(workflowsDest, file), projectType);
     }
-    
+
     success(`upgraded squad workflows (${wfFiles.length} files)`);
     filesUpdated.push(`workflows (${wfFiles.length} files)`);
   }
-  
+
   // Run migrations
   const migrationsApplied = await runMigrations(squadDirInfo.path, oldVersion, cliVersion);
-  
+
   // Update copilot-instructions.md if @copilot is enabled
   const copilotInstructionsSrc = path.join(templatesDir, 'copilot-instructions.md');
   const copilotInstructionsDest = path.join(dest, '.github', 'copilot-instructions.md');
   const teamMdPath = path.join(squadDirInfo.path, 'team.md');
-  
+
   if (storage.existsSync(teamMdPath)) {
     const teamContent = storage.readSync(teamMdPath) ?? '';
     const copilotEnabled = teamContent.includes('🤖 Coding Agent');
-    
+
     if (copilotEnabled && storage.existsSync(copilotInstructionsSrc)) {
       storage.mkdirSync(path.dirname(copilotInstructionsDest), { recursive: true });
       storage.copySync(copilotInstructionsSrc, copilotInstructionsDest);
@@ -677,10 +723,10 @@ export async function runUpgrade(dest: string, options: UpgradeOptions = {}): Pr
       filesUpdated.push('copilot-instructions.md');
     }
   }
-  
+
   // Run infrastructure ensure checks
   runEnsureChecks(dest, templatesDir, filesUpdated);
-  
+
   console.log();
   info(`Upgrade complete: v${fromLabel} → v${cliVersion}`);
   if (migrationsApplied.some(m => m.toLowerCase().includes('scrub email'))) {
@@ -689,7 +735,7 @@ export async function runUpgrade(dest: string, options: UpgradeOptions = {}): Pr
     dim('Preserves user state: team.md, decisions/, agents/*/history.md');
   }
   console.log();
-  
+
   return {
     fromVersion: fromLabel,
     toVersion: cliVersion,

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -340,7 +340,7 @@ prompt: |
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
-  
+
   {% if WORKTREE_MODE %}
   **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
   {% endif %}
@@ -779,17 +779,17 @@ name: "{name}"
 description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
-  
+
   YOUR CHARTER:
   {paste contents of .squad/agents/{name}/charter.md here}
-  
+
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
   All `.squad/` paths are relative to this root.
-  
+
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
-  
+
   {If PERSONAL_AGENT is true, append Ghost Protocol rules:}
   ## Ghost Protocol
   You are a personal agent operating in a project context. You MUST follow these rules:
@@ -798,10 +798,10 @@ prompt: |
   - Transparent origin: Tag all logs with [personal:{name}]
   - Consult mode: Provide recommendations, not direct changes
   {end Ghost Protocol block}
-  
+
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
-  
+
   {% if WORKTREE_MODE %}
   **WORKTREE:** You are working in a dedicated worktree at `{WORKTREE_PATH}`.
   - All file operations should be relative to this path
@@ -809,63 +809,63 @@ prompt: |
   - Build and test in the worktree, not the main repo
   - Commit and push from the worktree
   {% endif %}
-  
+
   STATE_BACKEND: {state_backend}
-  
+
   {% if STATE_BACKEND == "git-notes" %}
   ## State Protocol — Git Notes
   This project uses git-notes for mutable state. **DO NOT write to `.squad/` files for state.**
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-  
+
   **Reading your state:**
   Run: `powershell .squad/scripts/notes/fetch.ps1 -Setup` (first time per session)
   Then: `git notes --ref=squad/{name} show $(git rev-list --max-parents=0 HEAD) 2>$null`
   Falls back to empty if no note exists.
-  
+
   **Writing state (history, decisions, learnings):**
   Run: `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{json}'`
   The helper handles JSON validation, conflict retry, and push.
-  
+
   **Decisions:** Write decisions as JSON via your note ref. Scribe will merge them.
   **Skills:** Skills are static config — write to `.squad/skills/` on disk as normal.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "orphan" %}
   ## State Protocol — Orphan Branch
   This project uses an orphan branch (`squad-state`) for mutable state.
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-  
+
   **Reading state:** Read `.squad/` files on disk — they are synced from the orphan branch.
   **Writing state:** Write to `.squad/` files on disk as normal during your session.
   Scribe will commit your changes to the orphan branch (not the working branch) and
   ensure they persist across branch switches.
-  
+
   **Important:** Do NOT commit `.squad/` state files to the working branch yourself.
   Scribe handles the orphan branch commit workflow.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "two-layer" %}
   ## State Protocol — Two-Layer (Git Notes + Orphan Branch)
   This project uses the two-layer architecture from Tamir's blog:
   - **Layer 1 (git notes):** Commit-scoped "why" annotations — invisible in PRs
   - **Layer 2 (orphan branch):** Permanent state store — decisions, histories, logs
-  
+
   Static config (charters, team.md, routing.md) is on disk as normal.
-  
+
   **During your session:**
   1. Write commit-scoped annotations as git notes on HEAD:
      `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
   2. Write bulk state (history, logs) to `.squad/` files on disk — Scribe moves them to the orphan branch.
-  
+
   **Note flags:**
   - `"promote_to_permanent": true` — Ralph promotes this to decisions.md after PR merge
   - `"archive_on_close": true` — Worth keeping even if PR is rejected (valuable research)
   - Neither flag — silently ignored if PR is rejected (correct for branch-specific decisions)
-  
+
   **Important:** Do NOT commit `.squad/` state files to the working branch.
   Scribe handles orphan commits. Ralph handles note promotion.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "worktree" or STATE_BACKEND is not defined %}
   Read .squad/agents/{name}/history.md (your project knowledge).
   {% endif %}
@@ -881,22 +881,22 @@ prompt: |
   Check .copilot/skills/ for copilot-level skills (process, workflow, protocol).
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
-  
+
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
-  
+
   **Requested by:** {current user name}
-  
+
   INPUT ARTIFACTS: {list exact file paths to review/modify}
-  
+
   The user says: "{message}"
-  
+
   Do the work. Respond as {Name}.
-  
+
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
-  
+
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
@@ -921,7 +921,7 @@ prompt: |
   {% endif %}
   3. SKILL EXTRACTION: If you found a reusable pattern, write/update
      .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
-  
+
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.
 ```
@@ -976,7 +976,7 @@ prompt: |
 
   Tasks (in order):
   {% if STATE_BACKEND == "orphan" or STATE_BACKEND == "git-notes" or STATE_BACKEND == "two-layer" %}
-  0. STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
+  0. PRE-CHECK — STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
      (.squad/decisions.md, agents/*/history.md, log/*, orchestration-log/*, decisions/inbox/*)
      to the working branch. If found: unstage with `git reset HEAD -- {file}`, restore with
      `git checkout HEAD -- {file}`. If leaked in last commit, amend to remove. Log count.

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -238,6 +238,17 @@ The `name` parameter generates the human-readable agent ID shown in the tasks pa
 2. Acknowledge briefly: `"📌 Captured. {one-line summary of the directive}."`
 3. If the message ALSO contains a work request, route that work normally after capturing. If it's directive-only, you're done — no agent spawn needed.
 
+### Memory Governance Tools
+
+When memory tools are available, use them before writing durable memory by hand:
+
+- Classify candidate memories with `memory.classify`.
+- Persist approved durable facts, decisions, and policies with `memory.write`.
+- Search governed memory with `memory.search` before relying only on raw file search.
+- Promote, delete, and audit governed entries with `memory.promote`, `memory.delete`, and `memory.audit`.
+
+If memory tools are not available, keep the prompt-only fallback: write local `.squad/` files directly using the decision inbox, agent histories, and skills. Do not claim provider-backed Copilot Memory, semantic indexing, or remote deletion unless a configured tool or CLI bridge performed the operation. External semantic memory is opt-in; forbidden or transient content must not be persisted.
+
 ### Routing
 
 The routing table determines **WHO** handles work. After routing, use Response Mode Selection to determine **HOW** (Direct/Lightweight/Standard/Full).
@@ -340,7 +351,7 @@ prompt: |
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
-
+  
   {% if WORKTREE_MODE %}
   **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
   {% endif %}
@@ -779,17 +790,17 @@ name: "{name}"
 description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
-
+  
   YOUR CHARTER:
   {paste contents of .squad/agents/{name}/charter.md here}
-
+  
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
   All `.squad/` paths are relative to this root.
-
+  
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
-
+  
   {If PERSONAL_AGENT is true, append Ghost Protocol rules:}
   ## Ghost Protocol
   You are a personal agent operating in a project context. You MUST follow these rules:
@@ -798,10 +809,10 @@ prompt: |
   - Transparent origin: Tag all logs with [personal:{name}]
   - Consult mode: Provide recommendations, not direct changes
   {end Ghost Protocol block}
-
+  
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
-
+  
   {% if WORKTREE_MODE %}
   **WORKTREE:** You are working in a dedicated worktree at `{WORKTREE_PATH}`.
   - All file operations should be relative to this path
@@ -809,63 +820,63 @@ prompt: |
   - Build and test in the worktree, not the main repo
   - Commit and push from the worktree
   {% endif %}
-
+  
   STATE_BACKEND: {state_backend}
-
+  
   {% if STATE_BACKEND == "git-notes" %}
   ## State Protocol — Git Notes
   This project uses git-notes for mutable state. **DO NOT write to `.squad/` files for state.**
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-
+  
   **Reading your state:**
   Run: `powershell .squad/scripts/notes/fetch.ps1 -Setup` (first time per session)
   Then: `git notes --ref=squad/{name} show $(git rev-list --max-parents=0 HEAD) 2>$null`
   Falls back to empty if no note exists.
-
+  
   **Writing state (history, decisions, learnings):**
   Run: `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{json}'`
   The helper handles JSON validation, conflict retry, and push.
-
+  
   **Decisions:** Write decisions as JSON via your note ref. Scribe will merge them.
   **Skills:** Skills are static config — write to `.squad/skills/` on disk as normal.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "orphan" %}
   ## State Protocol — Orphan Branch
   This project uses an orphan branch (`squad-state`) for mutable state.
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-
+  
   **Reading state:** Read `.squad/` files on disk — they are synced from the orphan branch.
   **Writing state:** Write to `.squad/` files on disk as normal during your session.
   Scribe will commit your changes to the orphan branch (not the working branch) and
   ensure they persist across branch switches.
-
+  
   **Important:** Do NOT commit `.squad/` state files to the working branch yourself.
   Scribe handles the orphan branch commit workflow.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "two-layer" %}
   ## State Protocol — Two-Layer (Git Notes + Orphan Branch)
   This project uses the two-layer architecture from Tamir's blog:
   - **Layer 1 (git notes):** Commit-scoped "why" annotations — invisible in PRs
   - **Layer 2 (orphan branch):** Permanent state store — decisions, histories, logs
-
+  
   Static config (charters, team.md, routing.md) is on disk as normal.
-
+  
   **During your session:**
   1. Write commit-scoped annotations as git notes on HEAD:
      `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
   2. Write bulk state (history, logs) to `.squad/` files on disk — Scribe moves them to the orphan branch.
-
+  
   **Note flags:**
   - `"promote_to_permanent": true` — Ralph promotes this to decisions.md after PR merge
   - `"archive_on_close": true` — Worth keeping even if PR is rejected (valuable research)
   - Neither flag — silently ignored if PR is rejected (correct for branch-specific decisions)
-
+  
   **Important:** Do NOT commit `.squad/` state files to the working branch.
   Scribe handles orphan commits. Ralph handles note promotion.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "worktree" or STATE_BACKEND is not defined %}
   Read .squad/agents/{name}/history.md (your project knowledge).
   {% endif %}
@@ -881,22 +892,22 @@ prompt: |
   Check .copilot/skills/ for copilot-level skills (process, workflow, protocol).
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
-
+  
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
-
+  
   **Requested by:** {current user name}
-
+  
   INPUT ARTIFACTS: {list exact file paths to review/modify}
-
+  
   The user says: "{message}"
-
+  
   Do the work. Respond as {Name}.
-
+  
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
-
+  
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
@@ -921,7 +932,7 @@ prompt: |
   {% endif %}
   3. SKILL EXTRACTION: If you found a reusable pattern, write/update
      .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
-
+  
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.
 ```

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -194,6 +194,10 @@
       "types": "./dist/storage/index.d.ts",
       "import": "./dist/storage/index.js"
     },
+    "./memory": {
+      "types": "./dist/memory/index.d.ts",
+      "import": "./dist/memory/index.js"
+    },
     "./platform": {
       "types": "./dist/platform/index.d.ts",
       "import": "./dist/platform/index.js"

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -1,10 +1,10 @@
 /**
  * Squad Initialization Module (M2-6, PRD #98)
- * 
+ *
  * Creates new Squad projects with typed configuration.
  * Generates squad.config.ts or squad.config.json with agent definitions.
  * Scaffolds directory structure, templates, workflows, and agent files.
- * 
+ *
  * @module config/init
  */
 
@@ -18,6 +18,7 @@ import type { SquadConfig, ModelSelectionConfig, RoutingConfig } from '../runtim
 import type { SubSquadDefinition } from '../streams/types.js';
 import { ENGINEERING_ROLE_IDS } from '../roles/catalog.js';
 import { getRoleById } from '../roles/index.js';
+import { ensureMemoryGovernanceDefaults } from '../memory/index.js';
 
 // ============================================================================
 // Manifest-Curated Skills (must stay in sync with TEMPLATE_MANIFEST in CLI)
@@ -48,19 +49,19 @@ const MANIFEST_SKILL_NAMES = [
 export function getSDKTemplatesDir(storage: StorageProvider = new FSStorageProvider()): string | null {
   // Use fileURLToPath for cross-platform compatibility (handles Windows drive letters, URL encoding)
   const currentDir = dirname(fileURLToPath(import.meta.url));
-  
+
   // Try relative to this file (in dist/)
   const distPath = join(currentDir, '../../templates');
   if (storage.existsSync(distPath)) {
     return distPath;
   }
-  
+
   // Try relative to package root (for dev)
   const pkgPath = join(currentDir, '../../../templates');
   if (storage.existsSync(pkgPath)) {
     return pkgPath;
   }
-  
+
   return null;
 }
 
@@ -71,11 +72,11 @@ function copyRecursiveSync(src: string, dest: string, storage: StorageProvider =
   if (!storage.existsSync(dest)) {
     storage.mkdirSync(dest, { recursive: true });
   }
-  
+
   for (const entry of storage.isDirectorySync(src) ? storage.listSync(src) : []) {
     const srcPath = join(src, entry);
     const destPath = join(dest, entry);
-    
+
     if (storage.isDirectorySync(srcPath)) {
       copyRecursiveSync(srcPath, destPath, storage);
     } else {
@@ -219,7 +220,7 @@ function formatModelArray(chain: readonly string[]): string {
  */
 function generateTypeScriptConfig(options: InitOptions): string {
   const { projectName, projectDescription, agents } = options;
-  
+
   return `import type { SquadConfig } from '@bradygaster/squad';
 
 /**
@@ -228,7 +229,7 @@ function generateTypeScriptConfig(options: InitOptions): string {
  */
 const config: SquadConfig = {
   version: '1.0.0',
-  
+
   models: {
     defaultModel: '${MODELS.DEFAULT}',
     defaultTier: 'standard',
@@ -245,7 +246,7 @@ const config: SquadConfig = {
       maxRetriesBeforeNuclear: ${MODELS.NUCLEAR_MAX_RETRIES}
     }
   },
-  
+
   routing: {
     rules: [
       {
@@ -275,7 +276,7 @@ const config: SquadConfig = {
       allowRecursiveSpawn: false
     }
   },
-  
+
   casting: {
     allowlistUniverses: [
       'The Usual Suspects',
@@ -286,7 +287,7 @@ const config: SquadConfig = {
     overflowStrategy: 'generic',
     universeCapacity: {}
   },
-  
+
   platforms: {
     vscode: {
       disableModelSelection: false,
@@ -304,7 +305,7 @@ export default config;
  */
 function generateJsonConfig(options: InitOptions): string {
   const { agents } = options;
-  
+
   const config: SquadConfig = {
     version: '1.0.0',
     models: {
@@ -369,7 +370,7 @@ function generateJsonConfig(options: InitOptions): string {
       }
     }
   };
-  
+
   return JSON.stringify(config, null, 2);
 }
 
@@ -378,16 +379,16 @@ function generateJsonConfig(options: InitOptions): string {
  */
 function generateSDKBuilderConfig(options: InitOptions): string {
   const { projectName, projectDescription, agents } = options;
-  
+
   // Generate imports
   let code = `import {\n  defineSquad,\n  defineTeam,\n  defineAgent,\n} from '@bradygaster/squad-sdk';\n\n`;
-  
+
   code += `/**\n * Squad Configuration — ${projectName}\n`;
   if (projectDescription) {
     code += ` *\n * ${projectDescription}\n`;
   }
   code += ` */\n`;
-  
+
   // Generate agent definitions
   for (const agent of agents) {
     const displayName = agent.displayName || titleCase(agent.name);
@@ -398,7 +399,7 @@ function generateSDKBuilderConfig(options: InitOptions): string {
     code += `  status: 'active',\n`;
     code += `});\n\n`;
   }
-  
+
   // Generate squad config
   code += `export default defineSquad({\n`;
   code += `  version: '1.0.0',\n\n`;
@@ -411,7 +412,7 @@ function generateSDKBuilderConfig(options: InitOptions): string {
   code += `  }),\n\n`;
   code += `  agents: [${agents.map(a => a.name).join(', ')}],\n`;
   code += `});\n`;
-  
+
   return code;
 }
 
@@ -514,7 +515,7 @@ function generateCharter(agent: InitAgentSpec, projectName: string, projectDescr
   const template = AGENT_TEMPLATES[agent.role];
   const displayName = agent.displayName || template?.displayName || titleCase(agent.name);
   const description = template?.description || 'Team member focused on their assigned responsibilities.';
-  
+
   return `# ${displayName} — ${titleCase(agent.role)}
 
 ${description}
@@ -549,7 +550,7 @@ function generateInitialHistory(
 ): string {
   const displayName = agent.displayName || AGENT_TEMPLATES[agent.role]?.displayName || titleCase(agent.name);
   const now = new Date().toISOString().split('T')[0];
-  
+
   return `# Project Context
 
 ${userName ? `- **Owner:** ${userName}\n` : ''}- **Project:** ${projectName}
@@ -608,7 +609,7 @@ function stampVersionInContent(content: string, version: string): string {
 
 /**
  * Initialize a new Squad project.
- * 
+ *
  * Creates:
  * - .squad/ directory structure (agents, casting, decisions, skills, identity, etc.)
  * - squad.config.ts or squad.config.json
@@ -621,7 +622,7 @@ function stampVersionInContent(content: string, version: string): string {
  * - .copilot/mcp-config.json (optional)
  * - Identity files (now.md, wisdom.md)
  * - ceremonies.md
- * 
+ *
  * @param options - Initialization options
  * @returns Result with created file paths
  */
@@ -652,12 +653,12 @@ export async function initSquad(options: InitOptions, storage: StorageProvider =
     projectType = 'unknown',
     version = '0.0.0',
   } = options;
-  
+
   const createdFiles: string[] = [];
   const skippedFiles: string[] = [];
   const warnings: string[] = [];
   const agentDirs: string[] = [];
-  
+
   // Validate inputs
   if (!teamRoot) {
     throw new Error('teamRoot is required');
@@ -668,10 +669,10 @@ export async function initSquad(options: InitOptions, storage: StorageProvider =
   if (!agents || agents.length === 0) {
     throw new Error('At least one agent is required');
   }
-  
+
   // Get templates directory
   const templatesDir = getSDKTemplatesDir();
-  
+
   // Helper to convert absolute path to relative
   const toRelativePath = (absolutePath: string): string => {
     // Use path.relative for correct cross-root handling (monorepo: agentFileRoot != teamRoot)
@@ -690,7 +691,7 @@ export async function initSquad(options: InitOptions, storage: StorageProvider =
     createdFiles.push(toRelativePath(filePath));
     return true;
   };
-  
+
   // Helper to copy file (respects skipExisting)
   const copyIfNotExists = async (src: string, dest: string): Promise<boolean> => {
     if (storage.existsSync(dest) && skipExisting) {
@@ -702,17 +703,18 @@ export async function initSquad(options: InitOptions, storage: StorageProvider =
     createdFiles.push(toRelativePath(dest));
     return true;
   };
-  
+
   // -------------------------------------------------------------------------
   // Create .squad/ directory structure
   // -------------------------------------------------------------------------
-  
+
   const squadDir = join(teamRoot, '.squad');
   const directories = [
     join(squadDir, 'agents'),
     join(squadDir, 'casting'),
     join(squadDir, 'decisions'),
     join(squadDir, 'decisions', 'inbox'),
+    join(squadDir, 'memory'),
     join(teamRoot, '.copilot', 'skills'),
     join(squadDir, 'plugins'),
     join(squadDir, 'identity'),
@@ -720,13 +722,17 @@ export async function initSquad(options: InitOptions, storage: StorageProvider =
     join(squadDir, 'log'),
     join(squadDir, '.scratch'),
   ];
-  
+
   for (const dir of directories) {
     if (!storage.existsSync(dir)) {
       await storage.mkdir(dir, { recursive: true });
     }
   }
-  
+
+  for (const created of await ensureMemoryGovernanceDefaults(storage, teamRoot)) {
+    createdFiles.push(created);
+  }
+
   // -------------------------------------------------------------------------
   // Scaffold .squad/casting/ files (policy, registry, history)
   // -------------------------------------------------------------------------
@@ -757,7 +763,7 @@ export async function initSquad(options: InitOptions, storage: StorageProvider =
   // -------------------------------------------------------------------------
   // Create .squad/config.json for squad settings
   // -------------------------------------------------------------------------
-  
+
   const squadConfigPath = join(squadDir, 'config.json');
   if (!storage.existsSync(squadConfigPath)) {
     // Detect platform from git remote for config
@@ -826,56 +832,56 @@ export async function initSquad(options: InitOptions, storage: StorageProvider =
     await storage.write(squadConfigPath, JSON.stringify(squadConfig, null, 2));
     createdFiles.push(toRelativePath(squadConfigPath));
   }
-  
+
   // -------------------------------------------------------------------------
   // Create configuration file
   // -------------------------------------------------------------------------
-  
+
   // When configFormat is 'markdown', skip config file generation entirely
   let configPath: string;
   if (configFormat !== 'markdown') {
-    const configFileName = configFormat === 'sdk' ? 'squad.config.ts' : 
+    const configFileName = configFormat === 'sdk' ? 'squad.config.ts' :
                            configFormat === 'typescript' ? 'squad.config.ts' : 'squad.config.json';
     configPath = join(teamRoot, configFileName);
     const configContent = (configFormat === 'sdk' && options.roles) ? generateSDKBuilderConfigWithRoles(options) :
                           configFormat === 'sdk' ? generateSDKBuilderConfig(options) :
                           configFormat === 'typescript' ? generateTypeScriptConfig(options) :
                           generateJsonConfig(options);
-    
+
     await writeIfNotExists(configPath, configContent);
   } else {
     // No config file for markdown-only mode
     configPath = '';
   }
-  
+
   // -------------------------------------------------------------------------
   // Create agent directories and files
   // -------------------------------------------------------------------------
-  
+
   const agentsDir = join(squadDir, 'agents');
   for (const agent of agents) {
     const agentDir = join(agentsDir, agent.name);
     agentDirs.push(agentDir);
-    
+
     // Create charter.md
     const charterPath = join(agentDir, 'charter.md');
     const charterContent = generateCharter(agent, projectName, projectDescription);
     await writeIfNotExists(charterPath, charterContent);
-    
+
     // Create history.md
     const historyPath = join(agentDir, 'history.md');
     const historyContent = generateInitialHistory(agent, projectName, projectDescription, userName);
     await writeIfNotExists(historyPath, historyContent);
   }
-  
+
   // -------------------------------------------------------------------------
   // Create identity files (now.md, wisdom.md)
   // -------------------------------------------------------------------------
-  
+
   const identityDir = join(squadDir, 'identity');
   const nowMdPath = join(identityDir, 'now.md');
   const wisdomMdPath = join(identityDir, 'wisdom.md');
-  
+
   const nowContent = `---
 updated_at: ${new Date().toISOString()}
 focus_area: Initial setup
@@ -886,7 +892,7 @@ active_issues: []
 
 Getting started. Updated by coordinator at session start.
 `;
-  
+
   const wisdomContent = `---
 last_updated: ${new Date().toISOString()}
 ---
@@ -899,23 +905,23 @@ Reusable patterns and heuristics learned through work. NOT transcripts — each 
 
 <!-- Append entries below. Format: **Pattern:** description. **Context:** when it applies. -->
 `;
-  
+
   await writeIfNotExists(nowMdPath, nowContent);
   await writeIfNotExists(wisdomMdPath, wisdomContent);
-  
+
   // -------------------------------------------------------------------------
   // Create ceremonies.md
   // -------------------------------------------------------------------------
-  
+
   const ceremoniesDest = join(squadDir, 'ceremonies.md');
   if (templatesDir && storage.existsSync(join(templatesDir, 'ceremonies.md'))) {
     await copyIfNotExists(join(templatesDir, 'ceremonies.md'), ceremoniesDest);
   }
-  
+
   // -------------------------------------------------------------------------
   // Create decisions.md (canonical location at squad root)
   // -------------------------------------------------------------------------
-  
+
   const decisionsPath = join(squadDir, 'decisions.md');
   const decisionsContent = `# Squad Decisions
 
@@ -929,13 +935,13 @@ No decisions recorded yet.
 - Document architectural decisions here
 - Keep history focused on work, decisions focused on direction
 `;
-  
+
   await writeIfNotExists(decisionsPath, decisionsContent);
-  
+
   // -------------------------------------------------------------------------
   // Create team.md (required by shell lifecycle)
   // -------------------------------------------------------------------------
-  
+
   const teamPath = join(squadDir, 'team.md');
   const teamContent = `# Squad Team
 
@@ -959,11 +965,11 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
 `;
 
   await writeIfNotExists(teamPath, teamContent);
-  
+
   // -------------------------------------------------------------------------
   // Create routing.md
   // -------------------------------------------------------------------------
-  
+
   const routingPath = join(squadDir, 'routing.md');
   if (templatesDir && storage.existsSync(join(templatesDir, 'routing.md'))) {
     await copyIfNotExists(join(templatesDir, 'routing.md'), routingPath);
@@ -982,11 +988,11 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
 `;
     await writeIfNotExists(routingPath, routingContent);
   }
-  
+
   // -------------------------------------------------------------------------
   // Copy starter skills
   // -------------------------------------------------------------------------
-  
+
   const skillsDir = join(teamRoot, '.copilot', 'skills');
   if (templatesDir && storage.existsSync(join(templatesDir, 'skills'))) {
     const skillsSrc = join(templatesDir, 'skills');
@@ -1002,11 +1008,11 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
       createdFiles.push('.copilot/skills');
     }
   }
-  
+
   // -------------------------------------------------------------------------
   // Create .gitattributes for merge drivers
   // -------------------------------------------------------------------------
-  
+
   const gitattributesPath = join(teamRoot, '.gitattributes');
   const unionRules = [
     '.squad/decisions.md merge=union',
@@ -1014,12 +1020,12 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
     '.squad/log/** merge=union',
     '.squad/orchestration-log/** merge=union',
   ];
-  
+
   let existingAttrs = '';
   if (storage.existsSync(gitattributesPath)) {
     existingAttrs = storage.readSync(gitattributesPath) ?? '';
   }
-  
+
   const missingRules = unionRules.filter(rule => !existingAttrs.includes(rule));
   if (missingRules.length > 0) {
     const block = (existingAttrs && !existingAttrs.endsWith('\n') ? '\n' : '')
@@ -1028,13 +1034,13 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
     await storage.append(gitattributesPath, block);
     createdFiles.push(toRelativePath(gitattributesPath));
   }
-  
+
   // -------------------------------------------------------------------------
   // Create .gitignore entries for runtime state (logs, inbox, sessions)
   // These paths are written during normal squad operation but should not be
   // committed to version control (they are runtime state).
   // -------------------------------------------------------------------------
-  
+
   const gitignorePath = join(teamRoot, '.gitignore');
   const ignoreEntries = [
     '.squad/orchestration-log/',
@@ -1043,12 +1049,12 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
     '.squad/sessions/',
     '.squad/.scratch/',
   ];
-  
+
   let existingIgnore = '';
   if (storage.existsSync(gitignorePath)) {
     existingIgnore = storage.readSync(gitignorePath) ?? '';
   }
-  
+
   const missingIgnore = ignoreEntries.filter(entry => !existingIgnore.includes(entry));
   if (missingIgnore.length > 0) {
     const block = (existingIgnore && !existingIgnore.endsWith('\n') ? '\n' : '')
@@ -1057,11 +1063,11 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
     await storage.append(gitignorePath, block);
     createdFiles.push(toRelativePath(gitignorePath));
   }
-  
+
   // -------------------------------------------------------------------------
   // Create .github/agents/squad.agent.md
   // -------------------------------------------------------------------------
-  
+
   const agentFile = join(options.agentFileRoot ?? teamRoot, '.github', 'agents', 'squad.agent.md');
   if (!storage.existsSync(agentFile) || !skipExisting) {
     if (templatesDir && storage.existsSync(join(templatesDir, 'squad.agent.md.template'))) {
@@ -1075,11 +1081,11 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   } else {
     skippedFiles.push(toRelativePath(agentFile));
   }
-  
+
   // -------------------------------------------------------------------------
   // Copy .squad/templates/ (optional)
   // -------------------------------------------------------------------------
-  
+
   if (includeTemplates && templatesDir) {
     const templatesDest = join(teamRoot, '.squad', 'templates');
     if (!storage.existsSync(templatesDest)) {
@@ -1089,11 +1095,11 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
       skippedFiles.push(toRelativePath(templatesDest));
     }
   }
-  
+
   // -------------------------------------------------------------------------
   // Detect platform from git remote
   // -------------------------------------------------------------------------
-  
+
   let isGitHub = true;
   try {
     const remoteUrl = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd: teamRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
@@ -1108,7 +1114,7 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   // -------------------------------------------------------------------------
   // Copy workflows (optional) — skip for ADO repos
   // -------------------------------------------------------------------------
-  
+
   if (includeWorkflows && isGitHub && templatesDir && storage.existsSync(join(templatesDir, 'workflows'))) {
     // In monorepo mode (agentFileRoot != teamRoot), skip workflow placement.
     // GitHub Actions only reads from <repo-root>/.github/workflows/ — placing
@@ -1121,12 +1127,12 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
     } else {
     const workflowsSrc = join(templatesDir, 'workflows');
     const workflowsDest = join(teamRoot, '.github', 'workflows');
-    
+
     if (storage.isDirectorySync(workflowsSrc)) {
       const allWorkflowFiles = storage.listSync(workflowsSrc).filter(f => f.endsWith('.yml'));
       const workflowFiles = allWorkflowFiles.filter(f => FRAMEWORK_WORKFLOWS.includes(f));
       await storage.mkdir(workflowsDest, { recursive: true });
-      
+
       for (const file of workflowFiles) {
         const destFile = join(workflowsDest, file);
         if (!storage.existsSync(destFile) || !skipExisting) {
@@ -1139,11 +1145,11 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
     }
     }
   }
-  
+
   // -------------------------------------------------------------------------
   // Create sample MCP config (optional)
   // -------------------------------------------------------------------------
-  
+
   if (includeMcpConfig) {
     const mcpConfigPath = join(teamRoot, '.copilot', 'mcp-config.json');
     if (!storage.existsSync(mcpConfigPath)) {
@@ -1177,7 +1183,7 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
       skippedFiles.push(toRelativePath(mcpConfigPath));
     }
   }
-  
+
   // -------------------------------------------------------------------------
   // Generate .squad/workstreams.json (when SubSquads provided)
   // -------------------------------------------------------------------------
@@ -1213,23 +1219,23 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   // -------------------------------------------------------------------------
   // Create .first-run marker
   // -------------------------------------------------------------------------
-  
+
   const firstRunMarker = join(squadDir, '.first-run');
   if (!storage.existsSync(firstRunMarker)) {
     await storage.write(firstRunMarker, new Date().toISOString() + '\n');
     createdFiles.push(toRelativePath(firstRunMarker));
   }
-  
+
   // -------------------------------------------------------------------------
   // Store init prompt for REPL auto-casting
   // -------------------------------------------------------------------------
-  
+
   if (options.prompt) {
     const promptFile = join(squadDir, '.init-prompt');
     await storage.write(promptFile, options.prompt);
     createdFiles.push(toRelativePath(promptFile));
   }
-  
+
   return {
     createdFiles,
     skippedFiles,
@@ -1244,7 +1250,7 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
 /**
  * Clean up orphan .init-prompt file.
  * Called by CLI on Ctrl+C abort to remove partial state.
- * 
+ *
  * @param squadDir - Path to the .squad directory
  */
 export async function cleanupOrphanInitPrompt(squadDir: string, storage: StorageProvider = new FSStorageProvider()): Promise<void> {

--- a/packages/squad-sdk/src/index.ts
+++ b/packages/squad-sdk/src/index.ts
@@ -102,6 +102,7 @@ export type {
 export * from './roles/index.js';
 export * from './platform/index.js';
 export * from './storage/index.js';
+export * from './memory/index.js';
 
 // Git-native state backends (Issue #807)
 export type { StateBackend, StateBackendType, StateBackendConfig } from './state-backend.js';

--- a/packages/squad-sdk/src/memory/index.ts
+++ b/packages/squad-sdk/src/memory/index.ts
@@ -1,0 +1,945 @@
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { StorageProvider } from '../storage/storage-provider.js';
+
+export type MemoryClass =
+  | 'TRANSIENT'
+  | 'LOCAL'
+  | 'DECISION'
+  | 'POLICY'
+  | 'COPILOT_MEMORY'
+  | 'FORBIDDEN';
+
+export type MemoryLoadGuidance = 'ALWAYS' | 'ON-DEMAND' | 'ARCHIVE' | 'NEVER';
+
+export interface MemoryGovernanceConfig {
+  version: 1;
+  defaultProvider: 'local' | 'hostInjectedCopilotAdapter' | 'copilot';
+  promptOnlyFallback: true;
+  externalProviders: {
+    hostInjectedCopilotAdapter: {
+      enabled: boolean;
+      requireApproval: boolean;
+    };
+  };
+  policy: {
+    rejectForbidden: true;
+    rejectTransientDurableWrites: true;
+    auditContent: false;
+  };
+}
+
+export interface MemoryClassification {
+  class: MemoryClass;
+  allowed: boolean;
+  reason: string;
+  destination: 'none' | 'local' | 'decision-inbox' | 'policy-inbox' | 'external-semantic';
+  loadGuidance: MemoryLoadGuidance;
+}
+
+export interface MemoryWriteRequest {
+  content: string;
+  title?: string;
+  author?: string;
+  requestedClass?: MemoryClass;
+  approved?: boolean;
+  metadata?: Record<string, string>;
+}
+
+export interface MemoryWriteResult {
+  stored: boolean;
+  id?: string;
+  classification: MemoryClassification;
+  path?: string;
+}
+
+export interface MemorySearchResult {
+  id: string;
+  class: MemoryClass;
+  loadGuidance: MemoryLoadGuidance;
+  title: string;
+  path: string;
+  snippet: string;
+  provider?: 'local' | 'hostInjectedCopilotAdapter' | 'copilot';
+}
+
+export interface MemoryAuditRecord {
+  timestamp: string;
+  action: 'classify' | 'write' | 'reject' | 'promote' | 'delete' | 'search' | 'configure';
+  id?: string;
+  class?: MemoryClass;
+  title?: string;
+  path?: string;
+  reason?: string;
+  actor?: string;
+  provider?: 'local' | 'hostInjectedCopilotAdapter' | 'copilot';
+}
+
+export interface CopilotMemoryProviderWriteRequest {
+  content: string;
+  title: string;
+  author?: string;
+  metadata?: Record<string, string>;
+  classification: MemoryClassification;
+}
+
+export interface CopilotMemoryProviderWriteResult {
+  id: string;
+  path?: string;
+}
+
+export interface CopilotMemoryProviderSearchResult {
+  id: string;
+  title: string;
+  snippet: string;
+  path?: string;
+}
+
+export interface CopilotMemoryProviderClient {
+  write(request: CopilotMemoryProviderWriteRequest): Promise<CopilotMemoryProviderWriteResult>;
+  search(query: string): Promise<CopilotMemoryProviderSearchResult[]>;
+  delete(id: string): Promise<boolean>;
+}
+
+export interface LocalMemoryStoreOptions {
+  rootKind?: 'project' | 'squad';
+  hostInjectedCopilotAdapterClient?: CopilotMemoryProviderClient;
+  /** @deprecated Use hostInjectedCopilotAdapterClient. */
+  copilotMemoryClient?: CopilotMemoryProviderClient;
+}
+
+interface MemoryIndexEntry {
+  id: string;
+  class: MemoryClass;
+  loadGuidance: MemoryLoadGuidance;
+  title: string;
+  path: string;
+  status: 'active' | 'deleted' | 'superseded';
+  supersedes?: string;
+  supersededBy?: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt?: string;
+}
+
+const DEFAULT_CONFIG: MemoryGovernanceConfig = {
+  version: 1,
+  defaultProvider: 'local',
+  promptOnlyFallback: true,
+  externalProviders: {
+    hostInjectedCopilotAdapter: {
+      enabled: false,
+      requireApproval: true,
+    },
+  },
+  policy: {
+    rejectForbidden: true,
+    rejectTransientDurableWrites: true,
+    auditContent: false,
+  },
+};
+
+const FORBIDDEN_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  { pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/i, reason: 'private key material' },
+  { pattern: /\b(ghp|github_pat|glpat|xox[baprs])-?[A-Za-z0-9_=-]{12,}\b/i, reason: 'access token' },
+  { pattern: /\b(password|passwd|secret|token|api[_-]?key)\s*[:=]\s*\S+/i, reason: 'credential-like assignment' },
+  { pattern: /\b(AccountKey|SharedAccessKey|DefaultEndpointsProtocol)=/i, reason: 'connection string secret' },
+  { pattern: /\b\d{3}-\d{2}-\d{4}\b/, reason: 'PII-like identifier' },
+  { pattern: /\b(?:10|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}\b/, reason: 'internal network topology' },
+  { pattern: /\b(raw logs?|stack trace|telemetry payload|dump file)\b/i, reason: 'raw diagnostic payload' },
+  { pattern: /\b(CI|PR|build)\s+(status|failed|passed|output|log)\b/i, reason: 'transient CI/PR status' },
+  { pattern: /\b(private|confidential|restricted)\s+customer\s+(data|record|records|details|information|info)\b/i, reason: 'private customer data' },
+  { pattern: /\bcustomer\s+(pii|personal data|tenant secret|production data)\b/i, reason: 'private customer data' },
+  { pattern: /\bunreviewed\s+(security\s+)?vulnerabilit(?:y|ies)\b/i, reason: 'unreviewed vulnerability disclosure' },
+  { pattern: /\b(?:0-day|zero-day)\b/i, reason: 'unreviewed vulnerability disclosure' },
+];
+
+function cloneDefaultConfig(): MemoryGovernanceConfig {
+  return JSON.parse(JSON.stringify(DEFAULT_CONFIG)) as MemoryGovernanceConfig;
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 64);
+  return slug || 'memory';
+}
+
+function firstLine(value: string): string {
+  return value.split(/\r?\n/).find(line => line.trim().length > 0)?.trim().slice(0, 80) ?? 'Untitled memory';
+}
+
+function safeAuditTitle(title: string | undefined, placeholder = 'Rejected governed memory'): string {
+  const trimmed = title?.trim();
+  if (!trimmed) return placeholder;
+  return FORBIDDEN_PATTERNS.some(({ pattern }) => pattern.test(trimmed))
+    ? placeholder
+    : trimmed.slice(0, 80);
+}
+
+function loadGuidanceFor(memoryClass: MemoryClass): MemoryLoadGuidance {
+  switch (memoryClass) {
+    case 'POLICY':
+    case 'DECISION':
+      return 'ALWAYS';
+    case 'LOCAL':
+    case 'COPILOT_MEMORY':
+      return 'ON-DEMAND';
+    case 'TRANSIENT':
+    case 'FORBIDDEN':
+      return 'NEVER';
+  }
+}
+
+function normalizeLoadGuidance(value: string | undefined, fallback: MemoryLoadGuidance): MemoryLoadGuidance {
+  const normalized = value?.trim().replace(/^\[|\]$/g, '').toUpperCase();
+  return normalized === 'ALWAYS'
+    || normalized === 'ON-DEMAND'
+    || normalized === 'ARCHIVE'
+    || normalized === 'NEVER'
+    ? normalized
+    : fallback;
+}
+
+export const REAL_COPILOT_UNAVAILABLE_REASON =
+  'Real Copilot Memory API unavailable: no concrete callable API was found in installed @github/copilot SDK/tooling. Squad will not fake provider=copilot; use hostInjectedCopilotAdapter only when a host supplies a client.';
+
+function isRealCopilotProviderSelected(config: MemoryGovernanceConfig): boolean {
+  return config.defaultProvider === 'copilot';
+}
+
+function isHostInjectedCopilotAdapterConfigured(config: MemoryGovernanceConfig): boolean {
+  return config.externalProviders.hostInjectedCopilotAdapter.enabled;
+}
+
+export class HostInjectedCopilotMemoryAdapter {
+  constructor(private readonly client?: CopilotMemoryProviderClient) {}
+
+  isAvailable(): boolean {
+    return this.client !== undefined;
+  }
+
+  async write(request: CopilotMemoryProviderWriteRequest): Promise<CopilotMemoryProviderWriteResult> {
+    return this.requireClient().write(request);
+  }
+
+  async search(query: string): Promise<CopilotMemoryProviderSearchResult[]> {
+    return this.requireClient().search(query);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.requireClient().delete(id);
+  }
+
+  private requireClient(): CopilotMemoryProviderClient {
+    if (!this.client) {
+      throw new Error(
+        'hostInjectedCopilotAdapter is enabled, but no host-injected Copilot memory client was supplied. This is not real provider=copilot persistence.',
+      );
+    }
+    return this.client;
+  }
+}
+
+function destinationFor(memoryClass: MemoryClass): MemoryClassification['destination'] {
+  switch (memoryClass) {
+    case 'LOCAL':
+      return 'local';
+    case 'DECISION':
+      return 'decision-inbox';
+    case 'POLICY':
+      return 'policy-inbox';
+    case 'COPILOT_MEMORY':
+      return 'external-semantic';
+    default:
+      return 'none';
+  }
+}
+
+export async function ensureMemoryGovernanceDefaults(
+  storage: StorageProvider,
+  projectRoot: string,
+): Promise<string[]> {
+  const created: string[] = [];
+  const memoryDir = path.join(projectRoot, '.squad', 'memory');
+  for (const dir of ['local', 'policy-inbox', 'semantic-inbox', 'tombstones']) {
+    const fullPath = path.join(memoryDir, dir);
+    if (!await storage.exists(fullPath)) {
+      await storage.mkdir(fullPath, { recursive: true });
+      created.push(path.join('.squad', 'memory', dir));
+    }
+  }
+
+  const configPath = path.join(memoryDir, 'config.json');
+  if (!await storage.exists(configPath)) {
+    await storage.write(configPath, JSON.stringify(DEFAULT_CONFIG, null, 2) + '\n');
+    created.push(path.join('.squad', 'memory', 'config.json'));
+  }
+
+  const indexPath = path.join(memoryDir, 'index.json');
+  if (!await storage.exists(indexPath)) {
+    await storage.write(indexPath, '[]\n');
+    created.push(path.join('.squad', 'memory', 'index.json'));
+  }
+
+  const auditPath = path.join(memoryDir, 'audit.jsonl');
+  if (!await storage.exists(auditPath)) {
+    await storage.write(auditPath, '');
+    created.push(path.join('.squad', 'memory', 'audit.jsonl'));
+  }
+
+  return created;
+}
+
+export class LocalMemoryStore {
+  private readonly squadDir: string;
+  private readonly copilotProvider: HostInjectedCopilotMemoryAdapter;
+
+  constructor(
+    private readonly storage: StorageProvider,
+    rootDir: string,
+    options: LocalMemoryStoreOptions = {},
+  ) {
+    this.squadDir = options.rootKind === 'squad' ? rootDir : path.join(rootDir, '.squad');
+    this.copilotProvider = new HostInjectedCopilotMemoryAdapter(
+      options.hostInjectedCopilotAdapterClient ?? options.copilotMemoryClient,
+    );
+  }
+
+  async classify(
+    request: Pick<MemoryWriteRequest, 'content' | 'requestedClass' | 'metadata'>,
+    options: { audit?: boolean; actor?: string; title?: string } = {},
+  ): Promise<MemoryClassification> {
+    const content = request.content.trim();
+    let classification: MemoryClassification | undefined;
+    for (const { pattern, reason } of FORBIDDEN_PATTERNS) {
+      if (pattern.test(content)) {
+        classification = {
+          class: 'FORBIDDEN',
+          allowed: false,
+          reason: `Rejected as forbidden memory: ${reason}`,
+          destination: 'none',
+          loadGuidance: 'NEVER',
+        };
+        break;
+      }
+    }
+
+    if (!classification) {
+      let memoryClass = request.requestedClass;
+      if (!memoryClass) {
+        if (/\b(CI|PR|build)\s+(status|failed|passed|output|log)\b/i.test(content)) {
+          memoryClass = 'TRANSIENT';
+        } else if (/^\s*(always|never|must|do not)\b/i.test(content)) {
+          memoryClass = 'POLICY';
+        } else if (/\b(decision|decided|adopt|standardize|use .+ for)\b/i.test(content)) {
+          memoryClass = 'DECISION';
+        } else if (/\bcopilot memory|semantic memory\b/i.test(content)) {
+          memoryClass = 'COPILOT_MEMORY';
+        } else {
+          memoryClass = 'LOCAL';
+        }
+      }
+
+      if (memoryClass === 'FORBIDDEN') {
+        classification = {
+          class: 'FORBIDDEN',
+          allowed: false,
+          reason: 'Requested class is forbidden',
+          destination: 'none',
+          loadGuidance: 'NEVER',
+        };
+      } else if (memoryClass === 'TRANSIENT') {
+        classification = {
+          class: 'TRANSIENT',
+          allowed: false,
+          reason: 'Transient task state is not persisted as durable memory',
+          destination: 'none',
+          loadGuidance: 'NEVER',
+        };
+      } else {
+        const fallbackLoadGuidance = loadGuidanceFor(memoryClass);
+        classification = {
+          class: memoryClass,
+          allowed: true,
+          reason: memoryClass === 'COPILOT_MEMORY'
+            ? 'Content is allowed for governed Copilot Memory provider after opt-in checks'
+            : 'Content is allowed for governed local memory',
+          destination: destinationFor(memoryClass),
+          loadGuidance: normalizeLoadGuidance(request.metadata?.loadGuidance, fallbackLoadGuidance),
+        };
+      }
+    }
+
+    if (options.audit) {
+      await this.ensureInitialized();
+      await this.audit({
+        action: 'classify',
+        class: classification.class,
+        title: safeAuditTitle(options.title, 'Classified governed memory'),
+        reason: classification.reason,
+        actor: options.actor,
+      });
+    }
+
+    return classification;
+  }
+
+  async write(request: MemoryWriteRequest): Promise<MemoryWriteResult> {
+    await this.ensureInitialized();
+    const classification = await this.classify(request);
+    if (!classification.allowed) {
+      await this.audit({
+        action: 'reject',
+        class: classification.class,
+        title: safeAuditTitle(request.title),
+        reason: classification.reason,
+        actor: request.author,
+      });
+      return { stored: false, classification };
+    }
+
+    const config = await this.readConfig();
+    if (classification.class === 'COPILOT_MEMORY') {
+      if (isRealCopilotProviderSelected(config)) {
+        await this.audit({
+          action: 'reject',
+          class: classification.class,
+          title: safeAuditTitle(request.title),
+          reason: REAL_COPILOT_UNAVAILABLE_REASON,
+          actor: request.author,
+          provider: 'copilot',
+        });
+        return {
+          stored: false,
+          classification: { ...classification, allowed: false, reason: REAL_COPILOT_UNAVAILABLE_REASON },
+        };
+      }
+      const copilot = config.externalProviders.hostInjectedCopilotAdapter;
+      if (!copilot.enabled) {
+        const reason = 'COPILOT_MEMORY writes are disabled unless explicitly configured with hostInjectedCopilotAdapter. Real provider=copilot is unavailable locally.';
+        await this.audit({
+          action: 'reject',
+          class: classification.class,
+          title: safeAuditTitle(request.title),
+          reason,
+          actor: request.author,
+          provider: 'hostInjectedCopilotAdapter',
+        });
+        return {
+          stored: false,
+          classification: { ...classification, allowed: false, reason },
+        };
+      }
+      if (copilot.requireApproval && request.approved !== true) {
+        const reason = 'Copilot Memory writes require explicit approval';
+        await this.audit({
+          action: 'reject',
+          class: classification.class,
+          title: safeAuditTitle(request.title),
+          reason,
+          actor: request.author,
+          provider: 'hostInjectedCopilotAdapter',
+        });
+        return {
+          stored: false,
+          classification: { ...classification, allowed: false, reason },
+        };
+      }
+
+      let providerResult: CopilotMemoryProviderWriteResult;
+      try {
+        providerResult = await this.copilotProvider.write({
+          content: request.content.trim(),
+          title: request.title?.trim() || firstLine(request.content),
+          author: request.author,
+          metadata: request.metadata,
+          classification,
+        });
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        await this.audit({
+          action: 'reject',
+          class: classification.class,
+          title: safeAuditTitle(request.title),
+          reason,
+          actor: request.author,
+          provider: 'hostInjectedCopilotAdapter',
+        });
+        return {
+          stored: false,
+          classification: { ...classification, allowed: false, reason },
+        };
+      }
+
+      const now = new Date().toISOString();
+      const title = request.title?.trim() || firstLine(request.content);
+      const entry: MemoryIndexEntry = {
+        id: providerResult.id,
+        class: classification.class,
+        loadGuidance: classification.loadGuidance,
+        title,
+        path: providerResult.path ?? `host-injected-copilot-adapter:${providerResult.id}`,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      };
+      const index = await this.readIndex();
+      index.push(entry);
+      await this.writeIndex(index);
+      await this.audit({
+        action: 'write',
+        id: providerResult.id,
+        class: classification.class,
+        title,
+        path: entry.path,
+        reason: classification.reason,
+        actor: request.author,
+        provider: 'hostInjectedCopilotAdapter',
+      });
+      return {
+        stored: true,
+        id: providerResult.id,
+        classification,
+        path: entry.path,
+      };
+    }
+
+    const id = randomUUID();
+    const title = request.title?.trim() || firstLine(request.content);
+    const relativePath = this.destinationPath(classification.class, id, title, request.author);
+    const fullPath = path.join(this.squadDir, relativePath);
+    const content = this.renderMemoryFile(id, classification.class, title, request);
+    await this.storage.write(fullPath, content);
+
+    const now = new Date().toISOString();
+    const entry: MemoryIndexEntry = {
+      id,
+      class: classification.class,
+      loadGuidance: classification.loadGuidance,
+      title,
+      path: path.join('.squad', relativePath),
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+    };
+    const index = await this.readIndex();
+    index.push(entry);
+    await this.writeIndex(index);
+    await this.audit({
+      action: 'write',
+      id,
+      class: classification.class,
+      title,
+      path: entry.path,
+      reason: classification.reason,
+      actor: request.author,
+      provider: 'local',
+    });
+
+    return { stored: true, id, classification, path: entry.path };
+  }
+
+  async search(query: string): Promise<MemorySearchResult[]> {
+    await this.ensureInitialized();
+    const queryClassification = await this.classify({ content: query });
+    if (queryClassification.class === 'FORBIDDEN') {
+      await this.audit({
+        action: 'reject',
+        class: queryClassification.class,
+        title: 'Rejected governed memory search',
+        reason: queryClassification.reason,
+      });
+      return [];
+    }
+
+    const config = await this.readConfig();
+    if (isRealCopilotProviderSelected(config)) {
+      await this.audit({
+        action: 'reject',
+        class: 'COPILOT_MEMORY',
+        title: 'Rejected governed memory search',
+        reason: REAL_COPILOT_UNAVAILABLE_REASON,
+        provider: 'copilot',
+      });
+      return [];
+    }
+
+    const normalized = query.toLowerCase();
+    const index = await this.readIndex();
+    const results: MemorySearchResult[] = [];
+    for (const entry of index.filter(item => item.status === 'active')) {
+      if (
+        entry.class === 'COPILOT_MEMORY'
+        || entry.path.startsWith('copilot-memory:')
+        || entry.path.startsWith('host-injected-copilot-adapter:')
+      ) continue;
+      const content = await this.storage.read(this.absoluteFromEntryPath(entry.path));
+      if (!content) continue;
+      const haystack = `${entry.title}\n${content}`.toLowerCase();
+      if (!haystack.includes(normalized)) continue;
+      const matchLine = content.split(/\r?\n/).find(line => line.toLowerCase().includes(normalized));
+      results.push({
+          id: entry.id,
+          class: entry.class,
+          loadGuidance: entry.loadGuidance ?? loadGuidanceFor(entry.class),
+          title: entry.title,
+        path: entry.path,
+        snippet: (matchLine ?? entry.title).trim().slice(0, 240),
+        provider: 'local',
+      });
+    }
+    if (isHostInjectedCopilotAdapterConfigured(config)) {
+      const activeCopilotIds = new Set(index
+        .filter(item => item.status === 'active' && item.class === 'COPILOT_MEMORY')
+        .map(item => item.id));
+      const externalResults = await this.copilotProvider.search(query);
+      for (const result of externalResults) {
+        if (!activeCopilotIds.has(result.id)) continue;
+        results.push({
+          id: result.id,
+          class: 'COPILOT_MEMORY',
+          loadGuidance: 'ON-DEMAND',
+          title: result.title,
+          path: result.path ?? `host-injected-copilot-adapter:${result.id}`,
+          snippet: result.snippet.slice(0, 240),
+          provider: 'hostInjectedCopilotAdapter',
+        });
+      }
+    }
+    await this.audit({
+      action: 'search',
+      reason: `Search returned ${results.length} result(s)`,
+    });
+    return results;
+  }
+
+  async promote(id: string, targetClass: Exclude<MemoryClass, 'FORBIDDEN' | 'TRANSIENT'>, actor?: string): Promise<MemoryWriteResult> {
+    await this.ensureInitialized();
+    const index = await this.readIndex();
+    const entry = index.find(item => item.id === id && item.status === 'active');
+    if (!entry) {
+      throw new Error(`Memory '${id}' not found`);
+    }
+    const content = await this.storage.read(this.absoluteFromEntryPath(entry.path));
+    if (!content) {
+      throw new Error(`Memory '${id}' content not found`);
+    }
+    const body = content.split('---').slice(2).join('---').trim() || content;
+    const result = await this.write({
+      content: body,
+      title: entry.title,
+      author: actor,
+      requestedClass: targetClass,
+    });
+    if (result.stored && result.id) {
+      const now = new Date().toISOString();
+      const nextIndex = await this.readIndex();
+      const prior = nextIndex.find(item => item.id === id);
+      const successor = nextIndex.find(item => item.id === result.id);
+      if (successor) {
+        successor.supersedes = id;
+        successor.updatedAt = now;
+      }
+      if (prior) {
+        prior.status = 'superseded';
+        prior.loadGuidance = 'ARCHIVE';
+        prior.supersededBy = result.id;
+        prior.updatedAt = now;
+      }
+      await this.writeIndex(nextIndex);
+      if (prior && !prior.path.startsWith('host-injected-copilot-adapter:') && !prior.path.startsWith('copilot-memory:')) {
+        await this.updateMemoryFileMetadata(prior.path, {
+          status: 'superseded',
+          loadGuidance: '[ARCHIVE]',
+          supersededBy: result.id,
+        });
+      }
+      await this.audit({
+        action: 'promote',
+        id,
+        class: targetClass,
+        title: entry.title,
+        reason: `Promoted to ${targetClass}`,
+        actor,
+      });
+    }
+    return result;
+  }
+
+  async delete(id: string, actor?: string): Promise<boolean> {
+    await this.ensureInitialized();
+    const index = await this.readIndex();
+    const entry = index.find(item => item.id === id && item.status !== 'deleted');
+    if (!entry) return false;
+    const previousStatus = entry.status;
+    if (
+      entry.class === 'COPILOT_MEMORY'
+      || entry.path.startsWith('copilot-memory:')
+      || entry.path.startsWith('host-injected-copilot-adapter:')
+    ) {
+      const config = await this.readConfig();
+      if (isRealCopilotProviderSelected(config)) {
+        throw new Error(REAL_COPILOT_UNAVAILABLE_REASON);
+      }
+      if (!isHostInjectedCopilotAdapterConfigured(config)) {
+        throw new Error('COPILOT_MEMORY delete requires hostInjectedCopilotAdapter to be enabled; real provider=copilot is unavailable locally.');
+      }
+      const deleted = await this.copilotProvider.delete(id);
+      if (!deleted) return false;
+    } else {
+      await this.storage.delete(this.absoluteFromEntryPath(entry.path));
+    }
+    entry.status = 'deleted';
+    entry.loadGuidance = 'ARCHIVE';
+    entry.deletedAt = new Date().toISOString();
+    entry.updatedAt = entry.deletedAt;
+    await this.writeIndex(index);
+    await this.storage.write(
+      path.join(this.squadDir, 'memory', 'tombstones', `${id}.json`),
+      JSON.stringify({
+        id,
+        deletedAt: entry.deletedAt,
+        path: entry.path,
+        previousStatus,
+        supersedes: entry.supersedes,
+        supersededBy: entry.supersededBy,
+        loadGuidance: '[ARCHIVE]',
+      }, null, 2) + '\n',
+    );
+    await this.audit({
+      action: 'delete',
+      id,
+      class: entry.class,
+      title: entry.title,
+      path: entry.path,
+      reason: 'Deleted governed memory and wrote tombstone',
+      actor,
+      provider: entry.class === 'COPILOT_MEMORY' ? 'hostInjectedCopilotAdapter' : 'local',
+    });
+    return true;
+  }
+
+  async providerStatus(): Promise<{
+    defaultProvider: MemoryGovernanceConfig['defaultProvider'];
+    realCopilotMemory: { available: false; configured: boolean; reason: string };
+    hostInjectedCopilotAdapter: MemoryGovernanceConfig['externalProviders']['hostInjectedCopilotAdapter'] & { clientAvailable: boolean; configured: boolean };
+  }> {
+    await this.ensureInitialized();
+    const config = await this.readConfig();
+    return {
+      defaultProvider: config.defaultProvider,
+      realCopilotMemory: {
+        available: false,
+        configured: isRealCopilotProviderSelected(config),
+        reason: REAL_COPILOT_UNAVAILABLE_REASON,
+      },
+      hostInjectedCopilotAdapter: {
+        ...config.externalProviders.hostInjectedCopilotAdapter,
+        clientAvailable: this.copilotProvider.isAvailable(),
+        configured: isHostInjectedCopilotAdapterConfigured(config),
+      },
+    };
+  }
+
+  async configureHostInjectedCopilotAdapter(options: {
+    enabled: boolean;
+    requireApproval?: boolean;
+    defaultProvider?: Exclude<MemoryGovernanceConfig['defaultProvider'], 'copilot'>;
+    actor?: string;
+  }): Promise<MemoryGovernanceConfig> {
+    await this.ensureInitialized();
+    const current = await this.readConfig();
+    const next: MemoryGovernanceConfig = {
+      ...current,
+      defaultProvider: options.defaultProvider ?? current.defaultProvider,
+      externalProviders: {
+        ...current.externalProviders,
+          hostInjectedCopilotAdapter: {
+            enabled: options.enabled,
+            requireApproval: options.requireApproval ?? current.externalProviders.hostInjectedCopilotAdapter.requireApproval,
+          },
+        },
+    };
+    await this.storage.write(path.join(this.squadDir, 'memory', 'config.json'), JSON.stringify(next, null, 2) + '\n');
+    await this.audit({
+      action: 'configure',
+      reason: options.enabled
+        ? 'Configured hostInjectedCopilotAdapter; this is not real provider=copilot persistence'
+        : 'Disabled hostInjectedCopilotAdapter',
+      actor: options.actor,
+      provider: 'hostInjectedCopilotAdapter',
+    });
+    return next;
+  }
+
+  async configureCopilotProvider(options: {
+    enabled: boolean;
+    adapter?: 'host' | 'hostInjectedCopilotAdapter';
+    requireApproval?: boolean;
+    defaultProvider?: MemoryGovernanceConfig['defaultProvider'];
+    actor?: string;
+  }): Promise<MemoryGovernanceConfig> {
+    if (options.defaultProvider === 'copilot') {
+      throw new Error(REAL_COPILOT_UNAVAILABLE_REASON);
+    }
+    return this.configureHostInjectedCopilotAdapter({
+      enabled: options.enabled,
+      requireApproval: options.requireApproval,
+      defaultProvider: options.defaultProvider,
+      actor: options.actor,
+    });
+  }
+
+  async auditLog(): Promise<MemoryAuditRecord[]> {
+    await this.ensureInitialized();
+    const content = await this.storage.read(path.join(this.squadDir, 'memory', 'audit.jsonl'));
+    if (!content) return [];
+    return content
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map(line => JSON.parse(line) as MemoryAuditRecord);
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    const memoryDir = path.join(this.squadDir, 'memory');
+    for (const dir of ['local', 'policy-inbox', 'semantic-inbox', 'tombstones']) {
+      await this.storage.mkdir(path.join(memoryDir, dir), { recursive: true });
+    }
+    const configPath = path.join(memoryDir, 'config.json');
+    if (!await this.storage.exists(configPath)) {
+      await this.storage.write(configPath, JSON.stringify(DEFAULT_CONFIG, null, 2) + '\n');
+    }
+    const indexPath = path.join(memoryDir, 'index.json');
+    if (!await this.storage.exists(indexPath)) {
+      await this.storage.write(indexPath, '[]\n');
+    }
+    const auditPath = path.join(memoryDir, 'audit.jsonl');
+    if (!await this.storage.exists(auditPath)) {
+      await this.storage.write(auditPath, '');
+    }
+  }
+
+  private async readConfig(): Promise<MemoryGovernanceConfig> {
+    const content = await this.storage.read(path.join(this.squadDir, 'memory', 'config.json'));
+    if (!content) return cloneDefaultConfig();
+    try {
+      const parsed = JSON.parse(content) as Partial<MemoryGovernanceConfig>;
+      const defaults = cloneDefaultConfig();
+      const parsedExternalProviders = parsed.externalProviders as Partial<MemoryGovernanceConfig['externalProviders']> & {
+        copilotMemory?: { enabled?: boolean; requireApproval?: boolean; adapter?: string };
+      } | undefined;
+      const legacyHostInjected = parsedExternalProviders?.copilotMemory;
+      return {
+        ...defaults,
+        ...parsed,
+        externalProviders: {
+          ...defaults.externalProviders,
+          ...parsedExternalProviders,
+          hostInjectedCopilotAdapter: {
+            ...defaults.externalProviders.hostInjectedCopilotAdapter,
+            ...(legacyHostInjected
+              ? {
+                  enabled: legacyHostInjected.enabled ?? defaults.externalProviders.hostInjectedCopilotAdapter.enabled,
+                  requireApproval: legacyHostInjected.requireApproval ?? defaults.externalProviders.hostInjectedCopilotAdapter.requireApproval,
+                }
+              : {}),
+            ...parsedExternalProviders?.hostInjectedCopilotAdapter,
+          },
+        },
+        policy: {
+          ...defaults.policy,
+          ...parsed.policy,
+        },
+      };
+    } catch {
+      return cloneDefaultConfig();
+    }
+  }
+
+  private async readIndex(): Promise<MemoryIndexEntry[]> {
+    const content = await this.storage.read(path.join(this.squadDir, 'memory', 'index.json'));
+    if (!content) return [];
+    try {
+      const parsed = JSON.parse(content) as MemoryIndexEntry[];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private async writeIndex(index: MemoryIndexEntry[]): Promise<void> {
+    await this.storage.write(path.join(this.squadDir, 'memory', 'index.json'), JSON.stringify(index, null, 2) + '\n');
+  }
+
+  private async audit(record: Omit<MemoryAuditRecord, 'timestamp'>): Promise<void> {
+    const auditRecord: MemoryAuditRecord = {
+      timestamp: new Date().toISOString(),
+      ...record,
+    };
+    await this.storage.append(path.join(this.squadDir, 'memory', 'audit.jsonl'), JSON.stringify(auditRecord) + '\n');
+  }
+
+  private destinationPath(memoryClass: MemoryClass, id: string, title: string, author?: string): string {
+    const prefix = author ? `${slugify(author)}-` : '';
+    const fileName = `${prefix}${slugify(title)}-${id.slice(0, 8)}.md`;
+    if (memoryClass === 'DECISION') {
+      return path.join('decisions', 'inbox', fileName);
+    }
+    if (memoryClass === 'POLICY') {
+      return path.join('memory', 'policy-inbox', fileName);
+    }
+    return path.join('memory', 'local', fileName);
+  }
+
+  private renderMemoryFile(
+    id: string,
+    memoryClass: MemoryClass,
+    title: string,
+    request: MemoryWriteRequest,
+  ): string {
+    const metadata = request.metadata ? JSON.stringify(request.metadata) : '{}';
+    return [
+      '---',
+      `id: ${id}`,
+      `class: ${memoryClass}`,
+      `loadGuidance: [${normalizeLoadGuidance(request.metadata?.loadGuidance, loadGuidanceFor(memoryClass))}]`,
+      `title: ${JSON.stringify(title)}`,
+      `author: ${JSON.stringify(request.author ?? 'unknown')}`,
+      `createdAt: ${new Date().toISOString()}`,
+      `metadata: ${metadata}`,
+      '---',
+      '',
+      request.content.trim(),
+      '',
+    ].join('\n');
+  }
+
+  private absoluteFromEntryPath(entryPath: string): string {
+    const relative = entryPath.startsWith('.squad')
+      ? entryPath.slice('.squad'.length + 1)
+      : entryPath;
+    return path.join(this.squadDir, relative);
+  }
+
+  private async updateMemoryFileMetadata(entryPath: string, updates: Record<string, string>): Promise<void> {
+    const fullPath = this.absoluteFromEntryPath(entryPath);
+    const content = await this.storage.read(fullPath);
+    if (!content) return;
+    const lines = content.split(/\r?\n/);
+    if (lines[0] !== '---') return;
+    const endIndex = lines.findIndex((line, index) => index > 0 && line === '---');
+    if (endIndex < 0) return;
+    for (const [key, value] of Object.entries(updates)) {
+      const existingIndex = lines.findIndex((line, index) => index > 0 && index < endIndex && line.startsWith(`${key}:`));
+      if (existingIndex >= 0) {
+        lines[existingIndex] = `${key}: ${value}`;
+      } else {
+        lines.splice(endIndex, 0, `${key}: ${value}`);
+      }
+    }
+    await this.storage.write(fullPath, lines.join('\n'));
+  }
+}

--- a/packages/squad-sdk/src/memory/index.ts
+++ b/packages/squad-sdk/src/memory/index.ts
@@ -101,11 +101,194 @@ export interface CopilotMemoryProviderClient {
   delete(id: string): Promise<boolean>;
 }
 
+// ── MemoryProvider abstraction ───────────────────────────────────────────────
+//
+// A generic provider seam for external/local memory backends.
+// Governance classification always happens BEFORE provider calls.
+// FORBIDDEN and TRANSIENT content never reaches a provider.
+// provider=copilot is reserved and fails closed separately.
+
+export interface MemoryProviderStatus {
+  id: string;
+  name: string;
+  available: boolean;
+  reason?: string;
+}
+
+/**
+ * Generic external memory provider contract.
+ *
+ * Implementations receive only pre-classified, non-forbidden, non-transient
+ * memory. The {@link LocalMemoryStore} enforces governance before routing
+ * to any registered provider.
+ */
+export interface MemoryProvider {
+  readonly id: string;
+  readonly name: string;
+  /** Memory classes this provider is designed to store and retrieve. */
+  readonly supportedClasses: ReadonlyArray<MemoryClass>;
+  status(): Promise<MemoryProviderStatus>;
+  write(request: CopilotMemoryProviderWriteRequest): Promise<CopilotMemoryProviderWriteResult>;
+  search(query: string): Promise<CopilotMemoryProviderSearchResult[]>;
+  delete(id: string): Promise<boolean>;
+}
+
+/**
+ * MemPalace — in-memory test double for an external spatial memory provider.
+ *
+ * Models a "memory palace" (method of loci) where memories are stored at
+ * named loci. In production this would be replaced by a real spatial/external
+ * memory service. Set `metadata.locus` on a write request to tag the
+ * destination locus; defaults to `'default'`.
+ *
+ * Accepts: LOCAL, DECISION, POLICY.
+ * Never receives FORBIDDEN, TRANSIENT, or COPILOT_MEMORY (filtered upstream).
+ */
+export class MemPalaceMemoryProvider implements MemoryProvider {
+  readonly id = 'mempalace';
+  readonly name = 'MemPalace';
+  readonly supportedClasses: ReadonlyArray<MemoryClass> = ['LOCAL', 'DECISION', 'POLICY'];
+
+  private readonly loci = new Map<string, {
+    id: string;
+    title: string;
+    content: string;
+    class: MemoryClass;
+    locus: string;
+    path: string;
+  }>();
+
+  async status(): Promise<MemoryProviderStatus> {
+    return { id: this.id, name: this.name, available: true };
+  }
+
+  async write(request: CopilotMemoryProviderWriteRequest): Promise<CopilotMemoryProviderWriteResult> {
+    const id = `mempalace-${randomUUID()}`;
+    const locus = request.metadata?.['locus'] ?? 'default';
+    this.loci.set(id, {
+      id,
+      title: request.title,
+      content: request.content,
+      class: request.classification.class,
+      locus,
+      path: `mempalace:${locus}:${id}`,
+    });
+    return { id, path: `mempalace:${locus}:${id}` };
+  }
+
+  async search(query: string): Promise<CopilotMemoryProviderSearchResult[]> {
+    const normalized = query.toLowerCase();
+    const results: CopilotMemoryProviderSearchResult[] = [];
+    for (const entry of this.loci.values()) {
+      if (
+        entry.title.toLowerCase().includes(normalized) ||
+        entry.content.toLowerCase().includes(normalized)
+      ) {
+        results.push({
+          id: entry.id,
+          title: entry.title,
+          snippet: (entry.content.split('\n').find(l => l.toLowerCase().includes(normalized)) ?? entry.title).slice(0, 240),
+          path: entry.path,
+        });
+      }
+    }
+    return results;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.loci.delete(id);
+  }
+
+  /** Number of stored loci entries — for test introspection only. */
+  get size(): number {
+    return this.loci.size;
+  }
+}
+
+/**
+ * IndexServer — in-memory test double for a governed knowledge/instruction catalog.
+ *
+ * Models a server-side index of stable instructions and reference knowledge.
+ * In production this would be replaced by a real embedding-search or BM25 index.
+ * Set `metadata.topic` on a write request to tag the catalog entry; defaults to
+ * the memory class (lowercased).
+ *
+ * Accepts: LOCAL, DECISION, POLICY.
+ * Never receives FORBIDDEN, TRANSIENT, or COPILOT_MEMORY (filtered upstream).
+ */
+export class IndexServerMemoryProvider implements MemoryProvider {
+  readonly id = 'indexserver';
+  readonly name = 'IndexServer';
+  readonly supportedClasses: ReadonlyArray<MemoryClass> = ['LOCAL', 'DECISION', 'POLICY'];
+
+  private readonly catalog = new Map<string, {
+    id: string;
+    title: string;
+    content: string;
+    class: MemoryClass;
+    topic: string;
+    path: string;
+  }>();
+
+  async status(): Promise<MemoryProviderStatus> {
+    return { id: this.id, name: this.name, available: true };
+  }
+
+  async write(request: CopilotMemoryProviderWriteRequest): Promise<CopilotMemoryProviderWriteResult> {
+    const id = `indexserver-${randomUUID()}`;
+    const topic = request.metadata?.['topic'] ?? request.classification.class.toLowerCase();
+    this.catalog.set(id, {
+      id,
+      title: request.title,
+      content: request.content,
+      class: request.classification.class,
+      topic,
+      path: `indexserver:${topic}:${id}`,
+    });
+    return { id, path: `indexserver:${topic}:${id}` };
+  }
+
+  async search(query: string): Promise<CopilotMemoryProviderSearchResult[]> {
+    const normalized = query.toLowerCase();
+    const results: CopilotMemoryProviderSearchResult[] = [];
+    for (const entry of this.catalog.values()) {
+      if (
+        entry.title.toLowerCase().includes(normalized) ||
+        entry.content.toLowerCase().includes(normalized)
+      ) {
+        results.push({
+          id: entry.id,
+          title: entry.title,
+          snippet: (entry.content.split('\n').find(l => l.toLowerCase().includes(normalized)) ?? entry.title).slice(0, 240),
+          path: entry.path,
+        });
+      }
+    }
+    return results;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.catalog.delete(id);
+  }
+
+  /** Number of catalog entries — for test introspection only. */
+  get size(): number {
+    return this.catalog.size;
+  }
+}
+
 export interface LocalMemoryStoreOptions {
   rootKind?: 'project' | 'squad';
   hostInjectedCopilotAdapterClient?: CopilotMemoryProviderClient;
   /** @deprecated Use hostInjectedCopilotAdapterClient. */
   copilotMemoryClient?: CopilotMemoryProviderClient;
+  /**
+   * Optional additional external memory providers.
+   * Each provider receives writes/searches for its supported memory classes
+   * AFTER governance classification. FORBIDDEN and TRANSIENT content never
+   * reaches these providers. Results are merged with local search results.
+   */
+  registeredProviders?: MemoryProvider[];
 }
 
 interface MemoryIndexEntry {
@@ -296,6 +479,7 @@ export async function ensureMemoryGovernanceDefaults(
 export class LocalMemoryStore {
   private readonly squadDir: string;
   private readonly copilotProvider: HostInjectedCopilotMemoryAdapter;
+  private readonly registeredProviders: MemoryProvider[];
 
   constructor(
     private readonly storage: StorageProvider,
@@ -306,6 +490,7 @@ export class LocalMemoryStore {
     this.copilotProvider = new HostInjectedCopilotMemoryAdapter(
       options.hostInjectedCopilotAdapterClient ?? options.copilotMemoryClient,
     );
+    this.registeredProviders = options.registeredProviders ?? [];
   }
 
   async classify(
@@ -539,6 +724,35 @@ export class LocalMemoryStore {
       provider: 'local',
     });
 
+    // Route to registered external providers that support this memory class.
+    // Governance classification has already run; FORBIDDEN and TRANSIENT never
+    // reach this point. Providers receive only safe, non-copilot content.
+    const providerWriteRequest: CopilotMemoryProviderWriteRequest = {
+      content: request.content.trim(),
+      title,
+      author: request.author,
+      metadata: request.metadata,
+      classification,
+    };
+    for (const provider of this.registeredProviders) {
+      if (!provider.supportedClasses.includes(classification.class)) continue;
+      try {
+        const providerResult = await provider.write(providerWriteRequest);
+        await this.audit({
+          action: 'write',
+          id: providerResult.id,
+          class: classification.class,
+          title,
+          path: providerResult.path ?? `${provider.id}:${providerResult.id}`,
+          reason: `Replicated to ${provider.name} provider`,
+          actor: request.author,
+        });
+      } catch {
+        // Provider write failures are non-fatal; local write already succeeded.
+        // We intentionally do not log content or provider errors containing content.
+      }
+    }
+
     return { stored: true, id, classification, path: entry.path };
   }
 
@@ -609,6 +823,31 @@ export class LocalMemoryStore {
         });
       }
     }
+
+    // Query registered external providers. Governance filtering already
+    // passed. Deduplicates results by id (local takes precedence).
+    const seenIds = new Set(results.map(r => r.id));
+    for (const provider of this.registeredProviders) {
+      try {
+        const providerResults = await provider.search(query);
+        for (const result of providerResults) {
+          if (seenIds.has(result.id)) continue;
+          seenIds.add(result.id);
+          results.push({
+            id: result.id,
+            class: 'LOCAL',
+            loadGuidance: 'ON-DEMAND',
+            title: result.title,
+            path: result.path ?? `${provider.id}:${result.id}`,
+            snippet: result.snippet.slice(0, 240),
+            provider: 'local',
+          });
+        }
+      } catch {
+        // Provider search failures are non-fatal; partial results returned.
+      }
+    }
+
     await this.audit({
       action: 'search',
       reason: `Search returned ${results.length} result(s)`,
@@ -726,9 +965,13 @@ export class LocalMemoryStore {
     defaultProvider: MemoryGovernanceConfig['defaultProvider'];
     realCopilotMemory: { available: false; configured: boolean; reason: string };
     hostInjectedCopilotAdapter: MemoryGovernanceConfig['externalProviders']['hostInjectedCopilotAdapter'] & { clientAvailable: boolean; configured: boolean };
+    registeredProviders: MemoryProviderStatus[];
   }> {
     await this.ensureInitialized();
     const config = await this.readConfig();
+    const providerStatuses: MemoryProviderStatus[] = await Promise.all(
+      this.registeredProviders.map(p => p.status()),
+    );
     return {
       defaultProvider: config.defaultProvider,
       realCopilotMemory: {
@@ -741,6 +984,7 @@ export class LocalMemoryStore {
         clientAvailable: this.copilotProvider.isAvailable(),
         configured: isHostInjectedCopilotAdapterConfigured(config),
       },
+      registeredProviders: providerStatuses,
     };
   }
 

--- a/packages/squad-sdk/src/memory/index.ts
+++ b/packages/squad-sdk/src/memory/index.ts
@@ -26,6 +26,8 @@ export interface MemoryGovernanceConfig {
     rejectForbidden: true;
     rejectTransientDurableWrites: true;
     auditContent: false;
+    auditMaxBytes: number;
+    auditMaxArchives: number;
   };
 }
 
@@ -60,19 +62,20 @@ export interface MemorySearchResult {
   title: string;
   path: string;
   snippet: string;
-  provider?: 'local' | 'hostInjectedCopilotAdapter' | 'copilot';
+  provider?: string;
+  score?: number;
 }
 
 export interface MemoryAuditRecord {
   timestamp: string;
-  action: 'classify' | 'write' | 'reject' | 'promote' | 'delete' | 'search' | 'configure';
+  action: 'classify' | 'write' | 'reject' | 'promote' | 'delete' | 'search' | 'configure' | 'provider-error';
   id?: string;
   class?: MemoryClass;
   title?: string;
   path?: string;
   reason?: string;
   actor?: string;
-  provider?: 'local' | 'hostInjectedCopilotAdapter' | 'copilot';
+  provider?: string;
 }
 
 export interface CopilotMemoryProviderWriteRequest {
@@ -93,6 +96,12 @@ export interface CopilotMemoryProviderSearchResult {
   title: string;
   snippet: string;
   path?: string;
+}
+
+export interface MemoryProviderSearchResult extends CopilotMemoryProviderSearchResult {
+  class: MemoryClass;
+  loadGuidance: MemoryLoadGuidance;
+  score?: number;
 }
 
 export interface CopilotMemoryProviderClient {
@@ -129,7 +138,7 @@ export interface MemoryProvider {
   readonly supportedClasses: ReadonlyArray<MemoryClass>;
   status(): Promise<MemoryProviderStatus>;
   write(request: CopilotMemoryProviderWriteRequest): Promise<CopilotMemoryProviderWriteResult>;
-  search(query: string): Promise<CopilotMemoryProviderSearchResult[]>;
+  search(query: string): Promise<MemoryProviderSearchResult[]>;
   delete(id: string): Promise<boolean>;
 }
 
@@ -154,9 +163,13 @@ export class MemPalaceMemoryProvider implements MemoryProvider {
     title: string;
     content: string;
     class: MemoryClass;
+    loadGuidance: MemoryLoadGuidance;
     locus: string;
     path: string;
+    createdAt: number;
   }>();
+
+  constructor(private readonly maxEntries = 500) {}
 
   async status(): Promise<MemoryProviderStatus> {
     return { id: this.id, name: this.name, available: true };
@@ -164,35 +177,43 @@ export class MemPalaceMemoryProvider implements MemoryProvider {
 
   async write(request: CopilotMemoryProviderWriteRequest): Promise<CopilotMemoryProviderWriteResult> {
     const id = `mempalace-${randomUUID()}`;
-    const locus = request.metadata?.['locus'] ?? 'default';
+    const locus = providerPathSegment(request.metadata?.['locus'] ?? 'default');
     this.loci.set(id, {
       id,
       title: request.title,
       content: request.content,
       class: request.classification.class,
+      loadGuidance: request.classification.loadGuidance,
       locus,
       path: `mempalace:${locus}:${id}`,
+      createdAt: Date.now(),
     });
+    evictOldest(this.loci, this.maxEntries);
     return { id, path: `mempalace:${locus}:${id}` };
   }
 
-  async search(query: string): Promise<CopilotMemoryProviderSearchResult[]> {
+  async search(query: string): Promise<MemoryProviderSearchResult[]> {
     const normalized = query.toLowerCase();
-    const results: CopilotMemoryProviderSearchResult[] = [];
+    const results: MemoryProviderSearchResult[] = [];
     for (const entry of this.loci.values()) {
+      const score = providerRelevanceScore(entry.title, entry.content, normalized);
       if (
         entry.title.toLowerCase().includes(normalized) ||
-        entry.content.toLowerCase().includes(normalized)
+        entry.content.toLowerCase().includes(normalized) ||
+        score > 0
       ) {
         results.push({
           id: entry.id,
           title: entry.title,
           snippet: (entry.content.split('\n').find(l => l.toLowerCase().includes(normalized)) ?? entry.title).slice(0, 240),
           path: entry.path,
+          class: entry.class,
+          loadGuidance: entry.loadGuidance,
+          score,
         });
       }
     }
-    return results;
+    return results.sort((left, right) => (right.score ?? 0) - (left.score ?? 0) || left.id.localeCompare(right.id));
   }
 
   async delete(id: string): Promise<boolean> {
@@ -226,9 +247,13 @@ export class IndexServerMemoryProvider implements MemoryProvider {
     title: string;
     content: string;
     class: MemoryClass;
+    loadGuidance: MemoryLoadGuidance;
     topic: string;
     path: string;
+    createdAt: number;
   }>();
+
+  constructor(private readonly maxEntries = 500) {}
 
   async status(): Promise<MemoryProviderStatus> {
     return { id: this.id, name: this.name, available: true };
@@ -236,35 +261,43 @@ export class IndexServerMemoryProvider implements MemoryProvider {
 
   async write(request: CopilotMemoryProviderWriteRequest): Promise<CopilotMemoryProviderWriteResult> {
     const id = `indexserver-${randomUUID()}`;
-    const topic = request.metadata?.['topic'] ?? request.classification.class.toLowerCase();
+    const topic = providerPathSegment(request.metadata?.['topic'] ?? request.classification.class.toLowerCase());
     this.catalog.set(id, {
       id,
       title: request.title,
       content: request.content,
       class: request.classification.class,
+      loadGuidance: request.classification.loadGuidance,
       topic,
       path: `indexserver:${topic}:${id}`,
+      createdAt: Date.now(),
     });
+    evictOldest(this.catalog, this.maxEntries);
     return { id, path: `indexserver:${topic}:${id}` };
   }
 
-  async search(query: string): Promise<CopilotMemoryProviderSearchResult[]> {
+  async search(query: string): Promise<MemoryProviderSearchResult[]> {
     const normalized = query.toLowerCase();
-    const results: CopilotMemoryProviderSearchResult[] = [];
+    const results: MemoryProviderSearchResult[] = [];
     for (const entry of this.catalog.values()) {
+      const score = providerRelevanceScore(entry.title, entry.content, normalized);
       if (
         entry.title.toLowerCase().includes(normalized) ||
-        entry.content.toLowerCase().includes(normalized)
+        entry.content.toLowerCase().includes(normalized) ||
+        score > 0
       ) {
         results.push({
           id: entry.id,
           title: entry.title,
           snippet: (entry.content.split('\n').find(l => l.toLowerCase().includes(normalized)) ?? entry.title).slice(0, 240),
           path: entry.path,
+          class: entry.class,
+          loadGuidance: entry.loadGuidance,
+          score,
         });
       }
     }
-    return results;
+    return results.sort((left, right) => (right.score ?? 0) - (left.score ?? 0) || left.id.localeCompare(right.id));
   }
 
   async delete(id: string): Promise<boolean> {
@@ -319,6 +352,8 @@ const DEFAULT_CONFIG: MemoryGovernanceConfig = {
     rejectForbidden: true,
     rejectTransientDurableWrites: true,
     auditContent: false,
+    auditMaxBytes: 1_048_576,
+    auditMaxArchives: 3,
   },
 };
 
@@ -348,6 +383,34 @@ function slugify(value: string): string {
     .replace(/^-|-$/g, '')
     .slice(0, 64);
   return slug || 'memory';
+}
+
+function providerPathSegment(value: string): string {
+  return slugify(value).slice(0, 40) || 'default';
+}
+
+function providerRelevanceScore(title: string, content: string, normalizedQuery: string): number {
+  const queryTokens = normalizedQuery.split(/[^a-z0-9]+/).filter(token => token.length >= 4);
+  if (queryTokens.length === 0) return 0;
+  const haystack = new Set(`${title} ${content}`.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean));
+  return queryTokens.filter(token => haystack.has(token)).length;
+}
+
+function evictOldest<T extends { createdAt: number }>(entries: Map<string, T>, maxEntries: number): void {
+  if (maxEntries < 1) {
+    entries.clear();
+    return;
+  }
+  while (entries.size > maxEntries) {
+    const oldest = [...entries.entries()].sort((left, right) => left[1].createdAt - right[1].createdAt)[0];
+    if (!oldest) return;
+    entries.delete(oldest[0]);
+  }
+}
+
+function safeProviderErrorReason(provider: MemoryProvider, operation: 'write' | 'search', error: unknown): string {
+  const errorName = error instanceof Error ? error.name : 'UnknownError';
+  return `${provider.name} provider ${operation} failed (${errorName}); raw provider error text omitted`;
 }
 
 function firstLine(value: string): string {
@@ -747,9 +810,15 @@ export class LocalMemoryStore {
           reason: `Replicated to ${provider.name} provider`,
           actor: request.author,
         });
-      } catch {
-        // Provider write failures are non-fatal; local write already succeeded.
-        // We intentionally do not log content or provider errors containing content.
+      } catch (error) {
+        await this.audit({
+          action: 'provider-error',
+          class: classification.class,
+          title,
+          reason: safeProviderErrorReason(provider, 'write', error),
+          actor: request.author,
+          provider: provider.id,
+        });
       }
     }
 
@@ -835,16 +904,22 @@ export class LocalMemoryStore {
           seenIds.add(result.id);
           results.push({
             id: result.id,
-            class: 'LOCAL',
-            loadGuidance: 'ON-DEMAND',
+            class: result.class,
+            loadGuidance: result.loadGuidance,
             title: result.title,
             path: result.path ?? `${provider.id}:${result.id}`,
             snippet: result.snippet.slice(0, 240),
-            provider: 'local',
+            provider: provider.id,
+            score: result.score,
           });
         }
-      } catch {
-        // Provider search failures are non-fatal; partial results returned.
+      } catch (error) {
+        await this.audit({
+          action: 'provider-error',
+          title: 'Registered provider search failed',
+          reason: safeProviderErrorReason(provider, 'search', error),
+          provider: provider.id,
+        });
       }
     }
 
@@ -877,7 +952,11 @@ export class LocalMemoryStore {
       const now = new Date().toISOString();
       const nextIndex = await this.readIndex();
       const prior = nextIndex.find(item => item.id === id);
-      const successor = nextIndex.find(item => item.id === result.id);
+      const successorId = result.id;
+      if (!successorId) {
+        throw new Error(`Promoted memory '${id}' did not return a successor id`);
+      }
+      const successor = nextIndex.find(item => item.id === successorId);
       if (successor) {
         successor.supersedes = id;
         successor.updatedAt = now;
@@ -885,7 +964,7 @@ export class LocalMemoryStore {
       if (prior) {
         prior.status = 'superseded';
         prior.loadGuidance = 'ARCHIVE';
-        prior.supersededBy = result.id;
+        prior.supersededBy = successorId;
         prior.updatedAt = now;
       }
       await this.writeIndex(nextIndex);
@@ -893,7 +972,7 @@ export class LocalMemoryStore {
         await this.updateMemoryFileMetadata(prior.path, {
           status: 'superseded',
           loadGuidance: '[ARCHIVE]',
-          supersededBy: result.id,
+          supersededBy: successorId,
         });
       }
       await this.audit({
@@ -1119,11 +1198,38 @@ export class LocalMemoryStore {
   }
 
   private async audit(record: Omit<MemoryAuditRecord, 'timestamp'>): Promise<void> {
+    await this.rotateAuditIfNeeded();
     const auditRecord: MemoryAuditRecord = {
       timestamp: new Date().toISOString(),
       ...record,
     };
     await this.storage.append(path.join(this.squadDir, 'memory', 'audit.jsonl'), JSON.stringify(auditRecord) + '\n');
+  }
+
+  private async rotateAuditIfNeeded(): Promise<void> {
+    const config = await this.readConfig();
+    const maxBytes = config.policy.auditMaxBytes;
+    if (maxBytes <= 0) return;
+    const auditPath = path.join(this.squadDir, 'memory', 'audit.jsonl');
+    const stats = await this.storage.stat(auditPath);
+    if (!stats || stats.size < maxBytes) return;
+    const maxArchives = Math.max(0, config.policy.auditMaxArchives);
+    for (let index = maxArchives; index >= 1; index--) {
+      const current = path.join(this.squadDir, 'memory', `audit.${index}.jsonl`);
+      const next = path.join(this.squadDir, 'memory', `audit.${index + 1}.jsonl`);
+      if (!await this.storage.exists(current)) continue;
+      if (index === maxArchives) {
+        await this.storage.delete(current);
+      } else {
+        await this.storage.rename(current, next);
+      }
+    }
+    if (maxArchives > 0) {
+      await this.storage.rename(auditPath, path.join(this.squadDir, 'memory', 'audit.1.jsonl'));
+    } else {
+      await this.storage.delete(auditPath);
+    }
+    await this.storage.write(auditPath, '');
   }
 
   private destinationPath(memoryClass: MemoryClass, id: string, title: string, author?: string): string {
@@ -1162,10 +1268,18 @@ export class LocalMemoryStore {
   }
 
   private absoluteFromEntryPath(entryPath: string): string {
-    const relative = entryPath.startsWith('.squad')
-      ? entryPath.slice('.squad'.length + 1)
-      : entryPath;
-    return path.join(this.squadDir, relative);
+    if (/^[a-z][a-z0-9+.-]*:/i.test(entryPath)) {
+      throw new Error(`External memory path cannot be resolved locally: ${entryPath}`);
+    }
+    const normalizedInput = entryPath.replace(/\\/g, path.sep);
+    const relative = normalizedInput.startsWith('.squad')
+      ? normalizedInput.slice('.squad'.length + 1)
+      : normalizedInput;
+    const normalized = path.normalize(relative);
+    if (path.isAbsolute(normalized) || normalized === '..' || normalized.startsWith(`..${path.sep}`)) {
+      throw new Error(`Unsafe memory path blocked: ${entryPath}`);
+    }
+    return path.join(this.squadDir, normalized);
   }
 
   private async updateMemoryFileMetadata(entryPath: string, updates: Record<string, string>): Promise<void> {

--- a/packages/squad-sdk/src/memory/index.ts
+++ b/packages/squad-sdk/src/memory/index.ts
@@ -543,6 +543,12 @@ export class LocalMemoryStore {
   private readonly squadDir: string;
   private readonly copilotProvider: HostInjectedCopilotMemoryAdapter;
   private readonly registeredProviders: MemoryProvider[];
+  /**
+   * Async mutex tail for index read-modify-write operations.
+   * Each caller enqueues behind the current tail so concurrent writes
+   * are serialized without OS-level file locking.
+   */
+  private indexLockTail: Promise<unknown> = Promise.resolve();
 
   constructor(
     private readonly storage: StorageProvider,
@@ -554,6 +560,29 @@ export class LocalMemoryStore {
       options.hostInjectedCopilotAdapterClient ?? options.copilotMemoryClient,
     );
     this.registeredProviders = options.registeredProviders ?? [];
+  }
+
+  /**
+   * Serialize all index read-modify-write operations.
+   *
+   * All callers that do readIndex() → mutate → writeIndex() must go through
+   * this method so concurrent writes within the same store instance cannot
+   * interleave and lose entries. The critical section is purely async
+   * (no thread blocking), so this is safe in Node.js single-thread land.
+   */
+  private async withIndexLock<T>(fn: () => Promise<T>): Promise<T> {
+    let unlock!: () => void;
+    // Append a new "release" promise to the tail of the lock chain.
+    // The next caller will wait for this release before proceeding.
+    const release = new Promise<void>(resolve => { unlock = resolve; });
+    const prev = this.indexLockTail;
+    this.indexLockTail = release;
+    await prev;
+    try {
+      return await fn();
+    } finally {
+      unlock();
+    }
   }
 
   async classify(
@@ -734,9 +763,11 @@ export class LocalMemoryStore {
         createdAt: now,
         updatedAt: now,
       };
-      const index = await this.readIndex();
-      index.push(entry);
-      await this.writeIndex(index);
+      await this.withIndexLock(async () => {
+        const index = await this.readIndex();
+        index.push(entry);
+        await this.writeIndex(index);
+      });
       await this.audit({
         action: 'write',
         id: providerResult.id,
@@ -773,9 +804,13 @@ export class LocalMemoryStore {
       createdAt: now,
       updatedAt: now,
     };
-    const index = await this.readIndex();
-    index.push(entry);
-    await this.writeIndex(index);
+    // Serialize the read-modify-write under the index lock so concurrent
+    // calls within the same store instance cannot overwrite each other's entry.
+    await this.withIndexLock(async () => {
+      const index = await this.readIndex();
+      index.push(entry);
+      await this.writeIndex(index);
+    });
     await this.audit({
       action: 'write',
       id,
@@ -950,26 +985,32 @@ export class LocalMemoryStore {
     });
     if (result.stored && result.id) {
       const now = new Date().toISOString();
-      const nextIndex = await this.readIndex();
-      const prior = nextIndex.find(item => item.id === id);
       const successorId = result.id;
       if (!successorId) {
         throw new Error(`Promoted memory '${id}' did not return a successor id`);
       }
-      const successor = nextIndex.find(item => item.id === successorId);
-      if (successor) {
-        successor.supersedes = id;
-        successor.updatedAt = now;
-      }
-      if (prior) {
-        prior.status = 'superseded';
-        prior.loadGuidance = 'ARCHIVE';
-        prior.supersededBy = successorId;
-        prior.updatedAt = now;
-      }
-      await this.writeIndex(nextIndex);
-      if (prior && !prior.path.startsWith('host-injected-copilot-adapter:') && !prior.path.startsWith('copilot-memory:')) {
-        await this.updateMemoryFileMetadata(prior.path, {
+      // Serialize the supersedes/supersededBy mutation under the lock.
+      // write() above already released its lock before we reach here.
+      let priorEntryPath: string | undefined;
+      await this.withIndexLock(async () => {
+        const nextIndex = await this.readIndex();
+        const prior = nextIndex.find(item => item.id === id);
+        const successor = nextIndex.find(item => item.id === successorId);
+        if (successor) {
+          successor.supersedes = id;
+          successor.updatedAt = now;
+        }
+        if (prior) {
+          prior.status = 'superseded';
+          prior.loadGuidance = 'ARCHIVE';
+          prior.supersededBy = successorId;
+          prior.updatedAt = now;
+          priorEntryPath = prior.path;
+        }
+        await this.writeIndex(nextIndex);
+      });
+      if (priorEntryPath && !priorEntryPath.startsWith('host-injected-copilot-adapter:') && !priorEntryPath.startsWith('copilot-memory:')) {
+        await this.updateMemoryFileMetadata(priorEntryPath, {
           status: 'superseded',
           loadGuidance: '[ARCHIVE]',
           supersededBy: successorId,
@@ -989,55 +1030,75 @@ export class LocalMemoryStore {
 
   async delete(id: string, actor?: string): Promise<boolean> {
     await this.ensureInitialized();
-    const index = await this.readIndex();
-    const entry = index.find(item => item.id === id && item.status !== 'deleted');
-    if (!entry) return false;
-    const previousStatus = entry.status;
-    if (
-      entry.class === 'COPILOT_MEMORY'
-      || entry.path.startsWith('copilot-memory:')
-      || entry.path.startsWith('host-injected-copilot-adapter:')
-    ) {
-      const config = await this.readConfig();
-      if (isRealCopilotProviderSelected(config)) {
-        throw new Error(REAL_COPILOT_UNAVAILABLE_REASON);
+    return this.withIndexLock(async () => {
+      const index = await this.readIndex();
+      const entry = index.find(item => item.id === id && item.status !== 'deleted');
+      if (!entry) return false;
+      const previousStatus = entry.status;
+      const deletedAt = new Date().toISOString();
+      const tombstonePath = path.join(this.squadDir, 'memory', 'tombstones', `${id}.json`);
+      const tombstoneData =
+        JSON.stringify({
+          id,
+          deletedAt,
+          path: entry.path,
+          previousStatus,
+          supersedes: entry.supersedes,
+          supersededBy: entry.supersededBy,
+          loadGuidance: '[ARCHIVE]',
+        }, null, 2) + '\n';
+
+      if (
+        entry.class === 'COPILOT_MEMORY'
+        || entry.path.startsWith('copilot-memory:')
+        || entry.path.startsWith('host-injected-copilot-adapter:')
+      ) {
+        const config = await this.readConfig();
+        if (isRealCopilotProviderSelected(config)) {
+          throw new Error(REAL_COPILOT_UNAVAILABLE_REASON);
+        }
+        if (!isHostInjectedCopilotAdapterConfigured(config)) {
+          throw new Error('COPILOT_MEMORY delete requires hostInjectedCopilotAdapter to be enabled; real provider=copilot is unavailable locally.');
+        }
+        // For COPILOT_MEMORY: gate on external delete success before local mutations.
+        const deleted = await this.copilotProvider.delete(id);
+        if (!deleted) return false;
+        // Write tombstone first (local intent record), then update index.
+        await this.storage.write(tombstonePath, tombstoneData);
+        entry.status = 'deleted';
+        entry.loadGuidance = 'ARCHIVE';
+        entry.deletedAt = deletedAt;
+        entry.updatedAt = deletedAt;
+        await this.writeIndex(index);
+      } else {
+        // For local entries: tombstone FIRST (before any destructive action),
+        // then update index, then delete source file last.
+        // If tombstone write fails, source and index are untouched.
+        // If writeIndex fails after tombstone, source still exists and tombstone
+        // signals the delete intent for recovery.
+        await this.storage.write(tombstonePath, tombstoneData);
+        entry.status = 'deleted';
+        entry.loadGuidance = 'ARCHIVE';
+        entry.deletedAt = deletedAt;
+        entry.updatedAt = deletedAt;
+        await this.writeIndex(index);
+        // Source deletion is last: if it fails, the entry is already marked
+        // deleted in the index and a tombstone exists — recoverable.
+        await this.storage.delete(this.absoluteFromEntryPath(entry.path));
       }
-      if (!isHostInjectedCopilotAdapterConfigured(config)) {
-        throw new Error('COPILOT_MEMORY delete requires hostInjectedCopilotAdapter to be enabled; real provider=copilot is unavailable locally.');
-      }
-      const deleted = await this.copilotProvider.delete(id);
-      if (!deleted) return false;
-    } else {
-      await this.storage.delete(this.absoluteFromEntryPath(entry.path));
-    }
-    entry.status = 'deleted';
-    entry.loadGuidance = 'ARCHIVE';
-    entry.deletedAt = new Date().toISOString();
-    entry.updatedAt = entry.deletedAt;
-    await this.writeIndex(index);
-    await this.storage.write(
-      path.join(this.squadDir, 'memory', 'tombstones', `${id}.json`),
-      JSON.stringify({
+
+      await this.audit({
+        action: 'delete',
         id,
-        deletedAt: entry.deletedAt,
+        class: entry.class,
+        title: entry.title,
         path: entry.path,
-        previousStatus,
-        supersedes: entry.supersedes,
-        supersededBy: entry.supersededBy,
-        loadGuidance: '[ARCHIVE]',
-      }, null, 2) + '\n',
-    );
-    await this.audit({
-      action: 'delete',
-      id,
-      class: entry.class,
-      title: entry.title,
-      path: entry.path,
-      reason: 'Deleted governed memory and wrote tombstone',
-      actor,
-      provider: entry.class === 'COPILOT_MEMORY' ? 'hostInjectedCopilotAdapter' : 'local',
+        reason: 'Deleted governed memory and wrote tombstone',
+        actor,
+        provider: entry.class === 'COPILOT_MEMORY' ? 'hostInjectedCopilotAdapter' : 'local',
+      });
+      return true;
     });
-    return true;
   }
 
   async providerStatus(): Promise<{
@@ -1183,18 +1244,50 @@ export class LocalMemoryStore {
   }
 
   private async readIndex(): Promise<MemoryIndexEntry[]> {
-    const content = await this.storage.read(path.join(this.squadDir, 'memory', 'index.json'));
+    const indexPath = path.join(this.squadDir, 'memory', 'index.json');
+    const content = await this.storage.read(indexPath);
     if (!content) return [];
+    let parsed: unknown;
     try {
-      const parsed = JSON.parse(content) as MemoryIndexEntry[];
-      return Array.isArray(parsed) ? parsed : [];
+      parsed = JSON.parse(content);
+    } catch (err) {
+      // Do NOT silently reset to []. Backup the corrupt file and surface the error.
+      await this.backupCorruptIndex(indexPath, content);
+      throw new Error(
+        `Memory index is corrupt (JSON parse failed: ${err instanceof Error ? err.message : String(err)}). ` +
+        `A backup was written to ${indexPath}.corrupt. Manual recovery is required.`,
+      );
+    }
+    if (!Array.isArray(parsed)) {
+      await this.backupCorruptIndex(indexPath, content);
+      throw new Error(
+        `Memory index is corrupt (root is not an array). ` +
+        `A backup was written to ${indexPath}.corrupt. Manual recovery is required.`,
+      );
+    }
+    return parsed as MemoryIndexEntry[];
+  }
+
+  /**
+   * Best-effort backup of a corrupt index file.
+   * Writes the raw content to a `.corrupt` path alongside the index.
+   * Failure to write the backup is suppressed so callers see the original error.
+   */
+  private async backupCorruptIndex(indexPath: string, content: string): Promise<void> {
+    try {
+      await this.storage.write(`${indexPath}.corrupt`, content);
     } catch {
-      return [];
+      // Suppress backup write failure; caller will still throw the original error.
     }
   }
 
   private async writeIndex(index: MemoryIndexEntry[]): Promise<void> {
-    await this.storage.write(path.join(this.squadDir, 'memory', 'index.json'), JSON.stringify(index, null, 2) + '\n');
+    const indexPath = path.join(this.squadDir, 'memory', 'index.json');
+    const tmpPath = `${indexPath}.tmp`;
+    // Write to a temp file first, then atomically rename into place.
+    // This prevents a crash mid-write from leaving a partial/corrupt index.
+    await this.storage.write(tmpPath, JSON.stringify(index, null, 2) + '\n');
+    await this.storage.rename(tmpPath, indexPath);
   }
 
   private async audit(record: Omit<MemoryAuditRecord, 'timestamp'>): Promise<void> {

--- a/packages/squad-sdk/src/runtime/memory-value-benchmark.ts
+++ b/packages/squad-sdk/src/runtime/memory-value-benchmark.ts
@@ -1,0 +1,325 @@
+/**
+ * Deterministic memory-value benchmark.
+ *
+ * This does not pretend to measure LLM quality directly. It measures the part
+ * Squad can verify locally: whether governed memory retrieval reduces context
+ * payload while preserving relevant facts and excluding stale or unsafe memory.
+ */
+
+export type MemoryValueStatus = 'active' | 'superseded' | 'deleted';
+export type MemoryValueLoadGuidance = 'ALWAYS' | 'ON-DEMAND' | 'ARCHIVE' | 'NEVER';
+
+export interface MemoryValueFact {
+  id: string;
+  title: string;
+  content: string;
+  loadGuidance: MemoryValueLoadGuidance;
+  status: MemoryValueStatus;
+  tags: string[];
+}
+
+export interface MemoryValueTask {
+  id: string;
+  query: string;
+  expectedRelevantIds: string[];
+  conflictingIds: string[];
+}
+
+export interface MemoryValueFixture {
+  facts: MemoryValueFact[];
+  tasks: MemoryValueTask[];
+}
+
+export interface MemoryValueTaskResult {
+  taskId: string;
+  baselineLoadedIds: string[];
+  governedLoadedIds: string[];
+  baselineContextBytes: number;
+  governedContextBytes: number;
+  baselinePrecision: number;
+  governedPrecision: number;
+  baselineRecall: number;
+  governedRecall: number;
+  baselineDecisionConsistent: boolean;
+  governedDecisionConsistent: boolean;
+}
+
+export interface MemoryValueReport {
+  taskResults: MemoryValueTaskResult[];
+  baselineContextBytes: number;
+  governedContextBytes: number;
+  baselineEstimatedTokens: number;
+  governedEstimatedTokens: number;
+  contextReductionPercent: number;
+  baselinePrecision: number;
+  governedPrecision: number;
+  baselineRecall: number;
+  governedRecall: number;
+  baselineDecisionConsistency: number;
+  governedDecisionConsistency: number;
+  staleOrUnsafeFactsAvoided: number;
+  staleOrUnsafeFactsLoadedByBaseline: number;
+  verdict: 'pass' | 'fail';
+}
+
+const TOKEN_BYTES = 4;
+
+export function createDefaultMemoryValueFixture(): MemoryValueFixture {
+  return {
+    facts: [
+      {
+        id: 'policy-aspire-config',
+        title: 'Aspire configuration convention',
+        content: 'For Aspire-orchestrated samples, lead docs with Aspire-injected ConnectionStrings__X via WithReference/WithEnvironment.',
+        loadGuidance: 'ALWAYS',
+        status: 'active',
+        tags: ['aspire', 'configuration', 'docs'],
+      },
+      {
+        id: 'archive-raw-env-config',
+        title: 'Old standalone environment variable guidance',
+        content: 'Use raw environment variables first when documenting sample connection strings.',
+        loadGuidance: 'ARCHIVE',
+        status: 'superseded',
+        tags: ['aspire', 'configuration', 'docs'],
+      },
+      {
+        id: 'local-memory-diagnostics',
+        title: 'Memory diagnostics',
+        content: 'Memory command diagnostics go to stderr and can be enabled with memory.logLevel in .squad/config.json.',
+        loadGuidance: 'ON-DEMAND',
+        status: 'active',
+        tags: ['memory', 'diagnostics', 'logging'],
+      },
+      {
+        id: 'local-memory-governance',
+        title: 'Memory governance safety',
+        content: 'Governed memory writes classify facts, reject forbidden content, and keep audit records without raw secret values.',
+        loadGuidance: 'ON-DEMAND',
+        status: 'active',
+        tags: ['memory', 'governance', 'security'],
+      },
+      {
+        id: 'archive-ci-rotation',
+        title: 'Old CI rotation status',
+        content: 'CI rotation was green last week and does not require action.',
+        loadGuidance: 'ARCHIVE',
+        status: 'active',
+        tags: ['ci', 'rotation', 'status'],
+      },
+      {
+        id: 'never-secret',
+        title: 'Rejected credential',
+        content: 'password=do-not-load-this-secret',
+        loadGuidance: 'NEVER',
+        status: 'deleted',
+        tags: ['security', 'secret'],
+      },
+      {
+        id: 'policy-headed-browser',
+        title: 'Browser automation policy',
+        content: 'Run browser automation in headed mode unless explicitly asked otherwise.',
+        loadGuidance: 'ALWAYS',
+        status: 'active',
+        tags: ['browser', 'playwright', 'automation'],
+      },
+      {
+        id: 'local-teams-reporting',
+        title: 'Teams reporting',
+        content: 'Send concise Squad progress reports to Teams channel squad-chat when asked for updates.',
+        loadGuidance: 'ON-DEMAND',
+        status: 'active',
+        tags: ['teams', 'reporting', 'communication'],
+      },
+    ],
+    tasks: [
+      {
+        id: 'aspire-docs',
+        query: 'How should an Aspire sample document connection string configuration?',
+        expectedRelevantIds: ['policy-aspire-config'],
+        conflictingIds: ['archive-raw-env-config'],
+      },
+      {
+        id: 'memory-diagnostics',
+        query: 'How do I turn on logging for memory commands in the Squad config file?',
+        expectedRelevantIds: ['local-memory-diagnostics', 'local-memory-governance'],
+        conflictingIds: ['never-secret'],
+      },
+      {
+        id: 'browser-tests',
+        query: 'Should browser automation tests run headed or headless?',
+        expectedRelevantIds: ['policy-headed-browser'],
+        conflictingIds: [],
+      },
+      {
+        id: 'teams-update',
+        query: 'Where should a nicely formatted Squad status report be sent?',
+        expectedRelevantIds: ['local-teams-reporting'],
+        conflictingIds: [],
+      },
+    ],
+  };
+}
+
+export function runMemoryValueBenchmark(fixture = createDefaultMemoryValueFixture()): MemoryValueReport {
+  const taskResults = fixture.tasks.map(task => evaluateTask(fixture.facts, task));
+  const baselineContextBytes = sum(taskResults.map(result => result.baselineContextBytes));
+  const governedContextBytes = sum(taskResults.map(result => result.governedContextBytes));
+  const staleOrUnsafeFactsLoadedByBaseline = sum(
+    taskResults.map(result => result.baselineLoadedIds.filter(id => isStaleOrUnsafe(fixture.facts, id)).length),
+  );
+  const staleOrUnsafeFactsAvoided = sum(
+    taskResults.map(result => result.baselineLoadedIds.filter(id => (
+      isStaleOrUnsafe(fixture.facts, id) && !result.governedLoadedIds.includes(id)
+    )).length),
+  );
+
+  const report: MemoryValueReport = {
+    taskResults,
+    baselineContextBytes,
+    governedContextBytes,
+    baselineEstimatedTokens: estimateTokens(baselineContextBytes),
+    governedEstimatedTokens: estimateTokens(governedContextBytes),
+    contextReductionPercent: percentReduction(baselineContextBytes, governedContextBytes),
+    baselinePrecision: average(taskResults.map(result => result.baselinePrecision)),
+    governedPrecision: average(taskResults.map(result => result.governedPrecision)),
+    baselineRecall: average(taskResults.map(result => result.baselineRecall)),
+    governedRecall: average(taskResults.map(result => result.governedRecall)),
+    baselineDecisionConsistency: average(taskResults.map(result => result.baselineDecisionConsistent ? 1 : 0)),
+    governedDecisionConsistency: average(taskResults.map(result => result.governedDecisionConsistent ? 1 : 0)),
+    staleOrUnsafeFactsAvoided,
+    staleOrUnsafeFactsLoadedByBaseline,
+    verdict: 'fail',
+  };
+
+  report.verdict = report.contextReductionPercent >= 50
+    && report.governedRecall >= report.baselineRecall
+    && report.governedPrecision > report.baselinePrecision
+    && report.governedDecisionConsistency > report.baselineDecisionConsistency
+    && report.staleOrUnsafeFactsAvoided > 0
+    ? 'pass'
+    : 'fail';
+
+  return report;
+}
+
+export function formatMemoryValueReport(report: MemoryValueReport): string {
+  return [
+    'Memory value benchmark',
+    '======================',
+    `Verdict: ${report.verdict.toUpperCase()}`,
+    `Context bytes: baseline=${report.baselineContextBytes}, governed=${report.governedContextBytes}`,
+    `Estimated tokens: baseline=${report.baselineEstimatedTokens}, governed=${report.governedEstimatedTokens}`,
+    `Context reduction: ${report.contextReductionPercent.toFixed(1)}%`,
+    `Precision: baseline=${report.baselinePrecision.toFixed(2)}, governed=${report.governedPrecision.toFixed(2)}`,
+    `Recall: baseline=${report.baselineRecall.toFixed(2)}, governed=${report.governedRecall.toFixed(2)}`,
+    `Decision consistency: baseline=${report.baselineDecisionConsistency.toFixed(2)}, governed=${report.governedDecisionConsistency.toFixed(2)}`,
+    `Stale/unsafe facts avoided: ${report.staleOrUnsafeFactsAvoided}/${report.staleOrUnsafeFactsLoadedByBaseline}`,
+  ].join('\n');
+}
+
+function evaluateTask(facts: MemoryValueFact[], task: MemoryValueTask): MemoryValueTaskResult {
+  const baseline = baselineLoad(facts);
+  const governed = governedLoad(facts, task);
+  const baselineLoadedIds = baseline.map(fact => fact.id);
+  const governedLoadedIds = governed.map(fact => fact.id);
+
+  return {
+    taskId: task.id,
+    baselineLoadedIds,
+    governedLoadedIds,
+    baselineContextBytes: contextBytes(baseline),
+    governedContextBytes: contextBytes(governed),
+    baselinePrecision: precision(baselineLoadedIds, task.expectedRelevantIds),
+    governedPrecision: precision(governedLoadedIds, task.expectedRelevantIds),
+    baselineRecall: recall(baselineLoadedIds, task.expectedRelevantIds),
+    governedRecall: recall(governedLoadedIds, task.expectedRelevantIds),
+    baselineDecisionConsistent: decisionConsistent(baselineLoadedIds, task),
+    governedDecisionConsistent: decisionConsistent(governedLoadedIds, task),
+  };
+}
+
+function baselineLoad(facts: MemoryValueFact[]): MemoryValueFact[] {
+  return facts;
+}
+
+function governedLoad(facts: MemoryValueFact[], task: MemoryValueTask): MemoryValueFact[] {
+  const always = facts.filter(fact => fact.status === 'active' && fact.loadGuidance === 'ALWAYS');
+  const onDemand = facts
+    .filter(fact => fact.status === 'active' && fact.loadGuidance === 'ON-DEMAND')
+    .map(fact => ({ fact, score: relevanceScore(fact, task.query) }))
+    .filter(item => item.score > 0)
+    .sort((left, right) => right.score - left.score || left.fact.id.localeCompare(right.fact.id))
+    .map(item => item.fact);
+
+  return uniqueById([...always, ...onDemand]);
+}
+
+function relevanceScore(fact: MemoryValueFact, query: string): number {
+  const queryTokens = tokenize(query);
+  const factTokens = new Set(tokenize(`${fact.title} ${fact.content} ${fact.tags.join(' ')}`));
+  return queryTokens.filter(token => factTokens.has(token)).length;
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(token => token.length >= 4);
+}
+
+function uniqueById(facts: MemoryValueFact[]): MemoryValueFact[] {
+  const seen = new Set<string>();
+  return facts.filter(fact => {
+    if (seen.has(fact.id)) return false;
+    seen.add(fact.id);
+    return true;
+  });
+}
+
+function contextBytes(facts: MemoryValueFact[]): number {
+  return Buffer.byteLength(facts.map(fact => `${fact.title}\n${fact.content}`).join('\n\n'), 'utf8');
+}
+
+function estimateTokens(bytes: number): number {
+  return Math.ceil(bytes / TOKEN_BYTES);
+}
+
+function precision(loadedIds: string[], expectedRelevantIds: string[]): number {
+  if (loadedIds.length === 0) return 0;
+  const expected = new Set(expectedRelevantIds);
+  return loadedIds.filter(id => expected.has(id)).length / loadedIds.length;
+}
+
+function recall(loadedIds: string[], expectedRelevantIds: string[]): number {
+  if (expectedRelevantIds.length === 0) return 1;
+  const loaded = new Set(loadedIds);
+  return expectedRelevantIds.filter(id => loaded.has(id)).length / expectedRelevantIds.length;
+}
+
+function decisionConsistent(loadedIds: string[], task: MemoryValueTask): boolean {
+  const loaded = new Set(loadedIds);
+  return task.expectedRelevantIds.every(id => loaded.has(id))
+    && task.conflictingIds.every(id => !loaded.has(id));
+}
+
+function isStaleOrUnsafe(facts: MemoryValueFact[], id: string): boolean {
+  const fact = facts.find(item => item.id === id);
+  return fact?.status !== 'active'
+    || fact.loadGuidance === 'ARCHIVE'
+    || fact.loadGuidance === 'NEVER';
+}
+
+function percentReduction(baseline: number, governed: number): number {
+  if (baseline === 0) return 0;
+  return ((baseline - governed) / baseline) * 100;
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return sum(values) / values.length;
+}
+
+function sum(values: number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}

--- a/packages/squad-sdk/src/runtime/memory-value-benchmark.ts
+++ b/packages/squad-sdk/src/runtime/memory-value-benchmark.ts
@@ -109,8 +109,8 @@ export function createDefaultMemoryValueFixture(): MemoryValueFixture {
       },
       {
         id: 'never-secret',
-        title: 'Rejected credential',
-        content: 'password=do-not-load-this-secret',
+        title: 'Rejected credential placeholder',
+        content: 'Redacted credential-like placeholder used only to prove NEVER-load exclusion.',
         loadGuidance: 'NEVER',
         status: 'deleted',
         tags: ['security', 'secret'],

--- a/packages/squad-sdk/src/tools/index.ts
+++ b/packages/squad-sdk/src/tools/index.ts
@@ -18,13 +18,14 @@ import type { StorageProvider } from '../storage/storage-provider.js';
 import { FSStorageProvider } from '../storage/fs-storage-provider.js';
 import type { SquadState } from '../state/squad-state.js';
 import { spawnParallel, type FanOutDependencies } from '../coordinator/fan-out.js';
+import { LocalMemoryStore, type CopilotMemoryProviderClient, type MemoryClass } from '../memory/index.js';
 
 const tracer = trace.getTracer('squad-sdk');
 
 // --- Argument Sanitization ---
 
 /** Sensitive field patterns — strip before recording as span attributes. */
-const SENSITIVE_PATTERNS = /token|secret|password|key|auth/i;
+const SENSITIVE_PATTERNS = /^(content|query)$|token|secret|password|key|auth/i;
 
 /**
  * Sanitize tool arguments for OTel span attributes.
@@ -106,6 +107,29 @@ export interface SkillRequest {
   content?: string;
   /** Confidence level (required for write) */
   confidence?: 'low' | 'medium' | 'high';
+}
+
+export interface GovernedMemoryRequest {
+  content: string;
+  title?: string;
+  author?: string;
+  class?: MemoryClass;
+  approved?: boolean;
+}
+
+export interface GovernedMemorySearchRequest {
+  query: string;
+}
+
+export interface GovernedMemoryDeleteRequest {
+  id: string;
+  actor?: string;
+}
+
+export interface GovernedMemoryPromoteRequest {
+  id: string;
+  targetClass: Exclude<MemoryClass, 'FORBIDDEN' | 'TRANSIENT'>;
+  actor?: string;
 }
 
 // --- Tool Definition Helper ---
@@ -195,6 +219,7 @@ export class ToolRegistry {
   private storage: StorageProvider;
   private state?: SquadState;
   private fanOutDepsGetter?: () => FanOutDependencies | undefined;
+  private memoryStore: LocalMemoryStore;
 
   constructor(
     squadRoot = '.squad',
@@ -202,12 +227,17 @@ export class ToolRegistry {
     storage: StorageProvider = new FSStorageProvider(),
     state?: SquadState,
     fanOutDepsGetter?: () => FanOutDependencies | undefined,
+    hostInjectedCopilotAdapterClient?: CopilotMemoryProviderClient,
   ) {
     this.squadRoot = squadRoot;
     this.sessionPoolGetter = sessionPoolGetter;
     this.storage = storage;
     this.state = state;
     this.fanOutDepsGetter = fanOutDepsGetter;
+    this.memoryStore = new LocalMemoryStore(storage, squadRoot, {
+      rootKind: 'squad',
+      hostInjectedCopilotAdapterClient,
+    });
     this.registerSquadTools();
   }
 
@@ -484,7 +514,7 @@ export class ToolRegistry {
 
           // Fallback: raw StorageProvider
           const historyFile = path.join(this.squadRoot, 'agents', args.agent, 'history.md');
-          
+
           if (!this.storage.existsSync(historyFile)) {
             return {
               textResultForLlm: `Agent history file not found: agents/${args.agent}/history.md`,
@@ -505,7 +535,7 @@ export class ToolRegistry {
               error: 'History file could not be read',
             };
           }
-          
+
           // Find section and append
           const sectionIndex = content.indexOf(sectionHeader);
           if (sectionIndex !== -1) {
@@ -535,6 +565,172 @@ export class ToolRegistry {
       },
     });
 
+    const memoryClassify = defineTool<GovernedMemoryRequest>({
+      name: 'memory.classify',
+      description: 'Classify proposed memory with Squad governance policy without persisting content.',
+      parameters: {
+        type: 'object',
+        properties: {
+          content: { type: 'string', description: 'Memory content to classify' },
+          class: {
+            type: 'string',
+            enum: ['TRANSIENT', 'LOCAL', 'DECISION', 'POLICY', 'COPILOT_MEMORY', 'FORBIDDEN'],
+            description: 'Optional requested memory class',
+          },
+        },
+        required: ['content'],
+      },
+      handler: async (args) => {
+        const classification = await this.memoryStore.classify({
+          content: args.content,
+          requestedClass: args.class,
+        }, {
+          audit: true,
+          actor: args.author,
+          title: args.title,
+        });
+        return {
+          textResultForLlm: `${classification.class}: ${classification.reason}`,
+          resultType: classification.allowed ? 'success' : 'failure',
+          toolTelemetry: { classification },
+        };
+      },
+    });
+
+    const memoryWrite = defineTool<GovernedMemoryRequest>({
+      name: 'memory.write',
+      description: 'Classify and write governed local Squad memory. External semantic memory requires an explicit configured bridge.',
+      parameters: {
+        type: 'object',
+        properties: {
+          content: { type: 'string', description: 'Memory content to persist' },
+          title: { type: 'string', description: 'Short memory title' },
+          author: { type: 'string', description: 'Actor requesting the write' },
+          class: {
+            type: 'string',
+            enum: ['TRANSIENT', 'LOCAL', 'DECISION', 'POLICY', 'COPILOT_MEMORY', 'FORBIDDEN'],
+            description: 'Optional requested memory class',
+          },
+          approved: { type: 'boolean', description: 'Whether the write has explicit approval' },
+        },
+        required: ['content'],
+      },
+      handler: async (args) => {
+        const result = await this.memoryStore.write({
+          content: args.content,
+          title: args.title,
+          author: args.author,
+          requestedClass: args.class,
+          approved: args.approved,
+        });
+        return {
+          textResultForLlm: result.stored
+            ? `Stored ${result.classification.class} memory ${result.id} at ${result.path}`
+            : `Rejected ${result.classification.class} memory: ${result.classification.reason}`,
+          resultType: result.stored ? 'success' : 'failure',
+          toolTelemetry: {
+            id: result.id,
+            class: result.classification.class,
+            path: result.path,
+            stored: result.stored,
+          },
+        };
+      },
+    });
+
+    const memorySearch = defineTool<GovernedMemorySearchRequest>({
+      name: 'memory.search',
+      description: 'Search governed local Squad memory entries.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Search query' },
+        },
+        required: ['query'],
+      },
+      handler: async (args) => {
+        const results = await this.memoryStore.search(args.query);
+        const telemetryResults = results.map(({ id, class: memoryClass, title, path }) => ({
+          id,
+          class: memoryClass,
+          title,
+          path,
+        }));
+        return {
+          textResultForLlm: results.length === 0
+            ? 'No governed memory entries matched.'
+            : results.map(r => `${r.id} [${r.class}] ${r.title}: ${r.snippet}`).join('\n'),
+          resultType: 'success',
+          toolTelemetry: { count: results.length, results: telemetryResults },
+        };
+      },
+    });
+
+    const memoryPromote = defineTool<GovernedMemoryPromoteRequest>({
+      name: 'memory.promote',
+      description: 'Promote an existing governed memory entry to LOCAL, DECISION, POLICY, or approved semantic memory.',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Memory ID to promote' },
+          targetClass: {
+            type: 'string',
+            enum: ['LOCAL', 'DECISION', 'POLICY', 'COPILOT_MEMORY'],
+            description: 'Target memory class',
+          },
+          actor: { type: 'string', description: 'Actor requesting promotion' },
+        },
+        required: ['id', 'targetClass'],
+      },
+      handler: async (args) => {
+        const result = await this.memoryStore.promote(args.id, args.targetClass, args.actor);
+        return {
+          textResultForLlm: result.stored
+            ? `Promoted memory ${args.id} to ${args.targetClass} as ${result.id}`
+            : `Promotion rejected: ${result.classification.reason}`,
+          resultType: result.stored ? 'success' : 'failure',
+          toolTelemetry: { sourceId: args.id, targetId: result.id, stored: result.stored },
+        };
+      },
+    });
+
+    const memoryDelete = defineTool<GovernedMemoryDeleteRequest>({
+      name: 'memory.delete',
+      description: 'Delete a governed local memory entry and write an audit tombstone.',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'Memory ID to delete' },
+          actor: { type: 'string', description: 'Actor requesting deletion' },
+        },
+        required: ['id'],
+      },
+      handler: async (args) => {
+        const deleted = await this.memoryStore.delete(args.id, args.actor);
+        return {
+          textResultForLlm: deleted ? `Deleted memory ${args.id}` : `Memory ${args.id} not found`,
+          resultType: deleted ? 'success' : 'failure',
+          toolTelemetry: { id: args.id, deleted },
+        };
+      },
+    });
+
+    const memoryAudit = defineTool<Record<string, never>>({
+      name: 'memory.audit',
+      description: 'Return the governed memory audit log. Audit records do not include memory content.',
+      parameters: { type: 'object', properties: {} },
+      handler: async () => {
+        const records = await this.memoryStore.auditLog();
+        return {
+          textResultForLlm: records.length === 0
+            ? 'No governed memory audit records.'
+            : records.map(r => `${r.timestamp} ${r.action} ${r.class ?? ''} ${r.id ?? ''} ${r.title ?? ''} ${r.reason ?? ''}`.trim()).join('\n'),
+          resultType: 'success',
+          toolTelemetry: { count: records.length, records },
+        };
+      },
+    });
+
     // squad_status: Query session pool state
     const squadStatus = defineTool<StatusQuery>({
       name: 'squad_status',
@@ -559,7 +755,7 @@ export class ToolRegistry {
       },
       handler: async (args) => {
         const pool = this.sessionPoolGetter?.();
-        
+
         if (!pool) {
           return {
             textResultForLlm: 'Session pool not available. Pool size: 0, Active sessions: 0',
@@ -609,7 +805,7 @@ export class ToolRegistry {
         }
 
         let textResult = `Pool status: ${poolInfo.poolSize}/${poolInfo.capacity} sessions (${poolInfo.activeSessions} active)`;
-        
+
         if (args.agentName || args.status) {
           textResult += `\nFiltered results: ${poolInfo.filteredCount} sessions`;
         }
@@ -739,6 +935,12 @@ export class ToolRegistry {
     this.tools.set('squad_route', squadRoute);
     this.tools.set('squad_decide', squadDecide);
     this.tools.set('squad_memory', squadMemory);
+    this.tools.set('memory.classify', memoryClassify);
+    this.tools.set('memory.write', memoryWrite);
+    this.tools.set('memory.search', memorySearch);
+    this.tools.set('memory.promote', memoryPromote);
+    this.tools.set('memory.delete', memoryDelete);
+    this.tools.set('memory.audit', memoryAudit);
     this.tools.set('squad_status', squadStatus);
     this.tools.set('squad_skill', squadSkill);
   }

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -340,7 +340,7 @@ prompt: |
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
-  
+
   {% if WORKTREE_MODE %}
   **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
   {% endif %}
@@ -779,17 +779,17 @@ name: "{name}"
 description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
-  
+
   YOUR CHARTER:
   {paste contents of .squad/agents/{name}/charter.md here}
-  
+
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
   All `.squad/` paths are relative to this root.
-  
+
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
-  
+
   {If PERSONAL_AGENT is true, append Ghost Protocol rules:}
   ## Ghost Protocol
   You are a personal agent operating in a project context. You MUST follow these rules:
@@ -798,10 +798,10 @@ prompt: |
   - Transparent origin: Tag all logs with [personal:{name}]
   - Consult mode: Provide recommendations, not direct changes
   {end Ghost Protocol block}
-  
+
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
-  
+
   {% if WORKTREE_MODE %}
   **WORKTREE:** You are working in a dedicated worktree at `{WORKTREE_PATH}`.
   - All file operations should be relative to this path
@@ -809,63 +809,63 @@ prompt: |
   - Build and test in the worktree, not the main repo
   - Commit and push from the worktree
   {% endif %}
-  
+
   STATE_BACKEND: {state_backend}
-  
+
   {% if STATE_BACKEND == "git-notes" %}
   ## State Protocol — Git Notes
   This project uses git-notes for mutable state. **DO NOT write to `.squad/` files for state.**
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-  
+
   **Reading your state:**
   Run: `powershell .squad/scripts/notes/fetch.ps1 -Setup` (first time per session)
   Then: `git notes --ref=squad/{name} show $(git rev-list --max-parents=0 HEAD) 2>$null`
   Falls back to empty if no note exists.
-  
+
   **Writing state (history, decisions, learnings):**
   Run: `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{json}'`
   The helper handles JSON validation, conflict retry, and push.
-  
+
   **Decisions:** Write decisions as JSON via your note ref. Scribe will merge them.
   **Skills:** Skills are static config — write to `.squad/skills/` on disk as normal.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "orphan" %}
   ## State Protocol — Orphan Branch
   This project uses an orphan branch (`squad-state`) for mutable state.
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-  
+
   **Reading state:** Read `.squad/` files on disk — they are synced from the orphan branch.
   **Writing state:** Write to `.squad/` files on disk as normal during your session.
   Scribe will commit your changes to the orphan branch (not the working branch) and
   ensure they persist across branch switches.
-  
+
   **Important:** Do NOT commit `.squad/` state files to the working branch yourself.
   Scribe handles the orphan branch commit workflow.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "two-layer" %}
   ## State Protocol — Two-Layer (Git Notes + Orphan Branch)
   This project uses the two-layer architecture from Tamir's blog:
   - **Layer 1 (git notes):** Commit-scoped "why" annotations — invisible in PRs
   - **Layer 2 (orphan branch):** Permanent state store — decisions, histories, logs
-  
+
   Static config (charters, team.md, routing.md) is on disk as normal.
-  
+
   **During your session:**
   1. Write commit-scoped annotations as git notes on HEAD:
      `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
   2. Write bulk state (history, logs) to `.squad/` files on disk — Scribe moves them to the orphan branch.
-  
+
   **Note flags:**
   - `"promote_to_permanent": true` — Ralph promotes this to decisions.md after PR merge
   - `"archive_on_close": true` — Worth keeping even if PR is rejected (valuable research)
   - Neither flag — silently ignored if PR is rejected (correct for branch-specific decisions)
-  
+
   **Important:** Do NOT commit `.squad/` state files to the working branch.
   Scribe handles orphan commits. Ralph handles note promotion.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "worktree" or STATE_BACKEND is not defined %}
   Read .squad/agents/{name}/history.md (your project knowledge).
   {% endif %}
@@ -881,22 +881,22 @@ prompt: |
   Check .copilot/skills/ for copilot-level skills (process, workflow, protocol).
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
-  
+
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
-  
+
   **Requested by:** {current user name}
-  
+
   INPUT ARTIFACTS: {list exact file paths to review/modify}
-  
+
   The user says: "{message}"
-  
+
   Do the work. Respond as {Name}.
-  
+
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
-  
+
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
@@ -921,7 +921,7 @@ prompt: |
   {% endif %}
   3. SKILL EXTRACTION: If you found a reusable pattern, write/update
      .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
-  
+
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.
 ```
@@ -976,7 +976,7 @@ prompt: |
 
   Tasks (in order):
   {% if STATE_BACKEND == "orphan" or STATE_BACKEND == "git-notes" or STATE_BACKEND == "two-layer" %}
-  0. STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
+  0. PRE-CHECK — STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
      (.squad/decisions.md, agents/*/history.md, log/*, orchestration-log/*, decisions/inbox/*)
      to the working branch. If found: unstage with `git reset HEAD -- {file}`, restore with
      `git checkout HEAD -- {file}`. If leaked in last commit, amend to remove. Log count.

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -238,6 +238,17 @@ The `name` parameter generates the human-readable agent ID shown in the tasks pa
 2. Acknowledge briefly: `"📌 Captured. {one-line summary of the directive}."`
 3. If the message ALSO contains a work request, route that work normally after capturing. If it's directive-only, you're done — no agent spawn needed.
 
+### Memory Governance Tools
+
+When memory tools are available, use them before writing durable memory by hand:
+
+- Classify candidate memories with `memory.classify`.
+- Persist approved durable facts, decisions, and policies with `memory.write`.
+- Search governed memory with `memory.search` before relying only on raw file search.
+- Promote, delete, and audit governed entries with `memory.promote`, `memory.delete`, and `memory.audit`.
+
+If memory tools are not available, keep the prompt-only fallback: write local `.squad/` files directly using the decision inbox, agent histories, and skills. Do not claim provider-backed Copilot Memory, semantic indexing, or remote deletion unless a configured tool or CLI bridge performed the operation. External semantic memory is opt-in; forbidden or transient content must not be persisted.
+
 ### Routing
 
 The routing table determines **WHO** handles work. After routing, use Response Mode Selection to determine **HOW** (Direct/Lightweight/Standard/Full).
@@ -340,7 +351,7 @@ prompt: |
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
-
+  
   {% if WORKTREE_MODE %}
   **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
   {% endif %}
@@ -779,17 +790,17 @@ name: "{name}"
 description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
-
+  
   YOUR CHARTER:
   {paste contents of .squad/agents/{name}/charter.md here}
-
+  
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
   All `.squad/` paths are relative to this root.
-
+  
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
-
+  
   {If PERSONAL_AGENT is true, append Ghost Protocol rules:}
   ## Ghost Protocol
   You are a personal agent operating in a project context. You MUST follow these rules:
@@ -798,10 +809,10 @@ prompt: |
   - Transparent origin: Tag all logs with [personal:{name}]
   - Consult mode: Provide recommendations, not direct changes
   {end Ghost Protocol block}
-
+  
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
-
+  
   {% if WORKTREE_MODE %}
   **WORKTREE:** You are working in a dedicated worktree at `{WORKTREE_PATH}`.
   - All file operations should be relative to this path
@@ -809,63 +820,63 @@ prompt: |
   - Build and test in the worktree, not the main repo
   - Commit and push from the worktree
   {% endif %}
-
+  
   STATE_BACKEND: {state_backend}
-
+  
   {% if STATE_BACKEND == "git-notes" %}
   ## State Protocol — Git Notes
   This project uses git-notes for mutable state. **DO NOT write to `.squad/` files for state.**
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-
+  
   **Reading your state:**
   Run: `powershell .squad/scripts/notes/fetch.ps1 -Setup` (first time per session)
   Then: `git notes --ref=squad/{name} show $(git rev-list --max-parents=0 HEAD) 2>$null`
   Falls back to empty if no note exists.
-
+  
   **Writing state (history, decisions, learnings):**
   Run: `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{json}'`
   The helper handles JSON validation, conflict retry, and push.
-
+  
   **Decisions:** Write decisions as JSON via your note ref. Scribe will merge them.
   **Skills:** Skills are static config — write to `.squad/skills/` on disk as normal.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "orphan" %}
   ## State Protocol — Orphan Branch
   This project uses an orphan branch (`squad-state`) for mutable state.
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-
+  
   **Reading state:** Read `.squad/` files on disk — they are synced from the orphan branch.
   **Writing state:** Write to `.squad/` files on disk as normal during your session.
   Scribe will commit your changes to the orphan branch (not the working branch) and
   ensure they persist across branch switches.
-
+  
   **Important:** Do NOT commit `.squad/` state files to the working branch yourself.
   Scribe handles the orphan branch commit workflow.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "two-layer" %}
   ## State Protocol — Two-Layer (Git Notes + Orphan Branch)
   This project uses the two-layer architecture from Tamir's blog:
   - **Layer 1 (git notes):** Commit-scoped "why" annotations — invisible in PRs
   - **Layer 2 (orphan branch):** Permanent state store — decisions, histories, logs
-
+  
   Static config (charters, team.md, routing.md) is on disk as normal.
-
+  
   **During your session:**
   1. Write commit-scoped annotations as git notes on HEAD:
      `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
   2. Write bulk state (history, logs) to `.squad/` files on disk — Scribe moves them to the orphan branch.
-
+  
   **Note flags:**
   - `"promote_to_permanent": true` — Ralph promotes this to decisions.md after PR merge
   - `"archive_on_close": true` — Worth keeping even if PR is rejected (valuable research)
   - Neither flag — silently ignored if PR is rejected (correct for branch-specific decisions)
-
+  
   **Important:** Do NOT commit `.squad/` state files to the working branch.
   Scribe handles orphan commits. Ralph handles note promotion.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "worktree" or STATE_BACKEND is not defined %}
   Read .squad/agents/{name}/history.md (your project knowledge).
   {% endif %}
@@ -881,22 +892,22 @@ prompt: |
   Check .copilot/skills/ for copilot-level skills (process, workflow, protocol).
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
-
+  
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
-
+  
   **Requested by:** {current user name}
-
+  
   INPUT ARTIFACTS: {list exact file paths to review/modify}
-
+  
   The user says: "{message}"
-
+  
   Do the work. Respond as {Name}.
-
+  
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
-
+  
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
@@ -921,7 +932,7 @@ prompt: |
   {% endif %}
   3. SKILL EXTRACTION: If you found a reusable pattern, write/update
      .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
-
+  
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.
 ```

--- a/scripts/measure-memory-value.mjs
+++ b/scripts/measure-memory-value.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Run the deterministic memory-value benchmark.
+ *
+ * Requires `npm run build` because it imports the built SDK, matching the
+ * existing benchmark runner behavior.
+ */
+
+import { existsSync } from 'node:fs';
+import { resolve as resolvePath, dirname } from 'node:path';
+import { argv, exit, stderr, stdout } from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolvePath(__dirname, '..');
+const SDK_DIST = resolvePath(REPO_ROOT, 'packages/squad-sdk/dist/runtime/memory-value-benchmark.js');
+
+function printHelp() {
+  stdout.write([
+    'Usage: npm run experiment:memory-value -- [options]',
+    '',
+    'Options:',
+    '  --json      Emit JSON instead of a formatted report',
+    '  -h, --help  Show this help',
+    '',
+    'Note: requires `npm run build` to have produced packages/squad-sdk/dist/.',
+    '',
+  ].join('\n'));
+}
+
+function parseArgs(args) {
+  const opts = { json: false, help: false };
+  for (const arg of args) {
+    if (arg === '--json') {
+      opts.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      opts.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+async function main() {
+  let opts;
+  try {
+    opts = parseArgs(argv.slice(2));
+  } catch (error) {
+    stderr.write(`error: ${error.message}\n`);
+    printHelp();
+    exit(1);
+  }
+
+  if (opts.help) {
+    printHelp();
+    exit(0);
+  }
+
+  if (!existsSync(SDK_DIST)) {
+    stderr.write(
+      `error: SDK build output not found at ${SDK_DIST}\n` +
+        'Run `npm run build` first.\n',
+    );
+    exit(1);
+  }
+
+  const { runMemoryValueBenchmark, formatMemoryValueReport } = await import(pathToFileURL(SDK_DIST).href);
+  const report = runMemoryValueBenchmark();
+  stdout.write(opts.json ? `${JSON.stringify(report, null, 2)}\n` : `${formatMemoryValueReport(report)}\n`);
+  exit(report.verdict === 'pass' ? 0 : 1);
+}
+
+main().catch(error => {
+  stderr.write(`error: ${error.stack ?? error.message ?? String(error)}\n`);
+  exit(1);
+});

--- a/scripts/real-cli-ab.js
+++ b/scripts/real-cli-ab.js
@@ -1,0 +1,457 @@
+/**
+ * Run bounded real Copilot CLI paired A/B turns against local repositories.
+ *
+ * The harness intentionally isolates COPILOT_HOME by repo and variant:
+ *   <out-dir>/copilot-home/<repo-slug>/<variant>/
+ *
+ * It captures stdout/stderr, Copilot log-dir output, command metadata, and
+ * measured memory diagnostics evidence. If Copilot cannot be made to run
+ * in-turn memory commands, the diagnostics summary records that limitation
+ * instead of inventing evidence.
+ */
+
+import { spawn } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { delimiter, resolve, join, basename, dirname } from 'node:path';
+import { argv, cwd, env, exit, stderr, stdout } from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DEFAULT_PRODUCT_CLI = resolve(__dirname, '..', 'cli.js');
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+const MEMORY_MARKER = /\[memory:(error|info|debug)]\s+([^\r\n]+)/g;
+
+export function slugifyPath(repoPath) {
+  const resolved = resolve(repoPath);
+  const leaf = basename(resolved) || 'repo';
+  const hash = [...resolved].reduce((acc, ch) => ((acc * 33) ^ ch.charCodeAt(0)) >>> 0, 5381).toString(16);
+  return `${leaf.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'repo'}-${hash}`;
+}
+
+export function parseArgs(args) {
+  const opts = {
+    repos: [],
+    variants: ['baseline', 'memory-governance'],
+    outDir: env['SESSION_FILES']
+      ? join(env['SESSION_FILES'], 'expanded-memory-ab', `real-cli-rerun-${new Date().toISOString().replace(/[:.]/g, '-')}`)
+      : resolve(cwd(), 'artifacts', 'expanded-memory-ab', `real-cli-rerun-${new Date().toISOString().replace(/[:.]/g, '-')}`),
+    copilotBin: 'copilot',
+    productCli: DEFAULT_PRODUCT_CLI,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    model: undefined,
+    dryRun: false,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    const readValue = (name) => {
+      if (arg.startsWith(`${name}=`)) return arg.slice(name.length + 1);
+      if (arg === name) return args[++index];
+      return undefined;
+    };
+
+    const repo = readValue('--repo');
+    if (repo !== undefined) {
+      opts.repos.push(repo);
+      continue;
+    }
+
+    const repos = readValue('--repos');
+    if (repos !== undefined) {
+      opts.repos.push(...repos.split(/[;,]/).map(value => value.trim()).filter(Boolean));
+      continue;
+    }
+
+    const variants = readValue('--variants');
+    if (variants !== undefined) {
+      opts.variants = variants.split(',').map(value => value.trim()).filter(Boolean);
+      continue;
+    }
+
+    const outDir = readValue('--out-dir');
+    if (outDir !== undefined) {
+      opts.outDir = outDir;
+      continue;
+    }
+
+    const copilotBin = readValue('--copilot-bin');
+    if (copilotBin !== undefined) {
+      opts.copilotBin = copilotBin;
+      continue;
+    }
+
+    const productCli = readValue('--product-cli');
+    if (productCli !== undefined) {
+      opts.productCli = productCli;
+      continue;
+    }
+
+    const timeoutMs = readValue('--timeout-ms');
+    if (timeoutMs !== undefined) {
+      opts.timeoutMs = Number.parseInt(timeoutMs, 10);
+      continue;
+    }
+
+    const model = readValue('--model');
+    if (model !== undefined) {
+      opts.model = model;
+      continue;
+    }
+
+    if (arg === '--dry-run') {
+      opts.dryRun = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      opts.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!Number.isFinite(opts.timeoutMs) || opts.timeoutMs < 1000) {
+    throw new Error('--timeout-ms must be an integer >= 1000');
+  }
+  return opts;
+}
+
+export function buildPrompt({ repoPath, variant, productCli }) {
+  const shared = [
+    'You are executing one bounded A/B measurement turn for the Squad memory governance experiment.',
+    'Do not modify files. Do not commit. Do not install packages. Do not access private remotes.',
+    `Repository under test: ${repoPath}`,
+    'Keep the run short: execute only the requested shell commands and then summarize observations.',
+  ];
+
+  if (variant === 'baseline') {
+    return [
+      ...shared,
+      'Variant: baseline.',
+      'Run: git status --short',
+      'Run: git rev-parse --show-toplevel',
+      'Run: list the first 20 non-hidden top-level files/directories using the platform shell.',
+      'Do not run `squad memory` or `node cli.js memory` commands in this baseline turn.',
+      'Summarize whether any memory diagnostics appeared naturally.',
+    ].join('\n');
+  }
+
+  return [
+    ...shared,
+    `Variant: ${variant}.`,
+    'This variant measures whether memory command diagnostics can be captured during an actual Copilot turn.',
+    'Run exactly these memory diagnostics commands from the repository under test, adapting only path quoting for the shell:',
+    `node "${productCli}" memory provider --log-level debug`,
+    `node "${productCli}" memory classify --log-level debug --content "Use governed memory only for durable cross-session facts." --class LOCAL --load-guidance ON-DEMAND`,
+    'Then run: git status --short',
+    'In your final answer, state whether the memory commands executed and whether diagnostic lines beginning with [memory: appeared.',
+  ].join('\n');
+}
+
+export function buildRunPlan(options) {
+  const repos = options.repos.map(repo => resolve(repo));
+  const outDir = resolve(options.outDir);
+  return repos.flatMap(repoPath => {
+    if (!existsSync(repoPath)) throw new Error(`Repository path does not exist: ${repoPath}`);
+    const repoSlug = slugifyPath(repoPath);
+    return options.variants.map(variant => {
+      const runDir = join(outDir, repoSlug, variant);
+      return {
+        repoPath,
+        repoSlug,
+        variant,
+        runDir,
+        copilotHome: join(outDir, 'copilot-home', repoSlug, variant),
+        logDir: join(runDir, 'copilot-logs'),
+        stdoutPath: join(runDir, 'stdout.jsonl'),
+        stderrPath: join(runDir, 'stderr.txt'),
+        commandPath: join(runDir, 'command.json'),
+        diagnosticsPath: join(runDir, 'diagnostics.json'),
+        productCli: resolve(options.productCli),
+      };
+    });
+  });
+}
+
+function walkFiles(root) {
+  if (!existsSync(root)) return [];
+  const entries = [];
+  for (const name of readdirSync(root)) {
+    const full = join(root, name);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      entries.push(...walkFiles(full));
+    } else if (stat.isFile()) {
+      entries.push(full);
+    }
+  }
+  return entries;
+}
+
+export function extractMemoryDiagnostics(text) {
+  const events = [];
+  for (const match of text.matchAll(MEMORY_MARKER)) {
+    events.push({ level: match[1], message: match[2].trim() });
+  }
+  return events;
+}
+
+function removePromptOnlyJsonl(text) {
+  return text
+    .split(/\r?\n/)
+    .filter(line => {
+      if (!line.trim().startsWith('{')) return true;
+      try {
+        return JSON.parse(line).type !== 'user.message';
+      } catch {
+        return true;
+      }
+    })
+    .join('\n');
+}
+
+export function collectDiagnostics(run, stdoutText, stderrText) {
+  const logFiles = walkFiles(run.logDir);
+  const logEvidence = [];
+  for (const file of logFiles) {
+    let text = '';
+    try {
+      text = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    const events = extractMemoryDiagnostics(text);
+    if (events.length > 0) {
+      logEvidence.push({ file, events });
+    }
+  }
+
+  const stdioEvents = [
+    ...extractMemoryDiagnostics(stdoutText).map(event => ({ stream: 'stdout', ...event })),
+    ...extractMemoryDiagnostics(stderrText).map(event => ({ stream: 'stderr', ...event })),
+  ];
+
+  const combinedText = removePromptOnlyJsonl(`${stdoutText}\n${stderrText}`);
+  const memoryCommandMentions = [
+    /squad\s+memory/i,
+    /node\s+["']?[^"'\r\n]*cli\.js["']?\s+memory/i,
+    /memory\s+(provider|classify|write|search|audit)/i,
+  ].filter(pattern => pattern.test(combinedText)).length;
+
+  return {
+    memoryCommandMentioned: memoryCommandMentions > 0,
+    memoryDiagnosticEventCount: stdioEvents.length + logEvidence.reduce((sum, item) => sum + item.events.length, 0),
+    stdioEvents,
+    logEvidence,
+    limitation: stdioEvents.length === 0 && logEvidence.length === 0
+      ? 'No [memory:*] diagnostics were captured from stdout/stderr or Copilot log files for this run.'
+      : undefined,
+  };
+}
+
+function runProcess(command, args, options) {
+  return new Promise((resolvePromise) => {
+    const startedAt = Date.now();
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      windowsHide: true,
+      shell: false,
+    });
+
+    let stdoutText = '';
+    let stderrText = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+    }, options.timeoutMs);
+
+    child.stdout?.on('data', chunk => {
+      stdoutText += chunk.toString();
+    });
+    child.stderr?.on('data', chunk => {
+      stderrText += chunk.toString();
+    });
+    child.on('error', error => {
+      clearTimeout(timer);
+      resolvePromise({
+        exitCode: null,
+        signal: null,
+        durationMs: Date.now() - startedAt,
+        stdoutText,
+        stderrText: `${stderrText}\n${error.stack ?? error.message}`,
+      });
+    });
+    child.on('close', (exitCode, signal) => {
+      clearTimeout(timer);
+      resolvePromise({
+        exitCode,
+        signal,
+        durationMs: Date.now() - startedAt,
+        stdoutText,
+        stderrText,
+      });
+    });
+  });
+}
+
+export async function runOne(run, options, executor = runProcess) {
+  mkdirSync(run.runDir, { recursive: true });
+  mkdirSync(run.copilotHome, { recursive: true });
+  mkdirSync(run.logDir, { recursive: true });
+
+  const prompt = buildPrompt(run);
+  const args = [
+    '-C', run.repoPath,
+    '--prompt', prompt,
+    '--allow-all-tools',
+    '--allow-all-paths',
+    '--no-ask-user',
+    '--no-auto-update',
+    '--disable-builtin-mcps',
+    '--output-format', 'json',
+    '--log-level', 'debug',
+    '--log-dir', run.logDir,
+    '--name', `squad-memory-ab-${run.repoSlug}-${run.variant}`,
+  ];
+  if (options.model) args.push('--model', options.model);
+
+  const commandMetadata = {
+    command: options.copilotBin,
+    args,
+    cwd: run.repoPath,
+    variant: run.variant,
+    repoPath: run.repoPath,
+    copilotHome: run.copilotHome,
+    logDir: run.logDir,
+    productCli: run.productCli,
+    startedAt: new Date().toISOString(),
+  };
+  writeFileSync(run.commandPath, `${JSON.stringify(commandMetadata, null, 2)}\n`);
+
+  if (options.dryRun) {
+    const diagnostics = {
+      skipped: true,
+      reason: 'dry-run',
+      memoryCommandMentioned: run.variant !== 'baseline',
+      memoryDiagnosticEventCount: 0,
+    };
+    writeFileSync(run.stdoutPath, '');
+    writeFileSync(run.stderrPath, '');
+    writeFileSync(run.diagnosticsPath, `${JSON.stringify(diagnostics, null, 2)}\n`);
+    return { ...run, exitCode: 0, signal: null, durationMs: 0, diagnostics };
+  }
+
+  const result = await executor(options.copilotBin, args, {
+    cwd: run.repoPath,
+    timeoutMs: options.timeoutMs,
+    env: {
+      ...env,
+      COPILOT_HOME: run.copilotHome,
+      COPILOT_ALLOW_ALL: 'true',
+      NO_COLOR: '1',
+      CI: env['CI'] ?? '1',
+    },
+  });
+
+  writeFileSync(run.stdoutPath, result.stdoutText);
+  writeFileSync(run.stderrPath, result.stderrText);
+  const diagnostics = collectDiagnostics(run, result.stdoutText, result.stderrText);
+  writeFileSync(run.diagnosticsPath, `${JSON.stringify(diagnostics, null, 2)}\n`);
+
+  return {
+    ...run,
+    exitCode: result.exitCode,
+    signal: result.signal,
+    durationMs: result.durationMs,
+    diagnostics,
+  };
+}
+
+export async function runExperiment(options, executor = runProcess) {
+  if (options.repos.length === 0) {
+    throw new Error('At least one --repo or --repos path is required.');
+  }
+  if (!existsSync(resolve(options.productCli))) {
+    throw new Error(`Product CLI not found: ${options.productCli}`);
+  }
+
+  const outDir = resolve(options.outDir);
+  mkdirSync(outDir, { recursive: true });
+  const plan = buildRunPlan({ ...options, outDir });
+  const results = [];
+  for (const run of plan) {
+    stdout.write(`Running ${run.variant} on ${run.repoPath}\n`);
+    results.push(await runOne(run, { ...options, outDir }, executor));
+  }
+
+  const summary = {
+    startedAt: new Date().toISOString(),
+    outDir,
+    repos: [...new Set(plan.map(run => run.repoPath))],
+    variants: options.variants,
+    results: results.map(result => ({
+      repoPath: result.repoPath,
+      variant: result.variant,
+      exitCode: result.exitCode,
+      signal: result.signal,
+      durationMs: result.durationMs,
+      copilotHome: result.copilotHome,
+      logDir: result.logDir,
+      stdoutPath: result.stdoutPath,
+      stderrPath: result.stderrPath,
+      commandPath: result.commandPath,
+      diagnosticsPath: result.diagnosticsPath,
+      memoryCommandMentioned: result.diagnostics.memoryCommandMentioned,
+      memoryDiagnosticEventCount: result.diagnostics.memoryDiagnosticEventCount,
+      limitation: result.diagnostics.limitation,
+    })),
+  };
+  const summaryPath = join(outDir, 'summary.json');
+  writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  return { summaryPath, summary };
+}
+
+function printHelp() {
+  stdout.write([
+    'Usage: node scripts/real-cli-ab.mjs --repo <path> --repo <path> [options]',
+    '',
+    'Options:',
+    '  --repo <path>          Local repository to test (repeatable)',
+    `  --repos <paths>        Comma/semicolon-separated repositories (path delimiter is ${JSON.stringify(delimiter)})`,
+    '  --out-dir <path>       Artifact directory',
+    '  --variants <csv>       Variants to run (default: baseline,memory-governance)',
+    '  --copilot-bin <path>   Copilot CLI executable (default: copilot)',
+    '  --product-cli <path>   Built Squad CLI entry point (default: ./cli.js)',
+    '  --timeout-ms <n>       Per-turn timeout (default: 600000)',
+    '  --model <name>         Optional Copilot model override',
+    '  --dry-run              Write the plan/artifact skeleton without invoking Copilot',
+    '',
+  ].join('\n'));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(argv.slice(2));
+    if (options.help) {
+      printHelp();
+      exit(0);
+    }
+    const { summaryPath, summary } = await runExperiment(options);
+    stdout.write(`Summary: ${summaryPath}\n`);
+    stdout.write(`${JSON.stringify(summary.results, null, 2)}\n`);
+    exit(summary.results.every(result => result.exitCode === 0) ? 0 : 1);
+  } catch (error) {
+    stderr.write(`error: ${error.stack ?? error.message ?? String(error)}\n`);
+    printHelp();
+    exit(1);
+  }
+}

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -340,7 +340,7 @@ prompt: |
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
-  
+
   {% if WORKTREE_MODE %}
   **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
   {% endif %}
@@ -779,17 +779,17 @@ name: "{name}"
 description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
-  
+
   YOUR CHARTER:
   {paste contents of .squad/agents/{name}/charter.md here}
-  
+
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
   All `.squad/` paths are relative to this root.
-  
+
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
-  
+
   {If PERSONAL_AGENT is true, append Ghost Protocol rules:}
   ## Ghost Protocol
   You are a personal agent operating in a project context. You MUST follow these rules:
@@ -798,10 +798,10 @@ prompt: |
   - Transparent origin: Tag all logs with [personal:{name}]
   - Consult mode: Provide recommendations, not direct changes
   {end Ghost Protocol block}
-  
+
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
-  
+
   {% if WORKTREE_MODE %}
   **WORKTREE:** You are working in a dedicated worktree at `{WORKTREE_PATH}`.
   - All file operations should be relative to this path
@@ -809,63 +809,63 @@ prompt: |
   - Build and test in the worktree, not the main repo
   - Commit and push from the worktree
   {% endif %}
-  
+
   STATE_BACKEND: {state_backend}
-  
+
   {% if STATE_BACKEND == "git-notes" %}
   ## State Protocol — Git Notes
   This project uses git-notes for mutable state. **DO NOT write to `.squad/` files for state.**
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-  
+
   **Reading your state:**
   Run: `powershell .squad/scripts/notes/fetch.ps1 -Setup` (first time per session)
   Then: `git notes --ref=squad/{name} show $(git rev-list --max-parents=0 HEAD) 2>$null`
   Falls back to empty if no note exists.
-  
+
   **Writing state (history, decisions, learnings):**
   Run: `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{json}'`
   The helper handles JSON validation, conflict retry, and push.
-  
+
   **Decisions:** Write decisions as JSON via your note ref. Scribe will merge them.
   **Skills:** Skills are static config — write to `.squad/skills/` on disk as normal.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "orphan" %}
   ## State Protocol — Orphan Branch
   This project uses an orphan branch (`squad-state`) for mutable state.
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-  
+
   **Reading state:** Read `.squad/` files on disk — they are synced from the orphan branch.
   **Writing state:** Write to `.squad/` files on disk as normal during your session.
   Scribe will commit your changes to the orphan branch (not the working branch) and
   ensure they persist across branch switches.
-  
+
   **Important:** Do NOT commit `.squad/` state files to the working branch yourself.
   Scribe handles the orphan branch commit workflow.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "two-layer" %}
   ## State Protocol — Two-Layer (Git Notes + Orphan Branch)
   This project uses the two-layer architecture from Tamir's blog:
   - **Layer 1 (git notes):** Commit-scoped "why" annotations — invisible in PRs
   - **Layer 2 (orphan branch):** Permanent state store — decisions, histories, logs
-  
+
   Static config (charters, team.md, routing.md) is on disk as normal.
-  
+
   **During your session:**
   1. Write commit-scoped annotations as git notes on HEAD:
      `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
   2. Write bulk state (history, logs) to `.squad/` files on disk — Scribe moves them to the orphan branch.
-  
+
   **Note flags:**
   - `"promote_to_permanent": true` — Ralph promotes this to decisions.md after PR merge
   - `"archive_on_close": true` — Worth keeping even if PR is rejected (valuable research)
   - Neither flag — silently ignored if PR is rejected (correct for branch-specific decisions)
-  
+
   **Important:** Do NOT commit `.squad/` state files to the working branch.
   Scribe handles orphan commits. Ralph handles note promotion.
   {% endif %}
-  
+
   {% if STATE_BACKEND == "worktree" or STATE_BACKEND is not defined %}
   Read .squad/agents/{name}/history.md (your project knowledge).
   {% endif %}
@@ -881,22 +881,22 @@ prompt: |
   Check .copilot/skills/ for copilot-level skills (process, workflow, protocol).
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
-  
+
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
-  
+
   **Requested by:** {current user name}
-  
+
   INPUT ARTIFACTS: {list exact file paths to review/modify}
-  
+
   The user says: "{message}"
-  
+
   Do the work. Respond as {Name}.
-  
+
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
-  
+
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
@@ -921,7 +921,7 @@ prompt: |
   {% endif %}
   3. SKILL EXTRACTION: If you found a reusable pattern, write/update
      .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
-  
+
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.
 ```
@@ -976,7 +976,7 @@ prompt: |
 
   Tasks (in order):
   {% if STATE_BACKEND == "orphan" or STATE_BACKEND == "git-notes" or STATE_BACKEND == "two-layer" %}
-  0. STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
+  0. PRE-CHECK — STATE LEAK GUARD: Check if any agent accidentally committed or staged state files
      (.squad/decisions.md, agents/*/history.md, log/*, orchestration-log/*, decisions/inbox/*)
      to the working branch. If found: unstage with `git reset HEAD -- {file}`, restore with
      `git checkout HEAD -- {file}`. If leaked in last commit, amend to remove. Log count.

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -238,6 +238,17 @@ The `name` parameter generates the human-readable agent ID shown in the tasks pa
 2. Acknowledge briefly: `"📌 Captured. {one-line summary of the directive}."`
 3. If the message ALSO contains a work request, route that work normally after capturing. If it's directive-only, you're done — no agent spawn needed.
 
+### Memory Governance Tools
+
+When memory tools are available, use them before writing durable memory by hand:
+
+- Classify candidate memories with `memory.classify`.
+- Persist approved durable facts, decisions, and policies with `memory.write`.
+- Search governed memory with `memory.search` before relying only on raw file search.
+- Promote, delete, and audit governed entries with `memory.promote`, `memory.delete`, and `memory.audit`.
+
+If memory tools are not available, keep the prompt-only fallback: write local `.squad/` files directly using the decision inbox, agent histories, and skills. Do not claim provider-backed Copilot Memory, semantic indexing, or remote deletion unless a configured tool or CLI bridge performed the operation. External semantic memory is opt-in; forbidden or transient content must not be persisted.
+
 ### Routing
 
 The routing table determines **WHO** handles work. After routing, use Response Mode Selection to determine **HOW** (Direct/Lightweight/Standard/Full).
@@ -340,7 +351,7 @@ prompt: |
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
   **Requested by:** {current user name}
-
+  
   {% if WORKTREE_MODE %}
   **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
   {% endif %}
@@ -779,17 +790,17 @@ name: "{name}"
 description: "{emoji} {Name}: {brief task summary}"
 prompt: |
   You are {Name}, the {Role} on this project.
-
+  
   YOUR CHARTER:
   {paste contents of .squad/agents/{name}/charter.md here}
-
+  
   TEAM ROOT: {team_root}
   CURRENT_DATETIME: {current_datetime}
   All `.squad/` paths are relative to this root.
-
+  
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
-
+  
   {If PERSONAL_AGENT is true, append Ghost Protocol rules:}
   ## Ghost Protocol
   You are a personal agent operating in a project context. You MUST follow these rules:
@@ -798,10 +809,10 @@ prompt: |
   - Transparent origin: Tag all logs with [personal:{name}]
   - Consult mode: Provide recommendations, not direct changes
   {end Ghost Protocol block}
-
+  
   WORKTREE_PATH: {worktree_path}
   WORKTREE_MODE: {true|false}
-
+  
   {% if WORKTREE_MODE %}
   **WORKTREE:** You are working in a dedicated worktree at `{WORKTREE_PATH}`.
   - All file operations should be relative to this path
@@ -809,63 +820,63 @@ prompt: |
   - Build and test in the worktree, not the main repo
   - Commit and push from the worktree
   {% endif %}
-
+  
   STATE_BACKEND: {state_backend}
-
+  
   {% if STATE_BACKEND == "git-notes" %}
   ## State Protocol — Git Notes
   This project uses git-notes for mutable state. **DO NOT write to `.squad/` files for state.**
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-
+  
   **Reading your state:**
   Run: `powershell .squad/scripts/notes/fetch.ps1 -Setup` (first time per session)
   Then: `git notes --ref=squad/{name} show $(git rev-list --max-parents=0 HEAD) 2>$null`
   Falls back to empty if no note exists.
-
+  
   **Writing state (history, decisions, learnings):**
   Run: `powershell .squad/scripts/notes/write-note.ps1 -Ref "squad/{name}" -Content '{json}'`
   The helper handles JSON validation, conflict retry, and push.
-
+  
   **Decisions:** Write decisions as JSON via your note ref. Scribe will merge them.
   **Skills:** Skills are static config — write to `.squad/skills/` on disk as normal.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "orphan" %}
   ## State Protocol — Orphan Branch
   This project uses an orphan branch (`squad-state`) for mutable state.
   Static config (charters, team.md, routing.md) is on disk as normal — read those with `view`.
-
+  
   **Reading state:** Read `.squad/` files on disk — they are synced from the orphan branch.
   **Writing state:** Write to `.squad/` files on disk as normal during your session.
   Scribe will commit your changes to the orphan branch (not the working branch) and
   ensure they persist across branch switches.
-
+  
   **Important:** Do NOT commit `.squad/` state files to the working branch yourself.
   Scribe handles the orphan branch commit workflow.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "two-layer" %}
   ## State Protocol — Two-Layer (Git Notes + Orphan Branch)
   This project uses the two-layer architecture from Tamir's blog:
   - **Layer 1 (git notes):** Commit-scoped "why" annotations — invisible in PRs
   - **Layer 2 (orphan branch):** Permanent state store — decisions, histories, logs
-
+  
   Static config (charters, team.md, routing.md) is on disk as normal.
-
+  
   **During your session:**
   1. Write commit-scoped annotations as git notes on HEAD:
      `git notes --ref=squad/{name} add -f -m '{"agent":"{Name}","type":"decision","decision":"...","promote_to_permanent":true}' HEAD`
   2. Write bulk state (history, logs) to `.squad/` files on disk — Scribe moves them to the orphan branch.
-
+  
   **Note flags:**
   - `"promote_to_permanent": true` — Ralph promotes this to decisions.md after PR merge
   - `"archive_on_close": true` — Worth keeping even if PR is rejected (valuable research)
   - Neither flag — silently ignored if PR is rejected (correct for branch-specific decisions)
-
+  
   **Important:** Do NOT commit `.squad/` state files to the working branch.
   Scribe handles orphan commits. Ralph handles note promotion.
   {% endif %}
-
+  
   {% if STATE_BACKEND == "worktree" or STATE_BACKEND is not defined %}
   Read .squad/agents/{name}/history.md (your project knowledge).
   {% endif %}
@@ -881,22 +892,22 @@ prompt: |
   Check .copilot/skills/ for copilot-level skills (process, workflow, protocol).
   Check .squad/skills/ for team-level skills (patterns discovered during work).
   Read any relevant SKILL.md files before working.
-
+  
   {only if MCP tools detected — omit entirely if none:}
   MCP TOOLS: {service}: ✅ ({tools}) | ❌. Fall back to CLI when unavailable.
   {end MCP block}
-
+  
   **Requested by:** {current user name}
-
+  
   INPUT ARTIFACTS: {list exact file paths to review/modify}
-
+  
   The user says: "{message}"
-
+  
   Do the work. Respond as {Name}.
-
+  
   ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
   ⚠️ DATES: When writing dates in any file (decisions, history, logs), use ONLY the CURRENT_DATETIME value above. Never infer or guess the date.
-
+  
   AFTER work:
   {% if STATE_BACKEND == "git-notes" %}
   1. Persist your learnings as JSON via the State Protocol:
@@ -921,7 +932,7 @@ prompt: |
   {% endif %}
   3. SKILL EXTRACTION: If you found a reusable pattern, write/update
      .squad/skills/{skill-name}/SKILL.md (read templates/skill.md for format).
-
+  
   ⚠️ RESPONSE ORDER: After ALL tool calls, write a 2-3 sentence plain text
   summary as your FINAL output. No tool calls after this summary.
 ```

--- a/test/compat-v041.test.ts
+++ b/test/compat-v041.test.ts
@@ -253,16 +253,22 @@ describe('Compat v0.4.1: Config Path Equivalence', () => {
 // ============================================================================
 
 describe('Compat v0.4.1: Tool Registration', () => {
-  it('ToolRegistry registers all 5 built-in tools', () => {
+  it('ToolRegistry registers all built-in tools', () => {
     const registry = new ToolRegistry();
     const tools = registry.getTools();
-    expect(tools.length).toBe(5);
+    expect(tools.length).toBe(11);
     const names = tools.map((t) => t.name);
     expect(names).toEqual(
       expect.arrayContaining([
         'squad_route',
         'squad_decide',
         'squad_memory',
+        'memory.classify',
+        'memory.write',
+        'memory.search',
+        'memory.promote',
+        'memory.delete',
+        'memory.audit',
         'squad_status',
         'squad_skill',
       ]),
@@ -292,7 +298,7 @@ describe('Compat v0.4.1: Tool Registration', () => {
   it('getToolsForAgent returns all when no filter', () => {
     const registry = new ToolRegistry();
     const all = registry.getToolsForAgent(undefined);
-    expect(all.length).toBe(5);
+    expect(all.length).toBe(11);
   });
 });
 

--- a/test/memory-governance.test.ts
+++ b/test/memory-governance.test.ts
@@ -1,0 +1,567 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { FSStorageProvider } from '../packages/squad-sdk/src/storage/fs-storage-provider.js';
+import {
+  ensureMemoryGovernanceDefaults,
+  LocalMemoryStore,
+  type CopilotMemoryProviderClient,
+  type CopilotMemoryProviderWriteRequest,
+} from '../packages/squad-sdk/src/memory/index.js';
+import { runMemoryCommand } from '../packages/squad-cli/src/cli/commands/memory.js';
+import { ensureMemoryGovernanceUpgradeDefaults } from '../packages/squad-cli/src/cli/core/upgrade.js';
+
+const roots: string[] = [];
+
+function testRoot(prefix: string): string {
+  const root = path.join(process.cwd(), `.test-${prefix}-${randomUUID()}`);
+  roots.push(root);
+  fs.mkdirSync(path.join(root, '.squad'), { recursive: true });
+  return root;
+}
+
+function readMemoryIndex(root: string): Array<Record<string, unknown>> {
+  return JSON.parse(fs.readFileSync(path.join(root, '.squad', 'memory', 'index.json'), 'utf8')) as Array<Record<string, unknown>>;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('memory governance defaults', () => {
+  it('scaffolds local-only governance config idempotently without overwriting edits', async () => {
+    const root = testRoot('memory-defaults');
+    const storage = new FSStorageProvider();
+    const first = await ensureMemoryGovernanceDefaults(storage, root);
+    expect(first).toContain(path.join('.squad', 'memory', 'config.json'));
+
+    const configPath = path.join(root, '.squad', 'memory', 'config.json');
+    fs.writeFileSync(configPath, '{"version":1,"custom":true}\n');
+
+    const second = await ensureMemoryGovernanceDefaults(storage, root);
+    expect(second).toEqual([]);
+    expect(fs.readFileSync(configPath, 'utf8')).toContain('"custom":true');
+  });
+
+  it('upgrade scaffolding is idempotent and non-overwriting', () => {
+    const root = testRoot('memory-upgrade');
+    const first = ensureMemoryGovernanceUpgradeDefaults(root);
+    expect(first).toContain(path.join('.squad', 'memory', 'config.json'));
+
+    const configPath = path.join(root, '.squad', 'memory', 'config.json');
+    fs.writeFileSync(configPath, '{"version":1,"defaultProvider":"local","note":"keep"}\n');
+
+    const second = ensureMemoryGovernanceUpgradeDefaults(root);
+    expect(second).toEqual([]);
+    expect(fs.readFileSync(configPath, 'utf8')).toContain('"note":"keep"');
+  });
+});
+
+describe('LocalMemoryStore', () => {
+  it('rejects forbidden memory and audits without persisting content', async () => {
+    const root = testRoot('memory-forbidden');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    const result = await store.write({
+      content: 'password=super-secret-value',
+      title: 'bad memory',
+      author: 'worf',
+    });
+
+    expect(result.stored).toBe(false);
+    expect(result.classification.class).toBe('FORBIDDEN');
+    expect(fs.readdirSync(path.join(root, '.squad', 'memory', 'local'))).toHaveLength(0);
+    const audit = await store.auditLog();
+    expect(audit).toHaveLength(1);
+    expect(JSON.stringify(audit)).not.toContain('super-secret-value');
+  });
+
+  it('uses a safe placeholder title for no-title rejected sensitive writes', async () => {
+    const root = testRoot('memory-no-title-reject');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    const result = await store.write({
+      content: 'token=never-leak-this-value',
+      author: 'worf',
+    });
+
+    expect(result.stored).toBe(false);
+    const audit = await store.auditLog();
+    expect(audit[0]).toMatchObject({
+      action: 'reject',
+      title: 'Rejected governed memory',
+    });
+    expect(JSON.stringify(audit)).not.toContain('never-leak-this-value');
+  });
+
+  it('rejects private customer data before persistence', async () => {
+    const root = testRoot('memory-customer-data');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    const result = await store.write({
+      content: 'Private customer data: Contoso tenant contact and support details.',
+      title: 'customer case',
+      author: 'worf',
+    });
+
+    expect(result.stored).toBe(false);
+    expect(result.classification.class).toBe('FORBIDDEN');
+    expect(result.classification.reason).toContain('private customer data');
+    expect(fs.readdirSync(path.join(root, '.squad', 'memory', 'local'))).toHaveLength(0);
+  });
+
+  it('rejects unreviewed vulnerability notes before persistence', async () => {
+    const root = testRoot('memory-unreviewed-vuln');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    const result = await store.write({
+      content: 'Unreviewed vulnerability in production authentication flow.',
+      title: 'security note',
+      author: 'worf',
+    });
+
+    expect(result.stored).toBe(false);
+    expect(result.classification.class).toBe('FORBIDDEN');
+    expect(result.classification.reason).toContain('unreviewed vulnerability');
+    expect(fs.readdirSync(path.join(root, '.squad', 'memory', 'local'))).toHaveLength(0);
+  });
+
+  it('audits explicit classify calls without storing classified content', async () => {
+    const root = testRoot('memory-classify-audit');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    const classification = await store.classify(
+      { content: 'Use local governed memory for stable facts.' },
+      { audit: true, actor: 'seven' },
+    );
+
+    expect(classification.allowed).toBe(true);
+    const audit = await store.auditLog();
+    expect(audit).toHaveLength(1);
+    expect(audit[0]?.action).toBe('classify');
+    expect(JSON.stringify(audit)).not.toContain('stable facts');
+  });
+
+  it('assigns load-guidance tags for durable, on-demand, and rejected memory', async () => {
+    const root = testRoot('memory-load-guidance');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    await expect(store.classify({ content: 'Always use the Squad memory governance provider.' }))
+      .resolves.toMatchObject({ class: 'POLICY', loadGuidance: 'ALWAYS' });
+    await expect(store.classify({ content: 'Remember this stable implementation note.' }))
+      .resolves.toMatchObject({ class: 'LOCAL', loadGuidance: 'ON-DEMAND' });
+    await expect(store.classify({ content: 'password=do-not-store' }))
+      .resolves.toMatchObject({ class: 'FORBIDDEN', loadGuidance: 'NEVER' });
+
+    const write = await store.write({
+      content: 'Use load guidance metadata for selective memory loading.',
+      title: 'Load guidance metadata',
+      requestedClass: 'LOCAL',
+      metadata: { loadGuidance: '[ALWAYS]' },
+    });
+
+    expect(write.classification.loadGuidance).toBe('ALWAYS');
+    const index = readMemoryIndex(root);
+    expect(index[0]).toMatchObject({ id: write.id, loadGuidance: 'ALWAYS' });
+    expect(fs.readFileSync(path.join(root, write.path!), 'utf8')).toContain('loadGuidance: [ALWAYS]');
+    await expect(store.search('selective memory loading')).resolves.toEqual([
+      expect.objectContaining({ id: write.id, loadGuidance: 'ALWAYS' }),
+    ]);
+  });
+
+  it('writes, searches, deletes, and audits governed local memory', async () => {
+    const root = testRoot('memory-local');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    const write = await store.write({
+      content: 'Use Vitest for memory governance regression tests.',
+      title: 'Memory tests',
+      author: 'data',
+      requestedClass: 'LOCAL',
+    });
+
+    expect(write.stored).toBe(true);
+    expect(write.path).toContain(path.join('.squad', 'memory', 'local'));
+
+    const results = await store.search('Vitest');
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe(write.id);
+
+    const deleted = await store.delete(write.id!, 'data');
+    expect(deleted).toBe(true);
+    expect(await store.search('Vitest')).toEqual([]);
+
+    const audit = await store.auditLog();
+    expect(audit.map(r => r.action)).toEqual(['write', 'search', 'delete', 'search']);
+    expect(fs.existsSync(path.join(root, '.squad', 'memory', 'tombstones', `${write.id}.json`))).toBe(true);
+  });
+
+  it('routes decisions to the decision inbox and supports promotion', async () => {
+    const root = testRoot('memory-decision');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    const local = await store.write({
+      content: 'Use the local memory store as the default governance provider.',
+      title: 'Local default',
+      author: 'data',
+      requestedClass: 'LOCAL',
+    });
+    const promoted = await store.promote(local.id!, 'DECISION', 'scribe');
+
+    expect(promoted.stored).toBe(true);
+    expect(promoted.path).toContain(path.join('.squad', 'decisions', 'inbox'));
+    expect(fs.readdirSync(path.join(root, '.squad', 'decisions', 'inbox'))).toHaveLength(1);
+  });
+
+  it('links superseded entries forward while preserving archive tombstone metadata', async () => {
+    const root = testRoot('memory-superseded-forward-link');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    const local = await store.write({
+      content: 'Use a queryable forward link when memory is promoted.',
+      title: 'Forward link source',
+      author: 'data',
+      requestedClass: 'LOCAL',
+    });
+    const originalPath = local.path!;
+    const promoted = await store.promote(local.id!, 'DECISION', 'scribe');
+
+    expect(promoted.stored).toBe(true);
+    const promotedSearch = await store.search('forward link');
+    expect(promotedSearch).toEqual([
+      expect.objectContaining({ id: promoted.id, class: 'DECISION', loadGuidance: 'ALWAYS' }),
+    ]);
+
+    let index = readMemoryIndex(root);
+    expect(index.find(entry => entry.id === local.id)).toMatchObject({
+      status: 'superseded',
+      loadGuidance: 'ARCHIVE',
+      supersededBy: promoted.id,
+    });
+    expect(index.find(entry => entry.id === promoted.id)).toMatchObject({
+      status: 'active',
+      supersedes: local.id,
+    });
+    expect(fs.readFileSync(path.join(root, originalPath), 'utf8')).toContain(`supersededBy: ${promoted.id}`);
+
+    await expect(store.delete(local.id!, 'data')).resolves.toBe(true);
+    index = readMemoryIndex(root);
+    expect(index.find(entry => entry.id === local.id)).toMatchObject({
+      status: 'deleted',
+      loadGuidance: 'ARCHIVE',
+      supersededBy: promoted.id,
+    });
+    const tombstone = JSON.parse(fs.readFileSync(path.join(root, '.squad', 'memory', 'tombstones', `${local.id}.json`), 'utf8'));
+    expect(tombstone).toMatchObject({
+      id: local.id,
+      previousStatus: 'superseded',
+      supersededBy: promoted.id,
+      loadGuidance: '[ARCHIVE]',
+    });
+    expect(fs.existsSync(path.join(root, originalPath))).toBe(false);
+  });
+
+  it('preserves prompt-only fallback boundary by rejecting semantic provider writes by default', async () => {
+    const root = testRoot('memory-semantic');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    const result = await store.write({
+      content: 'Copilot Memory should remember this stable convention.',
+      title: 'Semantic candidate',
+      author: 'scribe',
+      requestedClass: 'COPILOT_MEMORY',
+      approved: true,
+    });
+
+    expect(result.stored).toBe(false);
+    expect(result.classification.reason).toContain('disabled');
+    expect(await store.search('Copilot Memory')).toEqual([]);
+  });
+
+  it('reports and configures hostInjectedCopilotAdapter selection explicitly', async () => {
+    const root = testRoot('memory-provider-selection');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    expect(await store.providerStatus()).toMatchObject({
+      defaultProvider: 'local',
+      realCopilotMemory: {
+        available: false,
+        configured: false,
+      },
+      hostInjectedCopilotAdapter: {
+        enabled: false,
+        requireApproval: true,
+        configured: false,
+        clientAvailable: false,
+      },
+    });
+
+    await store.configureHostInjectedCopilotAdapter({
+      enabled: true,
+      requireApproval: false,
+      defaultProvider: 'hostInjectedCopilotAdapter',
+      actor: 'data',
+    });
+
+    expect(await store.providerStatus()).toMatchObject({
+      defaultProvider: 'hostInjectedCopilotAdapter',
+      realCopilotMemory: {
+        available: false,
+        configured: false,
+      },
+      hostInjectedCopilotAdapter: {
+        enabled: true,
+        requireApproval: false,
+        configured: true,
+        clientAvailable: false,
+      },
+    });
+  });
+
+  it('fails closed when hostInjectedCopilotAdapter is configured without a host client', async () => {
+    const root = testRoot('memory-provider-missing-client');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+    await store.configureHostInjectedCopilotAdapter({ enabled: true, requireApproval: false });
+
+    const result = await store.write({
+      content: 'Semantic memory should be sent only through an available governed provider.',
+      title: 'Missing client',
+      requestedClass: 'COPILOT_MEMORY',
+      approved: true,
+    });
+
+    expect(result.stored).toBe(false);
+    expect(result.classification.reason).toContain('hostInjectedCopilotAdapter is enabled');
+    expect(JSON.stringify(await store.auditLog())).not.toContain('Semantic memory should be sent');
+  });
+
+  it('rejects provider=copilot because no real Copilot Memory API exists locally', async () => {
+    const root = testRoot('memory-provider-real-copilot-unavailable');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    await expect(store.configureCopilotProvider({
+      enabled: true,
+      defaultProvider: 'copilot',
+    })).rejects.toThrow('Real Copilot Memory API unavailable');
+  });
+
+  it('recognizes manually configured provider=copilot but fails closed without invoking host client', async () => {
+    const root = testRoot('memory-provider-real-copilot-configured');
+    await ensureMemoryGovernanceDefaults(new FSStorageProvider(), root);
+    const configPath = path.join(root, '.squad', 'memory', 'config.json');
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    fs.writeFileSync(configPath, JSON.stringify({ ...config, defaultProvider: 'copilot' }, null, 2) + '\n');
+
+    let writeCalls = 0;
+    let searchCalls = 0;
+    const client: CopilotMemoryProviderClient = {
+      async write() {
+        writeCalls += 1;
+        return { id: 'should-not-write' };
+      },
+      async search() {
+        searchCalls += 1;
+        return [{ id: 'should-not-search', title: 'Nope', snippet: 'Nope' }];
+      },
+      async delete() {
+        return true;
+      },
+    };
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, { hostInjectedCopilotAdapterClient: client });
+
+    await expect(store.providerStatus()).resolves.toMatchObject({
+      defaultProvider: 'copilot',
+      realCopilotMemory: {
+        available: false,
+        configured: true,
+      },
+    });
+
+    const write = await store.write({
+      content: 'Safe semantic memory that still needs a real Copilot provider.',
+      title: 'Real provider candidate',
+      author: 'data',
+      requestedClass: 'COPILOT_MEMORY',
+      approved: true,
+    });
+    expect(write.stored).toBe(false);
+    expect(write.classification.reason).toContain('Real Copilot Memory API unavailable');
+
+    await expect(store.search('safe semantic memory')).resolves.toEqual([]);
+    expect(writeCalls).toBe(0);
+    expect(searchCalls).toBe(0);
+    const audit = await store.auditLog();
+    expect(audit.map(r => r.action)).toEqual(['reject', 'reject']);
+    expect(audit.every(r => r.provider === 'copilot')).toBe(true);
+    expect(JSON.stringify(audit)).not.toContain('Safe semantic memory');
+    expect(JSON.stringify(audit)).not.toContain('safe semantic memory');
+  });
+
+  it('rejects forbidden search before provider=copilot availability handling', async () => {
+    const root = testRoot('memory-provider-real-copilot-forbidden-search');
+    await ensureMemoryGovernanceDefaults(new FSStorageProvider(), root);
+    const configPath = path.join(root, '.squad', 'memory', 'config.json');
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    fs.writeFileSync(configPath, JSON.stringify({ ...config, defaultProvider: 'copilot' }, null, 2) + '\n');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    await expect(store.search('password=never-send-provider-query')).resolves.toEqual([]);
+
+    const audit = await store.auditLog();
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({
+      action: 'reject',
+      class: 'FORBIDDEN',
+      title: 'Rejected governed memory search',
+    });
+    expect(audit[0]?.reason).toContain('credential-like assignment');
+    expect(audit[0]?.provider).toBeUndefined();
+    expect(JSON.stringify(audit)).not.toContain('never-send-provider-query');
+  });
+
+  it('CLI rejects provider=copilot configuration while reporting status honestly', async () => {
+    const root = testRoot('memory-provider-cli-real-copilot');
+
+    await expect(runMemoryCommand(root, ['provider', '--provider', 'copilot']))
+      .rejects.toThrow('Real Copilot Memory API unavailable');
+
+    const output: string[] = [];
+    const originalLog = console.log;
+    console.log = (value?: unknown) => {
+      output.push(String(value));
+    };
+    try {
+      await runMemoryCommand(root, ['provider']);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const status = JSON.parse(output[0] ?? '{}');
+    expect(status).toMatchObject({
+      defaultProvider: 'local',
+      realCopilotMemory: {
+        available: false,
+        configured: false,
+      },
+      hostInjectedCopilotAdapter: {
+        configured: false,
+        clientAvailable: false,
+      },
+    });
+  });
+
+  it('writes, searches, deletes, tombstones, and audits through hostInjectedCopilotAdapter', async () => {
+    const root = testRoot('memory-provider-host-client');
+    const providerWrites: CopilotMemoryProviderWriteRequest[] = [];
+    const providerSearches: string[] = [];
+    const deletedIds: string[] = [];
+    const client: CopilotMemoryProviderClient = {
+      async write(request) {
+        providerWrites.push(request);
+        return { id: 'copilot-1', path: 'host-injected-copilot-adapter:copilot-1' };
+      },
+      async search(query) {
+        providerSearches.push(query);
+        return query.includes('semantic')
+          ? [{ id: 'copilot-1', title: 'Provider memory', snippet: 'safe semantic result', path: 'host-injected-copilot-adapter:copilot-1' }]
+          : [];
+      },
+      async delete(id) {
+        deletedIds.push(id);
+        return true;
+      },
+    };
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, { hostInjectedCopilotAdapterClient: client });
+    await store.configureHostInjectedCopilotAdapter({ enabled: true, requireApproval: true });
+
+    const write = await store.write({
+      content: 'Safe semantic memory for provider-backed retrieval.',
+      title: 'Provider memory',
+      author: 'data',
+      requestedClass: 'COPILOT_MEMORY',
+      approved: true,
+    });
+
+    expect(write).toMatchObject({ stored: true, id: 'copilot-1', path: 'host-injected-copilot-adapter:copilot-1' });
+    expect(providerWrites).toHaveLength(1);
+
+    const results = await store.search('semantic');
+    expect(results).toEqual([
+      expect.objectContaining({ id: 'copilot-1', provider: 'hostInjectedCopilotAdapter', class: 'COPILOT_MEMORY' }),
+    ]);
+    expect(providerSearches).toEqual(['semantic']);
+
+    await expect(store.delete('copilot-1', 'data')).resolves.toBe(true);
+    expect(deletedIds).toEqual(['copilot-1']);
+    expect(fs.existsSync(path.join(root, '.squad', 'memory', 'tombstones', 'copilot-1.json'))).toBe(true);
+    const audit = await store.auditLog();
+    expect(audit.map(r => r.action)).toEqual(['configure', 'write', 'search', 'delete']);
+    expect(JSON.stringify(audit)).not.toContain('Safe semantic memory');
+  });
+
+  it('rejects forbidden search queries before invoking hostInjectedCopilotAdapter', async () => {
+    const root = testRoot('memory-provider-search-reject-first');
+    let searchCalls = 0;
+    const client: CopilotMemoryProviderClient = {
+      async write() {
+        return { id: 'unused' };
+      },
+      async search() {
+        searchCalls += 1;
+        return [{ id: 'unused', title: 'Should not happen', snippet: 'Should not happen' }];
+      },
+      async delete() {
+        return true;
+      },
+    };
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, { hostInjectedCopilotAdapterClient: client });
+    await store.configureHostInjectedCopilotAdapter({ enabled: true, requireApproval: false });
+
+    const results = await store.search('password=never-send-this-search-query');
+
+    expect(results).toEqual([]);
+    expect(searchCalls).toBe(0);
+    const audit = await store.auditLog();
+    expect(audit.map(r => r.action)).toEqual(['configure', 'reject']);
+    expect(audit[1]).toMatchObject({
+      action: 'reject',
+      class: 'FORBIDDEN',
+      title: 'Rejected governed memory search',
+    });
+    expect(JSON.stringify(audit)).not.toContain('never-send-this-search-query');
+  });
+
+  it('rejects forbidden memory before invoking hostInjectedCopilotAdapter', async () => {
+    const root = testRoot('memory-provider-reject-first');
+    let calls = 0;
+    const client: CopilotMemoryProviderClient = {
+      async write() {
+        calls += 1;
+        return { id: 'should-not-happen' };
+      },
+      async search() {
+        return [];
+      },
+      async delete() {
+        return true;
+      },
+    };
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, { hostInjectedCopilotAdapterClient: client });
+    await store.configureHostInjectedCopilotAdapter({ enabled: true, requireApproval: false });
+
+    const result = await store.write({
+      content: 'token=never-send-this-to-provider',
+      title: 'Forbidden external',
+      requestedClass: 'COPILOT_MEMORY',
+      approved: true,
+    });
+
+    expect(result.stored).toBe(false);
+    expect(result.classification.class).toBe('FORBIDDEN');
+    expect(calls).toBe(0);
+    expect(JSON.stringify(await store.auditLog())).not.toContain('never-send-this-to-provider');
+  });
+});

--- a/test/memory-governance.test.ts
+++ b/test/memory-governance.test.ts
@@ -453,6 +453,80 @@ describe('LocalMemoryStore', () => {
     });
   });
 
+
+  it('CLI emits safe memory diagnostics when log level is enabled', async () => {
+    const root = testRoot('memory-cli-diagnostics');
+    const output: string[] = [];
+    const diagnostics: string[] = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = (value?: unknown) => {
+      output.push(String(value));
+    };
+    console.error = (value?: unknown) => {
+      diagnostics.push(String(value));
+    };
+    try {
+      await runMemoryCommand(root, [
+        'write',
+        '--log-level',
+        'debug',
+        '--content',
+        'password=never-log-this-value',
+        '--title',
+        'Sensitive write',
+        '--class',
+        'LOCAL',
+      ]);
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+    }
+
+    expect(JSON.parse(output[0] ?? '{}')).toMatchObject({
+      stored: false,
+      classification: { class: 'FORBIDDEN' },
+    });
+    expect(diagnostics.join('\n')).toContain('[memory:info] command.start command=write');
+    expect(diagnostics.join('\n')).toContain('[memory:debug] write.request');
+    expect(diagnostics.join('\n')).toContain('contentLength=');
+    expect(diagnostics.join('\n')).not.toContain('never-log-this-value');
+  });
+
+  it('CLI memory diagnostics report safe counts and providers without breaking JSON stdout', async () => {
+    const root = testRoot('memory-cli-diagnostics-search');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+    await store.write({
+      content: 'Use safe diagnostic events for memory commands.',
+      title: 'Diagnostic events',
+      author: 'data',
+      requestedClass: 'LOCAL',
+    });
+
+    const output: string[] = [];
+    const diagnostics: string[] = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = (value?: unknown) => {
+      output.push(String(value));
+    };
+    console.error = (value?: unknown) => {
+      diagnostics.push(String(value));
+    };
+    try {
+      await runMemoryCommand(root, ['search', '--verbose', '--query', 'diagnostic events']);
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+    }
+
+    const results = JSON.parse(output[0] ?? '[]');
+    expect(results).toHaveLength(1);
+    expect(diagnostics.join('\n')).toContain('[memory:info] search.complete count=1 providers=local');
+    expect(diagnostics.join('\n')).toContain('[memory:debug] search.request queryLength=');
+    expect(diagnostics.join('\n')).not.toContain('diagnostic events');
+  });
+
   it('writes, searches, deletes, tombstones, and audits through hostInjectedCopilotAdapter', async () => {
     const root = testRoot('memory-provider-host-client');
     const providerWrites: CopilotMemoryProviderWriteRequest[] = [];

--- a/test/memory-governance.test.ts
+++ b/test/memory-governance.test.ts
@@ -25,6 +25,10 @@ function readMemoryIndex(root: string): Array<Record<string, unknown>> {
   return JSON.parse(fs.readFileSync(path.join(root, '.squad', 'memory', 'index.json'), 'utf8')) as Array<Record<string, unknown>>;
 }
 
+function writeSquadConfig(root: string, config: Record<string, unknown>): void {
+  fs.writeFileSync(path.join(root, '.squad', 'config.json'), `${JSON.stringify(config, null, 2)}\n`);
+}
+
 afterEach(() => {
   for (const root of roots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
@@ -491,6 +495,114 @@ describe('LocalMemoryStore', () => {
     expect(diagnostics.join('\n')).toContain('[memory:debug] write.request');
     expect(diagnostics.join('\n')).toContain('contentLength=');
     expect(diagnostics.join('\n')).not.toContain('never-log-this-value');
+  });
+
+  it('CLI reads memory diagnostics log level from .squad/config.json without leaking content', async () => {
+    const root = testRoot('memory-cli-config-diagnostics');
+    writeSquadConfig(root, { memory: { logLevel: 'debug' } });
+
+    const output: string[] = [];
+    const diagnostics: string[] = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = (value?: unknown) => {
+      output.push(String(value));
+    };
+    console.error = (value?: unknown) => {
+      diagnostics.push(String(value));
+    };
+    try {
+      await runMemoryCommand(root, [
+        'write',
+        '--content',
+        'password=config-must-not-log-this-value',
+        '--title',
+        'Config diagnostic write',
+        '--class',
+        'LOCAL',
+      ]);
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+    }
+
+    expect(JSON.parse(output[0] ?? '{}')).toMatchObject({
+      stored: false,
+      classification: { class: 'FORBIDDEN' },
+    });
+    expect(diagnostics.join('\n')).toContain('[memory:info] command.start command=write');
+    expect(diagnostics.join('\n')).toContain('[memory:debug] write.request');
+    expect(diagnostics.join('\n')).toContain('contentLength=');
+    expect(diagnostics.join('\n')).not.toContain('config-must-not-log-this-value');
+  });
+
+  it('CLI environment log level overrides .squad/config.json memory diagnostics', async () => {
+    const root = testRoot('memory-cli-env-over-config-diagnostics');
+    writeSquadConfig(root, { memory: { logLevel: 'debug' } });
+
+    const output: string[] = [];
+    const diagnostics: string[] = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    const originalEnv = process.env['SQUAD_MEMORY_LOG_LEVEL'];
+    console.log = (value?: unknown) => {
+      output.push(String(value));
+    };
+    console.error = (value?: unknown) => {
+      diagnostics.push(String(value));
+    };
+    process.env['SQUAD_MEMORY_LOG_LEVEL'] = 'info';
+    try {
+      await runMemoryCommand(root, ['search', '--query', 'env-over-config-secret-query']);
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env['SQUAD_MEMORY_LOG_LEVEL'];
+      } else {
+        process.env['SQUAD_MEMORY_LOG_LEVEL'] = originalEnv;
+      }
+      console.log = originalLog;
+      console.error = originalError;
+    }
+
+    expect(JSON.parse(output[0] ?? '[]')).toEqual([]);
+    expect(diagnostics.join('\n')).toContain('[memory:info] search.complete count=0 providers=none');
+    expect(diagnostics.join('\n')).not.toContain('[memory:debug] search.request');
+    expect(diagnostics.join('\n')).not.toContain('env-over-config-secret-query');
+  });
+
+  it('CLI log-level switch overrides environment and .squad/config.json memory diagnostics', async () => {
+    const root = testRoot('memory-cli-switch-overrides-diagnostics');
+    writeSquadConfig(root, { memory: { logLevel: 'debug' } });
+
+    const output: string[] = [];
+    const diagnostics: string[] = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    const originalEnv = process.env['SQUAD_MEMORY_LOG_LEVEL'];
+    console.log = (value?: unknown) => {
+      output.push(String(value));
+    };
+    console.error = (value?: unknown) => {
+      diagnostics.push(String(value));
+    };
+    process.env['SQUAD_MEMORY_LOG_LEVEL'] = 'error';
+    try {
+      await runMemoryCommand(root, ['provider', '--log-level', 'info']);
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env['SQUAD_MEMORY_LOG_LEVEL'];
+      } else {
+        process.env['SQUAD_MEMORY_LOG_LEVEL'] = originalEnv;
+      }
+      console.log = originalLog;
+      console.error = originalError;
+    }
+
+    expect(JSON.parse(output[0] ?? '{}')).toMatchObject({
+      defaultProvider: 'local',
+    });
+    expect(diagnostics.join('\n')).toContain('[memory:info] provider.status.complete');
+    expect(diagnostics.join('\n')).not.toContain('[memory:debug]');
   });
 
   it('CLI memory diagnostics report safe counts and providers without breaking JSON stdout', async () => {

--- a/test/memory-providers.test.ts
+++ b/test/memory-providers.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Tests for MemPalaceMemoryProvider and IndexServerMemoryProvider.
+ *
+ * Each test proves:
+ * - Governed safe memory can be written and searched through the provider
+ * - FORBIDDEN content is rejected BEFORE the provider is called
+ * - TRANSIENT content is rejected BEFORE the provider is called
+ * - provider=copilot path still fails closed (unrelated to these providers)
+ * - Providers appear in providerStatus()
+ * - Diagnostics do not contain raw memory content or raw query text
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { FSStorageProvider } from '../packages/squad-sdk/src/storage/fs-storage-provider.js';
+import {
+  LocalMemoryStore,
+  MemPalaceMemoryProvider,
+  IndexServerMemoryProvider,
+  type CopilotMemoryProviderWriteRequest,
+} from '../packages/squad-sdk/src/memory/index.js';
+
+const roots: string[] = [];
+
+function testRoot(prefix: string): string {
+  const root = path.join(process.cwd(), `.test-${prefix}-${randomUUID()}`);
+  roots.push(root);
+  fs.mkdirSync(path.join(root, '.squad'), { recursive: true });
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── MemPalaceMemoryProvider ────────────────────────────────────────────────
+
+describe('MemPalaceMemoryProvider', () => {
+  it('reports status as available', async () => {
+    const provider = new MemPalaceMemoryProvider();
+    const status = await provider.status();
+    expect(status).toMatchObject({ id: 'mempalace', name: 'MemPalace', available: true });
+  });
+
+  it('stores and retrieves a governed LOCAL memory', async () => {
+    const provider = new MemPalaceMemoryProvider();
+    const req: CopilotMemoryProviderWriteRequest = {
+      content: 'Use Vitest for unit tests in the SDK.',
+      title: 'Vitest SDK rule',
+      classification: {
+        class: 'LOCAL',
+        allowed: true,
+        reason: 'Content is allowed for governed local memory',
+        destination: 'local',
+        loadGuidance: 'ON-DEMAND',
+      },
+    };
+    const result = await provider.write(req);
+    expect(result.id).toMatch(/^mempalace-/);
+    expect(result.path).toContain('mempalace:default:');
+
+    const hits = await provider.search('Vitest');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.id).toBe(result.id);
+    expect(hits[0]?.title).toBe('Vitest SDK rule');
+  });
+
+  it('stores a DECISION memory at a named locus', async () => {
+    const provider = new MemPalaceMemoryProvider();
+    const req: CopilotMemoryProviderWriteRequest = {
+      content: 'All significant architecture decisions must be recorded in the decisions inbox.',
+      title: 'Architecture decisions policy',
+      metadata: { locus: 'decisions-locus' },
+      classification: {
+        class: 'DECISION',
+        allowed: true,
+        reason: 'Content is allowed for governed local memory',
+        destination: 'decision-inbox',
+        loadGuidance: 'ALWAYS',
+      },
+    };
+    const result = await provider.write(req);
+    expect(result.path).toContain('mempalace:decisions-locus:');
+
+    const hits = await provider.search('architecture decisions');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.path).toContain('decisions-locus');
+  });
+
+  it('deletes an entry and confirms it is gone', async () => {
+    const provider = new MemPalaceMemoryProvider();
+    const req: CopilotMemoryProviderWriteRequest = {
+      content: 'Temporary rule to test deletion.',
+      title: 'Temp rule',
+      classification: {
+        class: 'LOCAL',
+        allowed: true,
+        reason: 'Content is allowed for governed local memory',
+        destination: 'local',
+        loadGuidance: 'ON-DEMAND',
+      },
+    };
+    const result = await provider.write(req);
+    expect(provider.size).toBe(1);
+
+    const deleted = await provider.delete(result.id);
+    expect(deleted).toBe(true);
+    expect(provider.size).toBe(0);
+
+    const hits = await provider.search('deletion');
+    expect(hits).toHaveLength(0);
+  });
+
+  it('returns empty results for unmatched search query', async () => {
+    const provider = new MemPalaceMemoryProvider();
+    const hits = await provider.search('nonexistent-query-xyz');
+    expect(hits).toHaveLength(0);
+  });
+});
+
+// ── IndexServerMemoryProvider ──────────────────────────────────────────────
+
+describe('IndexServerMemoryProvider', () => {
+  it('reports status as available', async () => {
+    const provider = new IndexServerMemoryProvider();
+    const status = await provider.status();
+    expect(status).toMatchObject({ id: 'indexserver', name: 'IndexServer', available: true });
+  });
+
+  it('stores and retrieves a governed POLICY memory', async () => {
+    const provider = new IndexServerMemoryProvider();
+    const req: CopilotMemoryProviderWriteRequest = {
+      content: 'Always run tests before merging to the main branch.',
+      title: 'Test-before-merge policy',
+      classification: {
+        class: 'POLICY',
+        allowed: true,
+        reason: 'Content is allowed for governed local memory',
+        destination: 'policy-inbox',
+        loadGuidance: 'ALWAYS',
+      },
+    };
+    const result = await provider.write(req);
+    expect(result.id).toMatch(/^indexserver-/);
+    expect(result.path).toContain('indexserver:policy:');
+
+    const hits = await provider.search('run tests before merging');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.id).toBe(result.id);
+    expect(hits[0]?.title).toBe('Test-before-merge policy');
+  });
+
+  it('stores a DECISION memory under its topic', async () => {
+    const provider = new IndexServerMemoryProvider();
+    const req: CopilotMemoryProviderWriteRequest = {
+      content: 'Use semantic versioning for all SDK packages.',
+      title: 'SDK versioning decision',
+      metadata: { topic: 'versioning' },
+      classification: {
+        class: 'DECISION',
+        allowed: true,
+        reason: 'Content is allowed for governed local memory',
+        destination: 'decision-inbox',
+        loadGuidance: 'ALWAYS',
+      },
+    };
+    const result = await provider.write(req);
+    expect(result.path).toContain('indexserver:versioning:');
+
+    const hits = await provider.search('semantic versioning');
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.path).toContain('versioning');
+  });
+
+  it('deletes a catalog entry and confirms it is gone', async () => {
+    const provider = new IndexServerMemoryProvider();
+    const req: CopilotMemoryProviderWriteRequest = {
+      content: 'Ephemeral catalog entry for delete test.',
+      title: 'Ephemeral entry',
+      classification: {
+        class: 'LOCAL',
+        allowed: true,
+        reason: 'Content is allowed for governed local memory',
+        destination: 'local',
+        loadGuidance: 'ON-DEMAND',
+      },
+    };
+    const result = await provider.write(req);
+    expect(provider.size).toBe(1);
+
+    const deleted = await provider.delete(result.id);
+    expect(deleted).toBe(true);
+    expect(provider.size).toBe(0);
+
+    const hits = await provider.search('Ephemeral');
+    expect(hits).toHaveLength(0);
+  });
+
+  it('returns empty results for unmatched search query', async () => {
+    const provider = new IndexServerMemoryProvider();
+    const hits = await provider.search('nonexistent-query-xyz');
+    expect(hits).toHaveLength(0);
+  });
+});
+
+// ── LocalMemoryStore routing through registered providers ─────────────────
+
+describe('LocalMemoryStore with registered providers', () => {
+  it('routes a LOCAL write to MemPalace and IndexServer providers', async () => {
+    const root = testRoot('mp-is-write');
+    const memPalace = new MemPalaceMemoryProvider();
+    const indexServer = new IndexServerMemoryProvider();
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, {
+      registeredProviders: [memPalace, indexServer],
+    });
+
+    const result = await store.write({
+      content: 'Use governed memory providers to reduce context pressure.',
+      title: 'Memory provider note',
+      author: 'data',
+      requestedClass: 'LOCAL',
+    });
+
+    expect(result.stored).toBe(true);
+    // Local store wrote the file (path is .squad-relative, join with root to resolve)
+    expect(result.path).toContain('.squad');
+    expect(fs.existsSync(path.join(root, result.path!))).toBe(true);
+
+    // Both providers received the write
+    expect(memPalace.size).toBe(1);
+    expect(indexServer.size).toBe(1);
+  });
+
+  it('routes a POLICY write to both providers', async () => {
+    const root = testRoot('mp-is-policy');
+    const memPalace = new MemPalaceMemoryProvider();
+    const indexServer = new IndexServerMemoryProvider();
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, {
+      registeredProviders: [memPalace, indexServer],
+    });
+
+    await store.write({
+      content: 'Always use semantic versioning for release tags.',
+      title: 'Semantic versioning policy',
+      author: 'picard',
+      requestedClass: 'POLICY',
+    });
+
+    expect(memPalace.size).toBe(1);
+    expect(indexServer.size).toBe(1);
+  });
+
+  it('includes provider search results alongside local results', async () => {
+    const root = testRoot('mp-is-search');
+    const memPalace = new MemPalaceMemoryProvider();
+    const indexServer = new IndexServerMemoryProvider();
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, {
+      registeredProviders: [memPalace, indexServer],
+    });
+
+    await store.write({
+      content: 'Use pull request templates for consistent review checklists.',
+      title: 'PR template rule',
+      author: 'data',
+      requestedClass: 'LOCAL',
+    });
+
+    // Local search returns the local result
+    const localResults = await store.search('pull request templates');
+    expect(localResults.length).toBeGreaterThanOrEqual(1);
+    expect(localResults[0]?.provider).toBe('local');
+  });
+
+  it('rejects FORBIDDEN content BEFORE any provider receives the write', async () => {
+    const root = testRoot('mp-is-forbidden');
+    let memPalaceWriteCalls = 0;
+    let indexServerWriteCalls = 0;
+
+    const memPalace = new MemPalaceMemoryProvider();
+    const indexServer = new IndexServerMemoryProvider();
+
+    // Spy: wrap write to count calls
+    const origMpWrite = memPalace.write.bind(memPalace);
+    (memPalace as unknown as Record<string, unknown>)['write'] = async (req: CopilotMemoryProviderWriteRequest) => {
+      memPalaceWriteCalls++;
+      return origMpWrite(req);
+    };
+    const origIsWrite = indexServer.write.bind(indexServer);
+    (indexServer as unknown as Record<string, unknown>)['write'] = async (req: CopilotMemoryProviderWriteRequest) => {
+      indexServerWriteCalls++;
+      return origIsWrite(req);
+    };
+
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, {
+      registeredProviders: [memPalace, indexServer],
+    });
+
+    const result = await store.write({
+      content: 'password=never-send-to-provider',
+      title: 'Forbidden write',
+      author: 'worf',
+    });
+
+    expect(result.stored).toBe(false);
+    expect(result.classification.class).toBe('FORBIDDEN');
+    expect(memPalaceWriteCalls).toBe(0);
+    expect(indexServerWriteCalls).toBe(0);
+
+    const audit = await store.auditLog();
+    expect(JSON.stringify(audit)).not.toContain('never-send-to-provider');
+  });
+
+  it('rejects TRANSIENT content BEFORE any provider receives the write', async () => {
+    const root = testRoot('mp-is-transient');
+    const memPalace = new MemPalaceMemoryProvider();
+    const indexServer = new IndexServerMemoryProvider();
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, {
+      registeredProviders: [memPalace, indexServer],
+    });
+
+    // Explicitly request TRANSIENT class with safe content (auto-detected TRANSIENT
+    // content also matches FORBIDDEN patterns, so use requestedClass to isolate).
+    const result = await store.write({
+      content: 'Working notes for today that should not be persisted.',
+      title: 'Ephemeral working note',
+      author: 'ralph',
+      requestedClass: 'TRANSIENT',
+    });
+
+    expect(result.stored).toBe(false);
+    expect(result.classification.class).toBe('TRANSIENT');
+    expect(memPalace.size).toBe(0);
+    expect(indexServer.size).toBe(0);
+  });
+
+  it('COPILOT_MEMORY writes still reject without real host client regardless of registered providers', async () => {
+    const root = testRoot('mp-is-copilot-closed');
+    const memPalace = new MemPalaceMemoryProvider();
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, {
+      registeredProviders: [memPalace],
+    });
+
+    const result = await store.write({
+      content: 'Copilot Memory should remember this stable convention.',
+      title: 'Semantic candidate',
+      author: 'scribe',
+      requestedClass: 'COPILOT_MEMORY',
+      approved: true,
+    });
+
+    // Even with a registered provider, COPILOT_MEMORY is disabled by default
+    expect(result.stored).toBe(false);
+    expect(result.classification.reason).toContain('disabled');
+    // MemPalace did NOT receive the write
+    expect(memPalace.size).toBe(0);
+  });
+
+  it('provider=copilot still fails closed regardless of registered providers', async () => {
+    const root = testRoot('mp-is-copilot-reserved');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, {
+      registeredProviders: [new MemPalaceMemoryProvider(), new IndexServerMemoryProvider()],
+    });
+
+    await expect(
+      store.configureCopilotProvider({ enabled: true, defaultProvider: 'copilot' }),
+    ).rejects.toThrow('Real Copilot Memory API unavailable');
+  });
+
+  it('providerStatus includes registered provider statuses', async () => {
+    const root = testRoot('mp-is-provider-status');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, {
+      registeredProviders: [new MemPalaceMemoryProvider(), new IndexServerMemoryProvider()],
+    });
+
+    const status = await store.providerStatus();
+    expect(status.registeredProviders).toHaveLength(2);
+    expect(status.registeredProviders[0]).toMatchObject({ id: 'mempalace', name: 'MemPalace', available: true });
+    expect(status.registeredProviders[1]).toMatchObject({ id: 'indexserver', name: 'IndexServer', available: true });
+    // Core fields still present
+    expect(status.defaultProvider).toBe('local');
+    expect(status.realCopilotMemory.available).toBe(false);
+  });
+
+  it('does not include raw content or raw query in audit records when providers are registered', async () => {
+    const root = testRoot('mp-is-audit-safe');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, {
+      registeredProviders: [new MemPalaceMemoryProvider(), new IndexServerMemoryProvider()],
+    });
+
+    await store.write({
+      content: 'Use governed memory to reduce context pressure and improve precision.',
+      title: 'Governance note',
+      author: 'data',
+      requestedClass: 'LOCAL',
+    });
+
+    await store.search('context pressure');
+
+    const audit = await store.auditLog();
+    const auditJson = JSON.stringify(audit);
+    // Safe metadata is recorded; raw content is not
+    expect(auditJson).not.toContain('Use governed memory to reduce context pressure');
+    expect(auditJson).not.toContain('context pressure');
+    // Actions are recorded
+    expect(audit.map(r => r.action)).toContain('write');
+    expect(audit.map(r => r.action)).toContain('search');
+  });
+});

--- a/test/memory-providers.test.ts
+++ b/test/memory-providers.test.ts
@@ -20,6 +20,9 @@ import {
   MemPalaceMemoryProvider,
   IndexServerMemoryProvider,
   type CopilotMemoryProviderWriteRequest,
+  type MemoryProvider,
+  type MemoryProviderSearchResult,
+  type MemoryProviderStatus,
 } from '../packages/squad-sdk/src/memory/index.js';
 
 const roots: string[] = [];
@@ -67,6 +70,7 @@ describe('MemPalaceMemoryProvider', () => {
     expect(hits).toHaveLength(1);
     expect(hits[0]?.id).toBe(result.id);
     expect(hits[0]?.title).toBe('Vitest SDK rule');
+    expect(hits[0]).toMatchObject({ class: 'LOCAL', loadGuidance: 'ON-DEMAND' });
   });
 
   it('stores a DECISION memory at a named locus', async () => {
@@ -120,6 +124,24 @@ describe('MemPalaceMemoryProvider', () => {
     const hits = await provider.search('nonexistent-query-xyz');
     expect(hits).toHaveLength(0);
   });
+
+  it('bounds long-lived in-memory provider entries', async () => {
+    const provider = new MemPalaceMemoryProvider(1);
+    const classification = {
+      class: 'LOCAL' as const,
+      allowed: true,
+      reason: 'Content is allowed for governed local memory',
+      destination: 'local' as const,
+      loadGuidance: 'ON-DEMAND' as const,
+    };
+
+    await provider.write({ content: 'First memory', title: 'First', classification });
+    await provider.write({ content: 'Second memory', title: 'Second', classification });
+
+    expect(provider.size).toBe(1);
+    expect(await provider.search('First')).toHaveLength(0);
+    expect(await provider.search('Second')).toHaveLength(1);
+  });
 });
 
 // ── IndexServerMemoryProvider ──────────────────────────────────────────────
@@ -152,6 +174,7 @@ describe('IndexServerMemoryProvider', () => {
     expect(hits).toHaveLength(1);
     expect(hits[0]?.id).toBe(result.id);
     expect(hits[0]?.title).toBe('Test-before-merge policy');
+    expect(hits[0]).toMatchObject({ class: 'POLICY', loadGuidance: 'ALWAYS' });
   });
 
   it('stores a DECISION memory under its topic', async () => {
@@ -269,10 +292,10 @@ describe('LocalMemoryStore with registered providers', () => {
       requestedClass: 'LOCAL',
     });
 
-    // Local search returns the local result
-    const localResults = await store.search('pull request templates');
-    expect(localResults.length).toBeGreaterThanOrEqual(1);
-    expect(localResults[0]?.provider).toBe('local');
+    const results = await store.search('pull request templates');
+    expect(results.some(result => result.provider === 'local')).toBe(true);
+    expect(results.some(result => result.provider === 'mempalace')).toBe(true);
+    expect(results.some(result => result.provider === 'indexserver')).toBe(true);
   });
 
   it('rejects FORBIDDEN content BEFORE any provider receives the write', async () => {
@@ -408,5 +431,85 @@ describe('LocalMemoryStore with registered providers', () => {
     // Actions are recorded
     expect(audit.map(r => r.action)).toContain('write');
     expect(audit.map(r => r.action)).toContain('search');
+  });
+
+  it('records safe provider failures without raw provider error text', async () => {
+    const root = testRoot('mp-is-provider-error');
+    const provider: MemoryProvider = {
+      id: 'failing-provider',
+      name: 'FailingProvider',
+      supportedClasses: ['LOCAL'],
+      async status(): Promise<MemoryProviderStatus> {
+        return { id: 'failing-provider', name: 'FailingProvider', available: true };
+      },
+      async write(): Promise<{ id: string }> {
+        throw new Error('raw failure includes context pressure and secret-like text');
+      },
+      async search(): Promise<MemoryProviderSearchResult[]> {
+        throw new Error('raw search query context pressure leaked');
+      },
+      async delete(): Promise<boolean> {
+        return false;
+      },
+    };
+    const store = new LocalMemoryStore(new FSStorageProvider(), root, {
+      registeredProviders: [provider],
+    });
+
+    await store.write({
+      content: 'Use governed memory to reduce context pressure.',
+      title: 'Provider failure note',
+      author: 'data',
+      requestedClass: 'LOCAL',
+    });
+    await store.search('context pressure');
+
+    const auditJson = JSON.stringify(await store.auditLog());
+    expect(auditJson).toContain('provider-error');
+    expect(auditJson).toContain('FailingProvider provider write failed (Error); raw provider error text omitted');
+    expect(auditJson).toContain('FailingProvider provider search failed (Error); raw provider error text omitted');
+    expect(auditJson).not.toContain('raw failure includes');
+    expect(auditJson).not.toContain('raw search query');
+  });
+
+  it('rotates audit logs when configured size is exceeded', async () => {
+    const root = testRoot('mp-is-audit-rotate');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+    await store.configureHostInjectedCopilotAdapter({
+      enabled: false,
+      actor: 'test',
+    });
+    const configPath = path.join(root, '.squad', 'memory', 'config.json');
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
+      policy: { auditMaxBytes: number; auditMaxArchives: number };
+    };
+    config.policy.auditMaxBytes = 1;
+    config.policy.auditMaxArchives = 1;
+    fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+    await store.write({
+      content: 'Use bounded audit logs for long-running projects.',
+      title: 'Audit rotation note',
+      requestedClass: 'LOCAL',
+    });
+
+    expect(fs.existsSync(path.join(root, '.squad', 'memory', 'audit.1.jsonl'))).toBe(true);
+    expect(fs.existsSync(path.join(root, '.squad', 'memory', 'audit.jsonl'))).toBe(true);
+  });
+
+  it('blocks unsafe indexed paths during local search', async () => {
+    const root = testRoot('mp-is-path-safety');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+    await store.write({
+      content: 'Safe memory entry.',
+      title: 'Safe memory',
+      requestedClass: 'LOCAL',
+    });
+    const indexPath = path.join(root, '.squad', 'memory', 'index.json');
+    const index = JSON.parse(fs.readFileSync(indexPath, 'utf8')) as Array<Record<string, string>>;
+    index[0]!.path = '../outside.md';
+    fs.writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+
+    await expect(store.search('Safe')).rejects.toThrow('Unsafe memory path blocked');
   });
 });

--- a/test/memory-providers.test.ts
+++ b/test/memory-providers.test.ts
@@ -513,3 +513,174 @@ describe('LocalMemoryStore with registered providers', () => {
     await expect(store.search('Safe')).rejects.toThrow('Unsafe memory path blocked');
   });
 });
+
+// ── Regression tests for critical/medium PR comment fixes ─────────────────
+
+describe('LocalMemoryStore — concurrent writes and index integrity', () => {
+  it('two concurrent writes produce two index entries (no lost update)', async () => {
+    const root = testRoot('concurrent-writes');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+
+    // Fire both writes simultaneously and await together.
+    const [r1, r2] = await Promise.all([
+      store.write({ content: 'First concurrent memory.', title: 'First', requestedClass: 'LOCAL' }),
+      store.write({ content: 'Second concurrent memory.', title: 'Second', requestedClass: 'LOCAL' }),
+    ]);
+
+    expect(r1.stored).toBe(true);
+    expect(r2.stored).toBe(true);
+    expect(r1.id).not.toBe(r2.id);
+
+    // Both entries must survive in the persisted index.
+    const indexPath = path.join(root, '.squad', 'memory', 'index.json');
+    const index = JSON.parse(fs.readFileSync(indexPath, 'utf8')) as Array<{ id: string; status: string }>;
+    const activeIds = index.filter(e => e.status === 'active').map(e => e.id);
+    expect(activeIds).toContain(r1.id!);
+    expect(activeIds).toContain(r2.id!);
+  });
+
+  it('many concurrent writes all survive in the index', async () => {
+    const root = testRoot('concurrent-writes-many');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+    const N = 10;
+    const results = await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        store.write({ content: `Memory number ${i}.`, title: `Entry ${i}`, requestedClass: 'LOCAL' }),
+      ),
+    );
+
+    expect(results.every(r => r.stored)).toBe(true);
+    const ids = new Set(results.map(r => r.id));
+    expect(ids.size).toBe(N);
+
+    const indexPath = path.join(root, '.squad', 'memory', 'index.json');
+    const index = JSON.parse(fs.readFileSync(indexPath, 'utf8')) as Array<{ id: string; status: string }>;
+    const activeIds = new Set(index.filter(e => e.status === 'active').map(e => e.id));
+    for (const id of ids) {
+      expect(activeIds.has(id!)).toBe(true);
+    }
+  });
+});
+
+describe('LocalMemoryStore — corrupted index.json handling', () => {
+  it('throws a descriptive error when index.json contains invalid JSON', async () => {
+    const root = testRoot('corrupt-index-json');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+    // Initialize by writing a valid memory first.
+    await store.write({ content: 'Baseline memory.', title: 'Baseline', requestedClass: 'LOCAL' });
+
+    // Corrupt the index.
+    const indexPath = path.join(root, '.squad', 'memory', 'index.json');
+    fs.writeFileSync(indexPath, '{ this is: not valid JSON }');
+
+    // A subsequent write must throw, not silently reset to empty.
+    await expect(
+      store.write({ content: 'After corruption.', title: 'After', requestedClass: 'LOCAL' }),
+    ).rejects.toThrow(/Memory index is corrupt/);
+  });
+
+  it('preserves a backup of the corrupt index file when it throws', async () => {
+    const root = testRoot('corrupt-index-backup');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+    await store.write({ content: 'Baseline memory.', title: 'Baseline', requestedClass: 'LOCAL' });
+
+    const indexPath = path.join(root, '.squad', 'memory', 'index.json');
+    const corruptContent = '{ this is: not valid JSON }';
+    fs.writeFileSync(indexPath, corruptContent);
+
+    await expect(store.write({ content: 'x', title: 'x', requestedClass: 'LOCAL' })).rejects.toThrow();
+
+    // Backup must exist alongside the index with the original corrupt content.
+    const backupPath = `${indexPath}.corrupt`;
+    expect(fs.existsSync(backupPath)).toBe(true);
+    expect(fs.readFileSync(backupPath, 'utf8')).toBe(corruptContent);
+  });
+
+  it('throws when index.json root is not an array', async () => {
+    const root = testRoot('corrupt-index-not-array');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+    await store.write({ content: 'Baseline memory.', title: 'Baseline', requestedClass: 'LOCAL' });
+
+    const indexPath = path.join(root, '.squad', 'memory', 'index.json');
+    fs.writeFileSync(indexPath, JSON.stringify({ entries: [] }));
+
+    await expect(
+      store.write({ content: 'After corruption.', title: 'After', requestedClass: 'LOCAL' }),
+    ).rejects.toThrow(/Memory index is corrupt/);
+  });
+});
+
+describe('LocalMemoryStore — delete tombstone ordering', () => {
+  it('tombstone is written before source file is deleted', async () => {
+    const root = testRoot('delete-tombstone-order');
+    const store = new LocalMemoryStore(new FSStorageProvider(), root);
+    const { id, path: entryPath } = await store.write({
+      content: 'Memory to be deleted.',
+      title: 'To delete',
+      requestedClass: 'LOCAL',
+    });
+
+    // Intercept: record which files exist the moment delete() is called
+    // (we cannot easily hook into the middle of delete, so instead we verify
+    // the tombstone exists AFTER a successful delete and that the audit records
+    // "Deleted governed memory and wrote tombstone").
+    const deleted = await store.delete(id!);
+    expect(deleted).toBe(true);
+
+    const tombstonePath = path.join(root, '.squad', 'memory', 'tombstones', `${id}.json`);
+    expect(fs.existsSync(tombstonePath)).toBe(true);
+
+    const tombstone = JSON.parse(fs.readFileSync(tombstonePath, 'utf8')) as {
+      id: string; previousStatus: string; path: string;
+    };
+    expect(tombstone.id).toBe(id);
+    expect(tombstone.previousStatus).toBe('active');
+    expect(tombstone.path).toBe(entryPath);
+
+    // Source file must no longer exist.
+    const sourcePath = path.join(root, entryPath!);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+
+    // Audit must contain the delete record.
+    const audit = await store.auditLog();
+    expect(audit.some(r => r.action === 'delete' && r.id === id)).toBe(true);
+  });
+
+  it('tombstone survives when source deletion fails (source may be already gone)', async () => {
+    // Manually inject a storage provider that fails on delete() after tombstone
+    // to simulate a crash between index update and source deletion.
+    const root = testRoot('delete-tombstone-survives');
+    let deleteCallCount = 0;
+    const realProvider = new FSStorageProvider();
+
+    // Proxy that lets the tombstone write pass but throws on the source delete.
+    const faultingProvider = new Proxy(realProvider, {
+      get(target, prop) {
+        if (prop === 'delete') {
+          return async (filePath: string) => {
+            deleteCallCount++;
+            // Fail on the first real source delete call.
+            if (deleteCallCount === 1) throw new Error('Simulated source delete failure');
+            return (target.delete as (p: string) => Promise<void>)(filePath);
+          };
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (target as any)[prop];
+      },
+    }) as FSStorageProvider;
+
+    const store = new LocalMemoryStore(faultingProvider, root);
+    const { id } = await store.write({
+      content: 'Memory subject to delete fault.',
+      title: 'Delete fault test',
+      requestedClass: 'LOCAL',
+    });
+
+    // Delete should propagate the storage error.
+    await expect(store.delete(id!)).rejects.toThrow('Simulated source delete failure');
+
+    // Tombstone must exist (written before the source delete).
+    const tombstonePath = path.join(root, '.squad', 'memory', 'tombstones', `${id}.json`);
+    expect(fs.existsSync(tombstonePath)).toBe(true);
+  });
+});

--- a/test/memory-value-benchmark.test.ts
+++ b/test/memory-value-benchmark.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultMemoryValueFixture,
+  formatMemoryValueReport,
+  runMemoryValueBenchmark,
+} from '../packages/squad-sdk/src/runtime/memory-value-benchmark.js';
+
+describe('memory value benchmark', () => {
+  it('shows governed memory reducing context while preserving relevant facts', () => {
+    const report = runMemoryValueBenchmark();
+
+    expect(report.verdict).toBe('pass');
+    expect(report.contextReductionPercent).toBeGreaterThanOrEqual(50);
+    expect(report.governedEstimatedTokens).toBeLessThan(report.baselineEstimatedTokens);
+    expect(report.governedRecall).toBeGreaterThanOrEqual(report.baselineRecall);
+    expect(report.governedPrecision).toBeGreaterThan(report.baselinePrecision);
+    expect(report.governedDecisionConsistency).toBeGreaterThan(report.baselineDecisionConsistency);
+    expect(report.staleOrUnsafeFactsAvoided).toBe(report.staleOrUnsafeFactsLoadedByBaseline);
+  });
+
+  it('excludes archived, deleted, and never-load facts from governed task context', () => {
+    const fixture = createDefaultMemoryValueFixture();
+    const report = runMemoryValueBenchmark(fixture);
+    const staleOrUnsafeIds = fixture.facts
+      .filter(fact => fact.status !== 'active' || fact.loadGuidance === 'ARCHIVE' || fact.loadGuidance === 'NEVER')
+      .map(fact => fact.id);
+
+    for (const taskResult of report.taskResults) {
+      expect(taskResult.governedLoadedIds.some(id => staleOrUnsafeIds.includes(id))).toBe(false);
+    }
+  });
+
+  it('formats a human-readable report with the core measurement fields', () => {
+    const output = formatMemoryValueReport(runMemoryValueBenchmark());
+
+    expect(output).toContain('Memory value benchmark');
+    expect(output).toContain('Verdict: PASS');
+    expect(output).toContain('Context reduction:');
+    expect(output).toContain('Decision consistency:');
+    expect(output).toContain('Stale/unsafe facts avoided:');
+  });
+});

--- a/test/memory-value-benchmark.test.ts
+++ b/test/memory-value-benchmark.test.ts
@@ -39,4 +39,13 @@ describe('memory value benchmark', () => {
     expect(output).toContain('Decision consistency:');
     expect(output).toContain('Stale/unsafe facts avoided:');
   });
+
+  it('keeps benchmark output free of raw secret-shaped fixture values', () => {
+    const fixture = createDefaultMemoryValueFixture();
+    const report = runMemoryValueBenchmark(fixture);
+    const serialized = JSON.stringify({ fixture, report });
+
+    expect(serialized).not.toMatch(/\b(password|passwd|token|api[_-]?key)\s*[:=]\s*\S+/i);
+    expect(serialized).not.toContain('do-not-load-this-secret');
+  });
 });

--- a/test/real-cli-ab.test.ts
+++ b/test/real-cli-ab.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+async function loadHarness() {
+  return import('../scripts/real-cli-ab.js');
+}
+
+const roots: string[] = [];
+
+function testRoot(prefix: string): string {
+  const root = path.join(process.cwd(), `.test-${prefix}-${randomUUID()}`);
+  roots.push(root);
+  fs.mkdirSync(root, { recursive: true });
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('real Copilot CLI A/B harness', () => {
+  it('builds per-repo/per-variant isolated COPILOT_HOME paths', async () => {
+    const { buildRunPlan, slugifyPath } = await loadHarness();
+    const repo = testRoot('real-cli-ab-repo');
+    const outDir = testRoot('real-cli-ab-out');
+
+    const plan = buildRunPlan({
+      repos: [repo],
+      variants: ['baseline', 'memory-governance'],
+      outDir,
+      productCli: path.join(process.cwd(), 'cli.js'),
+    });
+
+    expect(plan).toHaveLength(2);
+    expect(plan[0].copilotHome).toContain(path.join(outDir, 'copilot-home', slugifyPath(repo), 'baseline'));
+    expect(plan[1].copilotHome).toContain(path.join(outDir, 'copilot-home', slugifyPath(repo), 'memory-governance'));
+    expect(plan[0].copilotHome).not.toBe(plan[1].copilotHome);
+  });
+
+  it('parses diagnostics from stdio without logging raw memory content requirements', async () => {
+    const { extractMemoryDiagnostics } = await loadHarness();
+    const events = extractMemoryDiagnostics([
+      '[memory:info] command.start command=classify projectRoot=C:\\repo',
+      '[memory:debug] classify.request contentLength=42 requestedClass=LOCAL',
+      '[memory:info] classify.complete class=LOCAL allowed=true elapsedMs=3',
+    ].join('\n'));
+
+    expect(events).toEqual([
+      expect.objectContaining({ level: 'info', message: expect.stringContaining('command.start') }),
+      expect.objectContaining({ level: 'debug', message: expect.stringContaining('contentLength=42') }),
+      expect.objectContaining({ level: 'info', message: expect.stringContaining('classify.complete') }),
+    ]);
+  });
+
+  it('writes command, stdio, diagnostics, and summary artifacts using an injected executor', async () => {
+    const { parseArgs, runExperiment } = await loadHarness();
+    const repo = testRoot('real-cli-ab-repo');
+    const outDir = testRoot('real-cli-ab-out');
+    const productCli = path.join(repo, 'cli.js');
+    fs.writeFileSync(productCli, '#!/usr/bin/env node\n');
+
+    const { summary } = await runExperiment({
+      ...parseArgs([
+        '--repo', repo,
+        '--out-dir', outDir,
+        '--product-cli', productCli,
+        '--variants', 'memory-governance',
+      ]),
+      copilotBin: 'fake-copilot',
+    }, async (_command, _args, childOptions) => ({
+      exitCode: 0,
+      signal: null,
+      durationMs: 25,
+      stdoutText: 'ran node cli.js memory provider\n',
+      stderrText: `[memory:info] command.start command=provider projectRoot=${childOptions.cwd}\n[memory:info] provider.status.complete defaultProvider=local elapsedMs=2\n`,
+    }));
+
+    const result = summary.results[0];
+    expect(result.copilotHome).toContain(path.join(outDir, 'copilot-home'));
+    expect(result.memoryCommandMentioned).toBe(true);
+    expect(result.memoryDiagnosticEventCount).toBe(2);
+    expect(fs.existsSync(result.commandPath)).toBe(true);
+    expect(fs.existsSync(result.stdoutPath)).toBe(true);
+    expect(fs.existsSync(result.stderrPath)).toBe(true);
+    expect(fs.existsSync(result.diagnosticsPath)).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'summary.json'))).toBe(true);
+  });
+
+  it('records a measured limitation when no memory diagnostics are captured', async () => {
+    const { collectDiagnostics } = await loadHarness();
+    const run = {
+      logDir: testRoot('real-cli-ab-logs'),
+    };
+
+    const diagnostics = collectDiagnostics(run, 'ordinary Copilot response', '');
+    expect(diagnostics.memoryDiagnosticEventCount).toBe(0);
+    expect(diagnostics.limitation).toContain('No [memory:*] diagnostics were captured');
+  });
+
+  it('does not count prompt-only memory command mentions as executed commands', async () => {
+    const { collectDiagnostics } = await loadHarness();
+    const run = {
+      logDir: testRoot('real-cli-ab-logs'),
+    };
+
+    const diagnostics = collectDiagnostics(
+      run,
+      JSON.stringify({
+        type: 'user.message',
+        data: { content: 'Do not run `squad memory` in this baseline turn.' },
+      }),
+      '',
+    );
+
+    expect(diagnostics.memoryCommandMentioned).toBe(false);
+  });
+});

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,6 +1,6 @@
 /**
  * Integration tests for ToolRegistry (M1-1, M1-2, Issues #88 #92)
- * 
+ *
  * Tests tool registration, lookup, filtering, and handler execution for:
  * - squad_route: Routing tasks to agents
  * - squad_decide: Writing decisions to inbox
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { ToolRegistry, defineTool, type RouteRequest, type DecisionRecord, type MemoryEntry } from '@bradygaster/squad-sdk/tools';
+import { ToolRegistry, defineTool, sanitizeArgs, type RouteRequest, type DecisionRecord, type MemoryEntry } from '@bradygaster/squad-sdk/tools';
 import { SessionPool, EventBus } from '@bradygaster/squad-sdk/client';
 import type { FanOutDependencies } from '@bradygaster/squad-sdk/coordinator';
 import type { AgentCharter } from '@bradygaster/squad-sdk/agents';
@@ -98,6 +98,22 @@ describe('defineTool', () => {
   });
 });
 
+describe('sanitizeArgs', () => {
+  it('redacts memory content and query fields before telemetry serialization', () => {
+    const serialized = sanitizeArgs({
+      content: 'password=do-not-record',
+      query: 'private customer data',
+      title: 'safe title',
+    });
+
+    expect(serialized).toContain('"content":"[REDACTED]"');
+    expect(serialized).toContain('"query":"[REDACTED]"');
+    expect(serialized).toContain('"title":"safe title"');
+    expect(serialized).not.toContain('do-not-record');
+    expect(serialized).not.toContain('private customer data');
+  });
+});
+
 describe('ToolRegistry', () => {
   let registry: ToolRegistry;
   let testRoot: string;
@@ -114,14 +130,20 @@ describe('ToolRegistry', () => {
   });
 
   describe('registration', () => {
-    it('should register all five squad tools', () => {
+    it('should register all squad and memory governance tools', () => {
       const tools = registry.getTools();
-      expect(tools.length).toBe(5);
+      expect(tools.length).toBe(11);
 
       const toolNames = tools.map(t => t.name);
       expect(toolNames).toContain('squad_route');
       expect(toolNames).toContain('squad_decide');
       expect(toolNames).toContain('squad_memory');
+      expect(toolNames).toContain('memory.classify');
+      expect(toolNames).toContain('memory.write');
+      expect(toolNames).toContain('memory.search');
+      expect(toolNames).toContain('memory.promote');
+      expect(toolNames).toContain('memory.delete');
+      expect(toolNames).toContain('memory.audit');
       expect(toolNames).toContain('squad_status');
       expect(toolNames).toContain('squad_skill');
     });
@@ -139,7 +161,7 @@ describe('ToolRegistry', () => {
     it('should return all registered tools', () => {
       const tools = registry.getTools();
       expect(Array.isArray(tools)).toBe(true);
-      expect(tools.length).toBe(5);
+      expect(tools.length).toBe(11);
     });
 
     it('should return tools with handler functions', () => {
@@ -153,7 +175,7 @@ describe('ToolRegistry', () => {
   describe('getToolsForAgent', () => {
     it('should return all tools when no filter provided', () => {
       const tools = registry.getToolsForAgent();
-      expect(tools.length).toBe(5);
+      expect(tools.length).toBe(11);
     });
 
     it('should filter tools by allowed list', () => {
@@ -402,7 +424,7 @@ describe('squad_decide handler', () => {
     const inboxDir = path.join(testRoot, 'decisions', 'inbox');
     const files = fs.readdirSync(inboxDir);
     const content = fs.readFileSync(path.join(inboxDir, files[0]), 'utf-8');
-    
+
     expect(content).toContain('Short decision');
     expect(content).toContain('**By:** brady');
     expect(content).not.toContain('**References:**');
@@ -420,7 +442,7 @@ describe('squad_memory handler', () => {
     // Create test agent history file
     const agentDir = path.join(testRoot, 'agents', 'fenster');
     fs.mkdirSync(agentDir, { recursive: true });
-    
+
     const historyContent = `# Fenster's History
 
 ## Learnings
@@ -469,15 +491,15 @@ Initial session entry.
 
     const historyFile = path.join(testRoot, 'agents', 'fenster', 'history.md');
     const content = fs.readFileSync(historyFile, 'utf-8');
-    
+
     expect(content).toContain('Learned how to implement ToolRegistry');
     expect(content).toContain('## Learnings');
-    
+
     // Check it's in the right section
     const learningsIndex = content.indexOf('## Learnings');
     const updatesIndex = content.indexOf('## Updates');
     const newEntryIndex = content.indexOf('Learned how to implement ToolRegistry');
-    
+
     expect(newEntryIndex).toBeGreaterThan(learningsIndex);
     expect(newEntryIndex).toBeLessThan(updatesIndex);
   });
@@ -509,7 +531,7 @@ Initial session entry.
 
     const historyFile = path.join(testRoot, 'agents', 'brady', 'history.md');
     const content = fs.readFileSync(historyFile, 'utf-8');
-    
+
     expect(content).toContain('## Context');
     expect(content).toContain('Session on M1-1 implementation');
   });
@@ -534,6 +556,113 @@ Initial session entry.
       resultType: 'failure',
       error: 'History file does not exist',
     });
+  });
+});
+
+describe('memory governance tool handlers', () => {
+  let registry: ToolRegistry;
+  let testRoot: string;
+
+  beforeEach(() => {
+    testRoot = path.join('.', '.test-memory-tools-' + randomUUID());
+    fs.mkdirSync(testRoot, { recursive: true });
+    registry = new ToolRegistry(testRoot);
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testRoot)) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects forbidden memory through memory.write and exposes audit', async () => {
+    const write = registry.getTool('memory.write')!;
+    const result = await write.handler(
+      { content: 'token=do-not-store-this', title: 'forbidden', author: 'worf' },
+      { sessionId: 's', toolCallId: 'c', toolName: 'memory.write', arguments: {} },
+    );
+
+    expect(result.resultType).toBe('failure');
+    expect((result as any).toolTelemetry.class).toBe('FORBIDDEN');
+
+    const audit = await registry.getTool('memory.audit')!.handler(
+      {},
+      { sessionId: 's', toolCallId: 'a', toolName: 'memory.audit', arguments: {} },
+    );
+    expect(audit.resultType).toBe('success');
+    expect((audit as any).textResultForLlm).toContain('reject');
+    expect((audit as any).textResultForLlm).not.toContain('do-not-store-this');
+  });
+
+  it('does not derive rejected no-title audit records from sensitive memory content', async () => {
+    const write = registry.getTool('memory.write')!;
+    const result = await write.handler(
+      { content: 'token=tool-bridge-secret', author: 'worf' },
+      { sessionId: 's', toolCallId: 'c', toolName: 'memory.write', arguments: {} },
+    );
+
+    expect(result.resultType).toBe('failure');
+    const audit = await registry.getTool('memory.audit')!.handler(
+      {},
+      { sessionId: 's', toolCallId: 'a', toolName: 'memory.audit', arguments: {} },
+    );
+    expect((audit as any).textResultForLlm).toContain('Rejected governed memory');
+    expect((audit as any).textResultForLlm).not.toContain('tool-bridge-secret');
+    expect(JSON.stringify((audit as any).toolTelemetry)).not.toContain('tool-bridge-secret');
+  });
+
+  it('audits memory.classify and memory.search without raw sensitive tool telemetry', async () => {
+    const classify = await registry.getTool('memory.classify')!.handler(
+      { content: 'Private customer data: Fabrikam tenant details.', author: 'seven' },
+      { sessionId: 's', toolCallId: 'c', toolName: 'memory.classify', arguments: {} },
+    );
+    expect(classify.resultType).toBe('failure');
+    expect((classify as any).toolTelemetry.classification.reason).toContain('private customer data');
+    expect(JSON.stringify((classify as any).toolTelemetry)).not.toContain('Fabrikam tenant details');
+
+    const write = await registry.getTool('memory.write')!.handler(
+      { content: 'Searchable governed memory for telemetry metadata.', title: 'Telemetry Memory', class: 'LOCAL', author: 'seven' },
+      { sessionId: 's', toolCallId: 'w', toolName: 'memory.write', arguments: {} },
+    );
+    expect(write.resultType).toBe('success');
+
+    const search = await registry.getTool('memory.search')!.handler(
+      { query: 'telemetry metadata' },
+      { sessionId: 's', toolCallId: 'q', toolName: 'memory.search', arguments: {} },
+    );
+    expect(search.resultType).toBe('success');
+    expect((search as any).toolTelemetry.count).toBe(1);
+    expect(JSON.stringify((search as any).toolTelemetry)).not.toContain('Searchable governed memory');
+
+    const audit = await registry.getTool('memory.audit')!.handler(
+      {},
+      { sessionId: 's', toolCallId: 'a', toolName: 'memory.audit', arguments: {} },
+    );
+    expect((audit as any).textResultForLlm).toContain('classify');
+    expect((audit as any).textResultForLlm).toContain('search');
+    expect(JSON.stringify((audit as any).toolTelemetry)).not.toContain('Fabrikam tenant details');
+    expect(JSON.stringify((audit as any).toolTelemetry)).not.toContain('telemetry metadata');
+  });
+
+  it('writes, searches, and deletes local governed memory through tool bridge', async () => {
+    const write = await registry.getTool('memory.write')!.handler(
+      { content: 'Prefer governed memory for durable facts.', title: 'Governed Facts', class: 'LOCAL', author: 'data' },
+      { sessionId: 's', toolCallId: 'w', toolName: 'memory.write', arguments: {} },
+    );
+    expect(write.resultType).toBe('success');
+    const id = (write as any).toolTelemetry.id as string;
+
+    const search = await registry.getTool('memory.search')!.handler(
+      { query: 'durable facts' },
+      { sessionId: 's', toolCallId: 'q', toolName: 'memory.search', arguments: {} },
+    );
+    expect((search as any).toolTelemetry.count).toBe(1);
+
+    const del = await registry.getTool('memory.delete')!.handler(
+      { id, actor: 'data' },
+      { sessionId: 's', toolCallId: 'd', toolName: 'memory.delete', arguments: {} },
+    );
+    expect(del.resultType).toBe('success');
   });
 });
 


### PR DESCRIPTION
## Summary

This PR represents the full memory governance/provider work on `squad/memory-governance-provider`, not just diagnostics config.

It adds:

- Governed memory classes: `TRANSIENT`, `LOCAL`, `DECISION`, `POLICY`, `COPILOT_MEMORY`, `FORBIDDEN`
- Load guidance: `[ALWAYS]`, `[ON-DEMAND]`, `[ARCHIVE]`, `[NEVER]`
- Local memory store with classification, write/search/audit, promotion, deletion, tombstones, and safe audit records
- CLI bridge: `squad memory classify|write|search|audit|provider`
- Honest provider boundaries: local default, `provider=copilot` reported unavailable without a concrete callable API, host-injected adapter opt-in and fail-closed
- Safe diagnostics to stderr with `.squad/config.json` support
- Real Copilot CLI A/B harness with isolated `COPILOT_HOME`
- Deterministic memory-value benchmark for context size, retrieval quality, decision consistency, and stale/unsafe memory exclusion
- Tests, docs, proposals, template guidance, and changeset coverage

This work is based on Tamir Dresher's blog post, [The Ship's Computer Has a Memory Problem — Designing Memory for AI Agent Squads](https://www.tamirdresher.com/blog/2026/05/06/scaling-ai-part13-agent-memory). The core idea is that agent memory is runtime state with lifecycle, governance, and context-budget implications — not just more Markdown in the repo or more text in the prompt.

## Short guide: how to use it

Initialize or upgrade a Squad repo so local governance files are scaffolded:

```bash
squad init
# or, for an existing repo:
squad upgrade
```

By default, governance is local-only:

- memory config lives under `.squad/memory/`
- audit records are written locally
- local `.squad/` memory remains the source of truth
- Copilot Memory provider integration is not assumed or faked

Use the CLI bridge:

```bash
squad memory classify "Always run tests before merge"

squad memory write \
  --content "Use Vitest for SDK regression tests" \
  --class DECISION \
  --author scribe \
  --approved

squad memory search --query "Vitest"
squad memory audit
squad memory provider
```

## Diagnostics and logs

For one command:

```bash
squad memory search --query "Vitest" --log-level info
squad memory provider --verbose
```

For project-level diagnostics, add this to `.squad/config.json`:

```json
{
  "memory": {
    "logLevel": "info"
  }
}
```

Supported levels:

```text
none | error | info | debug
```

Precedence:

1. CLI `--log-level` / `--verbose`
2. `SQUAD_MEMORY_LOG_LEVEL`
3. `.squad/config.json` `memory.logLevel`
4. default `none`

Diagnostics go to stderr; JSON output remains on stdout. Diagnostics include safe metadata such as command name, provider, paths, result counts, load guidance, and timing. They intentionally do not print raw memory content or raw search text.

## How to measure memory value

Run the deterministic benchmark:

```bash
npm run build -w packages/squad-sdk
npm run experiment:memory-value
npm run experiment:memory-value -- --json
```

The benchmark compares naive baseline behavior (`load all memory into context`) against governed retrieval (`ALWAYS` + relevant `ON-DEMAND`, excluding `ARCHIVE`, `NEVER`, deleted, or superseded facts). It measures context payload, estimated token pressure, precision, recall, decision consistency, and stale/unsafe-memory avoidance.

Latest local result from this branch:

```text
Verdict: PASS
Context bytes: baseline=3540, governed=1601
Estimated tokens: baseline=885, governed=401
Context reduction: 54.8%
Precision: baseline=0.16, governed=0.41
Recall: baseline=1.00, governed=1.00
Decision consistency: baseline=0.50, governed=1.00
Stale/unsafe facts avoided: 12/12
```

## Validation evidence

Latest branch validation:

```bash
npm run build -w packages/squad-sdk
npm run lint
npm run test -- test/memory-value-benchmark.test.ts test/memory-governance.test.ts test/real-cli-ab.test.ts test/bench-runner.test.ts
npm run experiment:memory-value
npm run experiment:real-cli-ab -- --repo <repo> --variants memory-governance --dry-run
```

Results:

- SDK build: passed
- TypeScript lint: passed
- Related memory/harness tests: 41 passed
- Deterministic memory-value benchmark: PASS
- Real CLI A/B dry-run plan/artifact path generation: passed
- Previous full GitHub Actions Squad CI before this benchmark commit: passed ([run 26140594530](https://github.com/bradygaster/squad/actions/runs/26140594530))
- Current GitHub Actions Squad CI for head `56bd3136`: passed ([run 26141373561](https://github.com/bradygaster/squad/actions/runs/26141373561))

## Real CLI A/B evidence

The branch includes a real Copilot CLI paired A/B harness and prior reruns across two local Squad repos:

- ADC Squad runner demo:
  - baseline: 0 memory diagnostic events
  - memory-governance variant: 10 memory diagnostic events
- Squad repo:
  - baseline: 0 memory diagnostic events
  - memory-governance variant: 9 memory diagnostic events

This proves the harness, isolated `COPILOT_HOME` runs, memory command invocation diagnostics, and baseline-vs-governance signal separation.

## Current verdict

Stronger than before, but still honest.

This PR now proves:

- governed local memory operations work
- classification/isolation behavior is enforced
- forbidden/transient content is rejected or kept out of durable memory
- provider status is honest
- host-injected provider mode fails closed without a real host client
- diagnostics are configurable and safe
- the real CLI A/B harness can isolate runs and capture evidence
- deterministic governed retrieval can reduce context pressure while preserving recall and improving precision/decision consistency in seeded memory tasks

This PR still does not prove:

- real Copilot Memory provider write/search/delete integration
- statistically significant live-agent quality gains from external semantic memory
- long-run production improvement across many repositories and real issues

The right claim is: this makes the blog-post promise measurable and demonstrates the local governed-memory mechanism can reduce context size and improve memory selection quality in deterministic tests. Full live-agent longitudinal proof still requires repeated real-world paired runs once a callable provider/host adapter exists.

