### PR TITLE
fix: keep squad_state MCP config portable

### DIFF
--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -1156,7 +1156,6 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
       const squadStateServer = {
         command: 'npx',
         args: ['-y', '@bradygaster/squad-cli', 'state-mcp'],
-        env: { SQUAD_TEAM_ROOT: teamRoot },
       };
       const mcpSample = isGitHub
         ? {

--- a/test/cli/init.test.ts
+++ b/test/cli/init.test.ts
@@ -93,6 +93,10 @@ describe('CLI: init command', () => {
     const content = await readFile(mcpPath, 'utf-8');
     const config = JSON.parse(content);
     expect(config).toHaveProperty('mcpServers');
+    expect(config.mcpServers).toHaveProperty('squad_state');
+    expect(config.mcpServers.squad_state).not.toHaveProperty('env');
+    expect(content).not.toContain('SQUAD_TEAM_ROOT');
+    expect(content).not.toContain(TEST_ROOT);
   });
 
   it('should create ceremonies.md', async () => {


### PR DESCRIPTION
## Summary

- Remove generated machine-local `SQUAD_TEAM_ROOT` from the repo-level `squad_state` MCP server config
- Keep `squad state-mcp` relying on its existing cwd-based resolution by default
- Add init regression coverage to ensure generated MCP config stays portable

Fixes #1162

## Tests

- `npx vitest run test/cli/init.test.ts test/cli/state-mcp.test.ts`
- `node --test test/mcp-config.test.cjs`