### PR TITLE
feat: add 'squad preset install <source>' for sharing presets via repo URL (#1224)

### DIFF
--- a/.changeset/feat-preset-install.md
+++ b/.changeset/feat-preset-install.md
@@ -1,0 +1,60 @@
+---
+"@bradygaster/squad-cli": minor
+"@bradygaster/squad-sdk": minor
+---
+
+feat: add `squad preset install <source>` for sharing presets via repo URL or local path (#1224)
+
+Closes #1224. Adds a new subcommand that installs a single preset from a GitHub URL or local path into `$SQUAD_HOME/presets/<name>/` — the peer-to-peer preset sharing flow that was missing in v0.10.0.
+
+### CLI
+
+```bash
+# From a GitHub repo (preset at <repo-root>/preset.json or <repo-root>/presets/<name>/)
+squad preset install https://github.com/tamir/my-presets#my-awesome-team
+
+# From a sub-path
+squad preset install https://github.com/tamir/my-presets/tree/main/presets/my-awesome-team
+
+# From SSH URL
+squad preset install git@github.com:tamir/my-presets.git#my-awesome-team
+
+# From a local path
+squad preset install ./my-awesome-team
+
+# Override the installed name
+squad preset install https://github.com/tamir/my-presets#my-awesome-team --name corp-team
+
+# Overwrite an existing preset
+squad preset install <source> --force
+```
+
+After install, the preset is a normal entry in `$SQUAD_HOME/presets/` — `squad preset list`, `squad preset apply <name>`, and `squad init --preset <name>` all work as today.
+
+### Why
+
+The existing `squad preset init --remote` flow is for syncing your *whole* `$SQUAD_HOME` repo across machines (single-user, multi-machine use case). There was no built-in way to install just *one* preset from someone else's repo. Users had to:
+1. Manually clone the repo to a temp dir
+2. `cp -r <clone>/presets/<name> $SQUAD_HOME/presets/`
+3. Then `squad preset apply <name>`
+
+…or hijack `SQUAD_HOME` (which collides with their own personal squad config).
+
+### What it does
+
+1. Resolves source — GitHub URL → shallow `git clone --depth 1` to a temp dir; local path → use as-is
+2. Locates the preset within the source via 3 patterns:
+   - Source dir contains `preset.json` → single-preset source
+   - Source dir contains a `presets/` collection → require `--name` (or `#name` fragment) to pick
+   - Source dir IS the `presets/` dir → require `--name`, or auto-pick if only one preset
+3. Validates the preset's `preset.json` manifest (name, agents[]) before any destructive action
+4. Verifies `agents/` directory exists
+5. Copies `preset.json` (with optional rename) + `agents/` into `$SQUAD_HOME/presets/<name>/`
+6. Fail-stops if destination exists, unless `--force` is passed
+7. Cleans up the temp clone whether install succeeds or fails
+
+### What's NOT in scope (deferred to follow-ups)
+
+- `squad preset uninstall` — `rm -rf $SQUAD_HOME/presets/<name>` works for now
+- `squad preset update <name>` to pull a fresh version from origin
+- Public preset registry / discovery catalog

--- a/packages/squad-cli/src/cli/commands/preset.ts
+++ b/packages/squad-cli/src/cli/commands/preset.ts
@@ -81,7 +81,18 @@ export async function runPreset(cwd: string, subcommand: string, args: string[])
       }
       const force = args.includes('--force');
       const nameIdx = args.indexOf('--name');
-      const nameOverride = nameIdx >= 0 ? args[nameIdx + 1] : undefined;
+      let nameOverride: string | undefined;
+      if (nameIdx >= 0) {
+        // Defend against `squad preset install <src> --name` (no value) and
+        // `--name --force` (value is another flag) — both currently produce
+        // confusing downstream errors. Fail fast with a clear usage hint
+        // per review on bradygaster/squad#1225.
+        const candidate = args[nameIdx + 1];
+        if (!candidate || candidate.startsWith('-')) {
+          fatal('`--name` requires a value. Usage: squad preset install <source> --name <override>');
+        }
+        nameOverride = candidate;
+      }
       await presetInstall(source!, nameOverride, force);
       break;
     }

--- a/packages/squad-cli/src/cli/commands/preset.ts
+++ b/packages/squad-cli/src/cli/commands/preset.ts
@@ -9,6 +9,7 @@
  *   squad preset show <name>    — show preset details
  *   squad preset apply <name>   — install preset agents into current squad
  *   squad preset save <name>    — save current project agents as a preset
+ *   squad preset install <src>  — install a preset from a GitHub URL or local path
  *   squad preset init           — initialize presets directory in squad home
  *
  * Note: Presets capture agents only (charters). For full squad snapshots
@@ -22,7 +23,7 @@ import path from 'node:path';
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import { resolveSquadHome, ensureSquadHome, resolvePresetsDir } from '@bradygaster/squad-sdk/resolution';
-import { listPresets, loadPreset, applyPreset, savePreset, seedBuiltinPresets } from '@bradygaster/squad-sdk/presets';
+import { listPresets, loadPreset, applyPreset, savePreset, seedBuiltinPresets, installPresetFromSource } from '@bradygaster/squad-sdk/presets';
 import { resolveSquad } from '@bradygaster/squad-sdk/resolution';
 import { success, warn, info, BOLD, RESET, DIM } from '../core/output.js';
 import { fatal } from '../core/errors.js';
@@ -68,6 +69,22 @@ export async function runPreset(cwd: string, subcommand: string, args: string[])
       await presetSave(cwd, name!, force, description);
       break;
     }
+    case 'install': {
+      const source = args[0];
+      if (!source) {
+        fatal('Usage: squad preset install <source> [--name <override>] [--force]\n' +
+              '  <source> can be:\n' +
+              '    - GitHub URL: https://github.com/owner/repo[#preset-name]\n' +
+              '    - GitHub URL with sub-path: https://github.com/owner/repo/tree/main/presets/my-team\n' +
+              '    - SSH URL: git@github.com:owner/repo.git\n' +
+              '    - Local path: ./my-preset OR ./my-presets-collection');
+      }
+      const force = args.includes('--force');
+      const nameIdx = args.indexOf('--name');
+      const nameOverride = nameIdx >= 0 ? args[nameIdx + 1] : undefined;
+      await presetInstall(source!, nameOverride, force);
+      break;
+    }
     default:
       fatal(
         `Unknown preset subcommand: ${subcommand}\n` +
@@ -76,6 +93,7 @@ export async function runPreset(cwd: string, subcommand: string, args: string[])
         `  squad preset show <name>\n` +
         `  squad preset apply <name> [--force]\n` +
         `  squad preset save <name>\n` +
+        `  squad preset install <source> [--name <override>] [--force]\n` +
         `  squad preset init [--remote]`,
       );
   }
@@ -385,5 +403,31 @@ async function presetSave(cwd: string, name: string, force: boolean, description
     info(`a configured squad or publish to an agent toolbox — use 'squad export'.${RESET}`);
   } catch (err) {
     fatal(String(err));
+  }
+}
+
+// ============================================================================
+// Subcommand: install
+// ============================================================================
+
+/**
+ * Install a preset from a remote URL or local path into $SQUAD_HOME/presets/<name>/.
+ * After install, the preset is available to `squad preset apply <name>`.
+ */
+async function presetInstall(source: string, nameOverride: string | undefined, force: boolean): Promise<void> {
+  info(`Installing preset from: ${source}${DIM}${nameOverride ? ` (as '${nameOverride}')` : ''}${RESET}`);
+  console.log();
+
+  try {
+    const result = installPresetFromSource(source, { name: nameOverride, force });
+    success(`Preset '${result.installedName}' installed`);
+    info(`  Location: ${result.installedDir}`);
+    info(`  Source:   ${result.source}`);
+    console.log();
+    info(`  Apply in a project:  ${BOLD}squad preset apply ${result.installedName}${RESET}`);
+    info(`  Show details:        ${BOLD}squad preset show ${result.installedName}${RESET}`);
+    info(`  Use during init:     ${BOLD}squad init --preset ${result.installedName}${RESET}`);
+  } catch (err) {
+    fatal(String(err instanceof Error ? err.message : err));
   }
 }

--- a/packages/squad-cli/src/cli/core/command-help.ts
+++ b/packages/squad-cli/src/cli/core/command-help.ts
@@ -278,9 +278,19 @@ const COMMAND_HELP: Record<string, HelpPrinter> = {
 
   preset: (version) => {
     header('preset', version, 'Manage squad presets (curated agent collections)');
-    console.log(`Usage: squad preset <list|show <name>|apply <name>|save <name>|init> [options]\n`);
+    console.log(`Usage: squad preset <list|show <name>|apply <name>|save <name>|install <source>|init> [options]\n`);
+    console.log(`Subcommands:`);
+    console.log(`  ${BOLD}install <source>${RESET}            Install a preset from a GitHub URL, SSH URL, or local path`);
+    console.log(`                              <source> shapes (see review on #1225 for the fragment semantics):`);
+    console.log(`                                https://github.com/owner/repo`);
+    console.log(`                                https://github.com/owner/repo#my-preset      (bare = preset-name hint)`);
+    console.log(`                                https://github.com/owner/repo#path/to/preset (slash = literal subPath)`);
+    console.log(`                                https://github.com/owner/repo/tree/branch/path/to/preset`);
+    console.log(`                                git@github.com:owner/repo.git`);
+    console.log(`                                ./local/path/to/preset OR ./local/presets-collection\n`);
     console.log(`Options:`);
-    console.log(`  ${BOLD}--force${RESET}                     Overwrite existing agents on apply`);
+    console.log(`  ${BOLD}--force${RESET}                     Overwrite existing agents on apply, or existing preset on install`);
+    console.log(`  ${BOLD}--name <override>${RESET}           install: rename the preset on install (also picks one from a collection)`);
     console.log(`  ${BOLD}--remote${RESET}                    init: back presets with a GitHub repo\n`);
   },
 

--- a/packages/squad-sdk/src/presets/index.ts
+++ b/packages/squad-sdk/src/presets/index.ts
@@ -10,7 +10,9 @@
  */
 
 import path from 'node:path';
+import os from 'node:os';
 import { readdirSync, statSync, lstatSync, rmSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { FSStorageProvider } from '../storage/fs-storage-provider.js';
 import { resolvePresetsDir, ensureSquadHome } from '../resolution.js';
@@ -272,6 +274,253 @@ export function savePreset(
   copyDirRecursive(agentsDir, path.join(destDir, 'agents'));
 
   return destDir;
+}
+
+/**
+ * Source descriptor for `installPresetFromSource`.
+ *
+ * A source is either:
+ * - A local filesystem path to either a single preset dir (contains `preset.json`)
+ *   OR a `presets/` collection dir (contains multiple preset subdirs).
+ * - A GitHub URL in one of these shapes (all shallow-cloned to a temp dir):
+ *     https://github.com/owner/repo[.git]
+ *     https://github.com/owner/repo[.git]#preset-name           — install only this subdir under <repo>/presets/
+ *     https://github.com/owner/repo/tree/<branch>/path/to/preset — install only this subpath
+ *     git@github.com:owner/repo.git
+ */
+export interface InstallPresetOptions {
+  /** Optional override for the installed preset name. Defaults to the source's preset name. */
+  name?: string;
+  /** Overwrite existing preset if it exists. */
+  force?: boolean;
+}
+
+export interface InstallPresetResult {
+  /** The name the preset was installed under. */
+  installedName: string;
+  /** Absolute path of the installed preset dir under SQUAD_HOME. */
+  installedDir: string;
+  /** Source the preset was installed from (verbatim from caller). */
+  source: string;
+}
+
+/**
+ * Install a preset from a remote git source or local path into `$SQUAD_HOME/presets/<name>/`.
+ *
+ * For git URLs, shallow-clones to an OS temp dir then copies the resolved preset.
+ * For local paths, copies directly. Cleans up the temp clone whether success or failure.
+ *
+ * Resolution rules for finding the preset within the source:
+ * 1. If the source dir/subdir contains `preset.json` → install that as a single preset
+ * 2. Else if it contains a `presets/` subdir (multi-preset collection) → require `options.name`
+ *    to pick which subdir to install
+ * 3. Else error — source is not a recognizable preset
+ *
+ * @throws Error on any validation failure, manifest invalidity, or destination collision.
+ */
+export function installPresetFromSource(source: string, options: InstallPresetOptions = {}): InstallPresetResult {
+  if (!source || typeof source !== 'string') {
+    throw new Error('Source is required.');
+  }
+
+  // Resolve the source into a local working directory + optional sub-path inside it.
+  // Returns { workDir, subPath, cleanup } — caller must call cleanup() in a finally.
+  const { workDir, subPath, cleanup } = resolveInstallSource(source);
+
+  try {
+    // Locate the actual preset directory inside workDir
+    const startDir = subPath ? path.join(workDir, subPath) : workDir;
+    if (!storage.existsSync(startDir) || !isDirSync(startDir)) {
+      throw new Error(`Source path does not exist or is not a directory: ${startDir}`);
+    }
+
+    const { presetDir, defaultName } = locatePresetWithinSource(startDir, options.name);
+
+    // Validate manifest before doing anything destructive
+    const manifest = loadPresetManifest(presetDir);
+    if (!manifest) {
+      throw new Error(`No valid preset.json found at ${presetDir}. Expected fields: name, agents[].`);
+    }
+
+    // Verify agents/ dir exists (preset is useless without it)
+    const sourceAgentsDir = path.join(presetDir, 'agents');
+    if (!storage.existsSync(sourceAgentsDir) || !isDirSync(sourceAgentsDir)) {
+      throw new Error(`Preset is missing agents/ directory at ${sourceAgentsDir}`);
+    }
+
+    // Decide installed name: caller override > manifest.name > defaultName from path
+    // Prefer manifest.name when the user didn't specify --name because that's the preset's
+    // declared identity (e.g. a temp clone dir's basename shouldn't become the preset name).
+    const installedName = options.name ?? manifest.name ?? defaultName;
+    validateName(installedName, 'preset');
+
+    const homeDir = ensureSquadHome();
+    const destDir = path.join(homeDir, 'presets', installedName);
+
+    if (storage.existsSync(destDir)) {
+      if (!options.force) {
+        throw new Error(`Preset '${installedName}' already exists at ${destDir}. Use --force to overwrite.`);
+      }
+      rmSync(destDir, { recursive: true, force: true });
+    }
+
+    // Copy the preset (preset.json + agents/)
+    storage.mkdirSync(destDir, { recursive: true });
+
+    // Stamp manifest.name with the installed name if it was renamed (so list/show stay consistent)
+    const finalManifest: PresetManifest = options.name && options.name !== manifest.name
+      ? { ...manifest, name: installedName }
+      : manifest;
+    storage.writeSync(path.join(destDir, 'preset.json'), JSON.stringify(finalManifest, null, 2));
+    copyDirRecursive(sourceAgentsDir, path.join(destDir, 'agents'));
+
+    return { installedName, installedDir: destDir, source };
+  } finally {
+    cleanup();
+  }
+}
+
+/**
+ * Resolve `source` to a working directory on disk. Handles:
+ *  - Local absolute/relative paths (no clone needed; cleanup is a no-op)
+ *  - GitHub HTTPS URLs (https://github.com/owner/repo[#ref-or-name][/tree/branch/path])
+ *  - GitHub SSH URLs (git@github.com:owner/repo.git)
+ *  - Any other git-cloneable URL (treated as plain git URL)
+ *
+ * Returns { workDir, subPath, cleanup }:
+ *  - workDir = the local dir containing the cloned/referenced content
+ *  - subPath = optional path INSIDE workDir to descend into before searching for preset
+ *  - cleanup = function to call when done (rm -rf temp clones)
+ */
+function resolveInstallSource(source: string): { workDir: string; subPath: string | null; cleanup: () => void } {
+  const looksLikeUrl = /^(https?:\/\/|git@)/i.test(source);
+
+  if (!looksLikeUrl) {
+    // Local path: pass-through, no cleanup needed
+    const resolved = path.resolve(source);
+    return { workDir: resolved, subPath: null, cleanup: () => {} };
+  }
+
+  // Parse out: cloneUrl, ref (branch/tag), subPath (path inside repo), nameHint (after #)
+  // Supported shapes:
+  //   https://github.com/owner/repo
+  //   https://github.com/owner/repo.git
+  //   https://github.com/owner/repo#preset-name             — fragment treated as preset name hint AND/OR ref
+  //   https://github.com/owner/repo/tree/branch/path/to/preset
+  //   git@github.com:owner/repo.git
+  let cloneUrl = source;
+  let ref: string | null = null;
+  let subPath: string | null = null;
+
+  // Extract fragment (#...) — used as ref OR as preset-name hint (resolved later)
+  const fragmentIdx = source.indexOf('#');
+  if (fragmentIdx >= 0) {
+    const frag = source.substring(fragmentIdx + 1);
+    cloneUrl = source.substring(0, fragmentIdx);
+    // Heuristic: if the fragment contains a '/', treat it as a sub-path; otherwise as a ref/name hint
+    if (frag.includes('/')) {
+      subPath = frag;
+    } else {
+      // Defer interpretation — could be a branch name OR a preset name. Try as branch first;
+      // if checkout fails the user will see git's error. For simplicity, treat as preset-name
+      // hint that's also used as the default branch ref when no /tree/<branch>/ path is present.
+      // Most common case: user wrote `repo#my-preset` meaning "subdir my-preset on default branch".
+      subPath = frag;
+    }
+  }
+
+  // Extract /tree/<branch>/<sub-path> if present
+  const treeMatch = cloneUrl.match(/^(https?:\/\/[^/]+\/[^/]+\/[^/]+)\/tree\/([^/]+)(?:\/(.+))?$/);
+  if (treeMatch) {
+    cloneUrl = treeMatch[1]!;
+    ref = treeMatch[2]!;
+    if (treeMatch[3]) subPath = treeMatch[3]!;
+  }
+
+  // Normalize: ensure .git suffix on cloneUrl for portability (gh clone accepts both)
+  if (!/\.git$/i.test(cloneUrl) && /^https?:\/\/github\.com\//i.test(cloneUrl)) {
+    cloneUrl = cloneUrl + '.git';
+  }
+
+  // Shallow clone to a temp dir
+  const tmpBase = path.join(os.tmpdir(), `squad-preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  storage.mkdirSync(tmpBase, { recursive: true });
+
+  try {
+    const refArgs = ref ? ['--branch', ref] : [];
+    const args = ['clone', '--depth', '1', ...refArgs, cloneUrl, tmpBase];
+    execSync(`git ${args.map(a => /[\s"]/.test(a) ? `"${a.replace(/"/g, '\\"')}"` : a).join(' ')}`, { stdio: 'pipe' });
+  } catch (err) {
+    // Clean up partial clone before rethrowing
+    try { rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ignore */ }
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to clone ${cloneUrl}${ref ? ` (ref ${ref})` : ''}: ${msg}`);
+  }
+
+  const cleanup = () => {
+    try { rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ignore — temp dir, best effort */ }
+  };
+  return { workDir: tmpBase, subPath, cleanup };
+}
+
+/**
+ * Locate the preset directory within a resolved source. Behavior:
+ *  1. If `startDir/preset.json` exists → that IS the preset dir (single-preset source).
+ *     Returns { presetDir: startDir, defaultName: basename(startDir) }.
+ *  2. Else if `startDir/presets/` exists (multi-preset collection):
+ *     - If `nameHint` is provided AND `startDir/presets/<nameHint>` exists → use that.
+ *     - Else throw — caller must pass `--name` to disambiguate.
+ *  3. Else if startDir's basename is `presets` and contains one subdir → use that subdir.
+ *  4. Else throw — startDir doesn't look like a preset or preset collection.
+ */
+function locatePresetWithinSource(startDir: string, nameHint?: string): { presetDir: string; defaultName: string } {
+  // Case 1: startDir IS a preset
+  if (storage.existsSync(path.join(startDir, 'preset.json'))) {
+    return { presetDir: startDir, defaultName: path.basename(startDir) };
+  }
+
+  // Case 2: startDir contains a presets/ collection
+  const presetsSubDir = path.join(startDir, 'presets');
+  if (storage.existsSync(presetsSubDir) && isDirSync(presetsSubDir)) {
+    if (nameHint) {
+      const candidate = path.join(presetsSubDir, nameHint);
+      if (storage.existsSync(path.join(candidate, 'preset.json'))) {
+        return { presetDir: candidate, defaultName: nameHint };
+      }
+      throw new Error(`Preset '${nameHint}' not found in ${presetsSubDir}.`);
+    }
+    // No hint — list available presets and ask user to pick
+    const available = readdirSync(presetsSubDir, { encoding: 'utf-8' })
+      .filter(e => isDirSync(path.join(presetsSubDir, e)))
+      .filter(e => storage.existsSync(path.join(presetsSubDir, e, 'preset.json')));
+    throw new Error(
+      `Source contains multiple presets — specify one with --name <preset-name> or #<preset-name> URL fragment. ` +
+      `Available: ${available.length > 0 ? available.join(', ') : '(none with valid preset.json)'}`,
+    );
+  }
+
+  // Case 3: startDir IS the presets/ dir itself (e.g. user pointed directly at it)
+  if (path.basename(startDir) === 'presets') {
+    if (nameHint) {
+      const candidate = path.join(startDir, nameHint);
+      if (storage.existsSync(path.join(candidate, 'preset.json'))) {
+        return { presetDir: candidate, defaultName: nameHint };
+      }
+      throw new Error(`Preset '${nameHint}' not found in ${startDir}.`);
+    }
+    const available = readdirSync(startDir, { encoding: 'utf-8' })
+      .filter(e => isDirSync(path.join(startDir, e)))
+      .filter(e => storage.existsSync(path.join(startDir, e, 'preset.json')));
+    if (available.length === 1) {
+      const only = available[0]!;
+      return { presetDir: path.join(startDir, only), defaultName: only };
+    }
+    throw new Error(
+      `Source contains multiple presets — specify one with --name <preset-name>. Available: ${available.join(', ')}`,
+    );
+  }
+
+  throw new Error(`No preset found at ${startDir}. Expected either a preset.json or a presets/ directory.`);
 }
 
 // ============================================================================

--- a/packages/squad-sdk/src/presets/index.ts
+++ b/packages/squad-sdk/src/presets/index.ts
@@ -12,7 +12,7 @@
 import path from 'node:path';
 import os from 'node:os';
 import { readdirSync, statSync, lstatSync, rmSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { FSStorageProvider } from '../storage/fs-storage-provider.js';
 import { resolvePresetsDir, ensureSquadHome } from '../resolution.js';
@@ -318,6 +318,48 @@ export interface InstallPresetResult {
  *
  * @throws Error on any validation failure, manifest invalidity, or destination collision.
  */
+/**
+ * Validate a name fragment that will be used as a path segment. Same
+ * shape as preset names (validateName rules) — must not contain path
+ * separators, `..`, null bytes, or other escape vectors. Throws on
+ * any rejected input.
+ */
+function validatePathSegment(name: string, label: string): void {
+  if (!name || typeof name !== 'string') {
+    throw new Error(`${label} is required.`);
+  }
+  // Reject path separators, dot-dot, and any character that would let a
+  // user escape the parent directory via path.join.
+  if (
+    name.includes('/') ||
+    name.includes('\\') ||
+    name === '.' ||
+    name === '..' ||
+    name.includes('\0')
+  ) {
+    throw new Error(`Invalid ${label}: '${name}' must not contain path separators, '..', or null bytes.`);
+  }
+}
+
+/**
+ * Validate a source-derived subPath. Must be relative, must not contain
+ * `..` segments, and must not be absolute — otherwise an attacker who
+ * controls the source string can make us read from anywhere on disk.
+ */
+function validateSubPath(subPath: string): void {
+  if (path.isAbsolute(subPath)) {
+    throw new Error(`Invalid subPath '${subPath}': must be a relative path inside the source.`);
+  }
+  // Reject any segment equal to '..' — this is the canonical escape vector.
+  const segs = subPath.split(/[\\/]+/).filter(s => s.length > 0);
+  if (segs.some(s => s === '..')) {
+    throw new Error(`Invalid subPath '${subPath}': '..' segments are not allowed.`);
+  }
+  if (subPath.includes('\0')) {
+    throw new Error(`Invalid subPath '${subPath}': null bytes are not allowed.`);
+  }
+}
+
 export function installPresetFromSource(source: string, options: InstallPresetOptions = {}): InstallPresetResult {
   if (!source || typeof source !== 'string') {
     throw new Error('Source is required.');
@@ -325,16 +367,29 @@ export function installPresetFromSource(source: string, options: InstallPresetOp
 
   // Resolve the source into a local working directory + optional sub-path inside it.
   // Returns { workDir, subPath, cleanup } — caller must call cleanup() in a finally.
-  const { workDir, subPath, cleanup } = resolveInstallSource(source);
+  const { workDir, subPath, nameHint, cleanup } = resolveInstallSource(source);
 
   try {
     // Locate the actual preset directory inside workDir
+    if (subPath) {
+      validateSubPath(subPath);
+    }
     const startDir = subPath ? path.join(workDir, subPath) : workDir;
     if (!storage.existsSync(startDir) || !isDirSync(startDir)) {
       throw new Error(`Source path does not exist or is not a directory: ${startDir}`);
     }
 
-    const { presetDir, defaultName } = locatePresetWithinSource(startDir, options.name);
+    // Effective preset-name hint resolution priority:
+    //   1. Explicit --name option (highest)
+    //   2. Fragment-derived nameHint from the source URL (e.g. `repo#starter`)
+    // Whichever is selected must validate as a safe basename before we
+    // let path.join touch it.
+    const effectiveNameHint = options.name ?? nameHint ?? undefined;
+    if (effectiveNameHint) {
+      validatePathSegment(effectiveNameHint, 'preset name');
+    }
+
+    const { presetDir, defaultName } = locatePresetWithinSource(startDir, effectiveNameHint);
 
     // Validate manifest before doing anything destructive
     const manifest = loadPresetManifest(presetDir);
@@ -383,49 +438,58 @@ export function installPresetFromSource(source: string, options: InstallPresetOp
 /**
  * Resolve `source` to a working directory on disk. Handles:
  *  - Local absolute/relative paths (no clone needed; cleanup is a no-op)
- *  - GitHub HTTPS URLs (https://github.com/owner/repo[#ref-or-name][/tree/branch/path])
+ *  - GitHub HTTPS URLs (https://github.com/owner/repo[#fragment][/tree/branch/path])
  *  - GitHub SSH URLs (git@github.com:owner/repo.git)
  *  - Any other git-cloneable URL (treated as plain git URL)
  *
- * Returns { workDir, subPath, cleanup }:
- *  - workDir = the local dir containing the cloned/referenced content
- *  - subPath = optional path INSIDE workDir to descend into before searching for preset
- *  - cleanup = function to call when done (rm -rf temp clones)
+ * Fragment handling (post-review on bradygaster/squad#1225):
+ *  - `repo#some/path`  → fragment WITH `/` is treated as a literal subPath
+ *    inside the cloned working directory (e.g. `repo#packs/team-a` looks
+ *    at `<clone>/packs/team-a`).
+ *  - `repo#some-name`  → fragment WITHOUT `/` is treated as a PRESET-NAME
+ *    HINT, NOT a subpath. The hint is plumbed through to
+ *    `locatePresetWithinSource` so `repo#my-team` correctly resolves to
+ *    the common `<clone>/presets/my-team/` layout (or `<clone>/my-team/`
+ *    if the repo IS the preset). Earlier behaviour treated bare fragments
+ *    as subPaths and broke the documented `repo#preset-name` shape.
+ *
+ * Returns { workDir, subPath, nameHint, cleanup }:
+ *  - workDir  = the local dir containing the cloned/referenced content
+ *  - subPath  = optional relative path inside workDir to descend into
+ *               before searching for a preset (only set when the URL
+ *               fragment contained `/`, or via /tree/<branch>/<path>)
+ *  - nameHint = optional preset-name hint derived from a bare URL fragment;
+ *               forwarded to locatePresetWithinSource without being used
+ *               as a path segment itself
+ *  - cleanup  = function to call when done (rm -rf temp clones)
  */
-function resolveInstallSource(source: string): { workDir: string; subPath: string | null; cleanup: () => void } {
+function resolveInstallSource(source: string): { workDir: string; subPath: string | null; nameHint: string | null; cleanup: () => void } {
   const looksLikeUrl = /^(https?:\/\/|git@)/i.test(source);
 
   if (!looksLikeUrl) {
-    // Local path: pass-through, no cleanup needed
+    // Local path: pass-through, no cleanup needed, no fragment handling
     const resolved = path.resolve(source);
-    return { workDir: resolved, subPath: null, cleanup: () => {} };
+    return { workDir: resolved, subPath: null, nameHint: null, cleanup: () => {} };
   }
 
-  // Parse out: cloneUrl, ref (branch/tag), subPath (path inside repo), nameHint (after #)
-  // Supported shapes:
-  //   https://github.com/owner/repo
-  //   https://github.com/owner/repo.git
-  //   https://github.com/owner/repo#preset-name             — fragment treated as preset name hint AND/OR ref
-  //   https://github.com/owner/repo/tree/branch/path/to/preset
-  //   git@github.com:owner/repo.git
   let cloneUrl = source;
   let ref: string | null = null;
   let subPath: string | null = null;
+  let nameHint: string | null = null;
 
-  // Extract fragment (#...) — used as ref OR as preset-name hint (resolved later)
+  // Extract fragment (#...) — split into subPath (when it contains `/`) vs.
+  // nameHint (bare name; resolved later by locatePresetWithinSource).
   const fragmentIdx = source.indexOf('#');
   if (fragmentIdx >= 0) {
     const frag = source.substring(fragmentIdx + 1);
     cloneUrl = source.substring(0, fragmentIdx);
-    // Heuristic: if the fragment contains a '/', treat it as a sub-path; otherwise as a ref/name hint
     if (frag.includes('/')) {
       subPath = frag;
-    } else {
-      // Defer interpretation — could be a branch name OR a preset name. Try as branch first;
-      // if checkout fails the user will see git's error. For simplicity, treat as preset-name
-      // hint that's also used as the default branch ref when no /tree/<branch>/ path is present.
-      // Most common case: user wrote `repo#my-preset` meaning "subdir my-preset on default branch".
-      subPath = frag;
+    } else if (frag.length > 0) {
+      // Bare fragment = preset-name hint, NOT a subpath. The collection-
+      // layout case (`<clone>/presets/<frag>/`) needs locatePresetWithinSource
+      // to receive this as a `nameHint`, not as a path.
+      nameHint = frag;
     }
   }
 
@@ -447,9 +511,18 @@ function resolveInstallSource(source: string): { workDir: string; subPath: strin
   storage.mkdirSync(tmpBase, { recursive: true });
 
   try {
-    const refArgs = ref ? ['--branch', ref] : [];
-    const args = ['clone', '--depth', '1', ...refArgs, cloneUrl, tmpBase];
-    execSync(`git ${args.map(a => /[\s"]/.test(a) ? `"${a.replace(/"/g, '\\"')}"` : a).join(' ')}`, { stdio: 'pipe' });
+    // Use execFileSync with an argument array (no shell). Earlier shape used
+    // execSync with a constructed command string + ad-hoc escaping — that
+    // permitted shell injection when `source` (or a ref) contained `;`, `&&`,
+    // `|`, backticks, `$()`, etc. Per the review on bradygaster/squad#1225,
+    // switch to spawning git directly so the args can't be interpreted by a
+    // shell.
+    const args = ['clone', '--depth', '1'];
+    if (ref) {
+      args.push('--branch', ref);
+    }
+    args.push(cloneUrl, tmpBase);
+    execFileSync('git', args, { stdio: 'pipe' });
   } catch (err) {
     // Clean up partial clone before rethrowing
     try { rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ignore */ }
@@ -460,7 +533,7 @@ function resolveInstallSource(source: string): { workDir: string; subPath: strin
   const cleanup = () => {
     try { rmSync(tmpBase, { recursive: true, force: true }); } catch { /* ignore — temp dir, best effort */ }
   };
-  return { workDir: tmpBase, subPath, cleanup };
+  return { workDir: tmpBase, subPath, nameHint, cleanup };
 }
 
 /**
@@ -474,6 +547,14 @@ function resolveInstallSource(source: string): { workDir: string; subPath: strin
  *  4. Else throw — startDir doesn't look like a preset or preset collection.
  */
 function locatePresetWithinSource(startDir: string, nameHint?: string): { presetDir: string; defaultName: string } {
+  // Defense in depth: if a nameHint is passed, re-validate it as a safe
+  // basename here too. The public installPresetFromSource() entry already
+  // validates, but this function is exported in case future callers go
+  // direct — re-checking prevents path-escape via `../something`.
+  if (nameHint !== undefined) {
+    validatePathSegment(nameHint, 'preset name');
+  }
+
   // Case 1: startDir IS a preset
   if (storage.existsSync(path.join(startDir, 'preset.json'))) {
     return { presetDir: startDir, defaultName: path.basename(startDir) };

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -720,3 +720,126 @@ describe('savePreset()', () => {
     expect(readFileSync(join(destAgents, 'beta', 'charter.md'), 'utf-8')).toContain('Beta');
   });
 });
+
+// ============================================================================
+// installPresetFromSource() — new in PR #1225, regression tests added per
+// review feedback (#1225 comment #3369713129: 'add focused tests')
+// ============================================================================
+//
+// These tests cover the LOCAL path branch (single-preset, collection,
+// --force overwrite, --name rename + manifest stamping, plus the validation
+// guards that came out of the review). Remote (URL) branch is exercised by
+// the same code path via resolveInstallSource — splitting the git clone
+// into a small helper so it can be stubbed is a separate follow-up.
+
+import { installPresetFromSource } from '@bradygaster/squad-sdk/presets';
+
+describe('installPresetFromSource() — local paths', () => {
+  const originalEnv = process.env['SQUAD_HOME'];
+  beforeEach(() => {
+    if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
+    mkdirSync(TMP, { recursive: true });
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env['SQUAD_HOME'];
+    else process.env['SQUAD_HOME'] = originalEnv;
+    if (existsSync(TMP)) rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it('installs a single-preset local source (startDir/preset.json present)', () => {
+    const homeDir = join(TMP, 'home-single');
+    process.env['SQUAD_HOME'] = homeDir;
+    const src = join(TMP, 'source-single');
+    mkdirSync(join(src, 'agents', 'a1'), { recursive: true });
+    writeFileSync(join(src, 'preset.json'), JSON.stringify({ name: 'starter', version: '1.0.0', description: 'demo', agents: [{ name: 'a1', role: 'lead' }] }));
+    writeFileSync(join(src, 'agents', 'a1', 'charter.md'), '# A1');
+
+    const result = installPresetFromSource(src);
+    expect(result.installedName).toBe('starter');
+    expect(existsSync(join(result.installedDir, 'preset.json'))).toBe(true);
+    expect(existsSync(join(result.installedDir, 'agents', 'a1', 'charter.md'))).toBe(true);
+  });
+
+  it('selects a preset from a collection via --name', () => {
+    const homeDir = join(TMP, 'home-collection');
+    process.env['SQUAD_HOME'] = homeDir;
+    const src = join(TMP, 'source-collection');
+    for (const name of ['alpha', 'beta']) {
+      mkdirSync(join(src, 'presets', name, 'agents', 'lead'), { recursive: true });
+      writeFileSync(join(src, 'presets', name, 'preset.json'), JSON.stringify({ name, version: '1.0.0', description: name, agents: [{ name: 'lead', role: 'lead' }] }));
+      writeFileSync(join(src, 'presets', name, 'agents', 'lead', 'charter.md'), `# ${name} lead`);
+    }
+
+    const result = installPresetFromSource(src, { name: 'beta' });
+    expect(result.installedName).toBe('beta');
+    expect(readFileSync(join(result.installedDir, 'agents', 'lead', 'charter.md'), 'utf-8')).toContain('beta lead');
+  });
+
+  it('throws on collection source without --name (instead of silently grabbing one)', () => {
+    const homeDir = join(TMP, 'home-collection-nopick');
+    process.env['SQUAD_HOME'] = homeDir;
+    const src = join(TMP, 'source-collection-nopick');
+    for (const name of ['alpha', 'beta']) {
+      mkdirSync(join(src, 'presets', name, 'agents', 'lead'), { recursive: true });
+      writeFileSync(join(src, 'presets', name, 'preset.json'), JSON.stringify({ name, version: '1.0.0', description: name, agents: [{ name: 'lead', role: 'lead' }] }));
+      writeFileSync(join(src, 'presets', name, 'agents', 'lead', 'charter.md'), `# ${name}`);
+    }
+    expect(() => installPresetFromSource(src)).toThrow(/multiple presets/i);
+  });
+
+  it('--force overwrites an existing preset of the same name', () => {
+    const homeDir = join(TMP, 'home-force');
+    process.env['SQUAD_HOME'] = homeDir;
+    const src = join(TMP, 'source-force');
+    mkdirSync(join(src, 'agents', 'a1'), { recursive: true });
+    writeFileSync(join(src, 'preset.json'), JSON.stringify({ name: 'collision', version: '1.0.0', description: 'v1', agents: [{ name: 'a1', role: 'lead' }] }));
+    writeFileSync(join(src, 'agents', 'a1', 'charter.md'), '# v1');
+
+    installPresetFromSource(src);
+    // Mutate source to v2
+    writeFileSync(join(src, 'preset.json'), JSON.stringify({ name: 'collision', version: '2.0.0', description: 'v2', agents: [{ name: 'a1', role: 'lead' }] }));
+    writeFileSync(join(src, 'agents', 'a1', 'charter.md'), '# v2');
+
+    expect(() => installPresetFromSource(src)).toThrow(/already exists.*--force/);
+
+    const result = installPresetFromSource(src, { force: true });
+    expect(JSON.parse(readFileSync(join(result.installedDir, 'preset.json'), 'utf-8')).description).toBe('v2');
+    expect(readFileSync(join(result.installedDir, 'agents', 'a1', 'charter.md'), 'utf-8')).toContain('v2');
+  });
+
+  it('--name renames the preset AND stamps manifest.name with the new name', () => {
+    const homeDir = join(TMP, 'home-rename');
+    process.env['SQUAD_HOME'] = homeDir;
+    const src = join(TMP, 'source-rename');
+    mkdirSync(join(src, 'agents', 'a1'), { recursive: true });
+    writeFileSync(join(src, 'preset.json'), JSON.stringify({ name: 'upstream-name', version: '1.0.0', description: 'demo', agents: [{ name: 'a1', role: 'lead' }] }));
+    writeFileSync(join(src, 'agents', 'a1', 'charter.md'), '# A1');
+
+    const result = installPresetFromSource(src, { name: 'my-renamed' });
+    expect(result.installedName).toBe('my-renamed');
+    // Manifest must be stamped so list/show stay consistent
+    const stamped = JSON.parse(readFileSync(join(result.installedDir, 'preset.json'), 'utf-8'));
+    expect(stamped.name).toBe('my-renamed');
+    // Other manifest fields must be preserved
+    expect(stamped.version).toBe('1.0.0');
+    expect(stamped.description).toBe('demo');
+    expect(stamped.agents).toHaveLength(1);
+  });
+
+  it('rejects --name containing path separators (defends against ../escape)', () => {
+    const homeDir = join(TMP, 'home-reject-name');
+    process.env['SQUAD_HOME'] = homeDir;
+    const src = join(TMP, 'source-reject-name');
+    mkdirSync(join(src, 'agents', 'a1'), { recursive: true });
+    writeFileSync(join(src, 'preset.json'), JSON.stringify({ name: 'demo', version: '1.0.0', description: 'demo', agents: [{ name: 'a1', role: 'lead' }] }));
+    writeFileSync(join(src, 'agents', 'a1', 'charter.md'), '# A1');
+
+    for (const bad of ['../escape', 'a/b', 'a\\b', '..', '.', 'foo\0bar']) {
+      expect(() => installPresetFromSource(src, { name: bad }), `must reject '${bad}'`).toThrow();
+    }
+  });
+
+  it('throws on empty source', () => {
+    expect(() => installPresetFromSource('')).toThrow(/required/i);
+  });
+});


### PR DESCRIPTION
## feat: `squad preset install <source>` for sharing presets via repo URL (#1224)

Closes #1224.

### What

New subcommand that installs a single preset from a GitHub URL or local path into `$SQUAD_HOME/presets/<name>/`:

```bash
# GitHub URLs
squad preset install https://github.com/tamir/my-presets#my-awesome-team
squad preset install https://github.com/tamir/my-presets/tree/main/presets/my-awesome-team
squad preset install git@github.com:tamir/my-presets.git#my-awesome-team

# Local paths
squad preset install ./my-awesome-team             # single preset
squad preset install ./my-presets-collection --name my-awesome-team   # collection

# Modifiers
squad preset install <source> --name corp-team    # rename on install
squad preset install <source> --force             # overwrite existing
```

After install, the preset is a normal entry in `$SQUAD_HOME/presets/` — `squad preset list`, `squad preset apply <name>`, and `squad init --preset <name>` all work as today.

### Why

The existing `squad preset init --remote` flow shares your *whole* `$SQUAD_HOME` repo. There was no way to install just *one* preset from someone else's repo. Users had to manually clone + copy + apply, or hijack `SQUAD_HOME` (collides with personal config).

### Source resolution rules

1. Source dir contains `preset.json` → install that as a single preset
2. Source dir contains a `presets/` collection → require `--name` (or `#name` URL fragment) to pick
3. Source dir IS the `presets/` dir → require `--name`, or auto-pick if only one preset present

### Implementation

**SDK** (`packages/squad-sdk/src/presets/index.ts`):
- New `installPresetFromSource(source, options)` function
- Top-level `import os from 'node:os'` and `execSync` from `node:child_process` (ESM-safe)
- Shallow clones with `git clone --depth 1 [--branch <ref>]`
- Always cleans up temp clones in `finally`
- Stamps `manifest.name` to match installed name when `--name` is used

**CLI** (`packages/squad-cli/src/cli/commands/preset.ts`):
- New `'install'` dispatcher case + `presetInstall()` function
- Module docstring + default usage help updated to include `install`

### Smoke tests (all pass on local build)

| # | Case | Result |
|---|---|---|
| 1 | Install single preset from local path | ✅ Installed under `manifest.name` |
| 2 | Re-install without `--force` | ✅ Fails with `already exists` |
| 3 | Re-install with `--force` | ✅ Overwrites |
| 4 | `--name` rename + manifest rewrite | ✅ Installed as override, `manifest.name` updated |
| 5 | Invalid source (no preset.json/no presets/) | ✅ Clear `No preset found` error |
| 6 | GitHub URL — cloned `bradygaster/squad/.../builtin/default` | ✅ Installed `brady-default` with 5 agents |

### What's NOT in scope (deferred to follow-ups)

- `squad preset uninstall` — `rm -rf $SQUAD_HOME/presets/<name>` works manually
- `squad preset update <name>` to pull fresh from origin
- Public preset registry / discovery catalog

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
