### PR TITLE
fix(cli): add externalize/internalize to top-level squad --help (#1050)

### DIFF
--- a/.changeset/help-externalize-internalize.md
+++ b/.changeset/help-externalize-internalize.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+Add `externalize` and `internalize` to the top-level `squad --help` command list so they are discoverable (#1050).

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -240,6 +240,8 @@ async function main(): Promise<void> {
     console.log(`             Aliases: workstreams, streams (deprecated)`);
     console.log(`  ${BOLD}link${RESET}       Link project to a remote team root`);
     console.log(`             Usage: link <team-repo-path>`);
+    console.log(`  ${BOLD}externalize${RESET}  Move local squad state to an external team root`);
+    console.log(`  ${BOLD}internalize${RESET}  Pull an external team root back into the project`);
     console.log(`  ${BOLD}build${RESET}      Compile squad.config.ts into .squad/ markdown`);
     console.log(`             Flags: --check (validate only), --dry-run (preview)`);
     console.log(`                    --watch (rebuild on change)`);

--- a/test/human-journeys.test.ts
+++ b/test/human-journeys.test.ts
@@ -565,7 +565,7 @@ describe('Cross-journey: CLI --help is the safety net', () => {
     await harness.close();
 
     // A confused human types --help. Do they see EVERY command?
-    const expectedCommands = ['init', 'status', 'doctor', 'help', 'upgrade', 'export', 'import'];
+    const expectedCommands = ['init', 'status', 'doctor', 'help', 'upgrade', 'export', 'import', 'externalize', 'internalize'];
     for (const cmd of expectedCommands) {
       expect(output.toLowerCase()).toContain(cmd);
     }


### PR DESCRIPTION
### What

Adds the `externalize` and `internalize` commands to the top-level `squad --help` command listing so they are discoverable, and adds a regression test that guards the listing.

### Why

Closes #1050. Both commands already exist and have per-command help (`squad externalize --help`, `squad internalize --help`), but they were missing from the top-level `squad --help` command list. Users browsing `squad --help` had no way to discover them.

### How

- Added two entries to the top-level help block in `packages/squad-cli/src/cli-entry.ts`, placed alphabetically between `link` and `build` to match the surrounding ordering.
- Descriptions are copied **verbatim** from the source of truth in `packages/squad-cli/src/cli/core/command-help.ts`, and the column alignment matches the existing long-command-name precedent (e.g. `scrub-emails`, `copilot-bridge`).
- Extended the existing "lists every major command" assertion in `test/human-journeys.test.ts` rather than adding a new test, keeping the diff minimal.
- Negative-checked the test: reverting the fix makes it fail, restoring makes it pass.

---

### ⚠️ Quick Check
- [x] If SDK/CLI source files changed: completed the applicable Changeset step below (`.changeset/help-externalize-internalize.md`, patch to `@bradygaster/squad-cli`)

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev` (not `main`)
- [x] Branch is up to date with `dev` (ahead 1, behind 0 at time of push)
- [x] Verified diff contains only intended changes (`git diff --cached --stat`: 3 files, +8/-1)
- [ ] PR is **not** in draft mode (intentionally opened as draft per CONTRIBUTING handoff flow; will mark ready once CI is green)
- [x] Commit history is clean (squashed to a single commit)

#### Build & Test
- [x] `npm run build` passes
- [x] `npm run lint` passes (type check clean)
- [x] Targeted help/command-listing tests pass (`test/human-journeys.test.ts`, command-help tests)
- [ ] `npm test` full suite — letting CI be the arbiter. Locally on a fresh Windows clone the full suite has pre-existing environmental failures (worker-RPC timeouts, `npm pack`/install integration smoke tests, storage-provider FS-contract tests) that are present on untouched `dev` as well; a baseline run of clean `dev` failed *more* than this branch, confirming this change introduces zero new failures.

#### Changeset
- [x] Changeset added (`.changeset/help-externalize-internalize.md`, patch to `@bradygaster/squad-cli`)

#### Docs
- [x] N/A — no new feature/module; this surfaces existing commands in help output.

#### Exports
- [x] N/A — no new modules or exports.

---

### Breaking Changes
None.

### Waivers
None.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
