### PR TITLE
Rename .NET Aspire references to Aspire

### DIFF
--- a/.changeset/rename-dotnet-aspire-to-aspire.md
+++ b/.changeset/rename-dotnet-aspire-to-aspire.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+Rename user-facing Aspire terminology in CLI help text and command output. Aspire is a standalone OTLP dashboard, not limited to .NET apps.

--- a/.squad/agents/_alumni/saul/charter.md
+++ b/.squad/agents/_alumni/saul/charter.md
@@ -18,7 +18,7 @@
 
 ## How I Work
 
-- It's "Aspire" — not ".NET Aspire." Aspire is a standalone dashboard for any OTLP app.
+- Use "Aspire" without a ".NET" prefix. Aspire is a standalone dashboard for any OTLP app.
 - Reference aspire.dev for documentation, NOT learn.microsoft.com
 - Use the very latest Aspire bits (mcr.microsoft.com/dotnet/aspire-dashboard:latest)
 - Aspire dashboard: port 18888 (UI), port 18889→4317 (OTLP/gRPC)

--- a/.squad/decisions-archive.md
+++ b/.squad/decisions-archive.md
@@ -75,7 +75,7 @@
 
 ### 2026-02-22: User directive — Aspire testing requirements
 **By:** Brady (via Copilot)
-**What:** Integration tests must launch the Aspire dashboard and validate OTel telemetry shows up. Use Playwright. Use latest Aspire bits. Reference aspire.dev (NOT learn.microsoft.com). It's "Aspire" not ".NET Aspire".
+**What:** Integration tests must launch the Aspire dashboard and validate OTel telemetry shows up. Use Playwright. Use latest Aspire bits. Reference aspire.dev (NOT learn.microsoft.com). Use "Aspire" without a ".NET" prefix.
 
 ### 2026-02-23: User directive — code fences
 **By:** Brady (via Copilot)

--- a/docs/src/content/blog/014-wave-1-otel-and-aspire.md
+++ b/docs/src/content/blog/014-wave-1-otel-and-aspire.md
@@ -47,7 +47,7 @@ Every file mutation by every agent becomes a traceable event. In the Aspire dash
 
 ## Aspire Dashboard Integration
 
-The `squad aspire` command (#265) wires Squad's OTLP exporter to a .NET Aspire dashboard. Aspire gives you:
+The `squad aspire` command (#265) wires Squad's OTLP exporter to a Aspire dashboard. Aspire gives you:
 
 - **Trace waterfall** — See agent spawns, tool calls, and file writes as a timeline
 - **Metrics** — Agent spawn counts, tool call durations, event bus throughput

--- a/docs/src/content/blog/022-welcome-to-the-new-squad.md
+++ b/docs/src/content/blog/022-welcome-to-the-new-squad.md
@@ -671,7 +671,7 @@ Squad exports traces and metrics via OpenTelemetry. Three-layer API:
 - Cost accumulation in real time
 
 **Export to:**
-- .NET Aspire Dashboard (`squad aspire`)
+- Aspire Dashboard (`squad aspire`)
 - Jaeger
 - Zipkin
 - Any OTLP-compatible backend

--- a/docs/src/content/docs/features/mcp.md
+++ b/docs/src/content/docs/features/mcp.md
@@ -269,7 +269,7 @@ Agents will now automatically propose Trello tasks for tracking work items.
 
 ## Example: Aspire Dashboard MCP (Deployment Monitoring)
 
-For .NET Aspire projects, configure the Aspire Dashboard MCP for deployment monitoring:
+For Aspire projects, configure the Aspire Dashboard MCP for deployment monitoring:
 
 **Config template:**
 ```json

--- a/docs/src/content/docs/guide/build-autonomous-agent.md
+++ b/docs/src/content/docs/guide/build-autonomous-agent.md
@@ -375,7 +375,7 @@ import {
   recordTokenUsage,
 } from '@bradygaster/squad-sdk';
 
-// Initialize OTel (connects to .NET Aspire dashboard if endpoint is set)
+// Initialize OTel (connects to Aspire dashboard if endpoint is set)
 const otelEndpoint = process.env['OTEL_EXPORTER_OTLP_ENDPOINT'];
 if (otelEndpoint) {
   initSquadTelemetry({
@@ -413,7 +413,7 @@ const summary = costTracker.getSummary();
 console.log(`Total: $${summary.totalEstimatedCost.toFixed(4)}`);
 ```
 
-To view traces and metrics in the .NET Aspire dashboard, see the [Aspire dashboard scenario](/scenarios/aspire-dashboard/).
+To view traces and metrics in the Aspire dashboard, see the [Aspire dashboard scenario](/scenarios/aspire-dashboard/).
 
 ---
 

--- a/docs/src/content/docs/guide/sample-prompts.md
+++ b/docs/src/content/docs/guide/sample-prompts.md
@@ -65,10 +65,10 @@ Set up the team and start with the backend data layer.
 
 ---
 
-### .NET Aspire Cloud-Native App
+### Aspire Cloud-Native App
 
 ```
-Build a cloud-native distributed app with .NET Aspire. I want:
+Build a cloud-native distributed app with Aspire. I want:
 - An AppHost that orchestrates all services
 - A Blazor frontend with interactive server components
 - A minimal API backend with OpenAPI endpoints

--- a/docs/src/content/docs/sample-prompts.md
+++ b/docs/src/content/docs/sample-prompts.md
@@ -215,7 +215,7 @@ Read SDK docs carefully. One agent owns SDK integration/streaming, another owns 
 ### 9. Aspire Cloud-Native App
 
 ```
-Build a cloud-native app with Aspire (read https://learn.microsoft.com/en-us/dotnet/aspire/):
+Build a cloud-native app with Aspire (read https://aspire.dev/):
 - AppHost orchestrating all services
 - Blazor Server dashboard: current conditions + 5-day forecast for saved cities
 - Weather API service: wraps OpenWeatherMap with Redis caching

--- a/docs/src/content/docs/sample-prompts.md
+++ b/docs/src/content/docs/sample-prompts.md
@@ -212,10 +212,10 @@ Read SDK docs carefully. One agent owns SDK integration/streaming, another owns 
 
 ---
 
-### 9. .NET Aspire Cloud-Native App
+### 9. Aspire Cloud-Native App
 
 ```
-Build a cloud-native app with .NET Aspire (read https://learn.microsoft.com/en-us/dotnet/aspire/):
+Build a cloud-native app with Aspire (read https://learn.microsoft.com/en-us/dotnet/aspire/):
 - AppHost orchestrating all services
 - Blazor Server dashboard: current conditions + 5-day forecast for saved cities
 - Weather API service: wraps OpenWeatherMap with Redis caching

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -243,7 +243,7 @@ async function main(): Promise<void> {
     console.log(`  ${BOLD}build${RESET}      Compile squad.config.ts into .squad/ markdown`);
     console.log(`             Flags: --check (validate only), --dry-run (preview)`);
     console.log(`                    --watch (rebuild on change)`);
-    console.log(`  ${BOLD}aspire${RESET}     Launch .NET Aspire dashboard for observability`);
+    console.log(`  ${BOLD}aspire${RESET}     Launch Aspire dashboard for observability`);
     console.log(`             Flags: --docker (force Docker), --port <n> (dashboard port)`);
     console.log(`  ${BOLD}schedule${RESET}   Manage scheduled tasks`);
     console.log(`             Usage: schedule list | run <id> | init | status`);

--- a/packages/squad-cli/src/cli/commands/aspire.ts
+++ b/packages/squad-cli/src/cli/commands/aspire.ts
@@ -1,5 +1,5 @@
 /**
- * Aspire command — Launch .NET Aspire dashboard for Squad observability
+ * Aspire command — Launch Aspire dashboard for Squad observability
  * (Issue #265)
  *
  * Starts the Aspire dashboard and configures OTLP export so Squad
@@ -128,7 +128,7 @@ export async function runAspire(options: AspireOptions = {}): Promise<void> {
   } else if (isDockerAvailable()) {
     child = launchWithDocker();
   } else {
-    console.log(`${RED}✗${RESET} Neither Docker nor .NET Aspire workload found.`);
+    console.log(`${RED}✗${RESET} Neither Docker nor Aspire workload found.`);
     console.log(`\n  Install options:`);
     console.log(`    ${BOLD}Docker:${RESET}  https://docker.com/get-started`);
     console.log(`    ${BOLD}Aspire:${RESET}  dotnet workload install aspire\n`);

--- a/packages/squad-cli/src/cli/core/command-help.ts
+++ b/packages/squad-cli/src/cli/core/command-help.ts
@@ -257,7 +257,7 @@ const COMMAND_HELP: Record<string, HelpPrinter> = {
   },
 
   aspire: (version) => {
-    header('aspire', version, 'Launch the .NET Aspire dashboard for observability');
+    header('aspire', version, 'Launch the Aspire dashboard for observability');
     console.log(`Usage: squad aspire [options]\n`);
     console.log(`Options:`);
     console.log(`  ${BOLD}--docker${RESET}                    Force the Docker launch path`);

--- a/samples/autonomous-pipeline/README.md
+++ b/samples/autonomous-pipeline/README.md
@@ -93,7 +93,7 @@ The sample demonstrates three key SDK tools for agent coordination:
 
 ## OpenTelemetry integration
 
-To view traces and metrics in the .NET Aspire dashboard:
+To view traces and metrics in the Aspire dashboard:
 
 ```bash
 # Start Aspire dashboard

--- a/samples/autonomous-pipeline/TEST-SCRIPT.md
+++ b/samples/autonomous-pipeline/TEST-SCRIPT.md
@@ -79,7 +79,7 @@
 
 ### Act 6: OTel / Aspire (30 seconds, if Aspire is running)
 
-**Say:** "And all of this feeds into .NET Aspire."
+**Say:** "And all of this feeds into Aspire."
 
 **Show:** Switch to browser at http://localhost:18888. Show traces and metrics.
 


### PR DESCRIPTION
## Summary
- Rename the old Aspire product wording to `Aspire` across CLI help, docs, samples, and historical Squad notes
- Add a patch changeset for the CLI user-facing text updates

## Validation
- `npm ci --no-audit --no-fund`
- `SKIP_BUILD_BUMP=1 npm run build`
- No remaining exact old Aspire wording matches outside `node_modules`

Review: FIDO approved the diff.