### PR TITLE
docs: clarify that .squad/casting/* files are identity, not two-layer state

### DIFF
--- a/.changeset/casting-identity-not-state.md
+++ b/.changeset/casting-identity-not-state.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-sdk": patch
+---
+
+docs: clarify in `init.ts` and `.gitattributes` / `.gitignore` generators that `.squad/casting/*` files are authoritative identity (registry + history), NOT mutable two-layer state. They belong on `main`, must be committed, and should NOT receive a `merge=union` driver or be added to `.gitignore`. Pure comment additions — no runtime behavior change.

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,12 @@
 .squad/agents/*/history.md merge=union
 .squad/log/** merge=union
 .squad/orchestration-log/** merge=union
+
+# NOTE: .squad/casting/* files are AUTHORITATIVE IDENTITY (team-defined agent
+# universe/roles, persistent name registry, universe assignment history).
+# They are committed to 'main' like team.md and routing.md, not to squad-state.
+# They do NOT need union merge and are intentionally NOT listed above.
+
 # Squad: union merge for append-only team state files
 .squad/decisions/decisions.md merge=union
 # Squad: union merge for append-only team state files

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ artifacts/
 *.user
 *.userprefs
 
+# NOTE: .squad/casting/* is AUTHORITATIVE IDENTITY and MUST be committed to main.
+# Do not add .squad/casting/ to this ignore list.

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -1336,6 +1336,9 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
 
   // -------------------------------------------------------------------------
   // Create .gitattributes for merge drivers
+  // Append-only mutable state files use union merge to handle concurrent appends.
+  // Note: .squad/casting/* files are identity (not mutable) so they don't need
+  // union merge and are NOT listed here.
   // -------------------------------------------------------------------------
 
   const gitattributesPath = join(teamRoot, '.gitattributes');
@@ -1366,6 +1369,10 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   // Create .gitignore entries for runtime state (logs, inbox, sessions)
   // These paths are written during normal squad operation but should not be
   // committed to version control (they are runtime state).
+  //
+  // Note: .squad/casting/* is AUTHORITATIVE IDENTITY (team-defined agent
+  // universe, persistent name registry, history). It belongs on 'main', not
+  // on the squad-state orphan branch. Do NOT add casting/* to ignoreEntries.
   // -------------------------------------------------------------------------
 
   const gitignorePath = join(teamRoot, '.gitignore');
@@ -1387,6 +1394,7 @@ ${projectDescription ? `- **Description:** ${projectDescription}\n` : ''}- **Cre
   if (missingIgnore.length > 0) {
     const block = (existingIgnore && !existingIgnore.endsWith('\n') ? '\n' : '')
       + '# Squad: ignore runtime state (logs, inbox, sessions)\n'
+      + '# Note: .squad/casting/* is identity and MUST be committed to main, not ignored\n'
       + missingIgnore.join('\n') + '\n';
     await storage.append(gitignorePath, block);
     createdFiles.push(toRelativePath(gitignorePath));


### PR DESCRIPTION
## Problem
.squad/casting/* files (policy.json, registry.json, history.json) have been misclassified as two-layer runtime mutable state that should live on the squad-state orphan branch. This causes confusion and blocks the use of these critical team identity files.

## Root Cause
The classification was unclear in the codebase. While .squad/casting/* files are correctly created and not ignored, there was no explicit documentation clarifying that they are AUTHORITATIVE IDENTITY files per squad.agent.md (the source-of-truth governance document).

## Solution
Added clarifying documentation to three files:

1. **.gitignore** - Added explicit NOTE that casting/* MUST be committed to main, not ignored
2. **.gitattributes** - Added NOTE explaining that casting/* files are identity (not append-only mutable state) and don't need union merge
3. **packages/squad-sdk/src/config/init.ts** - Enhanced comments explaining the correct classification

## Authority
Per .github/agents/squad.agent.md (the authoritative classification table):
- .squad/casting/policy.json: Authoritative casting config
- .squad/casting/registry.json: Authoritative name registry  
- .squad/casting/history.json: Derived / append-only

These files define the agent universe, persistent name-to-ID mappings, and usage history - fundamental team identity committed to main alongside team.md and routing.md.

## Files Changed
- .gitignore
- .gitattributes
- packages/squad-sdk/src/config/init.ts