### PR TITLE
Refactor MCP config generation into SDK helper

### DIFF
--- a/.changeset/fix-mcp-config-helpers.md
+++ b/.changeset/fix-mcp-config-helpers.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-sdk": patch
+"@bradygaster/squad-cli": patch
+---
+
+Share MCP config generation through the SDK config helpers and support CRLF agent frontmatter delimiters.

--- a/packages/squad-cli/src/cli/core/upgrade.ts
+++ b/packages/squad-cli/src/cli/core/upgrade.ts
@@ -7,6 +7,7 @@
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { FSStorageProvider } from '@bradygaster/squad-sdk';
+import { buildMcpServerSpecs, hasMcpFrontmatter, injectMcpFrontmatter, type McpConfigMode } from '@bradygaster/squad-sdk/config';
 import { success, warn, info, dim, bold } from './output.js';
 import { fatal } from './errors.js';
 import { detectSquadDir } from './detect-squad-dir.js';
@@ -19,94 +20,6 @@ export { resolveSquadStateMcpSpec } from './mcp-spec.js';
 import { ensureSquadStateMcpInRoot, tombstoneStaleSquadStateInProjectMcp } from './mcp-root.js';
 
 const storage = new FSStorageProvider();
-
-type McpConfigMode = 'copilot-file' | 'agent-frontmatter';
-
-interface McpServerSpec {
-  name: string;
-  command: string;
-  args: string[];
-  env?: Record<string, string>;
-}
-
-function buildMcpServerSpecs(isGitHub: boolean, cliVersion?: string): McpServerSpec[] {
-  // Pin the squad-cli package to the currently-installed CLI version so that
-  // `npx -y @bradygaster/squad-cli state-mcp` does NOT silently resolve to the
-  // npm `latest` dist-tag (which may predate the `state-mcp` command and thus
-  // expose zero tools to Copilot — see MCP-BRIDGE-BROKEN root cause).
-  const pkgSpec = cliVersion && cliVersion !== '0.0.0'
-    ? `@bradygaster/squad-cli@${cliVersion}`
-    : '@bradygaster/squad-cli';
-  const servers: McpServerSpec[] = [
-    {
-      name: 'squad_state',
-      command: 'npx',
-      args: ['-y', pkgSpec, 'state-mcp'],
-    },
-  ];
-
-  servers.push(isGitHub
-    ? {
-        name: 'EXAMPLE-github',
-        command: 'npx',
-        args: ['-y', '@anthropic/github-mcp-server'],
-        env: { GITHUB_TOKEN: '${GITHUB_TOKEN}' },
-      }
-    : {
-        name: 'EXAMPLE-azure-devops',
-        command: 'npx',
-        args: ['-y', '@azure/devops-mcp-server'],
-        env: {
-          AZURE_DEVOPS_ORG: '${AZURE_DEVOPS_ORG}',
-          AZURE_DEVOPS_PAT: '${AZURE_DEVOPS_PAT}',
-        },
-      });
-
-  return servers;
-}
-
-function yamlSingleQuoted(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-function yamlEnvValue(value: string): string {
-  if (/^\$\{[A-Z0-9_]+\}$/.test(value)) {
-    return value;
-  }
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
-}
-
-function buildMcpFrontmatterBlock(isGitHub: boolean, cliVersion?: string): string {
-  const lines = ['mcp-servers:'];
-  for (const server of buildMcpServerSpecs(isGitHub, cliVersion)) {
-    lines.push(`  ${server.name}:`);
-    lines.push('    type: local');
-    lines.push(`    command: ${server.command}`);
-    lines.push(`    args: [${server.args.map(yamlSingleQuoted).join(', ')}]`);
-    lines.push('    tools: ["*"]');
-
-    if (server.env && Object.keys(server.env).length > 0) {
-      lines.push('    env:');
-      for (const [key, value] of Object.entries(server.env)) {
-        lines.push(`      ${key}: ${yamlEnvValue(value)}`);
-      }
-    }
-  }
-
-  return lines.join('\n');
-}
-
-function injectMcpFrontmatter(content: string, isGitHub: boolean, cliVersion?: string): string {
-  const closingStart = content.indexOf('\n---', 4);
-  if (!content.startsWith('---') || closingStart === -1) {
-    return content;
-  }
-
-  return content.slice(0, closingStart)
-    + '\n'
-    + buildMcpFrontmatterBlock(isGitHub, cliVersion)
-    + content.slice(closingStart);
-}
 
 function copyDirRecursive(src: string, dest: string, force = true): void {
   storage.mkdirSync(dest, { recursive: true });
@@ -186,9 +99,7 @@ function detectMcpConfigMode(config: Record<string, unknown>, agentDest: string)
 
   if (storage.existsSync(agentDest)) {
     const existingAgent = storage.readSync(agentDest) ?? '';
-    const frontmatterEnd = existingAgent.indexOf('\n---', 4);
-    const frontmatter = frontmatterEnd === -1 ? '' : existingAgent.slice(0, frontmatterEnd);
-    if (frontmatter.includes('mcp-servers:')) {
+    if (hasMcpFrontmatter(existingAgent)) {
       return 'agent-frontmatter';
     }
   }
@@ -215,7 +126,7 @@ function detectIsGitHubForMcp(dest: string, config: Record<string, unknown>): bo
 function writeAgentTemplate(agentSrc: string, agentDest: string, cliVersion: string, mcpConfigMode: McpConfigMode, isGitHub: boolean): void {
   let agentContent = storage.readSync(agentSrc) ?? '';
   if (mcpConfigMode === 'agent-frontmatter') {
-    agentContent = injectMcpFrontmatter(agentContent, isGitHub, cliVersion);
+    agentContent = injectMcpFrontmatter(agentContent, buildMcpServerSpecs(isGitHub, cliVersion));
   }
   storage.writeSync(agentDest, agentContent);
   stampVersion(agentDest, cliVersion);

--- a/packages/squad-sdk/src/config/index.ts
+++ b/packages/squad-sdk/src/config/index.ts
@@ -6,6 +6,7 @@ export * from './schema.js';
 export * from './agent-source.js';
 export * from './routing.js';
 export * from './models.js';
+export * from './mcp-config.js';
 export * from './init.js';
 export * from './agent-doc.js';
 export * from './doc-sync.js';

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -19,6 +19,7 @@ import type { SubSquadDefinition } from '../streams/types.js';
 import { ENGINEERING_ROLE_IDS } from '../roles/catalog.js';
 import { getRoleById } from '../roles/index.js';
 import { ensureMemoryGovernanceDefaults } from '../memory/index.js';
+import { buildMcpConfigJson, buildMcpServerSpecs, injectMcpFrontmatter, type McpConfigMode } from './mcp-config.js';
 
 // ============================================================================
 // Manifest-Curated Skills (must stay in sync with TEMPLATE_MANIFEST in CLI)
@@ -613,101 +614,6 @@ function stampVersionInContent(content: string, version: string): string {
     `\`Squad v${version}\``
   );
   return content;
-}
-
-type McpConfigMode = 'copilot-file' | 'agent-frontmatter' | 'none';
-
-interface McpServerSpec {
-  name: string;
-  command: string;
-  args: string[];
-  env?: Record<string, string>;
-}
-
-function buildMcpServerSpecs(isGitHub: boolean, cliVersion?: string): McpServerSpec[] {
-  // Pin the squad-cli package to the currently-installed CLI version so that
-  // `npx -y @bradygaster/squad-cli state-mcp` does NOT silently resolve to the
-  // npm `latest` dist-tag (which may predate the `state-mcp` command and thus
-  // expose zero tools to Copilot — see MCP-BRIDGE-BROKEN root cause).
-  const pkgSpec = cliVersion && cliVersion !== '0.0.0'
-    ? `@bradygaster/squad-cli@${cliVersion}`
-    : '@bradygaster/squad-cli';
-  const servers: McpServerSpec[] = [
-    {
-      name: 'squad_state',
-      command: 'npx',
-      args: ['-y', pkgSpec, 'state-mcp'],
-    },
-  ];
-
-  servers.push(isGitHub
-    ? {
-        name: 'EXAMPLE-github',
-        command: 'npx',
-        args: ['-y', '@anthropic/github-mcp-server'],
-        env: { GITHUB_TOKEN: '${GITHUB_TOKEN}' },
-      }
-    : {
-        name: 'EXAMPLE-azure-devops',
-        command: 'npx',
-        args: ['-y', '@azure/devops-mcp-server'],
-        env: {
-          AZURE_DEVOPS_ORG: '${AZURE_DEVOPS_ORG}',
-          AZURE_DEVOPS_PAT: '${AZURE_DEVOPS_PAT}',
-        },
-      });
-
-  return servers;
-}
-
-function buildMcpConfigJson(servers: McpServerSpec[]): Record<string, unknown> {
-  return {
-    mcpServers: Object.fromEntries(servers.map(({ name, ...server }) => [name, server])),
-  };
-}
-
-function yamlSingleQuoted(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
-}
-
-function yamlEnvValue(value: string): string {
-  if (/^\$\{[A-Z0-9_]+\}$/.test(value)) {
-    return value;
-  }
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
-}
-
-function buildMcpFrontmatterBlock(servers: McpServerSpec[]): string {
-  const lines = ['mcp-servers:'];
-
-  for (const server of servers) {
-    lines.push(`  ${server.name}:`);
-    lines.push('    type: local');
-    lines.push(`    command: ${server.command}`);
-    lines.push(`    args: [${server.args.map(yamlSingleQuoted).join(', ')}]`);
-    lines.push('    tools: ["*"]');
-
-    if (server.env && Object.keys(server.env).length > 0) {
-      lines.push('    env:');
-      for (const [key, value] of Object.entries(server.env)) {
-        lines.push(`      ${key}: ${yamlEnvValue(value)}`);
-      }
-    }
-  }
-
-  return lines.join('\n');
-}
-
-function injectMcpFrontmatter(content: string, servers: McpServerSpec[]): string {
-  const closingStart = content.indexOf('\n---', 4);
-  if (!content.startsWith('---') || closingStart === -1) {
-    return content;
-  }
-
-  return content.slice(0, closingStart)
-    + '\n'
-    + buildMcpFrontmatterBlock(servers)
-    + content.slice(closingStart);
 }
 
 /**

--- a/packages/squad-sdk/src/config/mcp-config.ts
+++ b/packages/squad-sdk/src/config/mcp-config.ts
@@ -1,0 +1,115 @@
+export type McpConfigMode = 'copilot-file' | 'agent-frontmatter' | 'none';
+
+export interface McpServerSpec {
+  name: string;
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export function buildMcpServerSpecs(isGitHub: boolean, cliVersion?: string): McpServerSpec[] {
+  const pkgSpec = cliVersion && cliVersion !== '0.0.0'
+    ? `@bradygaster/squad-cli@${cliVersion}`
+    : '@bradygaster/squad-cli';
+  const servers: McpServerSpec[] = [
+    {
+      name: 'squad_state',
+      command: 'npx',
+      args: ['-y', pkgSpec, 'state-mcp'],
+    },
+  ];
+
+  servers.push(isGitHub
+    ? {
+        name: 'EXAMPLE-github',
+        command: 'npx',
+        args: ['-y', '@anthropic/github-mcp-server'],
+        env: { GITHUB_TOKEN: '${GITHUB_TOKEN}' },
+      }
+    : {
+        name: 'EXAMPLE-azure-devops',
+        command: 'npx',
+        args: ['-y', '@azure/devops-mcp-server'],
+        env: {
+          AZURE_DEVOPS_ORG: '${AZURE_DEVOPS_ORG}',
+          AZURE_DEVOPS_PAT: '${AZURE_DEVOPS_PAT}',
+        },
+      });
+
+  return servers;
+}
+
+export function buildMcpConfigJson(servers: McpServerSpec[]): Record<string, unknown> {
+  return {
+    mcpServers: Object.fromEntries(servers.map(({ name, ...server }) => [name, server])),
+  };
+}
+
+function yamlSingleQuoted(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function yamlEnvValue(value: string): string {
+  if (/^\$\{[A-Z0-9_]+\}$/.test(value)) {
+    return value;
+  }
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+export function buildMcpFrontmatterBlock(servers: McpServerSpec[]): string {
+  const lines = ['mcp-servers:'];
+
+  for (const server of servers) {
+    lines.push(`  ${server.name}:`);
+    lines.push('    type: local');
+    lines.push(`    command: ${server.command}`);
+    lines.push(`    args: [${server.args.map(yamlSingleQuoted).join(', ')}]`);
+    lines.push('    tools: ["*"]');
+
+    if (server.env && Object.keys(server.env).length > 0) {
+      lines.push('    env:');
+      for (const [key, value] of Object.entries(server.env)) {
+        lines.push(`      ${key}: ${yamlEnvValue(value)}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function findFrontmatterEnd(content: string): number {
+  if (!content.startsWith('---')) {
+    return -1;
+  }
+
+  const closingDelimiter = /\r?\n---(?=\r?\n|$)/g;
+  closingDelimiter.lastIndex = 3;
+  return closingDelimiter.exec(content)?.index ?? -1;
+}
+
+function contentLineEnding(content: string): '\r\n' | '\n' {
+  return content.includes('\r\n') ? '\r\n' : '\n';
+}
+
+export function injectMcpFrontmatter(content: string, servers: McpServerSpec[]): string {
+  const closingStart = findFrontmatterEnd(content);
+  if (closingStart === -1) {
+    return content;
+  }
+
+  const newline = contentLineEnding(content);
+  const frontmatterBlock = buildMcpFrontmatterBlock(servers).replace(/\n/g, newline);
+
+  return content.slice(0, closingStart)
+    + newline
+    + frontmatterBlock
+    + content.slice(closingStart);
+}
+
+export function hasMcpFrontmatter(content: string): boolean {
+  const frontmatterEnd = findFrontmatterEnd(content);
+  if (frontmatterEnd === -1) {
+    return false;
+  }
+  return content.slice(0, frontmatterEnd).includes('mcp-servers:');
+}

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -12,6 +12,83 @@ describe('SDK package exports', () => {
     expect(config).toBeDefined();
     // config barrel re-exports schema, routing, models, etc.
     expect(config.DEFAULT_CONFIG).toBeDefined();
+    expect(config.buildMcpServerSpecs).toBeDefined();
+    expect(config.injectMcpFrontmatter).toBeDefined();
+    expect(config.hasMcpFrontmatter).toBeDefined();
+  });
+
+  it('MCP config helpers build GitHub and Azure DevOps server specs', async () => {
+    const config = await import('@bradygaster/squad-sdk/config');
+
+    const githubServers = config.buildMcpServerSpecs(true);
+    expect(githubServers.map((server: { name: string }) => server.name)).toEqual(['squad_state', 'EXAMPLE-github']);
+    expect(githubServers[0]).not.toHaveProperty('env');
+    expect(githubServers[1]).toMatchObject({
+      command: 'npx',
+      args: ['-y', '@anthropic/github-mcp-server'],
+      env: { GITHUB_TOKEN: '${GITHUB_TOKEN}' },
+    });
+
+    const versionedServers = config.buildMcpServerSpecs(true, '1.2.3');
+    expect(versionedServers[0].args).toEqual(['-y', '@bradygaster/squad-cli@1.2.3', 'state-mcp']);
+
+    const adoServers = config.buildMcpServerSpecs(false);
+    expect(adoServers.map((server: { name: string }) => server.name)).toEqual(['squad_state', 'EXAMPLE-azure-devops']);
+    expect(adoServers[1]).toMatchObject({
+      command: 'npx',
+      args: ['-y', '@azure/devops-mcp-server'],
+      env: {
+        AZURE_DEVOPS_ORG: '${AZURE_DEVOPS_ORG}',
+        AZURE_DEVOPS_PAT: '${AZURE_DEVOPS_PAT}',
+      },
+    });
+  });
+
+  it('MCP config helpers build portable JSON config', async () => {
+    const config = await import('@bradygaster/squad-sdk/config');
+    const mcpConfig = config.buildMcpConfigJson(config.buildMcpServerSpecs(true));
+
+    expect(mcpConfig).toMatchObject({
+      mcpServers: {
+        squad_state: {
+          command: 'npx',
+          args: ['-y', '@bradygaster/squad-cli', 'state-mcp'],
+        },
+        'EXAMPLE-github': {
+          command: 'npx',
+          args: ['-y', '@anthropic/github-mcp-server'],
+          env: { GITHUB_TOKEN: '${GITHUB_TOKEN}' },
+        },
+      },
+    });
+    expect((mcpConfig as { mcpServers: Record<string, unknown> }).mcpServers.squad_state).not.toHaveProperty('env');
+  });
+
+  it('MCP frontmatter helpers only detect and inject frontmatter blocks', async () => {
+    const config = await import('@bradygaster/squad-sdk/config');
+    const bodyOnly = 'mcp-servers:\n  fake: true\n';
+    expect(config.hasMcpFrontmatter(bodyOnly)).toBe(false);
+    expect(config.injectMcpFrontmatter(bodyOnly, config.buildMcpServerSpecs(true))).toBe(bodyOnly);
+
+    const agent = '---\nname: Squad\ndescription: Test\n---\n\nBody mentions mcp-servers: only here.\n';
+    expect(config.hasMcpFrontmatter(agent)).toBe(false);
+
+    const injected = config.injectMcpFrontmatter(agent, config.buildMcpServerSpecs(true));
+    expect(config.hasMcpFrontmatter(injected)).toBe(true);
+    expect(injected).toContain('mcp-servers:\n  squad_state:');
+    expect(injected).toContain('\n---\n\nBody mentions mcp-servers: only here.\n');
+  });
+
+  it('MCP frontmatter helpers support CRLF frontmatter delimiters', async () => {
+    const config = await import('@bradygaster/squad-sdk/config');
+    const agent = '---\r\nname: Squad\r\ndescription: Test\r\n---\r\n\r\nBody.\r\n';
+
+    expect(config.hasMcpFrontmatter(agent)).toBe(false);
+
+    const injected = config.injectMcpFrontmatter(agent, config.buildMcpServerSpecs(true));
+    expect(config.hasMcpFrontmatter(injected)).toBe(true);
+    expect(injected).toContain('mcp-servers:\r\n  squad_state:');
+    expect(injected).toContain('\r\n---\r\n\r\nBody.\r\n');
   });
 
   it('exports from /resolution subpath', async () => {


### PR DESCRIPTION
## Summary

- extract duplicated MCP server/config/frontmatter generation into `@bradygaster/squad-sdk/config`
- update init and upgrade paths to use the shared MCP helper
- align CLI SDK dependency minimum and lockfile metadata with the new SDK export
- add behavioral package-export coverage for the shared MCP helper

## Tests

- `npm test -- test/package-exports.test.ts test/cli/init.test.ts test/cli/upgrade.test.ts`
- `npm run lint`

Follow-up to #1166
