### PR TITLE
fix(ci): update scribe-template test to read from scribe-charter.md

### DIFF
--- a/.changeset/fix-context-overflow-sentinel-1035.md
+++ b/.changeset/fix-context-overflow-sentinel-1035.md
@@ -1,0 +1,20 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+fix: context overflow sentinel and coordinator size reduction (retroactive for #1035)
+
+`squad.agent.md` was ~95.8KB and could be silently dropped from context in long sessions, degrading the coordinator to vanilla Copilot with no safety rails.
+
+Changes shipped in PR #1035 (merged without changeset):
+
+- **Canary sentinel** — `SQUAD_COORDINATOR_CANARY_a8f3` token appended to `squad.agent.md`; `copilot-instructions.md` checks for it and warns if the coordinator was dropped from context
+- **Coordinator slimming** — `squad.agent.md` reduced ~42% (95.8KB → ~55KB) by extracting to on-demand reference files: `spawn-reference.md`, `after-agent-reference.md`, `model-selection-reference.md`, `ralph-reference.md`, `worktree-reference.md`, `client-compatibility-reference.md`
+- **Scribe charter extraction** — Scribe's inline section moved from `squad.agent.md` to a standalone `scribe-charter.md`
+- **E2E skill overhaul** — Fast-fail rules, PII protection, anti-skip enforcement, live progress tracking comment (updated per step), duration tracking, Windows encoding fix, `--allow-all-tools` documentation, progressive verdicting, agent run time budget
+- **Build fix** — CLI dep changed from `@bradygaster/squad-sdk: >=0.9.0` to `>=0.9.0-0` so npm workspace resolution uses the local prerelease package instead of a stale published version
+
+All 4 template locations synced: `.squad-templates/`, `templates/`, `packages/squad-cli/templates/`, `packages/squad-sdk/templates/`.
+
+Closes #1017

--- a/.changeset/fix-scribe-test-charter-path.md
+++ b/.changeset/fix-scribe-test-charter-path.md
@@ -1,0 +1,9 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+fix(ci): update scribe-template test to read from scribe-charter.md
+
+PR #1035 moved the Scribe section from `.squad-templates/squad.agent.md` into a standalone `.squad-templates/scribe-charter.md` but the CI test was not updated. This caused the `test` CI job to fail with "Could not locate Scribe task block in template".
+
+Updated `test/ci/scribe-template.test.ts` to read from `scribe-charter.md` with new anchors and rewritten assertions matching the charter's actual numbered-step structure.

--- a/.changeset/fix-scribe-test-charter-path.md
+++ b/.changeset/fix-scribe-test-charter-path.md
@@ -2,8 +2,20 @@
 "@bradygaster/squad-cli": patch
 ---
 
-fix(ci): update scribe-template test to read from scribe-charter.md
+fix(ci): fix multiple CI test failures introduced by PR #1035 coordinator slimming
 
-PR #1035 moved the Scribe section from `.squad-templates/squad.agent.md` into a standalone `.squad-templates/scribe-charter.md` but the CI test was not updated. This caused the `test` CI job to fail with "Could not locate Scribe task block in template".
+PR #1035 extracted Scribe and spawn-template content out of `squad.agent.md` into
+standalone reference files but did not update the CI tests. Two tests failed:
 
-Updated `test/ci/scribe-template.test.ts` to read from `scribe-charter.md` with new anchors and rewritten assertions matching the charter's actual numbered-step structure.
+**`test/ci/scribe-template.test.ts`** — was reading from `squad.agent.md` with anchors
+that no longer exist. Fixed to read from `scribe-charter.md` with:
+- Number- and format-agnostic end-marker in `extractScribeTaskBlock`
+- Numbered-line assertions (verify phrases appear on actual `\d+.` list items)
+- Corrected file header comment (HEALTH REPORT and size thresholds ARE present)
+- New tests: HEALTH REPORT emission documented, Tier 1 (20KB) and Tier 2 (50KB)
+  archival thresholds documented (10 tests total, was 7)
+
+**`test/ci/datetime-template.test.ts`** — was counting `CURRENT_DATETIME:` lines in
+`squad.agent.md` only, expecting ≥4. After slimming only 2 remain there; the rest
+moved to `spawn-reference.md` and `after-agent-reference.md`. Fixed to combine all
+coordinator-owned template files for spawn-template assertions.

--- a/test/ci/datetime-template.test.ts
+++ b/test/ci/datetime-template.test.ts
@@ -18,7 +18,13 @@ function readTemplate(relPath: string): string {
 
 describe('current datetime template contract', () => {
   const squadTemplate = readTemplate('.squad-templates/squad.agent.md');
+  const spawnReference = readTemplate('.squad-templates/spawn-reference.md');
+  const afterAgentReference = readTemplate('.squad-templates/after-agent-reference.md');
   const scribeCharter = readTemplate('.squad-templates/scribe-charter.md');
+
+  // Coordinator + reference files that carry spawn templates and after-agent instructions.
+  // PR #1035 moved spawn-template details out of squad.agent.md into on-demand reference files.
+  const allCoordinatorTemplates = [squadTemplate, spawnReference, afterAgentReference].join('\n');
 
   it('requires resolving and validating the runtime current datetime once per session', () => {
     const sessionStart = squadTemplate.slice(
@@ -41,7 +47,9 @@ describe('current datetime template contract', () => {
   });
 
   it('keeps every coordinator spawn template wired with CURRENT_DATETIME', () => {
-    const currentDatetimeLines = squadTemplate
+    // PR #1035 moved spawn-template details to spawn-reference.md and after-agent-reference.md.
+    // Count across all coordinator-owned template files.
+    const currentDatetimeLines = allCoordinatorTemplates
       .split('\n')
       .filter(line => line.includes('CURRENT_DATETIME:'));
 
@@ -52,8 +60,9 @@ describe('current datetime template contract', () => {
   });
 
   it('tells agents to substitute the literal datetime in command examples', () => {
-    expect(squadTemplate).toContain('<literal CURRENT_DATETIME value from your prompt>');
-    expect(squadTemplate).toContain('Substitute the actual CURRENT_DATETIME value');
+    // These strings live in spawn-reference.md after PR #1035 moved spawn templates there.
+    expect(spawnReference).toContain('<literal CURRENT_DATETIME value from your prompt>');
+    expect(spawnReference).toContain('Substitute the actual CURRENT_DATETIME value');
   });
 
   it('keeps Scribe from writing placeholder datetime headings', () => {

--- a/test/ci/scribe-template.test.ts
+++ b/test/ci/scribe-template.test.ts
@@ -2,7 +2,8 @@
  * CI tests for the Scribe charter in scribe-charter.md.
  *
  * Verifies that:
- *  - The numbered task list is present in the "How I Work" section
+ *  - The numbered task list is present in the task block starting with
+ *    "After every substantial work session:"
  *  - HARD GATE enforcement is documented (decisions archival ceiling)
  *  - Decision inbox merge is a numbered step
  *  - Deduplication is a numbered step
@@ -33,17 +34,22 @@ function readTemplate(): string {
 /**
  * Extract the Scribe numbered task block from the charter.
  * Returns the substring from "After every substantial work session:"
- * up to and including the "Never speak to the user." step.
+ * up to and including the line containing "Never speak to the user."
+ * (number- and formatting-agnostic — works regardless of step count or bold markers).
  */
 function extractScribeTaskBlock(content: string): string {
   const startMarker = 'After every substantial work session:';
-  const endMarker = '6. **Never speak to the user.**';
   const start = content.indexOf(startMarker);
-  const end = content.indexOf(endMarker, start);
-  if (start === -1 || end === -1) {
-    throw new Error('Could not locate Scribe task block in charter');
-  }
-  return content.slice(start, end + endMarker.length);
+  if (start === -1) throw new Error('Could not locate task block start marker in charter');
+
+  // Find the line containing "Never speak to the user." after the start marker,
+  // without relying on its step number or Markdown formatting.
+  const afterStart = content.slice(start);
+  const lines = afterStart.split('\n');
+  const endLineIdx = lines.findIndex(l => l.includes('Never speak to the user.'));
+  if (endLineIdx === -1) throw new Error('Could not locate "Never speak to the user." in charter');
+
+  return lines.slice(0, endLineIdx + 1).join('\n');
 }
 
 describe('Scribe charter — task structure and HARD GATE enforcement', () => {
@@ -58,15 +64,21 @@ describe('Scribe charter — task structure and HARD GATE enforcement', () => {
   });
 
   it('decision inbox merge is a numbered step', () => {
-    expect(taskBlock, 'Decision inbox merge step not found').toContain('Merge the decision inbox');
+    const numberedLines = taskBlock.split('\n').filter(l => l.trim().match(/^\d+\./));
+    const hasStep = numberedLines.some(l => l.includes('Merge the decision inbox'));
+    expect(hasStep, 'Decision inbox merge must appear on a numbered step line').toBe(true);
   });
 
   it('deduplication step is present', () => {
-    expect(taskBlock, 'Deduplication step not found').toContain('Deduplicate');
+    const numberedLines = taskBlock.split('\n').filter(l => l.trim().match(/^\d+\./));
+    const hasStep = numberedLines.some(l => l.includes('Deduplicate'));
+    expect(hasStep, 'Deduplication must appear on a numbered step line').toBe(true);
   });
 
   it('commit step is present', () => {
-    expect(taskBlock, 'Commit step not found').toContain('Commit');
+    const numberedLines = taskBlock.split('\n').filter(l => l.trim().match(/^\d+\./));
+    const hasStep = numberedLines.some(l => l.includes('Commit'));
+    expect(hasStep, 'Commit must appear on a numbered step line').toBe(true);
   });
 
   it('HARD GATE enforcement is documented in the charter', () => {

--- a/test/ci/scribe-template.test.ts
+++ b/test/ci/scribe-template.test.ts
@@ -15,8 +15,9 @@
  *
  * Note: The Scribe section was extracted from squad.agent.md into this
  * standalone charter in PR #1035. The original test checked for
- * PRE-CHECK / HEALTH REPORT / GIT COMMIT task labels and an exact
- * 20480-byte threshold, which are not present in the new charter.
+ * PRE-CHECK / GIT COMMIT section labels (bold headers), which no longer
+ * exist in the new prose-based charter structure. HEALTH REPORT and the
+ * archival size thresholds (20KB / 50KB) are still present and tested below.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -83,6 +84,18 @@ describe('Scribe charter — task structure and HARD GATE enforcement', () => {
 
   it('HARD GATE enforcement is documented in the charter', () => {
     expect(content, 'HARD GATE label missing from charter').toContain('HARD GATE');
+  });
+
+  it('HEALTH REPORT emission is documented after archival runs', () => {
+    expect(content, 'HEALTH REPORT must be documented in charter').toContain('HEALTH REPORT');
+  });
+
+  it('Tier 1 archival threshold (20KB) is documented', () => {
+    expect(content, 'Tier 1 20KB archival threshold missing from charter').toContain('20KB');
+  });
+
+  it('Tier 2 archival threshold (50KB) is documented', () => {
+    expect(content, 'Tier 2 50KB archival threshold missing from charter').toContain('50KB');
   });
 
   it('"Never speak to the user." is the final numbered step', () => {

--- a/test/ci/scribe-template.test.ts
+++ b/test/ci/scribe-template.test.ts
@@ -1,15 +1,21 @@
 /**
- * CI tests for the Scribe spawn template in squad.agent.md.
+ * CI tests for the Scribe charter in scribe-charter.md.
  *
  * Verifies that:
- *  - DECISIONS ARCHIVE runs BEFORE DECISION INBOX (archival first, while context is fresh)
- *  - HARD GATE label is present on the archive task (haiku cannot claim discretion)
- *  - Exact byte threshold 20480 is used (not the fuzzy ~20KB)
- *  - PRE-CHECK is task 0 (measure before acting)
- *  - HEALTH REPORT is the final task (observe after)
- *  - GIT COMMIT precedes HEALTH REPORT
+ *  - The numbered task list is present in the "How I Work" section
+ *  - HARD GATE enforcement is documented (decisions archival ceiling)
+ *  - Decision inbox merge is a numbered step
+ *  - Deduplication is a numbered step
+ *  - A commit step is present
+ *  - "Never speak to the user." is the final numbered step (Scribe stays invisible)
+ *  - Commit step precedes the "never speak" step
  *
- * Canonical source: .squad-templates/squad.agent.md
+ * Canonical source: .squad-templates/scribe-charter.md
+ *
+ * Note: The Scribe section was extracted from squad.agent.md into this
+ * standalone charter in PR #1035. The original test checked for
+ * PRE-CHECK / HEALTH REPORT / GIT COMMIT task labels and an exact
+ * 20480-byte threshold, which are not present in the new charter.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -21,68 +27,68 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '../..');
 
 function readTemplate(): string {
-  return readFileSync(resolve(ROOT, '.squad-templates/squad.agent.md'), 'utf-8');
+  return readFileSync(resolve(ROOT, '.squad-templates/scribe-charter.md'), 'utf-8');
 }
 
 /**
- * Extract the Scribe task block from the template.
- * Returns the substring from "Tasks (in order):" up to (not including) "Never speak to user."
+ * Extract the Scribe numbered task block from the charter.
+ * Returns the substring from "After every substantial work session:"
+ * up to and including the "Never speak to the user." step.
  */
 function extractScribeTaskBlock(content: string): string {
-  const start = content.indexOf('Tasks (in order):');
-  const end = content.indexOf('Never speak to user.', start);
+  const startMarker = 'After every substantial work session:';
+  const endMarker = '6. **Never speak to the user.**';
+  const start = content.indexOf(startMarker);
+  const end = content.indexOf(endMarker, start);
   if (start === -1 || end === -1) {
-    throw new Error('Could not locate Scribe task block in template');
+    throw new Error('Could not locate Scribe task block in charter');
   }
-  return content.slice(start, end);
+  return content.slice(start, end + endMarker.length);
 }
 
-describe('Scribe spawn template — HARD GATE enforcement', () => {
+describe('Scribe charter — task structure and HARD GATE enforcement', () => {
   const content = readTemplate();
   const taskBlock = extractScribeTaskBlock(content);
 
-  it('DECISIONS ARCHIVE appears before DECISION INBOX in the task list', () => {
-    const archiveIndex = taskBlock.indexOf('DECISIONS ARCHIVE');
-    const inboxIndex = taskBlock.indexOf('DECISION INBOX');
-    expect(archiveIndex, 'DECISIONS ARCHIVE not found in task block').toBeGreaterThan(-1);
-    expect(inboxIndex, 'DECISION INBOX not found in task block').toBeGreaterThan(-1);
-    expect(archiveIndex, 'DECISIONS ARCHIVE must come before DECISION INBOX').toBeLessThan(inboxIndex);
-  });
-
-  it('DECISIONS ARCHIVE task carries the [HARD GATE] label', () => {
-    const archiveLine = taskBlock
+  it('numbered task list is present', () => {
+    const numberedLines = taskBlock
       .split('\n')
-      .find(line => line.includes('DECISIONS ARCHIVE'));
-    expect(archiveLine, 'DECISIONS ARCHIVE line not found').toBeDefined();
-    expect(archiveLine, '[HARD GATE] label missing on DECISIONS ARCHIVE').toContain('[HARD GATE]');
+      .filter(l => l.trim().match(/^\d+\./));
+    expect(numberedLines.length, 'No numbered tasks found in task block').toBeGreaterThan(0);
   });
 
-  it('exact byte threshold 20480 is used — not the fuzzy ~20KB', () => {
-    expect(taskBlock, '20480 byte threshold not found').toContain('20480');
-    expect(taskBlock, 'fuzzy ~20KB must be replaced with exact byte count').not.toMatch(/~20KB/);
+  it('decision inbox merge is a numbered step', () => {
+    expect(taskBlock, 'Decision inbox merge step not found').toContain('Merge the decision inbox');
   });
 
-  it('PRE-CHECK is task 0 (the first numbered task)', () => {
+  it('deduplication step is present', () => {
+    expect(taskBlock, 'Deduplication step not found').toContain('Deduplicate');
+  });
+
+  it('commit step is present', () => {
+    expect(taskBlock, 'Commit step not found').toContain('Commit');
+  });
+
+  it('HARD GATE enforcement is documented in the charter', () => {
+    expect(content, 'HARD GATE label missing from charter').toContain('HARD GATE');
+  });
+
+  it('"Never speak to the user." is the final numbered step', () => {
     const numberedLines = taskBlock
       .split('\n')
       .filter(l => l.trim().match(/^\d+\./));
     expect(numberedLines.length, 'No numbered tasks found').toBeGreaterThan(0);
-    expect(numberedLines[0], 'First task must be PRE-CHECK').toContain('PRE-CHECK');
+    expect(
+      numberedLines[numberedLines.length - 1],
+      'Last numbered step must be "Never speak to the user."'
+    ).toContain('Never speak to the user');
   });
 
-  it('HEALTH REPORT is the final task in the list', () => {
-    const numberedLines = taskBlock
-      .split('\n')
-      .filter(l => l.trim().match(/^\d+\./));
-    expect(numberedLines.length, 'No numbered tasks found').toBeGreaterThan(0);
-    expect(numberedLines[numberedLines.length - 1], 'Last task must be HEALTH REPORT').toContain('HEALTH REPORT');
-  });
-
-  it('GIT COMMIT appears before HEALTH REPORT', () => {
-    const commitIndex = taskBlock.indexOf('GIT COMMIT');
-    const healthIndex = taskBlock.indexOf('HEALTH REPORT');
-    expect(commitIndex, 'GIT COMMIT not found').toBeGreaterThan(-1);
-    expect(healthIndex, 'HEALTH REPORT not found').toBeGreaterThan(-1);
-    expect(commitIndex, 'GIT COMMIT must precede HEALTH REPORT').toBeLessThan(healthIndex);
+  it('commit step precedes "Never speak to the user."', () => {
+    const commitIndex = taskBlock.indexOf('Commit');
+    const neverSpeakIndex = taskBlock.indexOf('Never speak to the user.');
+    expect(commitIndex, 'Commit step not found in task block').toBeGreaterThan(-1);
+    expect(neverSpeakIndex, '"Never speak to the user." not found in task block').toBeGreaterThan(-1);
+    expect(commitIndex, 'Commit must precede "Never speak to the user."').toBeLessThan(neverSpeakIndex);
   });
 });


### PR DESCRIPTION
## Summary

Fixes two CI test failures introduced by PR #1035 (coordinator slimming / context overflow sentinel) that were not caught before merge.

Closes #1151

## Root Cause

PR #1035 extracted Scribe content and spawn-template content out of `squad.agent.md` into standalone reference files (`scribe-charter.md`, `spawn-reference.md`, `after-agent-reference.md`) but did not update the CI tests.

## Changes

### `test/ci/scribe-template.test.ts`

Was reading `squad.agent.md` with anchors that no longer exist after the Scribe section was extracted to `scribe-charter.md`. Now reads the correct file with:

- **Number- and format-agnostic end-marker** in `extractScribeTaskBlock` — no longer brittle to step numbering or bold formatting changes
- **Numbered-line assertions** — verify phrases appear on actual `\d+.` list items, not anywhere in the block
- **Corrected file header comment** — previous comment incorrectly stated HEALTH REPORT and size thresholds were absent; they are present and now tested
- **New tests added**: HEALTH REPORT emission documented, Tier 1 archival threshold (20KB), Tier 2 archival threshold (50KB) — 10 tests total (was 7)

### `test/ci/datetime-template.test.ts`

Was counting `CURRENT_DATETIME:` lines in `squad.agent.md` only, expecting ≥4. After slimming, only 2 remain in `squad.agent.md`; the rest moved to `spawn-reference.md` and `after-agent-reference.md`. Fixed to combine all coordinator-owned template files for spawn-template assertions.

## Also includes

A **retroactive changeset** for PR #1035 (merged without one), covering both `@bradygaster/squad-cli` and `@bradygaster/squad-sdk` at patch level.

## Testing

All 10 tests in `scribe-template.test.ts` and all 5 tests in `datetime-template.test.ts` pass locally.

> **Note:** Policy gate failures on this PR are due to the prerelease version (`0.9.6-build.4`) — that is addressed separately in PR #1155.