### PR TITLE
ci: add tamirdresher to CHANGELOG Write Protection allowlist

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -251,7 +251,7 @@ jobs:
       - name: "Gate: CHANGELOG Write Protection"
         if: always()
         env:
-          APPROVED_AUTHORS: 'bradygaster github-actions[bot] copilot-swe-agent[bot]'
+          APPROVED_AUTHORS: 'bradygaster tamirdresher github-actions[bot] copilot-swe-agent[bot]'
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           echo "## 🔒 CHANGELOG Write Protection" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Add `tamirdresher` to CHANGELOG Write Protection allowlist

`.github/workflows/squad-ci.yml:254` — `APPROVED_AUTHORS` for the "CHANGELOG Write Protection" gate currently allows only `bradygaster`, `github-actions[bot]`, and `copilot-swe-agent[bot]`. Every release PR I drive (e.g. v0.9.4 in PR #1023, today's v0.10.0 in #1218 + #1219) modifies `CHANGELOG.md` directly and trips this gate, requiring admin merge override each time.

Adding `tamirdresher` as a fourth approved author matches established convention:
- I'm a co-maintainer per the CODEOWNERS update in #1217
- Past convention has been to land release PRs as me with Brady's admin-merge unblock (#1042 then #1023 for v0.9.4)
- This change removes the bottleneck without weakening protection — CHANGELOG writes still require an explicit allowlist entry

### Why this PR doesn't trip the gate itself
This PR doesn't touch `CHANGELOG.md` (only the workflow file), so the "CHANGELOG Write Protection" gate is inactive. Should pass cleanly through the normal "Gate: Changelog" check too — no SDK/CLI source modified.

### Rebase plan
Once this lands on dev, I'll rebase PR #1219 (dev → main promote for v0.10.0) on top, and CI will pass without admin override.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
