### PR TITLE
feat: interactive agent runner menu and custom runner support

### DIFF
--- a/.squad/ralph-circuit-breaker.json
+++ b/.squad/ralph-circuit-breaker.json
@@ -1,0 +1,9 @@
+{
+  "status": "closed",
+  "openedAt": null,
+  "cooldownMinutes": 2,
+  "consecutiveFailures": 0,
+  "consecutiveSuccesses": 0,
+  "lastRateLimitRemaining": 5000,
+  "lastRateLimitTotal": 5000
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.9.6-build.3",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bradygaster/squad",
-      "version": "0.9.6-build.3",
+      "version": "0.9.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -8961,11 +8961,11 @@
     },
     "packages/squad-cli": {
       "name": "@bradygaster/squad-cli",
-      "version": "0.9.6-build.3",
+      "version": "0.9.6-build.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bradygaster/squad-sdk": "file:../squad-sdk",
+        "@bradygaster/squad-sdk": ">=0.9.0-0",
         "ink": "^6.8.0",
         "react": "^19.2.4",
         "vscode-jsonrpc": "^8.2.1"
@@ -8991,7 +8991,7 @@
     },
     "packages/squad-sdk": {
       "name": "@bradygaster/squad-sdk",
-      "version": "0.9.6-build.3",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.9.6",
+  "version": "0.9.6-build.19",
   "private": true,
   "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.9.6-build.4",
+  "version": "0.9.6-build.19",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -322,11 +322,13 @@ async function main(): Promise<void> {
     const roles = args.includes('--roles');
     const presetIdx = args.indexOf('--preset');
     const presetName = (presetIdx !== -1 && args[presetIdx + 1]) ? args[presetIdx + 1] : undefined;
+    const runnerIdx = args.indexOf('--agent-runner');
+    const initAgentRunner = (runnerIdx !== -1 && args[runnerIdx + 1]) ? args[runnerIdx + 1] : undefined;
     // Parse --state-backend flag for init
     const sbIdx = args.indexOf('--state-backend');
     const initStateBackend = (sbIdx !== -1 && args[sbIdx + 1]) ? args[sbIdx + 1] : undefined;
     // Global init: suppress workflows (no GitHub CI in ~/.config/squad/) and bootstrap personal squad
-    runInit(dest, { includeWorkflows: !noWorkflows && !hasGlobal, sdk, roles, isGlobal: hasGlobal, stateBackend: initStateBackend }).then(async () => {
+    runInit(dest, { includeWorkflows: !noWorkflows && !hasGlobal, sdk, roles, isGlobal: hasGlobal, stateBackend: initStateBackend, agentRunner: initAgentRunner }).then(async () => {
       if (presetName) {
         const { seedBuiltinPresets, applyPreset } = await import('@bradygaster/squad-sdk/presets');
         const { resolvePresetsDir, ensureSquadHome } = await import('@bradygaster/squad-sdk/resolution');

--- a/packages/squad-cli/src/cli/commands/loop.ts
+++ b/packages/squad-cli/src/cli/commands/loop.ts
@@ -52,6 +52,8 @@ export interface LoopConfig {
   copilotFlags?: string;
   /** Fully override the agent command (e.g., `gh copilot --yolo`). */
   agentCmd?: string;
+  /** Explicit subagent runner: copilot or antigravity. */
+  agentRunner?: 'copilot' | 'antigravity';
   /** Capability overrides, keyed by capability name. */
   capabilities: Record<string, boolean | Record<string, unknown>>;
 }
@@ -130,19 +132,52 @@ export function generateLoopFile(): string {
 
 // ── Agent Command Builder ────────────────────────────────────────
 
+/** Resolve the Antigravity IDE executable and args prefix.
+ *
+ * The .cmd wrapper does:
+ *   ELECTRON_RUN_AS_NODE=1 "Antigravity IDE.exe" "resources/app/out/cli.js" [args...]
+ *
+ * We replicate this directly so execFile can handle the path with spaces via CreateProcess,
+ * without going through cmd.exe which breaks on unquoted spaces.
+ */
+function resolveAntigravityExec(): { cmd: string; envOverrides: Record<string, string>; argPrefix: string[] } {
+  const localAppData = process.env['LOCALAPPDATA'];
+  if (localAppData) {
+    const base = path.join(localAppData, 'Programs', 'Antigravity IDE');
+    const exe = path.join(base, 'Antigravity IDE.exe');
+    const cliJs = path.join(base, 'resources', 'app', 'out', 'cli.js');
+    if (existsSync(exe) && existsSync(cliJs)) {
+      return {
+        cmd: exe,
+        envOverrides: { ELECTRON_RUN_AS_NODE: '1', VSCODE_DEV: '' },
+        argPrefix: [cliJs],
+      };
+    }
+  }
+  return { cmd: 'antigravity-ide', envOverrides: {}, argPrefix: [] };
+}
+
 function buildLoopAgentCommand(
-  prompt: string,
-  options: { agentCmd?: string; copilotFlags?: string },
-): { cmd: string; args: string[] } {
+  options: { agentCmd?: string; agentRunner?: 'copilot' | 'antigravity'; copilotFlags?: string },
+): { cmd: string; args: string[]; env?: Record<string, string>; useStdin: boolean } {
   if (options.agentCmd) {
     const parts = options.agentCmd.trim().split(/\s+/);
-    return { cmd: parts[0]!, args: [...parts.slice(1), '-p', prompt] };
+    return { cmd: parts[0]!, args: parts.slice(1), useStdin: false };
   }
-  const args = ['-p', prompt];
+  if (options.agentRunner === 'antigravity') {
+    const { cmd, envOverrides, argPrefix } = resolveAntigravityExec();
+    return {
+      cmd,
+      args: [...argPrefix, 'chat', '-m', 'agent', '-'],
+      env: envOverrides,
+      useStdin: true,
+    };
+  }
+  const args: string[] = [];
   if (options.copilotFlags) {
     args.push(...options.copilotFlags.trim().split(/\s+/));
   }
-  return { cmd: 'copilot', args };
+  return { cmd: 'copilot', args, useStdin: false };
 }
 
 // ── Capability Phase Runner ──────────────────────────────────────
@@ -330,6 +365,7 @@ export async function runLoop(dest: string, options: LoopConfig): Promise<void> 
     timeout: timeoutMinutes,
     copilotFlags: options.copilotFlags,
     agentCmd: options.agentCmd,
+    agentRunner: options.agentRunner,
     capabilities: options.capabilities,
   };
 
@@ -353,6 +389,7 @@ export async function runLoop(dest: string, options: LoopConfig): Promise<void> 
     roster: roster.map(r => ({ name: r.name, label: r.label, expertise: [] as string[] })),
     config: {},
     agentCmd: options.agentCmd,
+    agentRunner: options.agentRunner,
     copilotFlags: options.copilotFlags,
   };
 
@@ -382,17 +419,24 @@ export async function runLoop(dest: string, options: LoopConfig): Promise<void> 
 
     // Core: run the loop prompt
     const timeoutMs = timeoutMinutes * 60_000;
-    const { cmd, args } = buildLoopAgentCommand(prompt, {
+    const { cmd, args, env: envOverrides, useStdin } = buildLoopAgentCommand({
       agentCmd: options.agentCmd,
+      agentRunner: options.agentRunner,
       copilotFlags: options.copilotFlags,
     });
     console.log(`${GREEN}▶${RESET} [${ts}] Round ${round} — running loop prompt`);
 
+    // Merge env overrides (e.g. ELECTRON_RUN_AS_NODE for antigravity)
+    const childEnv = envOverrides ? { ...process.env, ...envOverrides } : undefined;
+
+    // For antigravity: prompt goes to stdin; for copilot: pass as -p arg
+    const finalArgs = useStdin ? args : ['-p', prompt, ...args];
+
     await new Promise<void>((resolve) => {
       currentChild = execFile(
         cmd,
-        args,
-        { cwd: teamRoot, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024 },
+        finalArgs,
+        { cwd: teamRoot, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024, env: childEnv },
         (err) => {
           currentChild = null;
           if (err) {
@@ -407,6 +451,12 @@ export async function runLoop(dest: string, options: LoopConfig): Promise<void> 
           resolve();
         },
       );
+
+      // Write prompt to stdin for antigravity, then close
+      if (useStdin && currentChild.stdin) {
+        currentChild.stdin.write(prompt, 'utf8');
+        currentChild.stdin.end();
+      }
 
       currentChild.stdout?.on('data', (chunk: Buffer | string) => {
         process.stdout.write(chunk);

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/execute.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/execute.ts
@@ -46,22 +46,56 @@ export function classifyIssue(title: string): 'read' | 'write' {
   return 'write'; // default to write (safer — gets full agent session)
 }
 
-/** Build agent command for a prompt. */
+/** Resolve the Antigravity IDE executable and args prefix.
+ *
+ * The .cmd wrapper does:
+ *   ELECTRON_RUN_AS_NODE=1 "Antigravity IDE.exe" "resources/app/out/cli.js" [args...]
+ *
+ * We replicate this directly so execFile can handle the path with spaces via CreateProcess,
+ * without going through cmd.exe which breaks on unquoted spaces.
+ */
+function resolveAntigravityExec(): { cmd: string; envOverrides: Record<string, string>; argPrefix: string[] } {
+  const localAppData = process.env['LOCALAPPDATA'];
+  if (localAppData) {
+    const base = path.join(localAppData, 'Programs', 'Antigravity IDE');
+    const exe = path.join(base, 'Antigravity IDE.exe');
+    const cliJs = path.join(base, 'resources', 'app', 'out', 'cli.js');
+    if (existsSync(exe) && existsSync(cliJs)) {
+      return {
+        cmd: exe,
+        envOverrides: { ELECTRON_RUN_AS_NODE: '1', VSCODE_DEV: '' },
+        argPrefix: [cliJs],
+      };
+    }
+  }
+  // Fallback: hope antigravity-ide is on PATH
+  return { cmd: 'antigravity-ide', envOverrides: {}, argPrefix: [] };
+}
+
+/** Build agent command — for antigravity, uses stdin piping (prompt not passed as arg). */
 function buildAgentCommand(
-  prompt: string,
   context: WatchContext,
-): { cmd: string; args: string[] } {
+): { cmd: string; args: string[]; env?: Record<string, string>; useStdin: boolean } {
   if (context.agentCmd) {
     const parts = context.agentCmd.trim().split(/\s+/);
-    const cmd = parts[0]!;
-    const args = [...parts.slice(1), '-p', prompt];
-    return { cmd, args };
+    return { cmd: parts[0]!, args: parts.slice(1), useStdin: false };
   }
-  const args = ['-p', prompt];
+  if (context.agentRunner === 'antigravity') {
+    // Resolve the exe directly — execFile uses CreateProcess which handles spaces in paths.
+    // Prompt is written to stdin using the '-' argument, avoiding all shell quoting issues.
+    const { cmd, envOverrides, argPrefix } = resolveAntigravityExec();
+    return {
+      cmd,
+      args: [...argPrefix, 'chat', '-m', 'agent', '-'],
+      env: envOverrides,
+      useStdin: true,
+    };
+  }
+  const args: string[] = [];
   if (context.copilotFlags) {
     args.push(...context.copilotFlags.trim().split(/\s+/));
   }
-  return { cmd: 'copilot', args };
+  return { cmd: 'copilot', args, useStdin: false };
 }
 
 /** Labels that indicate an issue should not be auto-executed. */
@@ -161,13 +195,19 @@ async function executeAll(
   }
 
   const fullPrompt = charterPrefix + prompt;
-  const { cmd, args } = buildAgentCommand(fullPrompt, context);
+  const { cmd, args, env: envOverrides, useStdin } = buildAgentCommand(context);
+
+  // Merge any env overrides (e.g. ELECTRON_RUN_AS_NODE for antigravity) with the current env
+  const childEnv = envOverrides ? { ...process.env, ...envOverrides } : undefined;
 
   return new Promise<{ success: boolean; error?: string }>((resolve) => {
+    // For antigravity: prompt goes to stdin; for copilot: pass as -p arg
+    const finalArgs = useStdin ? args : ['-p', fullPrompt, ...args];
+
     const cp: ChildProcess = execFile(
       cmd,
-      args,
-      { cwd: context.teamRoot, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024 },
+      finalArgs,
+      { cwd: context.teamRoot, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024, env: childEnv },
       (err) => {
         if (err) {
           const execErr = err as Error & { killed?: boolean };
@@ -179,10 +219,16 @@ async function executeAll(
       },
     );
 
+    // Write prompt to stdin for antigravity, then close
+    if (useStdin && cp.stdin) {
+      cp.stdin.write(fullPrompt, 'utf8');
+      cp.stdin.end();
+    }
+
     // Track child PID for cleanup on exit/crash
     if (context.pidTracker && cp.pid) {
       const issueNums = issues.map(i => `#${i.number}`).join(',');
-      context.pidTracker.track(cp.pid, `copilot-session-${issueNums}`);
+      context.pidTracker.track(cp.pid, `agent-session-${issueNums}`);
     }
 
     cp.on('exit', () => {
@@ -195,12 +241,19 @@ async function executeAll(
 
 export class ExecuteCapability implements WatchCapability {
   readonly name = 'execute';
-  readonly description = 'Spawn Copilot sessions to work on eligible issues';
+  readonly description = 'Spawn agent sessions to work on eligible issues';
   readonly configShape = 'boolean' as const;
-  readonly requires = ['gh'];
+  readonly requires = ['gh or antigravity-ide'];
   readonly phase = 'post-execute' as const;
 
-  async preflight(_context: WatchContext): Promise<PreflightResult> {
+  async preflight(context: WatchContext): Promise<PreflightResult> {
+    if (context.agentRunner === 'antigravity') {
+      const { cmd } = resolveAntigravityExec();
+      const found = existsSync(cmd) || cmd === 'antigravity-ide';
+      return found
+        ? { ok: true }
+        : { ok: false, reason: `Antigravity IDE executable not found at: ${cmd}` };
+    }
     return new Promise<PreflightResult>((resolve) => {
       execFile('gh', ['--version'], (err) => {
         resolve(err ? { ok: false, reason: 'gh CLI not found' } : { ok: true });

--- a/packages/squad-cli/src/cli/commands/watch/config.ts
+++ b/packages/squad-cli/src/cli/commands/watch/config.ts
@@ -22,6 +22,8 @@ export interface WatchConfig {
   copilotFlags?: string;
   /** Hidden — fully override the agent command. */
   agentCmd?: string;
+  /** Explicit subagent runner: copilot or antigravity. */
+  agentRunner?: 'copilot' | 'antigravity';
   /** Dispatch mode: 'task' (default 1:1), 'fleet' (batch read-only), 'hybrid' (auto-classify). */
   dispatchMode?: DispatchMode;
   /** Optional path to a log file. When set, console output is tee'd to the file with timestamps. */
@@ -88,6 +90,7 @@ export function loadWatchConfig(
     timeout: cliOverrides.timeout ?? fileConfig.timeout ?? DEFAULTS.timeout,
     copilotFlags: cliOverrides.copilotFlags ?? fileConfig.copilotFlags ?? DEFAULTS.copilotFlags,
     agentCmd: cliOverrides.agentCmd ?? fileConfig.agentCmd ?? DEFAULTS.agentCmd,
+    agentRunner: cliOverrides.agentRunner ?? fileConfig.agentRunner,
     dispatchMode: cliOverrides.dispatchMode ?? fileConfig.dispatchMode ?? DEFAULTS.dispatchMode,
     logFile: cliOverrides.logFile ?? fileConfig.logFile ?? DEFAULTS.logFile,
     capabilities: {
@@ -118,6 +121,7 @@ function normalizeFileConfig(raw: Record<string, unknown>): Partial<WatchConfig>
   if (typeof raw['timeout'] === 'number') result.timeout = raw['timeout'];
   if (typeof raw['copilotFlags'] === 'string') result.copilotFlags = raw['copilotFlags'];
   if (typeof raw['agentCmd'] === 'string') result.agentCmd = raw['agentCmd'];
+  if (typeof raw['agentRunner'] === 'string' && (raw['agentRunner'] === 'copilot' || raw['agentRunner'] === 'antigravity')) result.agentRunner = raw['agentRunner'];
   if (typeof raw['verbose'] === 'boolean') result.verbose = raw['verbose'];
   if (typeof raw['dispatchMode'] === 'string') {
     const mode = raw['dispatchMode'] as string;
@@ -146,7 +150,7 @@ function normalizeFileConfig(raw: Record<string, unknown>): Partial<WatchConfig>
 
   // Everything else is a capability key
   const caps: Record<string, boolean | Record<string, unknown>> = {};
-  const reserved = new Set(['interval', 'execute', 'maxConcurrent', 'timeout', 'copilotFlags', 'agentCmd', 'verbose', 'dispatchMode', 'logFile', 'authUser', 'notifyLevel', 'overnightStart', 'overnightEnd', 'sentinelFile', 'stateBackend']);
+  const reserved = new Set(['interval', 'execute', 'maxConcurrent', 'timeout', 'copilotFlags', 'agentCmd', 'agentRunner', 'verbose', 'dispatchMode', 'logFile', 'authUser', 'notifyLevel', 'overnightStart', 'overnightEnd', 'sentinelFile', 'stateBackend']);
   for (const [key, value] of Object.entries(raw)) {
     if (reserved.has(key)) continue;
     if (typeof value === 'boolean' || (typeof value === 'object' && value !== null && !Array.isArray(value))) {

--- a/packages/squad-cli/src/cli/commands/watch/index.ts
+++ b/packages/squad-cli/src/cli/commands/watch/index.ts
@@ -564,6 +564,7 @@ export interface WatchOptions {
   execute?: boolean;
   copilotFlags?: string;
   agentCmd?: string;
+  agentRunner?: 'copilot' | 'antigravity';
   maxConcurrent?: number;
   issueTimeoutMinutes?: number;
   monitorTeams?: boolean;
@@ -596,6 +597,7 @@ function legacyToConfig(options: WatchOptions): WatchConfig {
     timeout: options.issueTimeoutMinutes ?? 30,
     copilotFlags: options.copilotFlags,
     agentCmd: options.agentCmd,
+    agentRunner: options.agentRunner,
     capabilities,
   };
 }
@@ -616,6 +618,9 @@ export function buildAgentCommand(
   }
   const args = ['-p', prompt];
   if (options.copilotFlags) args.push(...options.copilotFlags.trim().split(/\s+/));
+  if (options.agentRunner === 'antigravity') {
+    return { cmd: 'antigravity', args };
+  }
   return { cmd: 'copilot', args };
 }
 
@@ -710,6 +715,7 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     interval: `${config.interval}m`,
     execute: config.execute ?? false,
     agentCmd: config.agentCmd ?? '(default: gh copilot)',
+    agentRunner: config.agentRunner ?? '(default: copilot)',
     dispatchMode: config.capabilities['wave-dispatch'] ? 'wave' : 'task',
     maxConcurrent: config.maxConcurrent ?? 1,
   });
@@ -808,6 +814,7 @@ export async function runWatch(dest: string, options: WatchOptions | WatchConfig
     roster: roster.map(r => ({ name: r.name, label: r.label, expertise: [] as string[] })),
     config: {},
     agentCmd: config.agentCmd,
+    agentRunner: config.agentRunner,
     copilotFlags: config.copilotFlags,
     verbose: config.verbose,
     pidTracker,

--- a/packages/squad-cli/src/cli/commands/watch/types.ts
+++ b/packages/squad-cli/src/cli/commands/watch/types.ts
@@ -36,6 +36,8 @@ export interface WatchContext {
   config: Record<string, unknown>;
   /** Hidden --agent-cmd override. */
   agentCmd?: string;
+  /** Explicit subagent runner: copilot or antigravity. */
+  agentRunner?: 'copilot' | 'antigravity';
   copilotFlags?: string;
   /** Verbose diagnostic output enabled. */
   verbose?: boolean;

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Init command implementation — uses SDK
  * Scaffolds a new Squad project with templates, workflows, and directory structure
  */
@@ -11,7 +11,16 @@ import { success, BOLD, RESET, YELLOW, GREEN, DIM } from './output.js';
 import { fatal } from './errors.js';
 import { detectProjectType } from './project-type.js';
 import { getPackageVersion, stampVersion } from './version.js';
-import { initSquad as sdkInitSquad, cleanupOrphanInitPrompt, ensurePersonalSquadDir, resolvePersonalSquadDir, clearResolveSquadCache, type InitOptions } from '@bradygaster/squad-sdk';
+import { 
+  type InitOptions, 
+  initSquad as sdkInitSquad, 
+  cleanupOrphanInitPrompt, 
+  ensurePersonalSquadDir, 
+  resolvePersonalSquadDir, 
+  clearResolveSquadCache,
+  KNOWN_AGENT_RUNNERS,
+  DEFAULT_AGENT_RUNNER
+} from '@bradygaster/squad-sdk';
 import { installGitHooks } from '../commands/install-hooks.js';
 
 const storage = new FSStorageProvider();
@@ -111,6 +120,8 @@ export interface RunInitOptions {
   isGlobal?: boolean;
   /** State backend to configure at init time (local, orphan, two-layer) */
   stateBackend?: string;
+  /** Expected agent runner platform */
+  agentRunner?: string;
 }
 
 /**
@@ -200,6 +211,40 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
     showDeprecationWarning();
   }
 
+  let finalAgentRunner = options.agentRunner;
+  if (!finalAgentRunner && process.stdin.isTTY) {
+    console.log();
+    console.log(`  Which agent runner will you use with this squad?`);
+    for (const runner of KNOWN_AGENT_RUNNERS) {
+      const isDefault = runner.id === DEFAULT_AGENT_RUNNER.id ? ' (default)' : '';
+      console.log(`  ${BOLD}[${runner.shortcut}]${RESET} ${runner.name}${isDefault}`);
+    }
+    console.log(`  ${BOLD}[o]${RESET} Other custom runner`);
+    console.log();
+    
+    const shortcuts = [...KNOWN_AGENT_RUNNERS.map(r => r.shortcut), 'o'].join('/');
+    
+    const { createInterface } = await import('node:readline/promises');
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      let answer = (await rl.question(`  Selection [${shortcuts}, default: ${DEFAULT_AGENT_RUNNER.shortcut}]: `)).trim().toLowerCase();
+      
+      const selected = KNOWN_AGENT_RUNNERS.find(r => r.shortcut === answer || r.id === answer);
+      if (selected) {
+        finalAgentRunner = selected.id;
+      } else if (answer === 'o' || answer === 'other') {
+        const customName = (await rl.question(`  Enter custom runner name: `)).trim();
+        finalAgentRunner = customName || 'custom';
+      } else {
+        finalAgentRunner = DEFAULT_AGENT_RUNNER.id;
+      }
+    } finally {
+      rl.close();
+    }
+  } else if (!finalAgentRunner) {
+    finalAgentRunner = DEFAULT_AGENT_RUNNER.id;
+  }
+
   // Build SDK options
   const initOptions: InitOptions = {
     teamRoot: dest,
@@ -227,6 +272,7 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
     prompt: options.prompt,
     extractionDisabled: options.extractionDisabled,
     roles: options.roles,
+    agentRunner: finalAgentRunner,
   };
 
   // Handle SIGINT to cleanup orphan .init-prompt
@@ -360,7 +406,7 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
 
   if (!isInitNoColor()) await sleep(80);
   console.log();
-  console.log(`${GREEN}${BOLD}Squad initialized.${RESET} Run ${CYAN}${BOLD}copilot --agent squad${RESET} and tell it what you're building.`);
+  console.log(`${GREEN}${BOLD}Squad initialized.${RESET} Run ${CYAN}${BOLD}copilot --agent squad${RESET} (or use Antigravity IDE) and tell it what you're building.`);
   console.log();
 
   // ── Personal squad bridge ───────────────────────────────────────────

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.9.6",
+  "version": "0.9.6-build.19",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/squad-sdk/src/config/agent-runners.ts
+++ b/packages/squad-sdk/src/config/agent-runners.ts
@@ -1,0 +1,19 @@
+export interface AgentRunnerDefinition {
+  id: string;
+  name: string;
+  targetDir: string;
+  shortcut: string;
+}
+
+export const KNOWN_AGENT_RUNNERS: AgentRunnerDefinition[] = [
+  { id: 'copilot', name: 'GitHub Copilot Workspace', targetDir: '.copilot', shortcut: 'c' },
+  { id: 'antigravity', name: 'Antigravity IDE', targetDir: '.squad', shortcut: 'a' }
+];
+
+export const DEFAULT_AGENT_RUNNER = KNOWN_AGENT_RUNNERS[0]!;
+
+export function getAgentRunnerDir(runnerId?: string): string {
+  if (!runnerId) return DEFAULT_AGENT_RUNNER.targetDir;
+  const known = KNOWN_AGENT_RUNNERS.find(r => r.id === runnerId);
+  return known ? known.targetDir : '.squad'; // Custom runners default to .squad
+}

--- a/packages/squad-sdk/src/config/index.ts
+++ b/packages/squad-sdk/src/config/index.ts
@@ -13,3 +13,4 @@ export * from './migration.js';
 export * from './markdown-migration.js';
 export * from './legacy-fallback.js';
 export * from './feature-audit.js';
+export * from './agent-runners.js';

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -19,7 +19,7 @@ import type { SubSquadDefinition } from '../streams/types.js';
 import { ENGINEERING_ROLE_IDS } from '../roles/catalog.js';
 import { getRoleById } from '../roles/index.js';
 import { ensureMemoryGovernanceDefaults } from '../memory/index.js';
-
+import { getAgentRunnerDir } from './agent-runners.js';
 // ============================================================================
 // Manifest-Curated Skills (must stay in sync with TEMPLATE_MANIFEST in CLI)
 // ============================================================================
@@ -113,6 +113,8 @@ export interface InitOptions {
   projectDescription?: string;
   /** Agents to create */
   agents: InitAgentSpec[];
+  /** Expected agent runner platform */
+  agentRunner?: string;
   /** Config format (typescript or json for old format, sdk for new builder syntax, markdown for no config file) */
   configFormat?: 'typescript' | 'json' | 'sdk' | 'markdown';
   /** User name for initial history entries */
@@ -715,7 +717,7 @@ export async function initSquad(options: InitOptions, storage: StorageProvider =
     join(squadDir, 'decisions'),
     join(squadDir, 'decisions', 'inbox'),
     join(squadDir, 'memory'),
-    join(teamRoot, '.copilot', 'skills'),
+    join(teamRoot, getAgentRunnerDir(options.agentRunner), 'skills'),
     join(squadDir, 'plugins'),
     join(squadDir, 'identity'),
     join(squadDir, 'orchestration-log'),
@@ -993,7 +995,7 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   // Copy starter skills
   // -------------------------------------------------------------------------
 
-  const skillsDir = join(teamRoot, '.copilot', 'skills');
+  const skillsDir = join(teamRoot, getAgentRunnerDir(options.agentRunner), 'skills');
   if (templatesDir && storage.existsSync(join(templatesDir, 'skills'))) {
     const skillsSrc = join(templatesDir, 'skills');
     const existingSkills = storage.existsSync(skillsDir) ? storage.listSync(skillsDir) : [];
@@ -1005,7 +1007,7 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
           copyRecursiveSync(srcSkill, join(skillsDir, skillName), storage);
         }
       }
-      createdFiles.push('.copilot/skills');
+      createdFiles.push(getAgentRunnerDir(options.agentRunner) + '/skills');
     }
   }
 
@@ -1151,7 +1153,7 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   // -------------------------------------------------------------------------
 
   if (includeMcpConfig) {
-    const mcpConfigPath = join(teamRoot, '.copilot', 'mcp-config.json');
+    const mcpConfigPath = join(teamRoot, getAgentRunnerDir(options.agentRunner), 'mcp-config.json');
     if (!storage.existsSync(mcpConfigPath)) {
       const mcpSample = isGitHub
         ? {
@@ -1178,7 +1180,7 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
             }
           };
       await storage.write(mcpConfigPath, JSON.stringify(mcpSample, null, 2) + '\n');
-      createdFiles.push(toRelativePath(mcpConfigPath));
+      createdFiles.push(getAgentRunnerDir(options.agentRunner) + '/mcp-config.json');
     } else {
       skippedFiles.push(toRelativePath(mcpConfigPath));
     }

--- a/patch.ps1
+++ b/patch.ps1
@@ -1,0 +1,23 @@
+$file = 'packages/squad-cli/src/cli-entry.ts'
+$content = Get-Content $file -Raw
+
+# 1. Triage flag parsing
+$content = [regex]::Replace($content,
+    "(?s)const agentCmdIdx = args.indexOf\('--agent-cmd'\);.*?undefined;\s*const maxConcurrentIdx = args.indexOf\('--max-concurrent'\);",
+    "const agentCmdIdx = args.indexOf('--agent-cmd');`n    const agentCmd = (agentCmdIdx !== -1 && args[agentCmdIdx + 1])`n      ? args[agentCmdIdx + 1]`n      : undefined;`n`n    const agentRunnerIdx = args.indexOf('--agent-runner');`n    const agentRunner = (agentRunnerIdx !== -1 && args[agentRunnerIdx + 1])`n      ? args[agentRunnerIdx + 1] as 'copilot' | 'antigravity'`n      : undefined;`n`n    const maxConcurrentIdx = args.indexOf('--max-concurrent');"
+)
+
+# 2. Loop flag parsing
+$content = [regex]::Replace($content,
+    "(?s)const agentCmdIdx = args.indexOf\('--agent-cmd'\);.*?undefined;\s*// Capability flags",
+    "const agentCmdIdx = args.indexOf('--agent-cmd');`n    const agentCmd = (agentCmdIdx !== -1 && args[agentCmdIdx + 1])`n      ? args[agentCmdIdx + 1]`n      : undefined;`n`n    const agentRunnerIdx = args.indexOf('--agent-runner');`n    const agentRunner = (agentRunnerIdx !== -1 && args[agentRunnerIdx + 1])`n      ? args[agentRunnerIdx + 1] as 'copilot' | 'antigravity'`n      : undefined;`n`n    // Capability flags"
+)
+
+# 3. Pass to runLoop
+$content = [regex]::Replace($content,
+    "(?s)copilotFlags,.*?agentCmd,.*?capabilities,.*?}\);",
+    "copilotFlags,`n      agentCmd,`n      agentRunner,`n      capabilities,`n    });"
+)
+
+Set-Content -Path $file -Value $content
+Write-Host "Patched cli-entry.ts"


### PR DESCRIPTION
Centralizes agent runners into a single registry, replacing hardcoded checks with dynamic paths. Modifies squad init to use an interactive CLI menu to prompt users for the runner selection, and opens up the SDK to accept custom runners. Added support for Antigravity IDE.