### PR TITLE
ci(Squad.Agents.AI): switch NuGet publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/squad-agents-ai-release.yml
+++ b/.github/workflows/squad-agents-ai-release.yml
@@ -1,4 +1,17 @@
-# Requires repo secret NUGET_API_KEY. Generate at nuget.org → API Keys → Create.
+# Publishes Squad.Agents.AI to NuGet.org via Trusted Publishing (OIDC).
+#
+# ## Authentication
+# No long-lived API key is stored. The job uses GitHub Actions OIDC to obtain a
+# short-lived (1 hour) NuGet API key via the NuGet/login@v1 action. A Trusted
+# Publishing policy must be configured at https://www.nuget.org/account/trusted-publishing
+# under the package owner (Squad organization) with:
+#   Repository Owner: bradygaster
+#   Repository:       squad
+#   Workflow File:    squad-agents-ai-release.yml
+#   Environment:      (leave empty)
+# Set repository variable NUGET_USER to the nuget.org profile name that should
+# perform the token exchange (a member of the Squad org). Use a variable, not a
+# secret — the username is non-sensitive.
 #
 # ## Failure recovery
 # Publishing is branch-driven: dev creates prerelease NuGet packages, main creates stable NuGet
@@ -38,6 +51,9 @@ jobs:
   publish:
     name: Pack and publish NuGet package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC token issuance to NuGet/login
     concurrency:
       group: squad-agents-ai-release-${{ github.ref }}
       cancel-in-progress: false
@@ -116,14 +132,14 @@ jobs:
           echo "PACKAGE_VERSION=${package_version}" >> "${GITHUB_OUTPUT}"
           echo "Resolved PACKAGE_VERSION=${package_version} (${version_source})"
 
-      - name: Verify NuGet API key
+      - name: Verify NUGET_USER variable
         shell: bash
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_USER: ${{ vars.NUGET_USER }}
         run: |
           set -euo pipefail
-          if [[ -z "${NUGET_API_KEY}" ]]; then
-            echo "::error::Missing repo secret NUGET_API_KEY. Generate at nuget.org → API Keys → Create, then add it as a repository secret."
+          if [[ -z "${NUGET_USER}" ]]; then
+            echo "::error::Missing repository variable NUGET_USER. Set it under Settings → Secrets and variables → Actions → Variables to the nuget.org profile name (NOT email) of a Squad org member that will perform the OIDC token exchange. Configure the matching Trusted Publishing policy at https://www.nuget.org/account/trusted-publishing."
             exit 1
           fi
 
@@ -153,8 +169,14 @@ jobs:
           path: nupkgs/*
           if-no-files-found: ignore
 
+      - name: NuGet login (OIDC → temp API key)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER }}
+
       - name: Push to NuGet.org
         shell: bash
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push nupkgs/*.nupkg --source https://api.nuget.org/v3/index.json --api-key "${NUGET_API_KEY}" --skip-duplicate
+          NUGET_TEMP_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        run: dotnet nuget push nupkgs/*.nupkg --source https://api.nuget.org/v3/index.json --api-key "${NUGET_TEMP_KEY}" --skip-duplicate


### PR DESCRIPTION
## What

Switch the `Squad.Agents.AI NuGet Release` workflow from a long-lived `NUGET_API_KEY` repo secret to **NuGet Trusted Publishing** (OIDC token exchange) via [`NuGet/login@v1`](https://github.com/NuGet/login). The workflow now obtains a 1-hour API key at publish time instead of relying on a stored credential.

Reference: https://learn.microsoft.com/nuget/nuget-org/trusted-publishing

## Why

- No long-lived credentials stored in the repo — eliminates the leak/rotation problem.
- Token is scoped to this exact workflow file + repo + branch via the OIDC subject claim and the Trusted Publishing policy registered on nuget.org. Even if the token is intercepted in flight, it cannot be used outside that scope.
- Eliminates the bootstrap chicken-and-egg: previously, the first publish required an admin to set `NUGET_API_KEY` before the workflow could validate end-to-end.
- This is the [recommended Microsoft path](https://aka.ms/nuget/trusted-publishing) for new GitHub Actions-based NuGet workflows.

## What changed

- Added `id-token: write` to the publish job permissions (required for OIDC token issuance).
- Removed the `Verify NuGet API key` step and the `--api-key secrets.NUGET_API_KEY` reference.
- Added a `NuGet/login@v1` step that exchanges the GitHub OIDC token for a short-lived NuGet API key (1 hour validity, single use per token).
- `dotnet nuget push` now consumes the `nuget-login` step's `NUGET_API_KEY` output (temporary key) instead of the long-lived secret.
- Added a fail-fast check for the new `vars.NUGET_USER` repository variable (non-sensitive; the nuget.org profile name that performs the exchange — must be a member of the package-owning org).
- Updated the file header documentation to reflect the new flow.

## Required configuration before first publish

These three steps must be completed on nuget.org and in repo settings before the next push to `dev`/`main` will succeed:

1. **Create the `Squad` organization on nuget.org** and add owners (Brady + Tamir).
2. **Configure a Trusted Publishing policy** at https://www.nuget.org/account/trusted-publishing owned by the Squad org:
   - Repository Owner: `bradygaster`
   - Repository: `squad`
   - Workflow File: `squad-agents-ai-release.yml`
   - Environment: *(empty)*
3. **Set repository variable `NUGET_USER`** (Settings → Secrets and variables → Actions → **Variables** tab, NOT Secrets) to a Squad-org-member's nuget.org profile name. Profile name, not email. Variable, not secret — the username is non-sensitive.

After (1)–(3) are in place, either `workflow_dispatch` the workflow or push any change under `src/Squad.Agents.AI/**` to trigger the first publish.

## Quick Check

- [x] Workflow YAML syntactically valid (verified with PyYAML).
- [x] `id-token: write` scoped to the job, not the workflow (least privilege).
- [x] Non-sensitive `NUGET_USER` is a variable, not a secret (correct hygiene).
- [x] Fail-fast guard for missing `NUGET_USER` with actionable error message.
- [x] No other workflows changed.
- [x] No source code or tests changed.
