### PR TITLE
fix(ci): align scribe + datetime template tests with current charter/spawn layout

### DIFF
--- a/test/ci/datetime-template.test.ts
+++ b/test/ci/datetime-template.test.ts
@@ -60,9 +60,13 @@ describe('current datetime template contract', () => {
   });
 
   it('tells agents to substitute the literal datetime in command examples', () => {
-    // These strings live in spawn-reference.md after PR #1035 moved spawn templates there.
-    expect(spawnReference).toContain('<literal CURRENT_DATETIME value from your prompt>');
-    expect(spawnReference).toContain('Substitute the actual CURRENT_DATETIME value');
+    // These substitution strings live in coordinator-owned spawn templates. PR #1035
+    // moved spawn-template details to on-demand reference files, but the Full Spawn
+    // Template block still lives in squad.agent.md alongside spawn-reference.md and
+    // after-agent-reference.md. Check across all coordinator-owned templates so the
+    // assertion is robust to future relocations within that set.
+    expect(allCoordinatorTemplates).toContain('<literal CURRENT_DATETIME value from your prompt>');
+    expect(allCoordinatorTemplates).toContain('Substitute the actual CURRENT_DATETIME value');
   });
 
   it('keeps Scribe from writing placeholder datetime headings', () => {

--- a/test/ci/scribe-template.test.ts
+++ b/test/ci/scribe-template.test.ts
@@ -7,9 +7,10 @@
  *  - HARD GATE enforcement is documented (decisions archival ceiling)
  *  - Decision inbox merge is a numbered step
  *  - Deduplication is a numbered step
- *  - A commit step is present
+ *  - A persistence-verification step is present (runtime state backend writes
+ *    are verified via state tools; Scribe never commits mutable squad state)
  *  - "Never speak to the user." is the final numbered step (Scribe stays invisible)
- *  - Commit step precedes the "never speak" step
+ *  - Persistence-verification step precedes the "never speak" step
  *
  * Canonical source: .squad-templates/scribe-charter.md
  *
@@ -18,6 +19,12 @@
  * PRE-CHECK / GIT COMMIT section labels (bold headers), which no longer
  * exist in the new prose-based charter structure. HEALTH REPORT and the
  * archival size thresholds (20KB / 50KB) are still present and tested below.
+ *
+ * The runtime-state-backend migration removed the explicit "git commit" step:
+ * mutable squad state is now persisted through `squad_state_*` tools, and the
+ * charter explicitly forbids Scribe from committing, switching branches, or
+ * pushing note refs. The persistence-verification step (squad_state_health +
+ * state re-reads) replaces the old commit step and is what we now assert.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -76,10 +83,20 @@ describe('Scribe charter — task structure and HARD GATE enforcement', () => {
     expect(hasStep, 'Deduplication must appear on a numbered step line').toBe(true);
   });
 
-  it('commit step is present', () => {
+  it('persistence-verification step is present', () => {
     const numberedLines = taskBlock.split('\n').filter(l => l.trim().match(/^\d+\./));
-    const hasStep = numberedLines.some(l => l.includes('Commit'));
-    expect(hasStep, 'Commit must appear on a numbered step line').toBe(true);
+    const hasStep = numberedLines.some(l => l.includes('Verify persistence'));
+    expect(
+      hasStep,
+      'Persistence-verification step (runtime state backend) must appear on a numbered step line',
+    ).toBe(true);
+  });
+
+  it('charter forbids Scribe from committing mutable squad state', () => {
+    expect(
+      content,
+      'Charter must explicitly forbid committing/pushing/branch-switching for mutable state',
+    ).toMatch(/Never commit[^.]*mutable squad state/);
   });
 
   it('HARD GATE enforcement is documented in the charter', () => {
@@ -109,11 +126,14 @@ describe('Scribe charter — task structure and HARD GATE enforcement', () => {
     ).toContain('Never speak to the user');
   });
 
-  it('commit step precedes "Never speak to the user."', () => {
-    const commitIndex = taskBlock.indexOf('Commit');
+  it('persistence-verification step precedes "Never speak to the user."', () => {
+    const verifyIndex = taskBlock.indexOf('Verify persistence');
     const neverSpeakIndex = taskBlock.indexOf('Never speak to the user.');
-    expect(commitIndex, 'Commit step not found in task block').toBeGreaterThan(-1);
+    expect(verifyIndex, 'Persistence-verification step not found in task block').toBeGreaterThan(-1);
     expect(neverSpeakIndex, '"Never speak to the user." not found in task block').toBeGreaterThan(-1);
-    expect(commitIndex, 'Commit must precede "Never speak to the user."').toBeLessThan(neverSpeakIndex);
+    expect(
+      verifyIndex,
+      'Persistence-verification step must precede "Never speak to the user."',
+    ).toBeLessThan(neverSpeakIndex);
   });
 });


### PR DESCRIPTION
﻿## Summary

Follow-up to #1154. PR #1154 fixed the original CI failures from #1151, but two assertions drifted again as the Scribe charter and spawn templates continued evolving. This PR re-aligns those tests with the current canonical sources.

Closes the lingering CI failure on `dev` (e.g. https://github.com/obit91/squad/actions/runs/26467955605/job/77933270562).

## Failures fixed

### `test/ci/scribe-template.test.ts`

Two tests expected a numbered `Commit` step in the Scribe task block:

- `commit step is present`
- `commit step precedes "Never speak to the user."`

The runtime-state-backend migration removed git commits from Scribe — mutable squad state is now persisted through `squad_state_*` tools, and `scribe-charter.md` explicitly forbids Scribe from committing, switching branches, or pushing note refs.

Replaced with:

- `persistence-verification step is present` — checks for the `Verify persistence` numbered step that now sits where `Commit` used to.
- `persistence-verification step precedes "Never speak to the user."` — preserves the ordering invariant.
- `charter forbids Scribe from committing mutable squad state` — guard so future edits don't quietly re-introduce commit behavior.

### `test/ci/datetime-template.test.ts`

`tells agents to substitute the literal datetime in command examples` expected the substitution strings (`<literal CURRENT_DATETIME value from your prompt>` and `Substitute the actual CURRENT_DATETIME value`) to live in `spawn-reference.md`. They are still defined in the Full Spawn Template inline block in `squad.agent.md`.

Widened the assertion to check across all coordinator-owned template files (`squad.agent.md` + `spawn-reference.md` + `after-agent-reference.md`) so it survives future relocations within that set without breaking again.

## Testing

All 16 tests across both files pass locally:

```
 Γ£ô test/ci/datetime-template.test.ts (5 tests)
 Γ£ô test/ci/scribe-template.test.ts (11 tests)
 Test Files  2 passed (2)
      Tests  16 passed (16)
```

## Scope

Test-only changes — no `packages/*/src/` modifications, so no changeset required per the project's changeset gate.

Related: #1151, #1154
