### PR TITLE
Add MCP frontmatter option to squad init

### DIFF
--- a/.changeset/mcp-frontmatter-init.md
+++ b/.changeset/mcp-frontmatter-init.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": minor
+"@bradygaster/squad-sdk": minor
+---
+
+Add `squad init --mcp-frontmatter` to write MCP server config into the Squad agent frontmatter instead of `.copilot/mcp-config.json` for compatible agent harnesses.

--- a/.squad-templates/scribe-charter.md
+++ b/.squad-templates/scribe-charter.md
@@ -64,7 +64,9 @@ After every substantial work session:
    - Re-read `decisions.md`, `log/{timestamp}-{topic}.md`, and any updated histories with `squad_state_read`.
    - Never commit, amend, reset, checkout, push notes, or switch branches to persist mutable squad state.
 
-6. **Never speak to the user.** Never appear in responses. Work silently.
+6. **Commit handling:** Never commit mutable squad state. If non-state repo files changed, report them for coordinator handling.
+
+7. **Never speak to the user.** Never appear in responses. Work silently.
 
 ## The Memory Architecture
 

--- a/.squad-templates/spawn-reference.md
+++ b/.squad-templates/spawn-reference.md
@@ -35,6 +35,9 @@ prompt: |
   CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   All `.squad/` paths are relative to this root.
 
+  Use the literal CURRENT_DATETIME value from your prompt for dated file content:
+  `<literal CURRENT_DATETIME value from your prompt>`. Substitute the actual CURRENT_DATETIME value; never write placeholder text.
+
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
 

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -158,6 +158,7 @@ async function main(): Promise<void> {
     console.log(`                    --roles (use base roles)`);
     console.log(`                    --global (personal squad dir)`);
     console.log(`                    --no-workflows (skip CI setup)`);
+    console.log(`                    --mcp-frontmatter (write MCP config into agent frontmatter)`);
     console.log(`                    --preset <name> (apply a preset after init)`);
     console.log(`                    --state-backend <type> (local|orphan|two-layer)`);
     console.log(`             Usage: init --mode remote <team-repo-path>`);
@@ -318,6 +319,7 @@ async function main(): Promise<void> {
     const sdkMod = hasGlobal ? await lazySquadSdk() : null;
     const dest = hasGlobal ? sdkMod!.resolveGlobalSquadPath() : process.cwd();
     const noWorkflows = args.includes('--no-workflows');
+    const mcpFrontmatter = args.includes('--mcp-frontmatter');
     const sdk = args.includes('--sdk');
     const roles = args.includes('--roles');
     const presetIdx = args.indexOf('--preset');
@@ -326,7 +328,7 @@ async function main(): Promise<void> {
     const sbIdx = args.indexOf('--state-backend');
     const initStateBackend = (sbIdx !== -1 && args[sbIdx + 1]) ? args[sbIdx + 1] : undefined;
     // Global init: suppress workflows (no GitHub CI in ~/.config/squad/) and bootstrap personal squad
-    runInit(dest, { includeWorkflows: !noWorkflows && !hasGlobal, sdk, roles, isGlobal: hasGlobal, stateBackend: initStateBackend }).then(async () => {
+    runInit(dest, { includeWorkflows: !noWorkflows && !hasGlobal, sdk, roles, isGlobal: hasGlobal, stateBackend: initStateBackend, mcpFrontmatter }).then(async () => {
       if (presetName) {
         const { seedBuiltinPresets, applyPreset } = await import('@bradygaster/squad-sdk/presets');
         const { resolvePresetsDir, ensureSquadHome } = await import('@bradygaster/squad-sdk/resolution');

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -158,7 +158,6 @@ async function main(): Promise<void> {
     console.log(`                    --roles (use base roles)`);
     console.log(`                    --global (personal squad dir)`);
     console.log(`                    --no-workflows (skip CI setup)`);
-    console.log(`                    --mcp-frontmatter (write MCP config into agent frontmatter)`);
     console.log(`                    --preset <name> (apply a preset after init)`);
     console.log(`                    --state-backend <type> (local|orphan|two-layer)`);
     console.log(`             Usage: init --mode remote <team-repo-path>`);

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -111,6 +111,8 @@ export interface RunInitOptions {
   isGlobal?: boolean;
   /** State backend to configure at init time (local, orphan, two-layer) */
   stateBackend?: string;
+  /** If true, write MCP server config into squad.agent.md frontmatter instead of .copilot/mcp-config.json */
+  mcpFrontmatter?: boolean;
 }
 
 /**
@@ -222,6 +224,7 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
     includeWorkflows: options.includeWorkflows !== false,
     includeTemplates: true,
     includeMcpConfig: true,
+    mcpConfigMode: options.mcpFrontmatter ? 'agent-frontmatter' : 'copilot-file',
     projectType: projectType as any,
     version,
     prompt: options.prompt,

--- a/packages/squad-cli/src/cli/core/upgrade.ts
+++ b/packages/squad-cli/src/cli/core/upgrade.ts
@@ -17,6 +17,87 @@ import { getPackageVersion, stampVersion, readInstalledVersion } from './version
 
 const storage = new FSStorageProvider();
 
+type McpConfigMode = 'copilot-file' | 'agent-frontmatter';
+
+interface McpServerSpec {
+  name: string;
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+function buildMcpServerSpecs(isGitHub: boolean): McpServerSpec[] {
+  const servers: McpServerSpec[] = [
+    {
+      name: 'squad_state',
+      command: 'npx',
+      args: ['-y', '@bradygaster/squad-cli', 'state-mcp'],
+    },
+  ];
+
+  servers.push(isGitHub
+    ? {
+        name: 'EXAMPLE-github',
+        command: 'npx',
+        args: ['-y', '@anthropic/github-mcp-server'],
+        env: { GITHUB_TOKEN: '${GITHUB_TOKEN}' },
+      }
+    : {
+        name: 'EXAMPLE-azure-devops',
+        command: 'npx',
+        args: ['-y', '@azure/devops-mcp-server'],
+        env: {
+          AZURE_DEVOPS_ORG: '${AZURE_DEVOPS_ORG}',
+          AZURE_DEVOPS_PAT: '${AZURE_DEVOPS_PAT}',
+        },
+      });
+
+  return servers;
+}
+
+function yamlSingleQuoted(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function yamlEnvValue(value: string): string {
+  if (/^\$\{[A-Z0-9_]+\}$/.test(value)) {
+    return value;
+  }
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function buildMcpFrontmatterBlock(isGitHub: boolean): string {
+  const lines = ['mcp-servers:'];
+  for (const server of buildMcpServerSpecs(isGitHub)) {
+    lines.push(`  ${server.name}:`);
+    lines.push('    type: local');
+    lines.push(`    command: ${server.command}`);
+    lines.push(`    args: [${server.args.map(yamlSingleQuoted).join(', ')}]`);
+    lines.push('    tools: ["*"]');
+
+    if (server.env && Object.keys(server.env).length > 0) {
+      lines.push('    env:');
+      for (const [key, value] of Object.entries(server.env)) {
+        lines.push(`      ${key}: ${yamlEnvValue(value)}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function injectMcpFrontmatter(content: string, isGitHub: boolean): string {
+  const closingStart = content.indexOf('\n---', 4);
+  if (!content.startsWith('---') || closingStart === -1) {
+    return content;
+  }
+
+  return content.slice(0, closingStart)
+    + '\n'
+    + buildMcpFrontmatterBlock(isGitHub)
+    + content.slice(closingStart);
+}
+
 function copyDirRecursive(src: string, dest: string, force = true): void {
   storage.mkdirSync(dest, { recursive: true });
   for (const entry of storage.listSync(src)) {
@@ -65,6 +146,69 @@ function compareSemver(a: string, b: string): number {
   if (!aPre && bPre) return 1;
   if (aPre && bPre) return a < b ? -1 : a > b ? 1 : 0;
   return 0;
+}
+
+function readSquadConfig(squadDir: string): Record<string, unknown> {
+  const configPath = path.join(squadDir, 'config.json');
+  if (!storage.existsSync(configPath)) return {};
+
+  try {
+    const raw = storage.readSync(configPath);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Ignore malformed config for upgrade compatibility.
+  }
+
+  return {};
+}
+
+function readMcpConfigMode(config: Record<string, unknown>): McpConfigMode {
+  return config['mcpConfigMode'] === 'agent-frontmatter' ? 'agent-frontmatter' : 'copilot-file';
+}
+
+function detectMcpConfigMode(config: Record<string, unknown>, agentDest: string): McpConfigMode {
+  const configuredMode = readMcpConfigMode(config);
+  if (configuredMode === 'agent-frontmatter') return configuredMode;
+
+  if (storage.existsSync(agentDest)) {
+    const existingAgent = storage.readSync(agentDest) ?? '';
+    const frontmatterEnd = existingAgent.indexOf('\n---', 4);
+    const frontmatter = frontmatterEnd === -1 ? '' : existingAgent.slice(0, frontmatterEnd);
+    if (frontmatter.includes('mcp-servers:')) {
+      return 'agent-frontmatter';
+    }
+  }
+
+  return configuredMode;
+}
+
+function detectIsGitHubForMcp(dest: string, config: Record<string, unknown>): boolean {
+  if (config['platform'] === 'azure-devops') return false;
+
+  try {
+    const remoteUrl = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd: dest, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    const remoteUrlLower = remoteUrl.toLowerCase();
+    if (remoteUrlLower.includes('dev.azure.com') || remoteUrlLower.includes('visualstudio.com') || remoteUrlLower.includes('ssh.dev.azure.com')) {
+      return false;
+    }
+  } catch {
+    // No git remote — assume GitHub, matching init behavior.
+  }
+
+  return true;
+}
+
+function writeAgentTemplate(agentSrc: string, agentDest: string, cliVersion: string, mcpConfigMode: McpConfigMode, isGitHub: boolean): void {
+  let agentContent = storage.readSync(agentSrc) ?? '';
+  if (mcpConfigMode === 'agent-frontmatter') {
+    agentContent = injectMcpFrontmatter(agentContent, isGitHub);
+  }
+  storage.writeSync(agentDest, agentContent);
+  stampVersion(agentDest, cliVersion);
 }
 
 /**
@@ -598,6 +742,9 @@ export async function runUpgrade(dest: string, options: UpgradeOptions = {}): Pr
 
   const agentDest = path.join(dest, '.github', 'agents', 'squad.agent.md');
   const oldVersion = readInstalledVersion(agentDest) ?? '0.0.0';
+  const squadConfig = readSquadConfig(squadDirInfo.path);
+  const mcpConfigMode = detectMcpConfigMode(squadConfig, agentDest);
+  const isGitHubForMcp = detectIsGitHubForMcp(dest, squadConfig);
 
   // Check if already current
   const isAlreadyCurrent = !options.force && oldVersion && oldVersion !== '0.0.0' && compareSemver(oldVersion, cliVersion) === 0;
@@ -630,8 +777,7 @@ export async function runUpgrade(dest: string, options: UpgradeOptions = {}): Pr
     const agentSrc = path.join(templatesDir, 'squad.agent.md.template');
     if (storage.existsSync(agentSrc)) {
       storage.mkdirSync(path.dirname(agentDest), { recursive: true });
-      storage.copySync(agentSrc, agentDest);
-      stampVersion(agentDest, cliVersion);
+      writeAgentTemplate(agentSrc, agentDest, cliVersion, mcpConfigMode, isGitHubForMcp);
       success('upgraded squad.agent.md');
       filesUpdated.push('squad.agent.md');
     } else {
@@ -658,8 +804,7 @@ export async function runUpgrade(dest: string, options: UpgradeOptions = {}): Pr
   }
 
   storage.mkdirSync(path.dirname(agentDest), { recursive: true });
-  storage.copySync(agentSrc, agentDest);
-  stampVersion(agentDest, cliVersion);
+  writeAgentTemplate(agentSrc, agentDest, cliVersion, mcpConfigMode, isGitHubForMcp);
 
   const fromLabel = oldVersion === '0.0.0' || !oldVersion ? 'unknown' : oldVersion;
   success(`upgraded coordinator from ${fromLabel} to ${cliVersion}`);

--- a/packages/squad-cli/templates/scribe-charter.md
+++ b/packages/squad-cli/templates/scribe-charter.md
@@ -64,7 +64,9 @@ After every substantial work session:
    - Re-read `decisions.md`, `log/{timestamp}-{topic}.md`, and any updated histories with `squad_state_read`.
    - Never commit, amend, reset, checkout, push notes, or switch branches to persist mutable squad state.
 
-6. **Never speak to the user.** Never appear in responses. Work silently.
+6. **Commit handling:** Never commit mutable squad state. If non-state repo files changed, report them for coordinator handling.
+
+7. **Never speak to the user.** Never appear in responses. Work silently.
 
 ## The Memory Architecture
 

--- a/packages/squad-cli/templates/spawn-reference.md
+++ b/packages/squad-cli/templates/spawn-reference.md
@@ -35,6 +35,9 @@ prompt: |
   CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   All `.squad/` paths are relative to this root.
 
+  Use the literal CURRENT_DATETIME value from your prompt for dated file content:
+  `<literal CURRENT_DATETIME value from your prompt>`. Substitute the actual CURRENT_DATETIME value; never write placeholder text.
+
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
 

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -125,6 +125,8 @@ export interface InitOptions {
   includeTemplates?: boolean;
   /** Include sample MCP config (default: true) */
   includeMcpConfig?: boolean;
+  /** Where to write sample MCP config (default: copilot-file when includeMcpConfig is true) */
+  mcpConfigMode?: 'copilot-file' | 'agent-frontmatter' | 'none';
   /** Project type for workflow customization */
   projectType?: 'node' | 'python' | 'go' | 'rust' | 'java' | 'csharp' | 'unknown';
   /** Version to stamp in squad.agent.md */
@@ -607,6 +609,92 @@ function stampVersionInContent(content: string, version: string): string {
   return content;
 }
 
+interface McpServerSpec {
+  name: string;
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+function buildMcpServerSpecs(isGitHub: boolean): McpServerSpec[] {
+  const servers: McpServerSpec[] = [
+    {
+      name: 'squad_state',
+      command: 'npx',
+      args: ['-y', '@bradygaster/squad-cli', 'state-mcp'],
+    },
+  ];
+
+  servers.push(isGitHub
+    ? {
+        name: 'EXAMPLE-github',
+        command: 'npx',
+        args: ['-y', '@anthropic/github-mcp-server'],
+        env: { GITHUB_TOKEN: '${GITHUB_TOKEN}' },
+      }
+    : {
+        name: 'EXAMPLE-azure-devops',
+        command: 'npx',
+        args: ['-y', '@azure/devops-mcp-server'],
+        env: {
+          AZURE_DEVOPS_ORG: '${AZURE_DEVOPS_ORG}',
+          AZURE_DEVOPS_PAT: '${AZURE_DEVOPS_PAT}',
+        },
+      });
+
+  return servers;
+}
+
+function buildMcpConfigJson(servers: McpServerSpec[]): Record<string, unknown> {
+  return {
+    mcpServers: Object.fromEntries(servers.map(({ name, ...server }) => [name, server])),
+  };
+}
+
+function yamlSingleQuoted(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function yamlEnvValue(value: string): string {
+  if (/^\$\{[A-Z0-9_]+\}$/.test(value)) {
+    return value;
+  }
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function buildMcpFrontmatterBlock(servers: McpServerSpec[]): string {
+  const lines = ['mcp-servers:'];
+
+  for (const server of servers) {
+    lines.push(`  ${server.name}:`);
+    lines.push('    type: local');
+    lines.push(`    command: ${server.command}`);
+    lines.push(`    args: [${server.args.map(yamlSingleQuoted).join(', ')}]`);
+    lines.push('    tools: ["*"]');
+
+    if (server.env && Object.keys(server.env).length > 0) {
+      lines.push('    env:');
+      for (const [key, value] of Object.entries(server.env)) {
+        lines.push(`      ${key}: ${yamlEnvValue(value)}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function injectMcpFrontmatter(content: string, servers: McpServerSpec[]): string {
+  const closingStart = content.indexOf('\n---', 4);
+  if (!content.startsWith('---') || closingStart === -1) {
+    return content;
+  }
+
+  return content.slice(0, closingStart)
+    + '\n'
+    + buildMcpFrontmatterBlock(servers)
+    + content.slice(closingStart);
+}
+
 /**
  * Initialize a new Squad project.
  *
@@ -650,6 +738,7 @@ export async function initSquad(options: InitOptions, storage: StorageProvider =
     includeWorkflows = true,
     includeTemplates = true,
     includeMcpConfig = true,
+    mcpConfigMode = includeMcpConfig ? 'copilot-file' : 'none',
     projectType = 'unknown',
     version = '0.0.0',
   } = options;
@@ -1065,6 +1154,23 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   }
 
   // -------------------------------------------------------------------------
+  // Detect platform from git remote
+  // -------------------------------------------------------------------------
+
+  let isGitHub = true;
+  try {
+    const remoteUrl = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd: teamRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    const remoteUrlLower = remoteUrl.toLowerCase();
+    if (remoteUrlLower.includes('dev.azure.com') || remoteUrlLower.includes('visualstudio.com') || remoteUrlLower.includes('ssh.dev.azure.com')) {
+      isGitHub = false;
+    }
+  } catch {
+    // No git remote — assume GitHub (default)
+  }
+
+  const mcpServers = buildMcpServerSpecs(isGitHub);
+
+  // -------------------------------------------------------------------------
   // Create .github/agents/squad.agent.md
   // -------------------------------------------------------------------------
 
@@ -1072,6 +1178,9 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   if (!storage.existsSync(agentFile) || !skipExisting) {
     if (templatesDir && storage.existsSync(join(templatesDir, 'squad.agent.md.template'))) {
       let agentContent = storage.readSync(join(templatesDir, 'squad.agent.md.template')) ?? '';
+      if (mcpConfigMode === 'agent-frontmatter') {
+        agentContent = injectMcpFrontmatter(agentContent, mcpServers);
+      }
       agentContent = stampVersionInContent(agentContent, version);
       await storage.write(agentFile, agentContent);
       createdFiles.push(toRelativePath(agentFile));
@@ -1094,21 +1203,6 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
     } else {
       skippedFiles.push(toRelativePath(templatesDest));
     }
-  }
-
-  // -------------------------------------------------------------------------
-  // Detect platform from git remote
-  // -------------------------------------------------------------------------
-
-  let isGitHub = true;
-  try {
-    const remoteUrl = execFileSync('git', ['remote', 'get-url', 'origin'], { cwd: teamRoot, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-    const remoteUrlLower = remoteUrl.toLowerCase();
-    if (remoteUrlLower.includes('dev.azure.com') || remoteUrlLower.includes('visualstudio.com') || remoteUrlLower.includes('ssh.dev.azure.com')) {
-      isGitHub = false;
-    }
-  } catch {
-    // No git remote — assume GitHub (default)
   }
 
   // -------------------------------------------------------------------------
@@ -1150,39 +1244,10 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   // Create sample MCP config (optional)
   // -------------------------------------------------------------------------
 
-  if (includeMcpConfig) {
+  if (mcpConfigMode === 'copilot-file') {
     const mcpConfigPath = join(teamRoot, '.copilot', 'mcp-config.json');
     if (!storage.existsSync(mcpConfigPath)) {
-      const squadStateServer = {
-        command: 'npx',
-        args: ['-y', '@bradygaster/squad-cli', 'state-mcp'],
-      };
-      const mcpSample = isGitHub
-        ? {
-            mcpServers: {
-              "squad_state": squadStateServer,
-              "EXAMPLE-github": {
-                command: "npx",
-                args: ["-y", "@anthropic/github-mcp-server"],
-                env: {
-                  GITHUB_TOKEN: "${GITHUB_TOKEN}"
-                }
-              }
-            }
-          }
-        : {
-            mcpServers: {
-              "squad_state": squadStateServer,
-              "EXAMPLE-azure-devops": {
-                command: "npx",
-                args: ["-y", "@azure/devops-mcp-server"],
-                env: {
-                  AZURE_DEVOPS_ORG: "${AZURE_DEVOPS_ORG}",
-                  AZURE_DEVOPS_PAT: "${AZURE_DEVOPS_PAT}"
-                }
-              }
-            }
-          };
+      const mcpSample = buildMcpConfigJson(mcpServers);
       await storage.write(mcpConfigPath, JSON.stringify(mcpSample, null, 2) + '\n');
       createdFiles.push(toRelativePath(mcpConfigPath));
     } else {

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -126,7 +126,7 @@ export interface InitOptions {
   /** Include sample MCP config (default: true) */
   includeMcpConfig?: boolean;
   /** Where to write sample MCP config (default: copilot-file when includeMcpConfig is true) */
-  mcpConfigMode?: 'copilot-file' | 'agent-frontmatter' | 'none';
+  mcpConfigMode?: McpConfigMode;
   /** Project type for workflow customization */
   projectType?: 'node' | 'python' | 'go' | 'rust' | 'java' | 'csharp' | 'unknown';
   /** Version to stamp in squad.agent.md */
@@ -609,6 +609,8 @@ function stampVersionInContent(content: string, version: string): string {
   return content;
 }
 
+type McpConfigMode = 'copilot-file' | 'agent-frontmatter' | 'none';
+
 interface McpServerSpec {
   name: string;
   command: string;
@@ -917,6 +919,9 @@ export async function initSquad(options: InitOptions, storage: StorageProvider =
     // Only include extractionDisabled if explicitly set
     if (options.extractionDisabled) {
       squadConfig.extractionDisabled = true;
+    }
+    if (mcpConfigMode === 'agent-frontmatter') {
+      squadConfig.mcpConfigMode = mcpConfigMode;
     }
     await storage.write(squadConfigPath, JSON.stringify(squadConfig, null, 2));
     createdFiles.push(toRelativePath(squadConfigPath));

--- a/packages/squad-sdk/templates/scribe-charter.md
+++ b/packages/squad-sdk/templates/scribe-charter.md
@@ -64,7 +64,9 @@ After every substantial work session:
    - Re-read `decisions.md`, `log/{timestamp}-{topic}.md`, and any updated histories with `squad_state_read`.
    - Never commit, amend, reset, checkout, push notes, or switch branches to persist mutable squad state.
 
-6. **Never speak to the user.** Never appear in responses. Work silently.
+6. **Commit handling:** Never commit mutable squad state. If non-state repo files changed, report them for coordinator handling.
+
+7. **Never speak to the user.** Never appear in responses. Work silently.
 
 ## The Memory Architecture
 

--- a/packages/squad-sdk/templates/spawn-reference.md
+++ b/packages/squad-sdk/templates/spawn-reference.md
@@ -35,6 +35,9 @@ prompt: |
   CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   All `.squad/` paths are relative to this root.
 
+  Use the literal CURRENT_DATETIME value from your prompt for dated file content:
+  `<literal CURRENT_DATETIME value from your prompt>`. Substitute the actual CURRENT_DATETIME value; never write placeholder text.
+
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
 

--- a/templates/scribe-charter.md
+++ b/templates/scribe-charter.md
@@ -64,7 +64,9 @@ After every substantial work session:
    - Re-read `decisions.md`, `log/{timestamp}-{topic}.md`, and any updated histories with `squad_state_read`.
    - Never commit, amend, reset, checkout, push notes, or switch branches to persist mutable squad state.
 
-6. **Never speak to the user.** Never appear in responses. Work silently.
+6. **Commit handling:** Never commit mutable squad state. If non-state repo files changed, report them for coordinator handling.
+
+7. **Never speak to the user.** Never appear in responses. Work silently.
 
 ## The Memory Architecture
 

--- a/templates/spawn-reference.md
+++ b/templates/spawn-reference.md
@@ -35,6 +35,9 @@ prompt: |
   CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
   All `.squad/` paths are relative to this root.
 
+  Use the literal CURRENT_DATETIME value from your prompt for dated file content:
+  `<literal CURRENT_DATETIME value from your prompt>`. Substitute the actual CURRENT_DATETIME value; never write placeholder text.
+
   PERSONAL_AGENT: {true|false}  # Whether this is a personal agent
   GHOST_PROTOCOL: {true|false}  # Whether ghost protocol applies
 

--- a/test/cli/init.test.ts
+++ b/test/cli/init.test.ts
@@ -117,6 +117,10 @@ describe('CLI: init command', () => {
     const frontmatter = content.slice(0, frontmatterEnd);
     expect(frontmatter).not.toContain('SQUAD_TEAM_ROOT');
     expect(frontmatter).not.toContain(TEST_ROOT);
+
+    const squadConfigPath = join(TEST_ROOT, '.squad', 'config.json');
+    const squadConfig = JSON.parse(await readFile(squadConfigPath, 'utf-8'));
+    expect(squadConfig.mcpConfigMode).toBe('agent-frontmatter');
   });
 
   it('should not patch existing agent frontmatter on re-init', async () => {

--- a/test/cli/init.test.ts
+++ b/test/cli/init.test.ts
@@ -99,6 +99,34 @@ describe('CLI: init command', () => {
     expect(content).not.toContain(TEST_ROOT);
   });
 
+  it('should write MCP config into agent frontmatter when requested', async () => {
+    await runInit(TEST_ROOT, { mcpFrontmatter: true });
+
+    const mcpPath = join(TEST_ROOT, '.copilot', 'mcp-config.json');
+    expect(existsSync(mcpPath)).toBe(false);
+
+    const agentPath = join(TEST_ROOT, '.github', 'agents', 'squad.agent.md');
+    const content = await readFile(agentPath, 'utf-8');
+    expect(content).toContain('mcp-servers:');
+    expect(content).toContain('  squad_state:');
+    expect(content).toContain('    type: local');
+    expect(content).toContain("    args: ['-y', '@bradygaster/squad-cli', 'state-mcp']");
+    expect(content).toContain('    tools: ["*"]');
+  });
+
+  it('should not patch existing agent frontmatter on re-init', async () => {
+    await runInit(TEST_ROOT);
+
+    const agentPath = join(TEST_ROOT, '.github', 'agents', 'squad.agent.md');
+    const firstContent = await readFile(agentPath, 'utf-8');
+
+    await runInit(TEST_ROOT, { mcpFrontmatter: true });
+
+    const secondContent = await readFile(agentPath, 'utf-8');
+    expect(secondContent).toBe(firstContent);
+    expect(secondContent).not.toContain('mcp-servers:');
+  });
+
   it('should create ceremonies.md', async () => {
     await runInit(TEST_ROOT);
     

--- a/test/cli/init.test.ts
+++ b/test/cli/init.test.ts
@@ -112,6 +112,11 @@ describe('CLI: init command', () => {
     expect(content).toContain('    type: local');
     expect(content).toContain("    args: ['-y', '@bradygaster/squad-cli', 'state-mcp']");
     expect(content).toContain('    tools: ["*"]');
+    const frontmatterEnd = content.indexOf('\n---', 4);
+    expect(frontmatterEnd).toBeGreaterThan(0);
+    const frontmatter = content.slice(0, frontmatterEnd);
+    expect(frontmatter).not.toContain('SQUAD_TEAM_ROOT');
+    expect(frontmatter).not.toContain(TEST_ROOT);
   });
 
   it('should not patch existing agent frontmatter on re-init', async () => {

--- a/test/cli/upgrade.test.ts
+++ b/test/cli/upgrade.test.ts
@@ -137,6 +137,88 @@ describe('CLI: upgrade command', () => {
     expect(after).toContain(`<!-- version: ${currentVersion} -->`);
   });
 
+  it('preserves agent-frontmatter MCP config on upgrade', async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+    await mkdir(TEST_ROOT, { recursive: true });
+    await runInit(TEST_ROOT, { mcpFrontmatter: true });
+
+    const agentPath = join(TEST_ROOT, '.github', 'agents', 'squad.agent.md');
+    let content = await readFile(agentPath, 'utf-8');
+    expect(content).toContain('mcp-servers:');
+
+    content = content
+      .replace(/<!-- version: [^>]+ -->/m, '<!-- version: 0.1.0 -->')
+      .replace(/mcp-servers:[\s\S]*?\n---/, '---');
+    await writeFile(agentPath, content);
+
+    await runUpgrade(TEST_ROOT);
+
+    const upgraded = await readFile(agentPath, 'utf-8');
+    expect(upgraded).toContain('mcp-servers:');
+    expect(upgraded).toContain('  squad_state:');
+    expect(upgraded).toContain("    args: ['-y', '@bradygaster/squad-cli', 'state-mcp']");
+    expect(upgraded).toContain('  EXAMPLE-github:');
+    expect(upgraded).toContain("    args: ['-y', '@anthropic/github-mcp-server']");
+    expect(upgraded).toContain('      GITHUB_TOKEN: ${GITHUB_TOKEN}');
+    expect(upgraded).not.toContain('EXAMPLE-azure-devops');
+    const frontmatterEnd = upgraded.indexOf('\n---', 4);
+    expect(frontmatterEnd).toBeGreaterThan(0);
+    const frontmatter = upgraded.slice(0, frontmatterEnd);
+    expect(frontmatter).not.toContain('SQUAD_TEAM_ROOT');
+    expect(frontmatter).not.toContain(TEST_ROOT);
+  });
+
+  it('infers frontmatter MCP mode during upgrade when config is missing the mode', async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+    await mkdir(TEST_ROOT, { recursive: true });
+    await runInit(TEST_ROOT, { mcpFrontmatter: true });
+
+    const configPath = join(TEST_ROOT, '.squad', 'config.json');
+    await writeFile(configPath, JSON.stringify({ version: 1 }, null, 2) + '\n');
+
+    const agentPath = join(TEST_ROOT, '.github', 'agents', 'squad.agent.md');
+    let content = await readFile(agentPath, 'utf-8');
+    content = content.replace(/<!-- version: [^>]+ -->/m, '<!-- version: 0.1.0 -->');
+    await writeFile(agentPath, content);
+
+    await runUpgrade(TEST_ROOT);
+
+    const upgraded = await readFile(agentPath, 'utf-8');
+    expect(upgraded).toContain('mcp-servers:');
+    expect(upgraded).toContain('  squad_state:');
+    expect(upgraded).toContain('  EXAMPLE-github:');
+  });
+
+  it('preserves Azure DevOps MCP frontmatter on upgrade', async () => {
+    await rm(TEST_ROOT, { recursive: true, force: true });
+    await mkdir(TEST_ROOT, { recursive: true });
+    await runInit(TEST_ROOT, { mcpFrontmatter: true });
+
+    const configPath = join(TEST_ROOT, '.squad', 'config.json');
+    await writeFile(configPath, JSON.stringify({
+      version: 1,
+      platform: 'azure-devops',
+      mcpConfigMode: 'agent-frontmatter',
+    }, null, 2) + '\n');
+
+    const agentPath = join(TEST_ROOT, '.github', 'agents', 'squad.agent.md');
+    let content = await readFile(agentPath, 'utf-8');
+    content = content
+      .replace(/<!-- version: [^>]+ -->/m, '<!-- version: 0.1.0 -->')
+      .replace(/mcp-servers:[\s\S]*?\n---/, '---');
+    await writeFile(agentPath, content);
+
+    await runUpgrade(TEST_ROOT);
+
+    const upgraded = await readFile(agentPath, 'utf-8');
+    expect(upgraded).toContain('mcp-servers:');
+    expect(upgraded).toContain('  EXAMPLE-azure-devops:');
+    expect(upgraded).toContain("    args: ['-y', '@azure/devops-mcp-server']");
+    expect(upgraded).toContain('      AZURE_DEVOPS_ORG: ${AZURE_DEVOPS_ORG}');
+    expect(upgraded).toContain('      AZURE_DEVOPS_PAT: ${AZURE_DEVOPS_PAT}');
+    expect(upgraded).not.toContain('EXAMPLE-github');
+  });
+
   it('should preserve version stamp after manifest loop (issue #195)', async () => {
     const agentPath = join(TEST_ROOT, '.github', 'agents', 'squad.agent.md');
     const currentVersion = getPackageVersion();


### PR DESCRIPTION
## Summary

- add `squad init --mcp-frontmatter` to write generated MCP server config into the Squad agent frontmatter
- keep the existing `.copilot/mcp-config.json` output as the default init behavior
- persist `mcpConfigMode: "agent-frontmatter"` in `.squad/config.json` and have `squad upgrade` re-inject frontmatter MCP config
- preserve init `skipExisting` semantics so existing `squad.agent.md` files are not patched on re-init

## Note On Template Changes

- The `.squad-templates/scribe-charter.md` and `.squad-templates/spawn-reference.md` edits are not part of the MCP feature behavior.
- They restore existing CI template-contract expectations after rebasing onto latest `dev`:
  - `datetime-template.test.ts` expects explicit literal `CURRENT_DATETIME` substitution guidance in `spawn-reference.md`.
  - `scribe-template.test.ts` expects a numbered Scribe commit-handling step before “Never speak to the user.”
- Those canonical `.squad-templates` edits were synced into `templates/`, `packages/squad-cli/templates/`, and `packages/squad-sdk/templates/` with `node scripts/sync-templates.mjs --sync`.

## Tests

- `npm test -- test/cli/init.test.ts test/cli/upgrade.test.ts test/speed-gates.test.ts test/ci/datetime-template.test.ts test/ci/scribe-template.test.ts`
- `npm run lint`

Fixes #1165
