### PR TITLE
chore: include CHANGELOG.md in published npm tarball

### DIFF
--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.10.0-build.4",
+  "version": "0.10.0",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.10.0",
+  "version": "0.10.0-build.4",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {
@@ -174,7 +174,8 @@
     "dist",
     "templates",
     "scripts",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "postinstall": "node scripts/patch-esm-imports.mjs && node scripts/patch-ink-rendering.mjs",

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.10.0",
+  "version": "0.10.0-build.4",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",
@@ -226,7 +226,8 @@
   "files": [
     "dist",
     "templates",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.10.0-build.4",
+  "version": "0.10.0",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Add `CHANGELOG.md` to the `files` array in both `packages/squad-cli/package.json` and `packages/squad-sdk/package.json` so changelogs ship in the published npm tarballs.

## Why

- Enables offline what's-new prompts in `squad upgrade`
- Removes dependency on GitHub Releases API + auth for showing release notes
- Follows ecosystem convention (most CLIs ship a CHANGELOG)

## Changes

- `packages/squad-cli/package.json`: added `CHANGELOG.md` to `files` array
- `packages/squad-sdk/package.json`: added `CHANGELOG.md` to `files` array

Closes #1171