### PR TITLE
docs(state-backends): document pre-commit hook, post-upgrade flow, and recovery

### DIFF
--- a/docs/src/content/docs/features/state-backends.md
+++ b/docs/src/content/docs/features/state-backends.md
@@ -416,6 +416,41 @@ Change `stateBackend` in `.squad/config.json`. The coordinator adapts on the nex
 
 ---
 
+## Steady-state safety net
+
+Once you've migrated to `orphan` or `two-layer`, two additional git hooks enforce the invariant that mutable state never lands in your working branch.
+
+### `pre-commit` — blocks state from entering the working tree
+
+Before every commit, this hook scans the staged index for files that belong on the orphan branch:
+
+- `.squad/decisions.md`
+- `.squad/agents/*/history.md`
+- `.squad/casting/`
+- `.squad/routing/`
+
+If any of those paths are staged, the commit is refused with:
+
+```
+⚠ squad pre-commit: refusing to commit two-layer state into the working tree.
+  Unstage the state files and let the post-commit hook sync them:
+    git restore --staged .squad/decisions.md .squad/agents/*/history.md
+```
+
+**Why files might reappear:** A tool, editor save, or agent code path that writes directly via `fs.writeFile` (bypassing `StateBackend`) will recreate the file on disk. Staging it and attempting a commit triggers this hook.
+
+For the full recovery flow see [troubleshooting](#squad-pre-commit-refusing-to-commit-two-layer-state-into-the-working-tree).
+
+### `post-commit` — keeps the orphan branch current
+
+After every successful commit, `squad sync --quiet` is called automatically. This pushes any pending state from the in-memory queue onto the `squad-state` branch, so the orphan branch stays up to date without manual intervention.
+
+### `SQUAD_SYNC_ACTIVE=1` bypass
+
+Setting `SQUAD_SYNC_ACTIVE=1` in the environment causes both hooks to exit immediately without running. This is used **internally** by `squad sync` itself to avoid hook recursion.
+
+> ⚠️ **Do not use `SQUAD_SYNC_ACTIVE=1` routinely.** Bypassing the pre-commit hook lets state files land in your working branch commits — exactly the situation `two-layer` is designed to prevent. Any PR created from that branch will carry squad state in the diff, defeating the clean-PR promise of the two-layer backend. Use the recovery flow instead.
+
 ## Troubleshooting
 
 ### "Pre-commit hook refused my commit"

--- a/docs/src/content/docs/scenarios/troubleshooting.md
+++ b/docs/src/content/docs/scenarios/troubleshooting.md
@@ -156,3 +156,50 @@ If below v20, upgrade to the latest LTS:
 - Use PowerShell or Git Bash (not cmd.exe)
 - Ensure git is in your PATH
 - Ensure `gh` CLI is in your PATH
+
+---
+
+## "⚠ squad pre-commit: refusing to commit two-layer state into the working tree"
+
+**Problem:** A `git commit` is blocked with the message above.
+
+**Cause:** You're on the `orphan` or `two-layer` backend, and one or more state files (`.squad/decisions.md`, `.squad/agents/*/history.md`, `.squad/casting/`, `.squad/routing/`) were staged for commit. These files belong on the `squad-state` orphan branch, not in your working branch. Something wrote them back to disk after the migration — a direct `fs.writeFile` call, an editor auto-save, or an external tool — and you staged them unintentionally.
+
+**Recovery flow:**
+
+1. **Unstage the state files:**
+   ```bash
+   git restore --staged .squad/decisions.md
+   git restore --staged ".squad/agents/*/history.md"
+   ```
+
+2. **Check whether the orphan branch already has the content** (it should, if `squad sync` has run):
+   ```bash
+   git show squad-state:decisions.md
+   git show squad-state:agents/<agent-name>/history.md
+   ```
+
+3. **If the working-tree copy contains new content not yet on the orphan branch**, lift it through Squad before deleting:
+   ```bash
+   squad memory write --file .squad/decisions.md
+   ```
+
+4. **Remove the working-tree copies:**
+   ```bash
+   # PowerShell
+   Remove-Item .squad\decisions.md -ErrorAction SilentlyContinue
+   Get-ChildItem .squad\agents -Recurse -Filter history.md | Remove-Item
+   ```
+   ```bash
+   # bash
+   rm -f .squad/decisions.md .squad/agents/*/history.md
+   ```
+
+5. **Commit normally** — the `post-commit` hook will call `squad sync --quiet` automatically:
+   ```bash
+   git commit -m "your commit message"
+   ```
+
+**When to use `SQUAD_SYNC_ACTIVE=1`:** Rarely. This env var bypasses both the pre-commit and post-commit hooks. It's intended for internal use by `squad sync` itself to prevent recursion. If you set it to unblock a commit, the state files will land in your working-branch history and appear in PRs — exactly what two-layer is designed to prevent. Use the recovery flow above instead.
+
+---

--- a/docs/src/content/docs/scenarios/upgrading.md
+++ b/docs/src/content/docs/scenarios/upgrading.md
@@ -153,3 +153,40 @@ No changes to `.ai-team/` — the diff is limited to Squad-owned files.
 - **Upgrade is safe.** It only overwrites files that Squad owns. Your team state is never modified.
 - **Don't customize `squad.agent.md`.** Any changes you make will be overwritten on the next upgrade. If you need custom behavior, use directives in `decisions.md` instead.
 - **Re-running upgrade is harmless.** If you're not sure whether an upgrade completed, run it again. It's idempotent.
+
+---
+
+## After upgrading to `two-layer` or `orphan`
+
+After running `squad upgrade --state-backend two-layer` (or `--state-backend orphan`), verify the migration completed cleanly:
+
+### 1. Working tree is clean
+
+```bash
+git status
+```
+
+You should see no changes. The migration removes the working-tree state files after copying them to the orphan branch — if `.squad/decisions.md` or any `history.md` files still appear as untracked or modified, rerun the migration.
+
+### 2. Orphan branch contains your state
+
+```bash
+git ls-tree --name-only -r squad-state
+```
+
+You should see your state files listed (e.g. `decisions.md`, `agents/scribe/history.md`). If the branch is missing or empty, the migration may not have completed.
+
+### 3. Push the orphan branch and notes once
+
+The orphan branch and any git notes need to be pushed to the remote so collaborators can access them:
+
+```bash
+git push origin squad-state
+git push origin 'refs/notes/squad*:refs/notes/squad*'
+```
+
+After this, the `post-commit` hook keeps both in sync automatically on every commit.
+
+### If state files reappear later
+
+If `.squad/decisions.md` or `history.md` files reappear in the working tree and a `git commit` is blocked with `⚠ squad pre-commit: refusing to commit two-layer state into the working tree`, see the [pre-commit troubleshooting entry](./troubleshooting#squad-pre-commit-refusing-to-commit-two-layer-state-into-the-working-tree) for the recovery flow.


### PR DESCRIPTION
Closes #1226

## Summary

Fixes three documentation gaps in the two-layer / orphan state-backend upgrade flow:

1. **Hook list corrected** — `state-backends.md` listed 4 hooks; the code installs 6 (`pre-commit` and `post-commit` were missing from the docs).
2. **Post-migration file fate corrected** — `state-backends.md:409` claimed `.squad/` files remain on disk as a read-only reference. The migration code at `migrate-backend.ts:218-235` actually removes them. Updated the doc to match.
3. **Recovery flow documented** — added a `troubleshooting.md` entry for the `warning squad pre-commit: refusing to commit two-layer state` message, an "After upgrading" verification checklist to `upgrading.md`, and a "Steady-state safety net" section in `state-backends.md` explaining the `pre-commit` + `post-commit` hooks and the `SQUAD_SYNC_ACTIVE=1` bypass.

## Files changed

- `docs/src/content/docs/features/state-backends.md` — hook list, post-migration claim, steady-state safety net section
- `docs/src/content/docs/scenarios/troubleshooting.md` — pre-commit recovery entry
- `docs/src/content/docs/scenarios/upgrading.md` — post-upgrade verification

## Out of scope

- No code changes. The hooks and migration behavior are correct — the docs just did not describe them accurately.
- No changeset (PR touches only `docs/`, no `packages/*/src/`).

## Test plan

- [x] `npm run build` passes locally
- [x] Manual review of rendered Markdown structure
- [ ] CI passes