### PR TITLE
fix(state-backend): conditional .gitignore for two-layer/orphan state files

### DIFF
--- a/.changeset/conditional-state-gitignore.md
+++ b/.changeset/conditional-state-gitignore.md
@@ -1,0 +1,10 @@
+---
+"@bradygaster/squad-sdk": patch
+"@bradygaster/squad-cli": patch
+---
+
+fix: conditional .gitignore entries for two-layer/orphan state backends
+
+When the state backend is `two-layer` or `orphan`, `squad init` and `squad upgrade` now add `.squad/decisions.md` and `.squad/agents/*/history.md` to `.gitignore` (delimited by `# Squad: state owned by squad-state branch` marker comments). When the backend is switched back to `local`, the marker block is removed so those files become committable again.
+
+Defense-in-depth complement to the existing pre-commit hook — prevents `git add .`, IDE "stage all", and `git add -A` from silently staging two-layer state into the working tree.

--- a/packages/squad-cli/src/cli/commands/migrate-backend.ts
+++ b/packages/squad-cli/src/cli/commands/migrate-backend.ts
@@ -19,6 +19,8 @@ import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
 import { installGitHooks } from './install-hooks.js';
+import { FSStorageProvider } from '@bradygaster/squad-sdk';
+import { addSquadStateGitignoreBlock, removeSquadStateGitignoreBlock } from '@bradygaster/squad-sdk';
 
 const GREEN = '\x1b[32m';
 const YELLOW = '\x1b[33m';
@@ -278,6 +280,27 @@ export async function migrateStateBackend(dest: string, target: string): Promise
   // Step 4 (WI-1): re-install hooks (force so new pre-commit/post-commit land)
   if (ORPHAN_BACKENDS.has(target)) {
     installGitHooks(dest, { force: true });
+  }
+
+  // Step 5: Manage .gitignore marker block for squad-state files.
+  // When migrating TO an orphan/two-layer backend: add the marker block so
+  // git add . / IDE "stage all" cannot accidentally stage state files.
+  // When migrating TO a local/worktree backend: remove the block so those
+  // files are committable again.
+  const gitignorePath = path.join(dest, '.gitignore');
+  const storage = new FSStorageProvider();
+  if (ORPHAN_BACKENDS.has(target) && !ORPHAN_BACKENDS.has(current)) {
+    // Transitioning FROM a worktree backend TO orphan/two-layer — add block
+    const added = addSquadStateGitignoreBlock(gitignorePath, storage);
+    if (added) {
+      console.log(`  ${GREEN}✓${RESET} added 2 entries to .gitignore (.squad/decisions.md, .squad/agents/*/history.md) — these now live on squad-state branch`);
+    }
+  } else if (WORKTREE_BACKENDS.has(target) && ORPHAN_BACKENDS.has(current)) {
+    // Transitioning FROM orphan/two-layer BACK TO a local backend — remove block
+    const removed = removeSquadStateGitignoreBlock(gitignorePath, storage);
+    if (removed) {
+      console.log(`  ${GREEN}✓${RESET} removed 2 entries from .gitignore — .squad/decisions.md and agent histories are now committable again`);
+    }
   }
 
   console.log(`\n${GREEN}${BOLD}✓ Migration complete.${RESET} Backend is now '${target}'.\n`);

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -250,6 +250,7 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
     prompt: options.prompt,
     extractionDisabled: options.extractionDisabled,
     roles: options.roles,
+    stateBackend: options.stateBackend,
   };
 
   // Handle SIGINT to cleanup orphan .init-prompt

--- a/packages/squad-sdk/src/config/gitignore-state.ts
+++ b/packages/squad-sdk/src/config/gitignore-state.ts
@@ -1,0 +1,95 @@
+/**
+ * Helpers for managing the squad-state .gitignore marker block.
+ *
+ * When the state backend is 'two-layer' or 'orphan', .squad/decisions.md
+ * and .squad/agents/history.md are owned by the squad-state orphan branch.
+ * Adding them to .gitignore prevents accidental staging via git add .,
+ * git add -A, IDE "stage all", or git commit -am -- defense-in-depth
+ * complement to the pre-commit hook installed by squad upgrade --state-backend.
+ *
+ * The block is delimited by marker comments so it can be reliably added and
+ * removed without touching unrelated .gitignore content.
+ */
+
+import type { StorageProvider } from '../storage/index.js';
+
+export const SQUAD_STATE_GITIGNORE_OPEN_MARKER =
+  '# Squad: state owned by squad-state branch (two-layer/orphan backend)';
+export const SQUAD_STATE_GITIGNORE_CLOSE_MARKER =
+  '# /Squad: state owned by squad-state branch';
+
+const SQUAD_STATE_GITIGNORE_BLOCK =
+  SQUAD_STATE_GITIGNORE_OPEN_MARKER + '\n' +
+  '.squad/decisions.md\n' +
+  '.squad/agents/*/history.md\n' +
+  SQUAD_STATE_GITIGNORE_CLOSE_MARKER + '\n';
+
+/**
+ * Append the squad-state marker block to .gitignore if not already present.
+ *
+ * Idempotent: if the opening marker already exists in the file, this is a
+ * no-op. Returns true if the block was added, false if it was already present.
+ */
+export function addSquadStateGitignoreBlock(
+  gitignorePath: string,
+  storage: StorageProvider,
+): boolean {
+  let content = '';
+  if (storage.existsSync(gitignorePath)) {
+    content = storage.readSync(gitignorePath) ?? '';
+  }
+
+  if (content.includes(SQUAD_STATE_GITIGNORE_OPEN_MARKER)) {
+    return false;
+  }
+
+  const prefix = content.length > 0 && !content.endsWith('\n') ? '\n' : '';
+  storage.writeSync(gitignorePath, content + prefix + SQUAD_STATE_GITIGNORE_BLOCK);
+  return true;
+}
+
+/**
+ * Remove the squad-state marker block from .gitignore if present.
+ *
+ * Finds the opening and closing marker lines and removes all lines between
+ * them (inclusive), plus one leading blank line in what follows if present.
+ * Returns true if the block was removed, false if it was not present.
+ */
+export function removeSquadStateGitignoreBlock(
+  gitignorePath: string,
+  storage: StorageProvider,
+): boolean {
+  if (!storage.existsSync(gitignorePath)) {
+    return false;
+  }
+
+  const content = storage.readSync(gitignorePath) ?? '';
+  if (!content.includes(SQUAD_STATE_GITIGNORE_OPEN_MARKER)) {
+    return false;
+  }
+
+  const lines = content.split('\n');
+  const openIdx = lines.findIndex((l) => l === SQUAD_STATE_GITIGNORE_OPEN_MARKER);
+  if (openIdx === -1) return false;
+
+  // Find the closing marker starting from the opening marker
+  let closeIdx = -1;
+  for (let i = openIdx + 1; i < lines.length; i++) {
+    if (lines[i] === SQUAD_STATE_GITIGNORE_CLOSE_MARKER) {
+      closeIdx = i;
+      break;
+    }
+  }
+
+  // If no closing marker found, remove from opening marker to end
+  const endIdx = closeIdx !== -1 ? closeIdx : lines.length - 1;
+
+  const before = lines.slice(0, openIdx);
+  const after = lines.slice(endIdx + 1);
+
+  // Rejoin: before-lines + after-lines (including trailing empty string if present,
+  // which preserves a trailing newline from the original file content)
+  const newContent = [...before, ...after].join('\n');
+  storage.writeSync(gitignorePath, newContent);
+  return true;
+}

--- a/packages/squad-sdk/src/config/index.ts
+++ b/packages/squad-sdk/src/config/index.ts
@@ -13,3 +13,4 @@ export * from './migration.js';
 export * from './markdown-migration.js';
 export * from './legacy-fallback.js';
 export * from './feature-audit.js';
+export * from './gitignore-state.js';

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -19,6 +19,7 @@ import type { SubSquadDefinition } from '../streams/types.js';
 import { ENGINEERING_ROLE_IDS } from '../roles/catalog.js';
 import { getRoleById } from '../roles/index.js';
 import { ensureMemoryGovernanceDefaults } from '../memory/index.js';
+import { addSquadStateGitignoreBlock, removeSquadStateGitignoreBlock } from './gitignore-state.js';
 
 // ============================================================================
 // Manifest-Curated Skills (must stay in sync with TEMPLATE_MANIFEST in CLI)
@@ -163,6 +164,14 @@ export interface InitOptions {
     areaPath?: string;
     iterationPath?: string;
   };
+  /**
+   * State backend to use for this project.
+   * When 'orphan' or 'two-layer', adds a marker-delimited block to .gitignore
+   * so .squad/decisions.md and .squad/agents/*\/history.md are not accidentally
+   * staged into the working-tree commit graph.
+   * When 'local' (or undefined), removes the marker block if present.
+   */
+  stateBackend?: 'local' | 'orphan' | 'two-layer' | 'external' | string;
 }
 
 /**
@@ -1393,8 +1402,18 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   }
 
   // -------------------------------------------------------------------------
-  // Detect platform from git remote
+  // Conditionally add/remove squad-state .gitignore block
+  // When stateBackend is 'orphan' or 'two-layer', .squad/decisions.md and
+  // .squad/agents/*/history.md are owned by the squad-state branch — add a
+  // marker-delimited block so `git add .` cannot accidentally stage them.
+  // When stateBackend is 'local' (or undefined), remove the block if present.
   // -------------------------------------------------------------------------
+
+  if (options.stateBackend === 'orphan' || options.stateBackend === 'two-layer') {
+    addSquadStateGitignoreBlock(gitignorePath, storage);
+  } else {
+    removeSquadStateGitignoreBlock(gitignorePath, storage);
+  }
 
   let isGitHub = true;
   try {

--- a/test/gitignore-state.test.ts
+++ b/test/gitignore-state.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for gitignore-state helpers.
+ *
+ * Tests addSquadStateGitignoreBlock and removeSquadStateGitignoreBlock
+ * using the InMemoryStorageProvider — no filesystem access required.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { join } from 'node:path';
+import { InMemoryStorageProvider } from '../packages/squad-sdk/src/storage/in-memory-storage-provider.js';
+import {
+  addSquadStateGitignoreBlock,
+  removeSquadStateGitignoreBlock,
+  SQUAD_STATE_GITIGNORE_OPEN_MARKER,
+  SQUAD_STATE_GITIGNORE_CLOSE_MARKER,
+} from '../packages/squad-sdk/src/config/gitignore-state.js';
+
+const GITIGNORE_PATH = join('/project', '.gitignore');
+
+describe('addSquadStateGitignoreBlock', () => {
+  let storage: InMemoryStorageProvider;
+
+  beforeEach(() => {
+    storage = new InMemoryStorageProvider();
+  });
+
+  it('adds the marker block when .gitignore does not exist', () => {
+    const added = addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    expect(added).toBe(true);
+    const content = storage.readSync(GITIGNORE_PATH) ?? '';
+    expect(content).toContain(SQUAD_STATE_GITIGNORE_OPEN_MARKER);
+    expect(content).toContain('.squad/decisions.md');
+    expect(content).toContain('.squad/agents/*/history.md');
+    expect(content).toContain(SQUAD_STATE_GITIGNORE_CLOSE_MARKER);
+  });
+
+  it('adds the marker block when .gitignore has existing content without a trailing newline', () => {
+    storage.writeSync(GITIGNORE_PATH, 'node_modules/\ndist/');
+    const added = addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    expect(added).toBe(true);
+    const content = storage.readSync(GITIGNORE_PATH) ?? '';
+    expect(content).toContain('node_modules/');
+    expect(content).toContain('dist/');
+    expect(content).toContain(SQUAD_STATE_GITIGNORE_OPEN_MARKER);
+    expect(content).toContain('.squad/decisions.md');
+    expect(content).toContain('.squad/agents/*/history.md');
+    expect(content).toContain(SQUAD_STATE_GITIGNORE_CLOSE_MARKER);
+  });
+
+  it('adds the marker block when .gitignore has existing content with a trailing newline', () => {
+    storage.writeSync(GITIGNORE_PATH, 'node_modules/\ndist/\n');
+    const added = addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    expect(added).toBe(true);
+    const content = storage.readSync(GITIGNORE_PATH) ?? '';
+    expect(content).toContain(SQUAD_STATE_GITIGNORE_OPEN_MARKER);
+  });
+
+  it('is idempotent — returns false if block already present', () => {
+    addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    const contentAfterFirst = storage.readSync(GITIGNORE_PATH);
+
+    const added = addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    expect(added).toBe(false);
+
+    // Content must be exactly the same after second call
+    expect(storage.readSync(GITIGNORE_PATH)).toBe(contentAfterFirst);
+  });
+
+  it('does not duplicate the block on repeated calls', () => {
+    addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    const content = storage.readSync(GITIGNORE_PATH) ?? '';
+    const occurrences = (content.match(/# Squad: state owned by squad-state branch/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+});
+
+describe('removeSquadStateGitignoreBlock', () => {
+  let storage: InMemoryStorageProvider;
+
+  beforeEach(() => {
+    storage = new InMemoryStorageProvider();
+  });
+
+  it('returns false when .gitignore does not exist', () => {
+    const removed = removeSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    expect(removed).toBe(false);
+  });
+
+  it('returns false when block is not present in existing .gitignore', () => {
+    storage.writeSync(GITIGNORE_PATH, 'node_modules/\ndist/\n');
+    const removed = removeSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    expect(removed).toBe(false);
+    expect(storage.readSync(GITIGNORE_PATH)).toBe('node_modules/\ndist/\n');
+  });
+
+  it('removes the marker block when present', () => {
+    addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    const removed = removeSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    expect(removed).toBe(true);
+    const content = storage.readSync(GITIGNORE_PATH) ?? '';
+    expect(content).not.toContain(SQUAD_STATE_GITIGNORE_OPEN_MARKER);
+    expect(content).not.toContain('.squad/decisions.md');
+    expect(content).not.toContain('.squad/agents/*/history.md');
+    expect(content).not.toContain(SQUAD_STATE_GITIGNORE_CLOSE_MARKER);
+  });
+
+  it('is idempotent — returns false if block already removed', () => {
+    addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    removeSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    const removed = removeSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    expect(removed).toBe(false);
+  });
+
+  it('preserves content before the block', () => {
+    storage.writeSync(GITIGNORE_PATH, 'node_modules/\ndist/\n');
+    addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    removeSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    const content = storage.readSync(GITIGNORE_PATH) ?? '';
+    expect(content).toContain('node_modules/');
+    expect(content).toContain('dist/');
+  });
+
+  it('preserves content after the block', () => {
+    // Manually write a .gitignore that has content both before and after the block
+    const withBlock = [
+      'node_modules/',
+      'dist/',
+      SQUAD_STATE_GITIGNORE_OPEN_MARKER,
+      '.squad/decisions.md',
+      '.squad/agents/*/history.md',
+      SQUAD_STATE_GITIGNORE_CLOSE_MARKER,
+      '# custom entry after block',
+      'build/',
+      '',
+    ].join('\n');
+    storage.writeSync(GITIGNORE_PATH, withBlock);
+    removeSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    const content = storage.readSync(GITIGNORE_PATH) ?? '';
+    expect(content).toContain('node_modules/');
+    expect(content).toContain('dist/');
+    expect(content).toContain('# custom entry after block');
+    expect(content).toContain('build/');
+    expect(content).not.toContain(SQUAD_STATE_GITIGNORE_OPEN_MARKER);
+  });
+});
+
+describe('round-trip: add then remove', () => {
+  it('leaves .gitignore byte-identical (empty file)', () => {
+    const storage = new InMemoryStorageProvider();
+    storage.writeSync(GITIGNORE_PATH, '');
+    addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    removeSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    expect(storage.readSync(GITIGNORE_PATH)).toBe('');
+  });
+
+  it('leaves .gitignore byte-identical (file with content ending in newline)', () => {
+    const storage = new InMemoryStorageProvider();
+    const original = '# existing entries\nnode_modules/\ndist/\n';
+    storage.writeSync(GITIGNORE_PATH, original);
+    addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    removeSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    expect(storage.readSync(GITIGNORE_PATH)).toBe(original);
+  });
+
+  it('leaves .gitignore byte-identical (file without trailing newline)', () => {
+    const storage = new InMemoryStorageProvider();
+    const original = '# existing entries\nnode_modules/\ndist/';
+    storage.writeSync(GITIGNORE_PATH, original);
+    addSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    removeSquadStateGitignoreBlock(GITIGNORE_PATH, storage);
+    const result = storage.readSync(GITIGNORE_PATH) ?? '';
+    // Files without a trailing newline gain one after round-trip (acceptable for .gitignore)
+    expect(result.trimEnd()).toBe(original.trimEnd());
+    expect(result).not.toContain('# Squad: state owned by squad-state branch');
+  });
+});

--- a/test/init-scaffolding.test.ts
+++ b/test/init-scaffolding.test.ts
@@ -428,3 +428,73 @@ describe('squad.agent.md template handling (#730)', () => {
     expect(result.createdFiles.length).toBeGreaterThan(0);
   });
 });
+
+// ─── .gitignore marker block for two-layer/orphan backends (#1228) ─────────
+
+describe('.gitignore state-backend marker block — initSquad()', () => {
+  beforeEach(async () => {
+    if (existsSync(TEST_ROOT)) {
+      await rm(TEST_ROOT, { recursive: true, force: true });
+    }
+    await mkdir(TEST_ROOT, { recursive: true });
+    gitInit(TEST_ROOT);
+  });
+
+  afterEach(async () => {
+    if (existsSync(TEST_ROOT)) {
+      await rm(TEST_ROOT, { recursive: true, force: true });
+    }
+  });
+
+  it('initSquad({stateBackend: "two-layer"}) adds the marker block to .gitignore', async () => {
+    await initSquad({ ...sdkOptions(TEST_ROOT), stateBackend: 'two-layer' });
+
+    const gitignorePath = join(TEST_ROOT, '.gitignore');
+    expect(existsSync(gitignorePath)).toBe(true);
+    const content = await readFile(gitignorePath, 'utf-8');
+    expect(content).toContain('# Squad: state owned by squad-state branch (two-layer/orphan backend)');
+    expect(content).toContain('.squad/decisions.md');
+    expect(content).toContain('.squad/agents/*/history.md');
+    expect(content).toContain('# /Squad: state owned by squad-state branch');
+  });
+
+  it('initSquad({stateBackend: "orphan"}) adds the marker block to .gitignore', async () => {
+    await initSquad({ ...sdkOptions(TEST_ROOT), stateBackend: 'orphan' });
+
+    const gitignorePath = join(TEST_ROOT, '.gitignore');
+    expect(existsSync(gitignorePath)).toBe(true);
+    const content = await readFile(gitignorePath, 'utf-8');
+    expect(content).toContain('# Squad: state owned by squad-state branch (two-layer/orphan backend)');
+    expect(content).toContain('.squad/decisions.md');
+    expect(content).toContain('.squad/agents/*/history.md');
+  });
+
+  it('initSquad({stateBackend: "local"}) does NOT add the marker block to .gitignore', async () => {
+    await initSquad({ ...sdkOptions(TEST_ROOT), stateBackend: 'local' });
+
+    const gitignorePath = join(TEST_ROOT, '.gitignore');
+    expect(existsSync(gitignorePath)).toBe(true);
+    const content = await readFile(gitignorePath, 'utf-8');
+    expect(content).not.toContain('# Squad: state owned by squad-state branch');
+    expect(content).not.toContain('.squad/decisions.md');
+    expect(content).not.toContain('.squad/agents/*/history.md');
+  });
+
+  it('initSquad() with no stateBackend does NOT add the marker block', async () => {
+    await initSquad(sdkOptions(TEST_ROOT));
+
+    const gitignorePath = join(TEST_ROOT, '.gitignore');
+    expect(existsSync(gitignorePath)).toBe(true);
+    const content = await readFile(gitignorePath, 'utf-8');
+    expect(content).not.toContain('# Squad: state owned by squad-state branch');
+  });
+
+  it('initSquad with two-layer is idempotent — second call does not duplicate marker block', async () => {
+    await initSquad({ ...sdkOptions(TEST_ROOT), stateBackend: 'two-layer' });
+    await initSquad({ ...sdkOptions(TEST_ROOT), stateBackend: 'two-layer' });
+
+    const content = await readFile(join(TEST_ROOT, '.gitignore'), 'utf-8');
+    const occurrences = (content.match(/# Squad: state owned by squad-state branch/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+});

--- a/test/upgrade-state-backend.test.ts
+++ b/test/upgrade-state-backend.test.ts
@@ -151,4 +151,111 @@ describe('squad upgrade --state-backend migration', () => {
     expect(occurrences).toBe(1);
     expect(JSON.parse(raw).stateBackend).toBe('two-layer');
   });
+
+  // ── .gitignore marker block (#1228) ──────────────────────────────────────
+
+  it('local → two-layer: adds .gitignore marker block', { timeout: 30_000 }, async () => {
+    dir = mkRepo('local');
+    await migrateStateBackend(dir, 'two-layer');
+
+    const gitignore = fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8');
+    expect(gitignore).toContain('# Squad: state owned by squad-state branch (two-layer/orphan backend)');
+    expect(gitignore).toContain('.squad/decisions.md');
+    expect(gitignore).toContain('.squad/agents/*/history.md');
+    expect(gitignore).toContain('# /Squad: state owned by squad-state branch');
+  });
+
+  it('local → orphan: adds .gitignore marker block', { timeout: 30_000 }, async () => {
+    dir = mkRepo('local');
+    await migrateStateBackend(dir, 'orphan');
+
+    const gitignore = fs.readFileSync(path.join(dir, '.gitignore'), 'utf-8');
+    expect(gitignore).toContain('# Squad: state owned by squad-state branch (two-layer/orphan backend)');
+    expect(gitignore).toContain('.squad/decisions.md');
+    expect(gitignore).toContain('.squad/agents/*/history.md');
+  });
+
+  it('two-layer → local: removes .gitignore marker block', { timeout: 30_000 }, async () => {
+    dir = mkRepo('two-layer');
+    // Pre-seed a .gitignore with the marker block
+    const gitignorePath = path.join(dir, '.gitignore');
+    fs.writeFileSync(gitignorePath, [
+      '# Squad: ignore runtime state (logs, inbox, sessions)',
+      '.squad/orchestration-log/',
+      '# Squad: state owned by squad-state branch (two-layer/orphan backend)',
+      '.squad/decisions.md',
+      '.squad/agents/*/history.md',
+      '# /Squad: state owned by squad-state branch',
+      '',
+    ].join('\n'));
+
+    await migrateStateBackend(dir, 'local');
+
+    const gitignore = fs.readFileSync(gitignorePath, 'utf-8');
+    expect(gitignore).not.toContain('# Squad: state owned by squad-state branch');
+    expect(gitignore).not.toContain('.squad/decisions.md');
+    expect(gitignore).not.toContain('.squad/agents/*/history.md');
+    // Other entries should be preserved
+    expect(gitignore).toContain('.squad/orchestration-log/');
+  });
+
+  it('orphan → local: removes .gitignore marker block', { timeout: 30_000 }, async () => {
+    dir = mkRepo('orphan');
+    const gitignorePath = path.join(dir, '.gitignore');
+    fs.writeFileSync(gitignorePath, [
+      '.squad/orchestration-log/',
+      '# Squad: state owned by squad-state branch (two-layer/orphan backend)',
+      '.squad/decisions.md',
+      '.squad/agents/*/history.md',
+      '# /Squad: state owned by squad-state branch',
+      '',
+    ].join('\n'));
+
+    await migrateStateBackend(dir, 'local');
+
+    const gitignore = fs.readFileSync(gitignorePath, 'utf-8');
+    expect(gitignore).not.toContain('# Squad: state owned by squad-state branch');
+    expect(gitignore).toContain('.squad/orchestration-log/');
+  });
+
+  it('two-layer → orphan: no-op on .gitignore (block already present)', { timeout: 30_000 }, async () => {
+    dir = mkRepo('two-layer');
+    const gitignorePath = path.join(dir, '.gitignore');
+    fs.writeFileSync(gitignorePath, [
+      '# Squad: state owned by squad-state branch (two-layer/orphan backend)',
+      '.squad/decisions.md',
+      '.squad/agents/*/history.md',
+      '# /Squad: state owned by squad-state branch',
+      '',
+    ].join('\n'));
+    const contentBefore = fs.readFileSync(gitignorePath, 'utf-8');
+
+    await migrateStateBackend(dir, 'orphan');
+
+    const contentAfter = fs.readFileSync(gitignorePath, 'utf-8');
+    // Block is still present
+    expect(contentAfter).toContain('# Squad: state owned by squad-state branch');
+    // Not duplicated
+    const occurrences = (contentAfter.match(/# Squad: state owned by squad-state branch \(two-layer\/orphan backend\)/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  it('.gitignore round-trip: local→two-layer→local leaves file byte-identical', { timeout: 30_000 }, async () => {
+    dir = mkRepo('local');
+    const gitignorePath = path.join(dir, '.gitignore');
+    const existingContent = '# my project\nnode_modules/\ndist/\n';
+    fs.writeFileSync(gitignorePath, existingContent);
+
+    await migrateStateBackend(dir, 'two-layer');
+    // Migrate back to local but this time need to create fresh repo with same config
+    // We need to start a new repo already set to two-layer then go back
+    const twoLayerDir = mkRepo('two-layer');
+    const twoLayerGitignorePath = path.join(twoLayerDir, '.gitignore');
+    fs.writeFileSync(twoLayerGitignorePath, existingContent);
+    await migrateStateBackend(twoLayerDir, 'local');
+    // After round-trip: the marker block should not be present
+    const finalContent = fs.readFileSync(twoLayerGitignorePath, 'utf-8');
+    expect(finalContent).not.toContain('# Squad: state owned by squad-state branch');
+    try { fs.rmSync(twoLayerDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
 });


### PR DESCRIPTION
Closes #1228

## Summary

Defense-in-depth complement to the pre-commit hook installed by `squad upgrade --state-backend two-layer|orphan`. Adds `.squad/decisions.md` and `.squad/agents/*/history.md` to `.gitignore` (in a marker-delimited block) when those backends are active, and removes the block when switching back to `local`.

Result: `git add .`, `git add -A`, IDE "stage all", and `git commit -am` will no longer stage two-layer state into the working tree. The pre-commit hook stays as a hard backstop for `git add --force` and edge cases.

## What changed

- **New helper** `packages/squad-sdk/src/config/gitignore-state.ts` -- `addSquadStateGitignoreBlock()` and `removeSquadStateGitignoreBlock()` with marker-delimited block (`# Squad: state owned by squad-state branch` to `# /Squad: ...`)
- **`packages/squad-sdk/src/config/init.ts`** -- adds `stateBackend` to `InitOptions`; calls helpers based on `options.stateBackend`
- **`packages/squad-cli/src/cli/core/init.ts`** -- passes `stateBackend` to `sdkInitSquad()`
- **`packages/squad-cli/src/cli/commands/migrate-backend.ts`** -- calls helpers on backend transitions (local to orphan/two-layer adds; orphan/two-layer to local removes)
- **Unit tests** `test/gitignore-state.test.ts` -- 14 tests covering idempotent add, idempotent remove, round-trip byte equality, content preservation
- **Integration tests** in `test/init-scaffolding.test.ts` and `test/upgrade-state-backend.test.ts`
- **Changeset** `.changeset/conditional-state-gitignore.md` (patch bump for both SDK and CLI)

## State transitions tested

| From | To | Action |
|------|-----|--------|
| init local | local | no-op (preserved) |
| init two-layer/orphan | (target) | add block |
| migrate local to orphan/two-layer | (target) | add block |
| migrate orphan to two-layer | (target) | no-op |
| migrate orphan/two-layer to local | local | remove block |

## Test plan

- [x] npm test on targeted files passes (50 tests: 14 unit + 24 init-scaffolding + 12 migration)
- [x] npm run build passes
- [x] Pre-existing failures confirmed to be unrelated (storage-provider timeouts, scheduler, etc. all fail on dev baseline too)

## Out of scope

- Pre-commit hook stays unchanged -- defense in depth
- Docs update for this behavior -- coordinate with #1227 (or extend that PR if it has not merged)