### PR TITLE
fix: release pipeline version pinning (#1203, #1204)

### DIFF
--- a/.changeset/fix-release-pipeline-versions.md
+++ b/.changeset/fix-release-pipeline-versions.md
@@ -1,0 +1,14 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+fix: release pipeline version pinning (#1203, #1204)
+
+- Lower SDK dependency floor from `>=0.10.0` to `>=0.9.0` so the CLI tarball
+  resolves against the last published SDK when the current version isn't yet on
+  the registry.
+- Add `isLocalOrUnpublishedVersion` guard to `buildMcpServerSpecs` so local dev
+  builds and versions with build metadata (`+`) fall back to `@insider` instead
+  of writing an unresolvable version string into MCP config.
+- Extend `resolveSquadStateMcpSpec` to short-circuit for build-metadata versions.
+- Add CI step to verify SDK dependency is resolvable before publishing the CLI.

--- a/.github/workflows/squad-npm-publish.yml
+++ b/.github/workflows/squad-npm-publish.yml
@@ -316,6 +316,31 @@ jobs:
             exit 1
           fi
           echo "SDK dependency is safe: $SDK_DEP"
+      - name: "Verify SDK version is resolvable on npm (#1203)"
+        run: |
+          # Extract the minimum version floor from the SDK dependency range
+          SDK_DEP=$(node -p "require('./packages/squad-cli/package.json').dependencies['@bradygaster/squad-sdk']")
+          echo "SDK dependency declared: $SDK_DEP"
+          # Verify that at least one version satisfying the range exists on the registry
+          if ! npm view "@bradygaster/squad-sdk" versions --json 2>/dev/null | node -e "
+            const semver = require('semver');
+            const range = process.argv[1];
+            let data = '';
+            process.stdin.on('data', c => data += c);
+            process.stdin.on('end', () => {
+              const versions = JSON.parse(data);
+              const arr = Array.isArray(versions) ? versions : [versions];
+              const match = arr.find(v => semver.satisfies(v, range));
+              if (!match) {
+                console.error('::error::No published SDK version satisfies ' + range);
+                process.exit(1);
+              }
+              console.log('✅ SDK dependency resolves to: ' + match);
+            });
+          " "$SDK_DEP"; then
+            echo "::error::Cannot verify SDK dependency is resolvable — aborting CLI publish to prevent #1203"
+            exit 1
+          fi
       - name: Build squad-sdk (required for CLI project references)
         run: npm -w packages/squad-sdk run build
       - name: Build squad-cli

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.10.0-build.2",
+  "version": "0.10.0",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.10.0",
+  "version": "0.10.0-build.2",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {
@@ -186,7 +186,7 @@
     "node": ">=22.5.0"
   },
   "dependencies": {
-    "@bradygaster/squad-sdk": ">=0.10.0",
+    "@bradygaster/squad-sdk": ">=0.9.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ink": "^6.8.0",
     "react": "^19.2.4",

--- a/packages/squad-cli/src/cli/core/mcp-spec.ts
+++ b/packages/squad-cli/src/cli/core/mcp-spec.ts
@@ -58,8 +58,9 @@ export async function resolveSquadStateMcpSpec(
   options: ResolveSquadStateMcpSpecOptions = {},
 ): Promise<SquadStateMcpSpec> {
   // 1. Try the pinned version on the public registry. Skip for placeholder
-  //    versions ('', '0.0.0') — the registry will obviously not have them.
-  if (cliVersion && cliVersion !== '0.0.0') {
+  //    versions ('', '0.0.0') and local/dev builds with build metadata ('+')
+  //    — the registry will obviously not have them (#1204).
+  if (cliVersion && cliVersion !== '0.0.0' && !cliVersion.includes('+')) {
     const probe = options.publishedCheck ?? defaultPublishedCheck;
     const published = await probe(cliVersion);
     if (published) {

--- a/packages/squad-cli/src/cli/core/upgrade.ts
+++ b/packages/squad-cli/src/cli/core/upgrade.ts
@@ -29,14 +29,37 @@ interface McpServerSpec {
   env?: Record<string, string>;
 }
 
+/**
+ * Returns true if the version looks like a local dev build or unpublished
+ * pre-release that cannot be resolved from the public npm registry.
+ * Guards against writing unresolvable version strings into MCP config
+ * (see #1204).
+ */
+export function isLocalOrUnpublishedVersion(version: string): boolean {
+  if (!version || version === '0.0.0') return true;
+  // Local linked builds often have 0.0.0-development or similar sentinel
+  if (/^0\.0\.0/.test(version)) return true;
+  // Versions with `+` build metadata (e.g. 0.10.0+local.1234) are not
+  // publishable to npm — they indicate a local build.
+  if (version.includes('+')) return true;
+  return false;
+}
+
 function buildMcpServerSpecs(isGitHub: boolean, cliVersion?: string): McpServerSpec[] {
   // Pin the squad-cli package to the currently-installed CLI version so that
   // `npx -y @bradygaster/squad-cli state-mcp` does NOT silently resolve to the
   // npm `latest` dist-tag (which may predate the `state-mcp` command and thus
   // expose zero tools to Copilot — see MCP-BRIDGE-BROKEN root cause).
-  const pkgSpec = cliVersion && cliVersion !== '0.0.0'
-    ? `@bradygaster/squad-cli@${cliVersion}`
-    : '@bradygaster/squad-cli';
+  //
+  // #1204: When the CLI is a local dev build or unpublished pre-release, fall
+  // back to the @insider dist-tag to avoid writing an unresolvable version
+  // string that breaks npx resolution at session start.
+  let pkgSpec: string;
+  if (!cliVersion || isLocalOrUnpublishedVersion(cliVersion)) {
+    pkgSpec = '@bradygaster/squad-cli@insider';
+  } else {
+    pkgSpec = `@bradygaster/squad-cli@${cliVersion}`;
+  }
   const servers: McpServerSpec[] = [
     {
       name: 'squad_state',

--- a/test/mcp-spec-init.test.ts
+++ b/test/mcp-spec-init.test.ts
@@ -84,6 +84,16 @@ describe('resolveSquadStateMcpSpec (iter-7: 2-tier resolver)', () => {
     expect(spec.command).toBe('npx');
   });
 
+  it('short-circuits for versions with build metadata (+ suffix) — returns @insider (#1204)', async () => {
+    const spec = await resolveSquadStateMcpSpec('0.10.0+local.1234', {
+      publishedCheck: async () => {
+        throw new Error('publishedCheck should not be called for build metadata version');
+      },
+    });
+    expect(spec.source).toBe('insider');
+    expect(spec.args[1]).toBe('@bradygaster/squad-cli@insider');
+  });
+
   it('uses the real npm-registry probe by default when publishedCheck is not injected', async () => {
     mockIsPublished.mockResolvedValue(false);
     const spec = await resolveSquadStateMcpSpec('0.9.6-preview.99999');
@@ -122,5 +132,38 @@ describe('init.ts uses resolveSquadStateMcpSpec (asymmetry fix)', () => {
     );
     const src = readFileSync(upgradePath, 'utf-8');
     expect(src).toMatch(/from ['"]\.\/mcp-spec\.js['"]/);
+  });
+});
+
+describe('isLocalOrUnpublishedVersion guard (#1204)', () => {
+  // Import the guard function directly
+  let isLocalOrUnpublishedVersion: (version: string) => boolean;
+
+  beforeEach(async () => {
+    const mod = await import('../packages/squad-cli/src/cli/core/upgrade.js');
+    isLocalOrUnpublishedVersion = mod.isLocalOrUnpublishedVersion;
+  });
+
+  it('returns true for empty string', () => {
+    expect(isLocalOrUnpublishedVersion('')).toBe(true);
+  });
+
+  it('returns true for 0.0.0 placeholder', () => {
+    expect(isLocalOrUnpublishedVersion('0.0.0')).toBe(true);
+  });
+
+  it('returns true for 0.0.0-development sentinel', () => {
+    expect(isLocalOrUnpublishedVersion('0.0.0-development')).toBe(true);
+  });
+
+  it('returns true for versions with + build metadata (local builds)', () => {
+    expect(isLocalOrUnpublishedVersion('0.10.0+local.1234')).toBe(true);
+    expect(isLocalOrUnpublishedVersion('1.0.0+build.42')).toBe(true);
+  });
+
+  it('returns false for normal published versions', () => {
+    expect(isLocalOrUnpublishedVersion('0.10.0')).toBe(false);
+    expect(isLocalOrUnpublishedVersion('0.9.6-preview.42')).toBe(false);
+    expect(isLocalOrUnpublishedVersion('1.0.0-rc.1')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes two release pipeline version pinning bugs that surfaced in v0.10.0:

**Closes #1203** — CLI tarball declares unpublished SDK dependency version

The CLI's `package.json` declared `"@bradygaster/squad-sdk": ">=0.10.0"` — matching its own version as the floor. If the SDK publish fails or registry propagation is slow, `npm install` gets ETARGET because no version satisfies the range.

**Fix:** Lower the floor to `>=0.9.0` (the last known published version) so there's always a resolvable version. Also added a CI gate step that verifies the SDK dependency is actually resolvable on npm before publishing the CLI, preventing a repeat.

**Closes #1204** — `ensureSquadStateMcpPinned` writes unresolvable version for local/dev builds

The `buildMcpServerSpecs` function (used for agent frontmatter MCP config) directly wrote the CLI version into the spec without checking if it's published. Local dev builds (version `0.0.0`, build metadata like `0.10.0+local.1234`) would write unresolvable `npx` specs.

**Fix:** Added `isLocalOrUnpublishedVersion()` guard that detects placeholder versions (`0.0.0`), build metadata (`+`), and other local-build indicators — falling back to `@insider` dist-tag. Also extended `resolveSquadStateMcpSpec` to short-circuit for build-metadata versions.

## Changes

| File | Change |
|------|--------|
| `packages/squad-cli/package.json` | SDK dep floor: `>=0.10.0` → `>=0.9.0` |
| `packages/squad-cli/src/cli/core/upgrade.ts` | Added `isLocalOrUnpublishedVersion` guard to `buildMcpServerSpecs` |
| `packages/squad-cli/src/cli/core/mcp-spec.ts` | Short-circuit build-metadata versions |
| `.github/workflows/squad-npm-publish.yml` | Added SDK resolvability check before CLI publish |
| `test/mcp-spec-init.test.ts` | Tests for new guards |
| `.changeset/fix-release-pipeline-versions.md` | Changeset |

## Testing

- All 59 existing + new tests pass
- Build succeeds