### PR TITLE
feat(cli): prompt to add @copilot during squad init (#1147)

### DIFF
--- a/.changeset/init-copilot-opt-in.md
+++ b/.changeset/init-copilot-opt-in.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": minor
+---
+
+`squad init` now offers to add @copilot as a team member (#1147). When run interactively it prompts "Add @copilot as an autonomous team member?"; answering yes adds the @copilot roster entry and `.github/copilot-instructions.md` inline. New `--copilot` / `--no-copilot` flags skip the prompt for non-interactive use, and non-interactive runs skip silently (unchanged behavior).

--- a/packages/squad-cli/README.md
+++ b/packages/squad-cli/README.md
@@ -67,6 +67,7 @@ For detailed documentation on each command, see the [CLI Reference](https://docs
 |---------|---------|
 | `squad` | Enter interactive shell (no arguments) |
 | `squad init` | Initialize Squad in current repo (idempotent) |
+| `squad init --copilot` | Initialize and add @copilot without prompting (`--no-copilot` to skip) |
 | `squad init --global` | Create a personal squad in your home directory |
 | `squad status` | Show which squad is active and why |
 | `squad doctor` | Validate setup integrity and diagnose issues |

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -161,6 +161,7 @@ async function main(): Promise<void> {
     console.log(`                    --no-workflows (skip CI setup)`);
     console.log(`                    --preset <name> (apply a preset after init)`);
     console.log(`                    --state-backend <type> (local|orphan|two-layer)`);
+    console.log(`                    --copilot / --no-copilot (add @copilot without prompting)`);
     console.log(`             Usage: init --mode remote <team-repo-path>`);
     console.log(`             Creates .squad/config.json pointing to an external team root`);
     console.log(`  ${BOLD}upgrade${RESET}    Update Squad-owned files to latest version`);
@@ -351,8 +352,14 @@ async function main(): Promise<void> {
     // Parse --state-backend flag for init
     const sbIdx = args.indexOf('--state-backend');
     const initStateBackend = (sbIdx !== -1 && args[sbIdx + 1]) ? args[sbIdx + 1] : undefined;
+    // Tri-state @copilot opt-in: --no-copilot wins (safe skip), then --copilot, else prompt.
+    const copilot = args.includes('--no-copilot')
+      ? false
+      : args.includes('--copilot')
+        ? true
+        : undefined;
     // Global init: suppress workflows (no GitHub CI in ~/.config/squad/) and bootstrap personal squad
-    runInit(dest, { includeWorkflows: !noWorkflows && !hasGlobal, sdk, roles, isGlobal: hasGlobal, stateBackend: initStateBackend, mcpFrontmatter }).then(async () => {
+    runInit(dest, { includeWorkflows: !noWorkflows && !hasGlobal, sdk, roles, isGlobal: hasGlobal, stateBackend: initStateBackend, mcpFrontmatter, copilot }).then(async () => {
       if (presetName) {
         const { seedBuiltinPresets, applyPreset } = await import('@bradygaster/squad-sdk/presets');
         const { resolvePresetsDir, ensureSquadHome } = await import('@bradygaster/squad-sdk/resolution');

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -155,8 +155,7 @@ async function main(): Promise<void> {
     console.log(`  ${BOLD}(default)${RESET}  Launch interactive shell (no args)`);
     console.log(`             Flags: --global (init in personal squad directory)`);
     console.log(`  ${BOLD}init${RESET}       Initialize Squad (markdown-only, default)`);
-    console.log(`             Flags: --sdk (SDK builder syntax)`);
-    console.log(`                    --roles (use base roles)`);
+    console.log(`             Flags: --sdk (SDK builder syntax), --roles (use base roles)`);
     console.log(`                    --global (personal squad dir)`);
     console.log(`                    --no-workflows (skip CI setup)`);
     console.log(`                    --preset <name> (apply a preset after init)`);

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -160,7 +160,7 @@ async function main(): Promise<void> {
     console.log(`                    --no-workflows (skip CI setup)`);
     console.log(`                    --preset <name> (apply a preset after init)`);
     console.log(`                    --state-backend <type> (local|orphan|two-layer)`);
-    console.log(`                    --copilot / --no-copilot (add @copilot without prompting)`);
+    console.log(`                    --copilot (add @copilot) / --no-copilot (skip), no prompt`);
     console.log(`             Usage: init --mode remote <team-repo-path>`);
     console.log(`             Creates .squad/config.json pointing to an external team root`);
     console.log(`  ${BOLD}upgrade${RESET}    Update Squad-owned files to latest version`);

--- a/packages/squad-cli/src/cli/commands/copilot.ts
+++ b/packages/squad-cli/src/cli/commands/copilot.ts
@@ -4,6 +4,7 @@
  */
 
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { FSStorageProvider } from '@bradygaster/squad-sdk';
 
 const storage = new FSStorageProvider();
@@ -24,18 +25,17 @@ export interface CopilotFlags {
 }
 
 /**
- * Copy the bundled copilot-instructions.md template into <dest>/.github/.
+ * Copy the bundled copilot-instructions.md template into <root>/.github/.
+ * `root` is the directory whose `.github/` should hold the file — usually the
+ * git root (in a monorepo this differs from the team's `.squad/` location).
  * Returns true if the template existed and was copied.
  */
-export function copyCopilotInstructions(dest: string): boolean {
+export function copyCopilotInstructions(root: string): boolean {
   // Templates are at the root of the package (../../../templates from dist/cli/commands/)
-  const currentFileUrl = new URL(import.meta.url);
-  const currentFilePath = currentFileUrl.pathname.startsWith('/') && process.platform === 'win32'
-    ? currentFileUrl.pathname.substring(1) // Remove leading / on Windows
-    : currentFileUrl.pathname;
+  const currentFilePath = fileURLToPath(import.meta.url);
   const templatesSrc = path.resolve(path.dirname(currentFilePath), '..', '..', '..', 'templates');
   const instructionsSrc = path.join(templatesSrc, 'copilot-instructions.md');
-  const instructionsDest = path.join(dest, '.github', 'copilot-instructions.md');
+  const instructionsDest = path.join(root, '.github', 'copilot-instructions.md');
 
   if (storage.existsSync(instructionsSrc)) {
     storage.mkdirSync(path.dirname(instructionsDest), { recursive: true });
@@ -49,12 +49,17 @@ export function copyCopilotInstructions(dest: string): boolean {
  * Add @copilot to the team roster and copy copilot-instructions.md.
  * Shared by the `squad copilot` command and the `squad init` opt-in prompt.
  *
+ * `dest` locates the team's `.squad/`; `instructionsRoot` (defaulting to `dest`)
+ * is the directory whose `.github/copilot-instructions.md` is written — pass the
+ * git root in monorepo/subfolder layouts so Copilot picks it up at the repo root.
+ *
  * Idempotent: when @copilot is already on the team the roster is left untouched
  * (returns added: false). Throws when no squad directory exists.
  */
 export function addCopilotToTeam(
   dest: string,
-  autoAssign: boolean = false
+  autoAssign: boolean = false,
+  instructionsRoot: string = dest
 ): { added: boolean; instructionsWritten: boolean } {
   const squadDir = detectSquadDir(dest).path;
 
@@ -69,7 +74,7 @@ export function addCopilotToTeam(
 
   content = insertCopilotSection(content, autoAssign);
   writeTeamMd(squadDir, content);
-  const instructionsWritten = copyCopilotInstructions(dest);
+  const instructionsWritten = copyCopilotInstructions(instructionsRoot);
   return { added: true, instructionsWritten };
 }
 

--- a/packages/squad-cli/src/cli/commands/copilot.ts
+++ b/packages/squad-cli/src/cli/commands/copilot.ts
@@ -24,6 +24,56 @@ export interface CopilotFlags {
 }
 
 /**
+ * Copy the bundled copilot-instructions.md template into <dest>/.github/.
+ * Returns true if the template existed and was copied.
+ */
+export function copyCopilotInstructions(dest: string): boolean {
+  // Templates are at the root of the package (../../../templates from dist/cli/commands/)
+  const currentFileUrl = new URL(import.meta.url);
+  const currentFilePath = currentFileUrl.pathname.startsWith('/') && process.platform === 'win32'
+    ? currentFileUrl.pathname.substring(1) // Remove leading / on Windows
+    : currentFileUrl.pathname;
+  const templatesSrc = path.resolve(path.dirname(currentFilePath), '..', '..', '..', 'templates');
+  const instructionsSrc = path.join(templatesSrc, 'copilot-instructions.md');
+  const instructionsDest = path.join(dest, '.github', 'copilot-instructions.md');
+
+  if (storage.existsSync(instructionsSrc)) {
+    storage.mkdirSync(path.dirname(instructionsDest), { recursive: true });
+    storage.copySync(instructionsSrc, instructionsDest);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Add @copilot to the team roster and copy copilot-instructions.md.
+ * Shared by the `squad copilot` command and the `squad init` opt-in prompt.
+ *
+ * Idempotent: when @copilot is already on the team the roster is left untouched
+ * (returns added: false). Throws when no squad directory exists.
+ */
+export function addCopilotToTeam(
+  dest: string,
+  autoAssign: boolean = false
+): { added: boolean; instructionsWritten: boolean } {
+  const squadDir = detectSquadDir(dest).path;
+
+  if (!storage.existsSync(squadDir)) {
+    throw new Error('No squad found — run init first, then add the copilot agent.');
+  }
+
+  let content = readTeamMd(squadDir);
+  if (hasCopilot(content)) {
+    return { added: false, instructionsWritten: false };
+  }
+
+  content = insertCopilotSection(content, autoAssign);
+  writeTeamMd(squadDir, content);
+  const instructionsWritten = copyCopilotInstructions(dest);
+  return { added: true, instructionsWritten };
+}
+
+/**
  * Run copilot command
  */
 export async function runCopilot(dest: string, flags: CopilotFlags): Promise<void> {
@@ -72,27 +122,16 @@ export async function runCopilot(dest: string, flags: CopilotFlags): Promise<voi
   }
 
   // Add copilot
-  content = insertCopilotSection(content, flags.autoAssign);
-  writeTeamMd(squadDir, content);
+  addCopilotToTeam(dest, flags.autoAssign);
   success('Added @copilot (Coding Agent) to team roster');
   
   if (flags.autoAssign) {
     success('Auto-assign enabled — squad-labeled issues will be assigned to @copilot');
   }
 
-  // Copy copilot-instructions.md from templates
-  // Templates are at the root of the package (../../../templates from dist/cli/commands/)
-  const currentFileUrl = new URL(import.meta.url);
-  const currentFilePath = currentFileUrl.pathname.startsWith('/') && process.platform === 'win32'
-    ? currentFileUrl.pathname.substring(1) // Remove leading / on Windows
-    : currentFileUrl.pathname;
-  const templatesSrc = path.resolve(path.dirname(currentFilePath), '..', '..', '..', 'templates');
-  const instructionsSrc = path.join(templatesSrc, 'copilot-instructions.md');
+  // copilot-instructions.md was copied by addCopilotToTeam (when the template exists)
   const instructionsDest = path.join(dest, '.github', 'copilot-instructions.md');
-  
-  if (storage.existsSync(instructionsSrc)) {
-    storage.mkdirSync(path.dirname(instructionsDest), { recursive: true });
-    storage.copySync(instructionsSrc, instructionsDest);
+  if (storage.existsSync(instructionsDest)) {
     success('.github/copilot-instructions.md');
   }
 

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -138,18 +138,18 @@ export interface RunInitOptions {
  *   - undefined + TTY           → prompt the user
  *   - undefined + non-interactive → skip silently
  */
-async function promptCopilot(dest: string, options: RunInitOptions): Promise<void> {
+async function promptCopilot(dest: string, agentFileRoot: string, options: RunInitOptions): Promise<void> {
   // @copilot is a repo concept — not relevant for the personal/global squad.
   if (options.isGlobal) return;
 
-  // Already on the team (e.g. re-init) — nothing to do.
+  // Already on the team (e.g. re-init), or no squad to add to — skip.
   try {
     const squadDir = detectSquadDir(dest).path;
     if (storage.existsSync(squadDir) && hasCopilot(readTeamMd(squadDir))) {
       return;
     }
   } catch {
-    // No squad / unreadable team.md — fall through; nothing to add.
+    // No squad / unreadable team.md — nothing to add.
     return;
   }
 
@@ -174,7 +174,9 @@ async function promptCopilot(dest: string, options: RunInitOptions): Promise<voi
   }
 
   if (enable) {
-    const { added, instructionsWritten } = addCopilotToTeam(dest);
+    // In a monorepo, .github/ lives at the git root (agentFileRoot), so copilot-instructions.md
+    // must land there — alongside .github/agents/ — even though .squad/ is in the subfolder.
+    const { added, instructionsWritten } = addCopilotToTeam(dest, false, agentFileRoot);
     if (added) {
       success('Added @copilot (Coding Agent) to team roster');
       if (instructionsWritten) success('.github/copilot-instructions.md');
@@ -498,7 +500,7 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
   // ── @copilot opt-in ─────────────────────────────────────────────────
   // .github/copilot-instructions.md affects every Copilot interaction in the
   // repo, so adding @copilot is an explicit opt-in rather than a silent default.
-  await promptCopilot(dest, options);
+  await promptCopilot(dest, agentFileRoot, options);
 
   console.log(`${GREEN}${BOLD}Squad initialized.${RESET} Run ${CYAN}${BOLD}copilot --agent squad${RESET} and tell it what you're building.`);
   console.log();

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -7,6 +7,8 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { FSStorageProvider } from '@bradygaster/squad-sdk';
 import { detectSquadDir, resolveWorktreeMainCheckout } from './detect-squad-dir.js';
+import { readTeamMd, hasCopilot } from './team-md.js';
+import { addCopilotToTeam } from '../commands/copilot.js';
 import { success, BOLD, RESET, YELLOW, GREEN, DIM } from './output.js';
 import { fatal } from './errors.js';
 import { detectProjectType } from './project-type.js';
@@ -117,6 +119,72 @@ export interface RunInitOptions {
   stateBackend?: string;
   /** If true, write MCP server config into squad.agent.md frontmatter instead of .copilot/mcp-config.json */
   mcpFrontmatter?: boolean;
+  /**
+   * Controls the @copilot opt-in during init.
+   * - true: add @copilot inline without prompting (e.g. `--copilot`)
+   * - false: skip silently (e.g. `--no-copilot`)
+   * - undefined: prompt interactively when attached to a TTY, otherwise skip silently
+   */
+  copilot?: boolean;
+}
+
+/**
+ * Interactive @copilot opt-in shown after init scaffolding completes.
+ *
+ * @copilot is a repo-level team member and `.github/copilot-instructions.md`
+ * affects every Copilot interaction in the repo, so it is never added silently:
+ *   - options.copilot === true  → add inline (e.g. `--copilot`)
+ *   - options.copilot === false → skip silently (e.g. `--no-copilot`)
+ *   - undefined + TTY           → prompt the user
+ *   - undefined + non-interactive → skip silently
+ */
+async function promptCopilot(dest: string, options: RunInitOptions): Promise<void> {
+  // @copilot is a repo concept — not relevant for the personal/global squad.
+  if (options.isGlobal) return;
+
+  // Already on the team (e.g. re-init) — nothing to do.
+  try {
+    const squadDir = detectSquadDir(dest).path;
+    if (storage.existsSync(squadDir) && hasCopilot(readTeamMd(squadDir))) {
+      return;
+    }
+  } catch {
+    // No squad / unreadable team.md — fall through; nothing to add.
+    return;
+  }
+
+  // Explicit opt-out, or non-interactive without an explicit opt-in: skip silently.
+  if (options.copilot === false) return;
+  if (options.copilot !== true && !process.stdin.isTTY) return;
+
+  let enable = options.copilot === true;
+  let answeredInteractively = false;
+  if (!enable) {
+    const { createInterface } = await import('node:readline/promises');
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      const answer = (await rl.question(
+        `${BOLD}Add @copilot as an autonomous team member?${RESET} ${DIM}[y/N]${RESET} `,
+      )).trim().toLowerCase();
+      enable = answer === 'y' || answer === 'yes';
+      answeredInteractively = true;
+    } finally {
+      rl.close();
+    }
+  }
+
+  if (enable) {
+    const { added, instructionsWritten } = addCopilotToTeam(dest);
+    if (added) {
+      success('Added @copilot (Coding Agent) to team roster');
+      if (instructionsWritten) success('.github/copilot-instructions.md');
+      console.log(`${DIM}  Enable auto-assignment later with ${RESET}${BOLD}squad copilot --auto-assign${RESET}`);
+    }
+    console.log();
+  } else if (answeredInteractively) {
+    console.log(`${DIM}Skipped @copilot — add it later with ${RESET}${BOLD}squad copilot${RESET}${DIM}.${RESET}`);
+    console.log();
+  }
 }
 
 /**
@@ -426,6 +494,12 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
 
   if (!isInitNoColor()) await sleep(80);
   console.log();
+
+  // ── @copilot opt-in ─────────────────────────────────────────────────
+  // .github/copilot-instructions.md affects every Copilot interaction in the
+  // repo, so adding @copilot is an explicit opt-in rather than a silent default.
+  await promptCopilot(dest, options);
+
   console.log(`${GREEN}${BOLD}Squad initialized.${RESET} Run ${CYAN}${BOLD}copilot --agent squad${RESET} and tell it what you're building.`);
   console.log();
   console.log(`${DIM}Tip: for non-interactive scripts that need squad_state tools, add to package.json:${RESET}`);

--- a/test/cli/init.test.ts
+++ b/test/cli/init.test.ts
@@ -260,4 +260,49 @@ describe('CLI: init command', () => {
     const secondContent = await readFile(agentPath, 'utf-8');
     expect(secondContent).toContain('<!-- MODIFIED -->');
   });
+
+  describe('@copilot opt-in (#1147)', () => {
+    it('does not add @copilot by default in non-interactive mode', async () => {
+      await runInit(TEST_ROOT);
+
+      const instructionsPath = join(TEST_ROOT, '.github', 'copilot-instructions.md');
+      expect(existsSync(instructionsPath)).toBe(false);
+
+      const teamPath = join(TEST_ROOT, '.squad', 'team.md');
+      const team = await readFile(teamPath, 'utf-8');
+      expect(team.toLowerCase()).not.toContain('@copilot');
+    });
+
+    it('skips @copilot silently when copilot: false', async () => {
+      await runInit(TEST_ROOT, { copilot: false });
+
+      const instructionsPath = join(TEST_ROOT, '.github', 'copilot-instructions.md');
+      expect(existsSync(instructionsPath)).toBe(false);
+    });
+
+    it('adds @copilot inline when copilot: true', async () => {
+      await runInit(TEST_ROOT, { copilot: true });
+
+      const instructionsPath = join(TEST_ROOT, '.github', 'copilot-instructions.md');
+      expect(existsSync(instructionsPath)).toBe(true);
+
+      const teamPath = join(TEST_ROOT, '.squad', 'team.md');
+      const team = await readFile(teamPath, 'utf-8');
+      expect(team).toContain('@copilot');
+    });
+
+    it('is idempotent across re-init with copilot: true', async () => {
+      await runInit(TEST_ROOT, { copilot: true });
+      const teamPath = join(TEST_ROOT, '.squad', 'team.md');
+      const firstTeam = await readFile(teamPath, 'utf-8');
+
+      // Re-init should not duplicate the @copilot roster section.
+      await runInit(TEST_ROOT, { copilot: true });
+      const secondTeam = await readFile(teamPath, 'utf-8');
+
+      const count = (secondTeam.match(/@copilot/g) || []).length;
+      const firstCount = (firstTeam.match(/@copilot/g) || []).length;
+      expect(count).toBe(firstCount);
+    });
+  });
 });


### PR DESCRIPTION
Closes #1147

## Problem
Running `squad init` scaffolds the team but never creates `.github/copilot-instructions.md` — that file (and the `@copilot` roster entry) was only produced by the separate `squad copilot` command. New users who didn't know about that step got a confusing Copilot first-run experience, since Copilot had no Squad context.

## Change
During interactive `squad init` (after scaffolding completes), Squad now prompts:

> Add @copilot as an autonomous team member? [y/N]

- **yes** → adds the `@copilot` roster entry and copies `.github/copilot-instructions.md` inline
- **no** → notes it can be added later with `squad copilot`
- **non-interactive** (no TTY) → skips silently, preserving existing behavior

New flags `--copilot` / `--no-copilot` skip the prompt for scripted/non-interactive use (e.g. E2E).

## Implementation
- Extracted `addCopilotToTeam` and `copyCopilotInstructions` helpers in `copilot.ts`, now shared by the `squad copilot` command and init. `squad copilot` behavior is unchanged.
- `runInit` gains a `copilot?: boolean` option (tri-state) and a `promptCopilot` step.
- `@copilot` opt-in is skipped for `--global` (personal squad) and when `@copilot` is already on the team (idempotent re-init).

## Tests
- Extended `test/cli/init.test.ts`: default non-interactive does not add @copilot; `copilot: false` skips; `copilot: true` adds roster + instructions; re-init is idempotent.
- `npm run build` passes; init + copilot suites green (25 tests).

## Notes
- Includes a `minor` changeset for `@bradygaster/squad-cli`.
- The canonical command is `squad copilot` (the issue's `squad copilot enable` phrasing); messaging uses `squad copilot`.
