### PR TITLE
Add OSS release checklist files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# For more information, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# This repository is maintained by:
+* @bradygaster @tamirdresher

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <opensource@github.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ For SDK installation: `npm install @bradygaster/squad-sdk`
 ## Requirements
 
 - **Node.js** ≥22.5.0
-- **npm** ≥10.0.0 (for workspace support)
+- **npm** ≥10.0.0
 - **Git** with SSH agent
 - **GitHub CLI** (`gh`) for GitHub integration
 

--- a/README.md
+++ b/README.md
@@ -518,3 +518,35 @@ The SDK provides programmatic control over agent orchestration — custom tools,
 - [Samples](samples/README.md) — eight working examples from beginner to advanced
 
 For SDK installation: `npm install @bradygaster/squad-sdk`
+
+---
+
+## Requirements
+
+- **Node.js** ≥22.5.0
+- **npm** ≥10.0.0 (for workspace support)
+- **Git** with SSH agent
+- **GitHub CLI** (`gh`) for GitHub integration
+
+## License
+
+This project is licensed under the terms of the MIT open source license. Please refer to the [LICENSE](./LICENSE) file for the full terms.
+
+## Maintainers
+
+- [@bradygaster](https://github.com/bradygaster)
+- [@tamirdresher](https://github.com/tamirdresher)
+
+See [CODEOWNERS](.github/CODEOWNERS) for the full list.
+
+## Support
+
+For help or questions about using Squad, please use [GitHub Discussions](https://github.com/github/squad/discussions). See [SUPPORT.md](./SUPPORT.md) for details.
+
+## Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](./CONTRIBUTING.md) for build setup, monorepo structure, and guidelines.
+
+## Code of Conduct
+
+This project has adopted the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md). See the full text for details on expected behavior and reporting.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,7 +4,7 @@
 
 This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new issue.
 
-For help or questions about using Squad, please use [GitHub Discussions](https://github.com/github/squad/discussions) on this repository.
+For help or questions about using Squad, please use [GitHub Discussions](https://github.com/bradygaster/squad/discussions) on this repository.
 
 **Squad** is under active development and maintained by GitHub staff and the community. We will do our best to respond to support, feature requests, and community questions in a timely manner.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,13 @@
+# Support
+
+## How to file issues and get help
+
+This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new issue.
+
+For help or questions about using Squad, please use [GitHub Discussions](https://github.com/github/squad/discussions) on this repository.
+
+**Squad** is under active development and maintained by GitHub staff and the community. We will do our best to respond to support, feature requests, and community questions in a timely manner.
+
+## GitHub Support Policy
+
+Support for this project is limited to the resources listed above.


### PR DESCRIPTION
## Summary

Adds required files from the open-source release checklist to prepare Squad for transfer.

## Changes

- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v1.4 (per GitHub template)
- **`SUPPORT.md`** — Points users to GitHub Discussions for help
- **`.github/CODEOWNERS`** — @bradygaster @tamirdresher
- **`README.md`** — Appended required sections: Requirements, License, Maintainers, Support, Contributing, Code of Conduct

## Checklist items addressed

- [x] Add and update `CODEOWNERS`
- [x] Add `CODE_OF_CONDUCT.md`
- [x] Add and update `SUPPORT.md`
- [x] Update README.md to include sections from template
