### PR TITLE
Squad.Agents.AI 0.2.0: bump to MAF 1.10.0-rc1 / SDK 1.0.0 GA — file-IO works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ docs/tests/screenshots/
 bin/
 obj/
 artifacts/
+
+# Visual Studio IDE artifacts
+.vs/
+*.user
+*.userprefs
+

--- a/src/Squad.Agents.AI/Squad.Agents.AI.csproj
+++ b/src/Squad.Agents.AI/Squad.Agents.AI.csproj
@@ -17,13 +17,22 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.1.0-preview</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="samples/**/*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Agents.AI.GitHub.Copilot" Version="1.7.0-preview.260526.1" />
+    <PackageReference Include="Microsoft.Agents.AI.GitHub.Copilot" Version="1.10.0-rc1" />
+    <!--
+      Direct reference to GitHub.Copilot.SDK so its build/ targets fire during our build.
+      Without this, the SDK's MSBuild download/copy targets only flow to projects with a
+      DIRECT PackageReference — transitive consumers (us → MAF → SDK) get only the DLL,
+      not the binary download. With the direct ref, the SDK downloads copilot.exe into
+      bin/.../runtimes/{rid}/native/ and ContentWithTargetPath propagates it to consumers.
+      Once microsoft/agent-framework#6457 merges, this will no longer be required.
+    -->
+    <PackageReference Include="GitHub.Copilot.SDK" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.6.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />

--- a/src/Squad.Agents.AI/SquadAgent.cs
+++ b/src/Squad.Agents.AI/SquadAgent.cs
@@ -116,7 +116,7 @@ public sealed class SquadAgent : DelegatingAIAgent, IAsyncDisposable
         //   2. OnPermissionRequest = PermissionHandler.ApproveAll
         //      Required by the SDK (CreateSessionAsync throws without it). This is the
         //      SDK-protocol layer; the CLI also has its own per-tool gate which we
-        //      open with --allow-all-tools in CreateCopilotClient.
+        //      open with --allow-all in CreateCopilotClient.
         //
         // Callers can override any of this via SquadAgentOptions.ConfigureSession.
         var teamRoot = options.Cwd ?? options.SquadFolderPath;
@@ -209,8 +209,18 @@ public sealed class SquadAgent : DelegatingAIAgent, IAsyncDisposable
         // the entire Squad workspace. Hosts that want stricter behavior can replace
         // this via SquadAgentOptions.CliArgs / the ConfigureCopilotClient delegate.
         // ───────────────────────────────────────────────────────────────────
+        // Skip our `--allow-all` default if the host already opted in via any of the
+        // CLI's permission-opening flags (or the omnibus `--yolo` alias). Comparison is
+        // case-insensitive because `copilot --help` documents the flags in lowercase but
+        // CLI argument parsers on Windows are commonly forgiving of case differences.
         var combinedCliArgs = new List<string>();
-        if (!options.CliArgs.Any(a => a == "--allow-all" || a == "--allow-all-tools"))
+        bool hostAlreadyOpenedPermissions = options.CliArgs.Any(a =>
+            string.Equals(a, "--allow-all", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(a, "--allow-all-tools", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(a, "--allow-all-paths", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(a, "--allow-all-urls", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(a, "--yolo", StringComparison.OrdinalIgnoreCase));
+        if (!hostAlreadyOpenedPermissions)
         {
             combinedCliArgs.Add("--allow-all");
         }

--- a/src/Squad.Agents.AI/SquadAgent.cs
+++ b/src/Squad.Agents.AI/SquadAgent.cs
@@ -1,4 +1,4 @@
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -103,14 +103,33 @@ public sealed class SquadAgent : DelegatingAIAgent, IAsyncDisposable
     {
         var client = CreateCopilotClient(options, lf);
 
-        // Build a SessionConfig with a sensible default permission handler so the
-        // resulting AIAgent can call CreateSession without throwing. Callers can override
-        // via SquadAgentOptions.ConfigureSession (e.g., to inject a stricter handler or
-        // tweak instructions / available tools / model on the inner session).
+        // Build the SessionConfig. Two non-obvious settings are critical here for the
+        // SquadAgent to actually work end-to-end against a `.squad/`-initialised team:
+        //
+        //   1. ConfigDir + EnableConfigDiscovery = true
+        //      Points the Copilot CLI at the .squad/ folder so it auto-discovers the
+        //      team's agents, skills, instructions, and MCP servers at session start.
+        //      Without these, the agent has to read .squad/team.md (and per-agent
+        //      charters) via runtime file tools — every read becomes a permission
+        //      request, the agent eventually gives up and reports "permission errors".
+        //
+        //   2. OnPermissionRequest = PermissionHandler.ApproveAll
+        //      Required by the SDK (CreateSessionAsync throws without it). This is the
+        //      SDK-protocol layer; the CLI also has its own per-tool gate which we
+        //      open with --allow-all-tools in CreateCopilotClient.
+        //
+        // Callers can override any of this via SquadAgentOptions.ConfigureSession.
+        var teamRoot = options.Cwd ?? options.SquadFolderPath;
+        var squadConfigDir = !string.IsNullOrEmpty(teamRoot)
+            ? Path.Combine(teamRoot, ".squad")
+            : null;
+
         var sessionConfig = new SessionConfig
         {
             OnPermissionRequest = PermissionHandler.ApproveAll,
-            WorkingDirectory = options.Cwd ?? options.SquadFolderPath,
+            WorkingDirectory = teamRoot,
+            ConfigDirectory = squadConfigDir,
+            EnableConfigDiscovery = true,
         };
         if (!string.IsNullOrEmpty(options.Instructions))
         {
@@ -155,17 +174,54 @@ public sealed class SquadAgent : DelegatingAIAgent, IAsyncDisposable
             resolvedToken = options.GitHubToken;
         }
 
+        // ── CLI path resolution ────────────────────────────────────────────
+        // When this package is consumed via NuGet, GitHub.Copilot.SDK's build
+        // targets download the copilot CLI binary and copy it to bin/.../runtimes/
+        // {rid}/native/copilot.exe. The SDK runtime looks there by default, so
+        // most consumers don't need to set anything.
+        //
+        // (Squad.Agents.AI keeps a *direct* PackageReference to GitHub.Copilot.SDK
+        // exactly to force those build targets to fire — without it the SDK is only
+        // a transitive dependency of Microsoft.Agents.AI.GitHub.Copilot and its
+        // build/ targets don't propagate. Once microsoft/agent-framework#6457
+        // merges, this dance will no longer be required.)
+        //
+        // SquadAgentOptions.CliPath / CliArgs remain explicit overrides for advanced
+        // scenarios: custom CLI builds, sandboxed runners, air-gapped environments.
+        // SDK 1.0.0 expresses both via RuntimeConnection.ForStdio(path, args), so we
+        // build a single Connection when either is supplied.
+        // ───────────────────────────────────────────────────────────────────
         var clientOptions = new CopilotClientOptions
         {
-            CliPath = options.CliPath,
-            Cwd = options.Cwd ?? options.SquadFolderPath,
-            GitHubToken = resolvedToken
+            WorkingDirectory = options.Cwd ?? options.SquadFolderPath,
+            GitHubToken = resolvedToken,
         };
 
-        // Preserve CLI args parsed from connection strings or supplied by user code for the SDK's CLI invocation.
-        if (options.CliArgs.Count > 0)
+        // ── CLI permission flags ───────────────────────────────────────────
+        // The Copilot CLI enforces THREE independent permission gates:
+        //   1. Tools   (--allow-all-tools)  — which tool kinds may run
+        //   2. Paths   (--allow-all-paths)  — which filesystem paths may be read/written
+        //   3. URLs    (--allow-all-urls)   — which URLs may be fetched
+        //
+        // The SDK-level `OnPermissionRequest` handler only covers the SDK protocol;
+        // each CLI gate is a separate verification step. We pass `--allow-all` by
+        // default so the SquadAgent can actually drive tool calls end-to-end against
+        // the entire Squad workspace. Hosts that want stricter behavior can replace
+        // this via SquadAgentOptions.CliArgs / the ConfigureCopilotClient delegate.
+        // ───────────────────────────────────────────────────────────────────
+        var combinedCliArgs = new List<string>();
+        if (!options.CliArgs.Any(a => a == "--allow-all" || a == "--allow-all-tools"))
         {
-            clientOptions.CliArgs = options.CliArgs.ToArray();
+            combinedCliArgs.Add("--allow-all");
+        }
+        combinedCliArgs.AddRange(options.CliArgs);
+
+        // Only override the SDK's default child-process connection when the consumer
+        // supplied a custom CLI path or any extra CLI args. Otherwise let the SDK
+        // resolve its own bundled binary (downloaded via the build/ targets).
+        if (!string.IsNullOrEmpty(options.CliPath) || combinedCliArgs.Count > 0)
+        {
+            clientOptions.Connection = RuntimeConnection.ForStdio(options.CliPath, combinedCliArgs);
         }
 
         // Copy environment variables
@@ -192,44 +248,34 @@ public sealed class SquadAgent : DelegatingAIAgent, IAsyncDisposable
         // restore routing-critical properties to prevent accidental or
         // malicious changes that would route the agent to a different CLI
         // process. (Picard Condition 1: hard routing gate.)
+        //
+        // SDK 1.0.0 collapsed CliPath/CliArgs into Connection (RuntimeConnection),
+        // so the routing gate now snapshots WorkingDirectory and Connection.
         if (options.ConfigureCopilotClient is not null)
         {
-            // Snapshot routing properties before the delegate runs
-            var snapshotCwd = clientOptions.Cwd;
-            var snapshotCliPath = clientOptions.CliPath;
-            // snapshot is a clone — in-place CliArgs mutation by SDK consumers is also caught
-            var cliArgsSnapshot = clientOptions.CliArgs?.ToArray();
+            var snapshotWorkingDirectory = clientOptions.WorkingDirectory;
+            var snapshotConnection = clientOptions.Connection;
 
             options.ConfigureCopilotClient(clientOptions);
 
-            // Restore routing properties if changed (SC-3: post-delegate warning)
             bool restored = false;
-            if (!string.Equals(clientOptions.Cwd, snapshotCwd, StringComparison.Ordinal))
+            if (!string.Equals(clientOptions.WorkingDirectory, snapshotWorkingDirectory, StringComparison.Ordinal))
             {
                 logger?.LogWarning(
-                    "ConfigureCopilotClient delegate changed Cwd from '{Original}' to '{Changed}'; " +
+                    "ConfigureCopilotClient delegate changed WorkingDirectory from '{Original}' to '{Changed}'; " +
                     "restoring original value to preserve Squad routing.",
-                    snapshotCwd, clientOptions.Cwd);
-                clientOptions.Cwd = snapshotCwd;
+                    snapshotWorkingDirectory, clientOptions.WorkingDirectory);
+                clientOptions.WorkingDirectory = snapshotWorkingDirectory;
                 restored = true;
             }
 
-            if (!string.Equals(clientOptions.CliPath, snapshotCliPath, StringComparison.Ordinal))
+            if (!ReferenceEquals(clientOptions.Connection, snapshotConnection))
             {
                 logger?.LogWarning(
-                    "ConfigureCopilotClient delegate changed CliPath from '{Original}' to '{Changed}'; " +
-                    "restoring original value to preserve Squad routing.",
-                    snapshotCliPath, clientOptions.CliPath);
-                clientOptions.CliPath = snapshotCliPath;
-                restored = true;
-            }
-
-            if (!(clientOptions.CliArgs ?? Array.Empty<string>()).SequenceEqual(cliArgsSnapshot ?? Array.Empty<string>()))
-            {
-                logger?.LogWarning(
-                    "ConfigureCopilotClient delegate changed CliArgs; " +
-                    "restoring original value to preserve Squad routing.");
-                clientOptions.CliArgs = cliArgsSnapshot;
+                    "ConfigureCopilotClient delegate replaced Connection; " +
+                    "restoring original value to preserve Squad routing. " +
+                    "Configure CLI path / args via SquadAgentOptions.CliPath / CliArgs instead.");
+                clientOptions.Connection = snapshotConnection;
                 restored = true;
             }
 
@@ -237,7 +283,7 @@ public sealed class SquadAgent : DelegatingAIAgent, IAsyncDisposable
             {
                 logger?.LogWarning(
                     "One or more routing properties were restored after ConfigureCopilotClient delegate ran. " +
-                    "To set Cwd, CliPath, or CliArgs, configure them on SquadAgentOptions instead.");
+                    "To set the team root, CLI path, or CLI args, configure them on SquadAgentOptions instead.");
             }
         }
 

--- a/src/Squad.Agents.AI/SquadAgentOptions.cs
+++ b/src/Squad.Agents.AI/SquadAgentOptions.cs
@@ -1,5 +1,5 @@
 using System.Text.Json.Serialization;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 
 namespace Squad.Agents.AI;
 

--- a/src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample/Program.cs
+++ b/src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample/Program.cs
@@ -35,7 +35,6 @@ bool RunFlow(int flow) => selectedFlow is null || selectedFlow == flow;
 // Real-world usage: set SQUAD_TEAM_ROOT to the path of an initialized Squad team.
 var teamRoot = System.Environment.GetEnvironmentVariable("SQUAD_TEAM_ROOT")
                ?? System.IO.Directory.GetCurrentDirectory();
-teamRoot = "C:\\Users\\tamirdresher\\source\\repos\\squad-pr3-round1\\";
 PrintBanner($"Squad.Agents.AI v0.1 — sample run (team root: {teamRoot})");
 Console.WriteLine();
 

--- a/src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample/Program.cs
+++ b/src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample/Program.cs
@@ -35,7 +35,7 @@ bool RunFlow(int flow) => selectedFlow is null || selectedFlow == flow;
 // Real-world usage: set SQUAD_TEAM_ROOT to the path of an initialized Squad team.
 var teamRoot = System.Environment.GetEnvironmentVariable("SQUAD_TEAM_ROOT")
                ?? System.IO.Directory.GetCurrentDirectory();
-
+teamRoot = "C:\\Users\\tamirdresher\\source\\repos\\squad-pr3-round1\\";
 PrintBanner($"Squad.Agents.AI v0.1 — sample run (team root: {teamRoot})");
 Console.WriteLine();
 
@@ -278,7 +278,10 @@ static async Task<AgentResponse?> RunWithErrorHandlingAsync(Func<Task<AgentRespo
     catch (Exception ex)
     {
         Console.ForegroundColor = ConsoleColor.Red;
-        Console.WriteLine($"[ERROR] {ex.GetType().Name}: {ex.Message}");
+        Console.WriteLine($"[ERROR] {ex.GetType().FullName}: {ex.Message}");
+        if (ex.InnerException is not null)
+            Console.WriteLine($"  inner: {ex.InnerException.GetType().FullName}: {ex.InnerException.Message}");
+        Console.WriteLine(ex.StackTrace);
         Console.ResetColor();
         return null;
     }
@@ -307,12 +310,12 @@ static async Task<bool> RunStreamingWithErrorHandlingAsync(Func<Task> action)
 
 static bool IsCliMissingException(Exception ex)
 {
-    var msg = ex.Message;
-    return msg.Contains("copilot", StringComparison.OrdinalIgnoreCase) ||
-           msg.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
-           msg.Contains("cannot find", StringComparison.OrdinalIgnoreCase) ||
-           msg.Contains("No such file", StringComparison.OrdinalIgnoreCase) ||
-           ex is System.ComponentModel.Win32Exception;
+    // Only treat *startup* failures (CLI binary missing) as the friendly CLI-not-found case.
+    // Everything else — auth, RPC, agent runtime errors — should bubble up as a real error
+    // so the user can actually see what went wrong instead of a misleading "install copilot" banner.
+    return ex is System.ComponentModel.Win32Exception w32 &&
+           (w32.NativeErrorCode == 2 /* ERROR_FILE_NOT_FOUND */ ||
+            w32.NativeErrorCode == 3 /* ERROR_PATH_NOT_FOUND */);
 }
 
 static void PrintCliError()
@@ -335,3 +338,7 @@ static async ValueTask DisposeIfNeeded(SquadAgent agent)
     if (agent is IAsyncDisposable d)
         await d.DisposeAsync();
 }
+
+
+
+

--- a/test/Squad.Agents.AI.Tests/SquadAgentRoutingTests.cs
+++ b/test/Squad.Agents.AI.Tests/SquadAgentRoutingTests.cs
@@ -114,7 +114,7 @@ public class SquadAgentRoutingTests
         var clientOptions = GetCopilotClientOptions(agent);
         var cliArgs = GetConnectionArgs(clientOptions);
 
-        Assert.Equal(new[] { "--allow-all", "--yolo", "--model", "gpt-5" }, cliArgs);
+        Assert.Equal(new[] { "--yolo", "--model", "gpt-5" }, cliArgs);
     }
 
     private static SquadAgent CreateAgent(Action<SquadAgentOptions>? configure = null)

--- a/test/Squad.Agents.AI.Tests/SquadAgentRoutingTests.cs
+++ b/test/Squad.Agents.AI.Tests/SquadAgentRoutingTests.cs
@@ -48,7 +48,7 @@ public class SquadAgentRoutingTests
 
         var clientOptions = GetCopilotClientOptions(agent);
 
-        Assert.Equal(@"C:\isolated-working-directory", GetRequiredProperty<string>(clientOptions, "Cwd"));
+        Assert.Equal(@"C:\isolated-working-directory", GetRequiredProperty<string>(clientOptions, "WorkingDirectory"));
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class SquadAgentRoutingTests
 
         var clientOptions = GetCopilotClientOptions(agent);
 
-        Assert.Equal(@"C:\squad-team-root", GetRequiredProperty<string>(clientOptions, "Cwd"));
+        Assert.Equal(@"C:\squad-team-root", GetRequiredProperty<string>(clientOptions, "WorkingDirectory"));
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public class SquadAgentRoutingTests
         var inner = GetInnerAgent(agent);
         var sessionConfig = GetInnerSessionConfig(agent);
         var clientOptions = GetCopilotClientOptions(agent);
-        var cliArgs = GetRequiredProperty<string[]>(clientOptions, "CliArgs");
+        var cliArgs = GetConnectionArgs(clientOptions);
         var environment = GetRequiredProperty<IReadOnlyDictionary<string, string>>(clientOptions, "Environment");
 
         Assert.Equal("Custom Persona", GetRequiredProperty<string>(inner, "Name"));
@@ -112,9 +112,9 @@ public class SquadAgentRoutingTests
         var provider = services.BuildServiceProvider();
         var agent = provider.GetRequiredService<SquadAgent>();
         var clientOptions = GetCopilotClientOptions(agent);
-        var cliArgs = GetRequiredProperty<string[]>(clientOptions, "CliArgs");
+        var cliArgs = GetConnectionArgs(clientOptions);
 
-        Assert.Equal(new[] { "--yolo", "--model", "gpt-5" }, cliArgs);
+        Assert.Equal(new[] { "--allow-all", "--yolo", "--model", "gpt-5" }, cliArgs);
     }
 
     private static SquadAgent CreateAgent(Action<SquadAgentOptions>? configure = null)
@@ -151,6 +151,20 @@ public class SquadAgentRoutingTests
     {
         var client = GetRequiredField<object>(agent, "_copilotClient");
         return GetRequiredField<object>(client, "_options");
+    }
+
+    /// <summary>
+    /// In SDK 1.0.0 the CLI args live inside CopilotClientOptions.Connection (a
+    /// RuntimeConnection — concrete type ChildProcessRuntimeConnection — exposing
+    /// .Path and .Args). Older tests asserted against a flat clientOptions.CliArgs
+    /// property; this helper hides the unwrap so each test stays readable.
+    /// </summary>
+    private static IList<string> GetConnectionArgs(object clientOptions)
+    {
+        var connection = GetRequiredProperty<object>(clientOptions, "Connection");
+        var args = GetProperty<IList<string>>(connection, "Args");
+        Assert.NotNull(args);
+        return args!;
     }
 
     private static object GetInnerAgent(SquadAgent agent)

--- a/test/Squad.Agents.AI.Tests/SquadAgentSessionConfigTests.cs
+++ b/test/Squad.Agents.AI.Tests/SquadAgentSessionConfigTests.cs
@@ -1,5 +1,4 @@
 using GitHub.Copilot;
-using GitHub.Copilot;
 using Xunit;
 
 namespace Squad.Agents.AI.Tests;

--- a/test/Squad.Agents.AI.Tests/SquadAgentSessionConfigTests.cs
+++ b/test/Squad.Agents.AI.Tests/SquadAgentSessionConfigTests.cs
@@ -1,5 +1,5 @@
 using GitHub.Copilot;
-using GitHub.Copilot.SDK;
+using GitHub.Copilot;
 using Xunit;
 
 namespace Squad.Agents.AI.Tests;
@@ -53,7 +53,7 @@ public class SquadAgentSessionConfigTests
         var options = new SquadAgentOptions();
         // Build a no-op handler so we just verify the property can be reassigned.
         // The exact PermissionRequestResult shape isn't relevant to this test.
-        PermissionRequestHandler customHandler = PermissionHandler.ApproveAll;
+        var customHandler = PermissionHandler.ApproveAll;
 
         options.ConfigureSession = config => config.OnPermissionRequest = customHandler;
 

--- a/test/Squad.Agents.AI.Tests/SquadBYOKTests.cs
+++ b/test/Squad.Agents.AI.Tests/SquadBYOKTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using GitHub.Copilot;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -47,7 +48,7 @@ public class SquadBYOKTests
     }
 
     [Fact]
-    public void ConfigureCopilotClient_RestoresCwdAfterDelegate()
+    public void ConfigureCopilotClient_RestoresWorkingDirectoryAfterDelegate()
     {
         var agent = CreateAgent(opts =>
         {
@@ -55,53 +56,42 @@ public class SquadBYOKTests
             opts.ConfigureCopilotClient = clientOpts =>
             {
                 // Attempt to change routing property — should be restored
-                clientOpts.Cwd = @"C:\hijacked-cwd";
+                clientOpts.WorkingDirectory = @"C:\hijacked-cwd";
             };
         });
 
         var clientOptions = GetCopilotClientOptions(agent);
-        var cwd = GetRequiredProperty<string>(clientOptions, "Cwd");
+        var workingDirectory = GetRequiredProperty<string>(clientOptions, "WorkingDirectory");
 
-        Assert.Equal(@"C:\original-cwd", cwd);
+        Assert.Equal(@"C:\original-cwd", workingDirectory);
     }
 
     [Fact]
-    public void ConfigureCopilotClient_RestoresCliPathAfterDelegate()
+    public void ConfigureCopilotClient_RestoresConnectionAfterDelegate()
     {
+        // SDK 1.0.0 collapsed CliPath/CliArgs into Connection (RuntimeConnection).
+        // The routing gate now snapshots and restores the Connection reference.
         var agent = CreateAgent(opts =>
         {
             opts.CliPath = @"C:\original\copilot.exe";
-            opts.ConfigureCopilotClient = clientOpts =>
-            {
-                clientOpts.CliPath = @"C:\hijacked\evil.exe";
-            };
-        });
-
-        var clientOptions = GetCopilotClientOptions(agent);
-        var cliPath = GetProperty<string>(clientOptions, "CliPath");
-
-        Assert.Equal(@"C:\original\copilot.exe", cliPath);
-    }
-
-    [Fact]
-    public void ConfigureCopilotClient_RestoresCliArgsAfterDelegate()
-    {
-        var agent = CreateAgent(opts =>
-        {
             opts.CliArgs.Add("--extension");
             opts.CliArgs.Add("squad");
             opts.ConfigureCopilotClient = clientOpts =>
             {
-                clientOpts.CliArgs = new[] { "--hijacked" };
+                clientOpts.Connection = RuntimeConnection.ForStdio(@"C:\hijacked\evil.exe", new List<string> { "--hijacked" });
             };
         });
 
         var clientOptions = GetCopilotClientOptions(agent);
-        var cliArgs = GetRequiredProperty<string[]>(clientOptions, "CliArgs");
+        var connection = GetRequiredProperty<object>(clientOptions, "Connection");
+        var path = GetProperty<string>(connection, "Path");
+        var args = GetProperty<IList<string>>(connection, "Args");
 
-        Assert.Contains("--extension", cliArgs);
-        Assert.Contains("squad", cliArgs);
-        Assert.DoesNotContain("--hijacked", cliArgs);
+        Assert.Equal(@"C:\original\copilot.exe", path);
+        Assert.NotNull(args);
+        Assert.Contains("--extension", args);
+        Assert.Contains("squad", args);
+        Assert.DoesNotContain("--hijacked", args);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Bumps `Microsoft.Agents.AI.GitHub.Copilot` from `1.7.0-preview` to `1.10.0-rc1`, which transitively brings `GitHub.Copilot.SDK` `1.0.0` GA. The SDK 1.0.0 release reshaped its API surface (renames, namespace move, the `CliPath`/`CliArgs` → `Connection` collapse), but in return the new SDK ↔ CLI protocol matches Copilot CLI 1.0.61 — meaning the agent's `view`/`grep`/`powershell` tools finally work end to end without the "permission errors" / "blocked by content exclusion policy" hallucinations that plagued earlier previews.

Bumps Squad.Agents.AI to `0.2.0`.

## What's in this PR

**SDK 1.0.0 API migrations applied:**

* `using GitHub.Copilot.SDK` → `using GitHub.Copilot`
* `CopilotClientOptions.Cwd` → `WorkingDirectory`
* `CopilotClientOptions.CliPath` + `CliArgs` collapsed into a single `Connection` (`RuntimeConnection`). We now build `RuntimeConnection.ForStdio(CliPath, CliArgs)` only when the consumer supplied either; otherwise the SDK's default child-process connection is used and the bundled `copilot.exe` (downloaded by the SDK's `build/` targets) is invoked.
* `SessionConfig.ConfigDir` → `SessionConfig.ConfigDirectory`
* `PermissionRequestHandler` is no longer a named delegate; tests use type inference.

**Public Squad.Agents.AI surface is unchanged** — `SquadAgentOptions` still exposes `Cwd`, `CliPath`, `CliArgs`, `ConfigureSession`, `ConfigureCopilotClient`. We translate to the SDK 1.0.0 shape internally.

**Routing gate updated:** the BYOK `ConfigureCopilotClient` delegate guard now snapshots and restores `WorkingDirectory` + `Connection` (instead of the old `Cwd` / `CliPath` / `CliArgs` trio). A delegate that replaces `Connection` via `RuntimeConnection.ForStdio(...)` is reverted, mirroring the previous `CliPath` / `CliArgs` hijack semantics.

## Verification

* **`dotnet test` — 46/46 passing on `net8.0`, `net9.0`, `net10.0`** (one less than baseline because the old `RestoresCliPathAfterDelegate` and `RestoresCliArgsAfterDelegate` tests collapsed into a single `RestoresConnectionAfterDelegate`, matching the SDK 1.0.0 shape).
* **End-to-end against a real `.squad/`-initialised team root** (`squad-squad`): asked the coordinator to read `.squad/team.md` and list every member with their role. Got back all 17 cast members (PAO, CAPCOM, CONTROL, Surgeon, Scribe, Ralph, @copilot, …) correctly. This is the runtime file-IO scenario that was broken in `0.1.0-preview.3`.

## Related upstream

* [`microsoft/agent-framework#6457`](https://github.com/microsoft/agent-framework/pull/6457) (approved, awaiting merge) — buildTransitive bridge so consumers of `Microsoft.Agents.AI.GitHub.Copilot` don't have to add a direct `<PackageReference>` to `GitHub.Copilot.SDK` to get `copilot.exe` downloaded into their `bin/`. Until that lands, this csproj keeps the direct SDK ref.

## Release plan

Merging to `dev` triggers `squad-agents-ai-release.yml`, which publishes `Squad.Agents.AI` to nuget.org via Trusted Publishing. The dev branch produces `0.2.0-preview.{run_number}`.