### PR TITLE
feat(mcp): bridge governed memory tools (memory.*) through squad_state MCP server

### DIFF
--- a/.changeset/memory-mcp-bridge.md
+++ b/.changeset/memory-mcp-bridge.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+feat(mcp): bridge governed memory tools (memory.classify, memory.write, memory.search, memory.promote, memory.delete, memory.audit) through the squad_state MCP server. Previously these tools were registered in the SDK ToolRegistry but not exposed via MCP, so autonomous agents running in Copilot CLI couldn't invoke them. Now `squad init` and `squad upgrade` produce a deck that includes the full governed-memory surface for agents.

--- a/packages/squad-cli/src/cli/commands/state-mcp.ts
+++ b/packages/squad-cli/src/cli/commands/state-mcp.ts
@@ -32,6 +32,15 @@ const MCP_TOOL_ALIASES: Record<string, string> = {
   squad_state_delete: 'squad_state_delete',
   squad_state_list: 'squad_state_list',
   squad_state_health: 'squad_state_health',
+  // Governed memory tools — bridge SDK ToolRegistry entries through the MCP server
+  // so autonomous agents (Copilot CLI) can invoke classify/write/search/promote/delete/audit.
+  // Underscore in the alias key per MCP cross-client safety; value keeps the dotted SDK name.
+  memory_classify: 'memory.classify',
+  memory_write: 'memory.write',
+  memory_search: 'memory.search',
+  memory_promote: 'memory.promote',
+  memory_delete: 'memory.delete',
+  memory_audit: 'memory.audit',
 };
 
 function parseObject(value: unknown): Record<string, unknown> {

--- a/test/cli/state-mcp.test.ts
+++ b/test/cli/state-mcp.test.ts
@@ -62,6 +62,58 @@ describe('state-mcp bridge', () => {
     expect(tools.find(tool => tool.name === 'squad_state_write')?.inputSchema.required).toEqual(['key', 'content']);
   });
 
+  it('lists all 13 tools including the 6 governed memory bridges', async () => {
+    const messages: JsonRpcMessage[] = [];
+    const session = createStateMcpSession(TMP, message => messages.push(message as JsonRpcMessage));
+
+    await session.handleRequest({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+
+    const tools = resultAsRecord(messages[0]!)['tools'] as Array<{ name: string }>;
+    const names = tools.map(tool => tool.name);
+
+    // Existing 7 state tools
+    expect(names).toContain('squad_decide');
+    expect(names).toContain('squad_state_read');
+    expect(names).toContain('squad_state_write');
+    expect(names).toContain('squad_state_append');
+    expect(names).toContain('squad_state_delete');
+    expect(names).toContain('squad_state_list');
+    expect(names).toContain('squad_state_health');
+
+    // New 6 governed memory bridges
+    expect(names).toContain('memory_classify');
+    expect(names).toContain('memory_write');
+    expect(names).toContain('memory_search');
+    expect(names).toContain('memory_promote');
+    expect(names).toContain('memory_delete');
+    expect(names).toContain('memory_audit');
+
+    expect(tools).toHaveLength(13);
+  });
+
+  it('routes memory_classify via MCP to the SDK ToolRegistry memory.classify handler', { timeout: 30000 }, async () => {
+    const messages: JsonRpcMessage[] = [];
+    const session = createStateMcpSession(TMP, message => messages.push(message as JsonRpcMessage));
+
+    await session.handleRequest({
+      jsonrpc: '2.0',
+      id: 'classify',
+      method: 'tools/call',
+      params: {
+        name: 'memory_classify',
+        arguments: { content: 'Always deploy on Tuesdays' },
+      },
+    });
+
+    const result = resultAsRecord(messages[0]!);
+    expect(result['isError']).not.toBe(true);
+    const content = result['content'] as Array<{ type: string; text: string }>;
+    expect(content).toBeDefined();
+    expect(content[0]?.type).toBe('text');
+    // The classification result should be a non-empty text response
+    expect(content[0]?.text.length).toBeGreaterThan(0);
+  });
+
   it('writes and reads two-layer state without mutating the worktree .squad files', async () => {
     const messages: JsonRpcMessage[] = [];
     const session = createStateMcpSession(TMP, message => messages.push(message as JsonRpcMessage));


### PR DESCRIPTION
Closes #1244

## Summary

Adds 6 entries to `MCP_TOOL_ALIASES` in `packages/squad-cli/src/cli/commands/state-mcp.ts` so the existing `squad_state` MCP server advertises the governed memory tools alongside the `squad_state_*` family. Without this change, the memory.* tools are registered in the SDK ToolRegistry but invisible to agents running in Copilot CLI.

## What changes

- `MCP_TOOL_ALIASES` grows from 7 → 13 entries
- New aliases: `memory_classify`, `memory_write`, `memory_search`, `memory_promote`, `memory_delete`, `memory_audit` → routed to the existing SDK ToolRegistry tools `memory.classify`, etc.
- Underscore-in-key / dot-in-value follows the existing convention and MCP cross-client safety practice

## What does NOT change

- No SDK changes (the ToolRegistry already has these tools)
- No init/upgrade config changes (the `squad_state` MCP server registration is unchanged)
- No new MCP server
- No behavior change to existing `squad_state_*` or `squad_decide` flows
- Agents with `tools: ["*"]` automatically pick up the new tools

## Why this matters

The governed memory subsystem (classification, audit log, forbidden-scan, loadGuidance) was previously reachable only from the CLI (`squad memory ...`) and direct SDK consumers. Autonomous agents in Copilot CLI couldn't invoke it, so the safety/governance benefits were dormant for the runtime path that Squad teams actually use. With this change, agents can:

- Dry-run a write via `memory_classify` before committing
- Record governed entries with classification + audit via `memory_write`
- Search the governed memory index via `memory_search`
- Promote/delete entries via `memory_promote` / `memory_delete`
- Read the audit trail via `memory_audit`

## Test plan

- [x] `npm run build` passes
- [x] Targeted tests pass: all 4 `state-mcp` tests pass (2 existing + 2 new)
  - `lists all 13 tools including the 6 governed memory bridges`
  - `routes memory_classify via MCP to the SDK ToolRegistry memory.classify handler`
- [x] Changeset added (patch bump for `@bradygaster/squad-cli`)
- [ ] CI passes

## Out of scope

- Updating agent charters to instruct agents WHEN to use the memory tools (separate decision)
- Documenting the new tools in user-facing docs (follow-up docs PR)
- Adding a separate `squad_memory` MCP server (this PR uses the existing `squad_state` server — simpler, no new install)