### PR TITLE
Updating installation instructions for Squad to include default initialization in core README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ git init
 
 **✓ Validate:** Run `git status` — you should see "No commits yet".
 
-### 2. Install Squad
+### 2. Install Squad and init with defaults
 
 ```bash
 npm install -g @bradygaster/squad-cli
-squad init
+squad init --preset default
 ```
 
 **✓ Validate:** Check that `.squad/team.md` was created in your project.

--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ git init
 
 **✓ Validate:** Run `git status` — you should see "No commits yet".
 
-### 2. Install Squad and init with defaults
+### 2. Install Squad
 
 ```bash
 npm install -g @bradygaster/squad-cli
-squad init --preset default
+squad init
 ```
+
+> **⚡ Want to be up and running in under a second?** Use `squad init --preset default` to start with a fully-configured squad — complete with members, charters, and routing rules — ready to go immediately. The default `squad init` (without the flag) walks you through setup step by step, ideal if you prefer to build and customize your squad deliberately.
 
 **✓ Validate:** Check that `.squad/team.md` was created in your project.
 


### PR DESCRIPTION
Updated installation instructions for Squad to include default initialization.

### What

This pull request updates the installation instructions in the `README.md` to clarify the initialization process for Squad. The change specifies the use of the `--preset default` flag when running `squad init` to ensure users initialize with default settings.  The net impact is the squad is ready to run sub-second with good starting points for squad members and charters.  

### Why
faster init for people wanting to use squad before customizing it


---

### ⚠️ Quick Check
- [ ] If SDK/CLI source files changed: completed the applicable Changeset step below (`npx changeset add` / `.changeset/*.md`, direct `CHANGELOG.md` entry for maintainers, or `skip-changelog` label for no user-facing changes)

### PR Readiness Checklist

> The PR readiness bot will validate these automatically after push.
> Check each item before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for full details.

#### Branch & Commit
- [x] Branch created from `dev` (not `main`)
- [x] Branch is up to date with `dev` (`git fetch upstream && git rebase upstream/dev`)
- [x] Verified diff contains only intended changes (`git diff --cached --stat`)
- [x] PR is **not** in draft mode (mark ready when checks pass)
- [x] Commit history is clean (squash fixups before review)
