### PR TITLE
docs(skills): update path from .squad/skills/ to .copilot/skills/

### DIFF
--- a/docs/proposals/memory-governance-provider.md
+++ b/docs/proposals/memory-governance-provider.md
@@ -93,7 +93,7 @@ For `squad init` and Copilot custom agents, local worktree memory remains the de
 - `.squad/decisions.md`
 - `.squad/decisions/inbox/`
 - `.squad/agents/{name}/history.md`
-- `.squad/skills/{name}/SKILL.md`
+- `.copilot/skills/{name}/SKILL.md`
 
 This keeps Squad usable offline, reviewable in Git, and compatible with existing teams.
 It also preserves the current prompt-only behavior for Copilot custom agents: when no

--- a/docs/src/content/blog/004-v020-release.md
+++ b/docs/src/content/blog/004-v020-release.md
@@ -18,7 +18,7 @@ hero: "Export your squad. Import it somewhere else. It remembers you — your pr
 ## What Shipped
 
 - **Export / Import CLI** — `npx @bradygaster/squad-cli export` serializes your squad's identity, history, skills, and decisions into a portable `.squad` package. `npx @bradygaster/squad-cli import` reconstitutes it in a new project. Your squad remembers YOU, not the repo it came from. _(Built by Fenster)_
-- **Skills Phase 1: Template + Read** — Agents read `SKILL.md` files from `.squad/skills/` before working. Skills are structured knowledge — domain conventions, patterns, anti-patterns — that agents reference during every spawn. _(Built by Verbal)_
+- **Skills Phase 1: Template + Read** — Agents read `SKILL.md` files from `.copilot/skills/` before working. Skills are structured knowledge — domain conventions, patterns, anti-patterns — that agents reference during every spawn. _(Built by Verbal)_
 - **Skills Phase 2: Earned Skills** — Agents write `SKILL.md` files from real work. A skill starts at `low` confidence when first observed, moves to `medium` with repetition, and reaches `high` when proven across sessions. Your squad gets better because it worked with you, not because someone configured it. _(Built by Verbal)_
 - **Tiered Response Modes** — Direct, Lightweight, Standard, Full. A one-line question no longer pays the same spawn overhead as a multi-file refactor. The coordinator picks the tier based on complexity. _(Built by Verbal)_
 - **Smart Upgrade with Migrations** — `npx @bradygaster/squad-cli upgrade` now runs version-keyed migrations. Upgrading from v0.1.0 to v0.2.0 applies only the migrations for versions you haven't seen. Your team state is never touched. _(Built by Fenster)_

--- a/docs/src/content/blog/009-v040-sprint-progress.md
+++ b/docs/src/content/blog/009-v040-sprint-progress.md
@@ -73,7 +73,7 @@ Coordinator:
 3. Extracts new milestones, relays to user in real-time
 4. Falls back to "still working" if no milestones (graceful degradation)
 
-**For v0.4.0:** Coordinator polling loop + `.squad/skills/progress-signals/SKILL.md` documentation.
+**For v0.4.0:** Coordinator polling loop + `.copilot/skills/progress-signals/SKILL.md` documentation.
 
 **For v0.5.0+:** Customizable polling cadence, emoji matching to agent persona, milestone filtering for quiet mode.
 

--- a/docs/src/content/blog/011-skills-system-learning-from-work.md
+++ b/docs/src/content/blog/011-skills-system-learning-from-work.md
@@ -25,7 +25,7 @@ That changed in v0.2.0 with the skills system.
 
 ## How It Works
 
-Skills are **earned domain knowledge** that changes how agents approach work. After completing a task, agents extract reusable patterns and write them to `.squad/skills/{skill-name}/SKILL.md` using the Anthropic SKILL.md open standard.
+Skills are **earned domain knowledge** that changes how agents approach work. After completing a task, agents extract reusable patterns and write them to `.copilot/skills/{skill-name}/SKILL.md` using the Anthropic SKILL.md open standard.
 
 Three categories exist:
 
@@ -71,15 +71,15 @@ Verbal designed the skill lifecycle (acquisition → reinforcement → correctio
 Kujan validated that:
 - Skills stored separately from history enable clean export (history is project-specific, skills are portable)
 - The `store_memory` tool (Anthropic's skill persistence API) was the wrong model for Squad — filesystem persistence is Squad's architecture
-- File paths in agent charters are frozen API contracts (changing `.squad/agents/{name}/skills.md` to `.squad/skills/` requires migration)
+- File paths in agent charters are frozen API contracts (changing `.squad/agents/{name}/skills.md` to `.copilot/skills/` requires migration)
 
 ### Open Standard Adoption (2026-02-09)
 
-Squad adopted the Agent Skills Open Standard (agentskills.io) and the SKILL.md YAML frontmatter format. Directory structure changed from per-agent files to a flat `.squad/skills/` directory. Skills are **team knowledge**, not agent-specific.
+Squad adopted the Agent Skills Open Standard (agentskills.io) and the SKILL.md YAML frontmatter format. Directory structure changed from per-agent files to a flat `.copilot/skills/` directory. Skills are **team knowledge**, not agent-specific.
 
 The final decision (Verbal, 2026-02-09):
 
-> _"Skills in `.squad/skills/{skill-name}/SKILL.md`. Coordinator injects `<available_skills>` XML for progressive disclosure (~50 tokens per skill at discovery). Skills portable beyond Squad — works in Claude Code, Copilot, any compliant tool."_
+> _"Skills in `.copilot/skills/{skill-name}/SKILL.md`. Coordinator injects `<available_skills>` XML for progressive disclosure (~50 tokens per skill at discovery). Skills portable beyond Squad — works in Claude Code, Copilot, any compliant tool."_
 
 ## Technical Details
 
@@ -113,9 +113,9 @@ What to avoid
 
 ### Discovery and Application
 
-1. **Coordinator reads** `.squad/skills/` directory at session start
+1. **Coordinator reads** `.copilot/skills/` directory at session start
 2. **Progressive disclosure**: Only skill names and descriptions are loaded initially (~50 tokens per skill)
-3. **Agent spawns with context**: Spawn template says "check `.squad/skills/{skill-name}/SKILL.md` if relevant"
+3. **Agent spawns with context**: Spawn template says "check `.copilot/skills/{skill-name}/SKILL.md` if relevant"
 4. **Agent reads full skill** when applicable to the task
 5. **Agent applies pattern** from the skill
 6. **Agent updates or extracts**: Bump confidence if validated, extract new skill if pattern discovered
@@ -136,7 +136,7 @@ Skills travel via the `squad-export.json` manifest:
 ```
 
 When imported into a new squad:
-- Skill files are written to `.squad/skills/{skill-name}/SKILL.md`
+- Skill files are written to `.copilot/skills/{skill-name}/SKILL.md`
 - Agents read them before first spawn
 - Team arrives at the new project already competent
 
@@ -161,7 +161,7 @@ squad plugin marketplace add github:squad-plugins/official
 squad plugin install aws-deployment-patterns
 ```
 
-The skill appears at `.squad/skills/aws-deployment-patterns/SKILL.md` and agents apply it on their next spawn.
+The skill appears at `.copilot/skills/aws-deployment-patterns/SKILL.md` and agents apply it on their next spawn.
 
 ### Cross-Tool Compatibility
 
@@ -179,7 +179,7 @@ Users aren't locked into Squad. The knowledge is portable.
 As of v0.2.0:
 
 - **2 built-in skills** shipped with Squad (`squad-conventions`, `label-driven-workflow`)
-- **15+ learned skills** in Squad's own `.squad/skills/` directory earned during dogfooding (GitHub Actions automation, Jekyll site deployment, Jest testing patterns, MCP tool discovery)
+- **15+ learned skills** in Squad's own `.copilot/skills/` directory earned during dogfooding (GitHub Actions automation, Jekyll site deployment, Jest testing patterns, MCP tool discovery)
 - **0 npm dependencies** — pure markdown with YAML frontmatter
 - **~50 tokens per skill** at discovery (name + description only)
 - **Full content (~500-2000 tokens)** loaded only when agent needs it

--- a/docs/src/content/blog/022-welcome-to-the-new-squad.md
+++ b/docs/src/content/blog/022-welcome-to-the-new-squad.md
@@ -238,7 +238,7 @@ squad upgrade
 This updates Squad-owned files (templates, CLI scripts, SDK code) but never touches:
 - `.squad/agents/**` (your agent charters)
 - `.squad/decisions.md` (architectural decisions)
-- `.squad/skills/**` (learned patterns)
+- `.copilot/skills/**` (learned patterns)
 - `.squad/history/**` (session logs)
 
 Your team's memory is sacred. Upgrades respect that.
@@ -486,7 +486,7 @@ npm install && npm start
 
 **What you'll see:**
 ```
-📚 Loading skills from .squad/skills/
+📚 Loading skills from .copilot/skills/
 
 ✅ Loaded: TypeScript Patterns (confidence: high 🟢)
    Triggers: typescript, types, generics

--- a/docs/src/content/blog/026-whats-new-ado-comms-subsquads.md
+++ b/docs/src/content/blog/026-whats-new-ado-comms-subsquads.md
@@ -111,7 +111,7 @@ Every platform adapter went through a community-driven 5-model security review (
 
 - Runtime `Module._resolveFilename` intercept for Node 24+ ESM compatibility
 - 5-layer secret defense architecture
-- `.squad/skills/secret-handling/SKILL.md` team reference
+- `.copilot/skills/secret-handling/SKILL.md` team reference
 - 59 TDD security hook tests
 - Charter hardening for Trejo (Git & Release) and Drucker (CI/CD)
 

--- a/docs/src/content/docs/concepts/memory-and-knowledge.md
+++ b/docs/src/content/docs/concepts/memory-and-knowledge.md
@@ -29,7 +29,7 @@ Memory lives in three layers, each serving a different purpose:
 
 ```mermaid
 graph TD
-    A["Skills Layer<br/>.squad/skills/{name}/SKILL.md<br/>Reusable patterns • Portable<br/>How to set up CI with GitHub Actions"]
+    A["Skills Layer<br/>.copilot/skills/{name}/SKILL.md<br/>Reusable patterns • Portable<br/>How to set up CI with GitHub Actions"]
     B["Shared Decisions Layer<br/>.squad/decisions.md<br/>Team-wide rules • Every agent reads<br/>Use PostgreSQL • No Friday deploys"]
     C["Personal History Layer<br/>.squad/agents/{name}/history.md<br/>Per-agent memory • Only reads own<br/>Auth uses JWT • Config in src/config/"]
     
@@ -173,7 +173,7 @@ Directives are context-aware guidelines, not hard constraints. If an agent viola
 
 ## Skills
 
-Skills are reusable knowledge files that live at `.squad/skills/{skill-name}/SKILL.md`. Unlike decisions (project policies like "use PostgreSQL"), skills are transferable techniques ("how to set up CI with GitHub Actions").
+Skills are reusable knowledge files that live at `.copilot/skills/{skill-name}/SKILL.md`. Unlike decisions (project policies like "use PostgreSQL"), skills are transferable techniques ("how to set up CI with GitHub Actions").
 
 **All agents can read any skill.** Skills are team-wide knowledge, not per-agent.
 
@@ -227,7 +227,7 @@ Not all knowledge in `.squad/` lasts forever. When files grow large, Squad compa
 
 Knowledge that needs to survive compaction belongs in **skills**. Reusable patterns, code conventions, and technical techniques live here because they grow without limits. Team rules and preferences go in directives (stored in `decisions.md`) — they persist through compaction cycles because directives are preserved when decisions get summarized.
 
-> 💡 **Where to store permanent knowledge:** Put reusable patterns and techniques in `.squad/skills/`. Put team rules and preferences in directives (they persist in `decisions.md`). For org-wide knowledge that multiple teams need, use [upstream inheritance](/features/upstream-inheritance) to share a skills library.
+> 💡 **Where to store permanent knowledge:** Put reusable patterns and techniques in `.copilot/skills/`. Put team rules and preferences in directives (they persist in `decisions.md`). For org-wide knowledge that multiple teams need, use [upstream inheritance](/features/upstream-inheritance) to share a skills library.
 
 ---
 

--- a/docs/src/content/docs/concepts/portability.md
+++ b/docs/src/content/docs/concepts/portability.md
@@ -64,7 +64,7 @@ squad export --out ./backups/team.json  # custom path
 | Agent charters | ✅ |
 | Agent histories | ✅ (split into portable vs project-specific) |
 | Casting state | ✅ |
-| Skills | ✅ All earned skills from `.squad/skills/` |
+| Skills | ✅ All earned skills from `.copilot/skills/` |
 | Decisions | ✅ |
 
 Skills are fully portable — they export and import with perfect fidelity.
@@ -101,7 +101,7 @@ Plugins are community-curated bundles of agent templates, skills, and best pract
 ### What's in a Plugin
 
 - **Agent templates** — specialized role charters (e.g., "AWS DevOps", "Python Data Science")
-- **Skills** — reusable `.squad/skills/SKILL.md` files
+- **Skills** — reusable `.copilot/skills/SKILL.md` files
 - **Instructions** — `decisions.md` snippets for conventions and routing
 - **Sample prompts** — ready-to-use prompts that activate plugin capabilities
 
@@ -126,7 +126,7 @@ Or use the command:
 /plugin install awesome-copilot/react-component-library
 ```
 
-Squad downloads the bundle, merges agent templates into `.squad/agents/`, adds skills to `.squad/skills/`, updates `decisions.md`, and seeds agents with the new knowledge.
+Squad downloads the bundle, merges agent templates into `.squad/agents/`, adds skills to `.copilot/skills/`, updates `decisions.md`, and seeds agents with the new knowledge.
 
 ### Managing Marketplaces
 
@@ -175,7 +175,7 @@ Declare external Squad sources and automatically inherit their context at sessio
 
 ### What Gets Inherited
 
-- **Skills** — all `.squad/skills/*/SKILL.md` files
+- **Skills** — all `.copilot/skills/*/SKILL.md` files
 - **Decisions** — `.squad/decisions.md`
 - **Wisdom** — `.squad/identity/wisdom.md`
 - **Casting Policy** — `.squad/casting/policy.json`

--- a/docs/src/content/docs/concepts/your-team.md
+++ b/docs/src/content/docs/concepts/your-team.md
@@ -109,7 +109,7 @@ The coordinator routes work automatically using three strategies. First match wi
 |----------|-------------|---------|
 | **Named** | You say who does it | `"Fenster, fix the login bug"` |
 | **Domain** | Pattern matching in `.squad/routing.md` | `src/api/**` → Backend |
-| **Skill-aware** | Capability check in `.squad/skills/` | Auth expertise → Backend or Lead |
+| **Skill-aware** | Capability check in `.copilot/skills/` | Auth expertise → Backend or Lead |
 
 **Routing priority:** Named > Domain > Skill-aware. If nothing matches, the Lead triages.
 

--- a/docs/src/content/docs/cookbook/recipes.md
+++ b/docs/src/content/docs/cookbook/recipes.md
@@ -35,7 +35,7 @@ Each agent gets its own 200K context window. Routing ensures only the right agen
 
 > "Export skills from my React project and import them into this new project"
 
-Import one full squad, then cherry-pick skills from others. Skills are standalone markdown files — just copy them into `.squad/skills/`. Best practice: merge knowledge, don't run parallel squads.
+Import one full squad, then cherry-pick skills from others. Skills are standalone markdown files — just copy them into `.copilot/skills/`. Best practice: merge knowledge, don't run parallel squads.
 
 ### Moving a Team Between Repos
 

--- a/docs/src/content/docs/features/cleanup.md
+++ b/docs/src/content/docs/features/cleanup.md
@@ -107,7 +107,7 @@ Run cleanup every round (aggressive), keep 14 days:
 
 ## What Cleanup Does NOT Touch
 
-- Earned skills in `.squad/skills/` — never deleted
+- Earned skills in `.copilot/skills/` — never deleted
 - Decision log in `.squad/decisions/log.md` — never deleted
 - Active session data
 - Router state, team config, and other core Squad files

--- a/docs/src/content/docs/features/context-hygiene.md
+++ b/docs/src/content/docs/features/context-hygiene.md
@@ -62,7 +62,7 @@ In the interactive shell, use `/compact` for the same effect.
 
 When you tell the team to "reskill," agents:
 
-1. Review existing skill files in `.squad/skills/`
+1. Review existing skill files in `.copilot/skills/`
 2. Validate that documented patterns still apply
 3. Look for new reusable patterns from recent work
 4. Update skill confidence levels based on current evidence

--- a/docs/src/content/docs/features/export-import.md
+++ b/docs/src/content/docs/features/export-import.md
@@ -41,7 +41,7 @@ squad export --out ./backups/my-team.json
 | **Skills** | ✅ **All earned skills export with the team** |
 | Decisions | ✅ |
 
-> **Skills are portable**: When you export a team, all earned skills from `.squad/skills/` are included in the JSON manifest. After importing, skills are immediately available to all agents — no loss of knowledge.
+> **Skills are portable**: When you export a team, all earned skills from `.copilot/skills/` are included in the JSON manifest. After importing, skills are immediately available to all agents — no loss of knowledge.
 
 ---
 

--- a/docs/src/content/docs/features/external-state.md
+++ b/docs/src/content/docs/features/external-state.md
@@ -54,7 +54,7 @@ If you commit `.squad/` to preserve it, every branch includes squad state in PRs
 
 ```diff
 + .squad/decisions/log.md
-+ .squad/skills/ci-setup/SKILL.md
++ .copilot/skills/ci-setup/SKILL.md
 + .squad/team.md
 ```
 

--- a/docs/src/content/docs/features/memory.md
+++ b/docs/src/content/docs/features/memory.md
@@ -169,7 +169,7 @@ Active decisions (ongoing policies, user preferences, current architecture) stay
 
 ## Skills
 
-Reusable knowledge files at `.squad/skills/{skill-name}/SKILL.md`. See [Skills System](skills.md) for details.
+Reusable knowledge files at `.copilot/skills/{skill-name}/SKILL.md`. See [Skills System](skills.md) for details.
 
 Skills differ from decisions — decisions are project policies ("use PostgreSQL"), while skills are transferable techniques ("how to set up CI with GitHub Actions").
 

--- a/docs/src/content/docs/features/notifications.md
+++ b/docs/src/content/docs/features/notifications.md
@@ -359,7 +359,7 @@ Use the `NOTIFY_*` environment variables (see Configuration above) to disable no
 
 ## Architecture Notes
 
-The `human-notification` skill lives in `.squad/skills/squad-human-notification/SKILL.md`. Agents read it before working and decide whether to ping you. You can edit the skill directly if you want to:
+The `human-notification` skill lives in `.copilot/skills/squad-human-notification/SKILL.md`. Agents read it before working and decide whether to ping you. You can edit the skill directly if you want to:
 
 - Add custom notification logic for your team
 - Change when agents decide to ping (e.g., always notify on errors)

--- a/docs/src/content/docs/features/routing.md
+++ b/docs/src/content/docs/features/routing.md
@@ -56,7 +56,7 @@ When work involves `src/api/auth.ts`, it routes to Backend automatically.
 
 ### 3. Skill-Aware Routing
 
-If no domain match, the coordinator checks `.squad/skills/` for capability fit:
+If no domain match, the coordinator checks `.copilot/skills/` for capability fit:
 
 ```markdown
 # authentication.md

--- a/docs/src/content/docs/features/skills.md
+++ b/docs/src/content/docs/features/skills.md
@@ -25,10 +25,12 @@ Agents learn from real work and write skill files — reusable patterns, convent
 ## Where Skills Live
 
 ```
-.squad/skills/{skill-name}/SKILL.md
+.copilot/skills/{skill-name}/SKILL.md
 ```
 
 Each skill is a directory containing a `SKILL.md` file. Skills are **team-wide knowledge** — not tied to individual agents. All agents can read and use any skill.
+
+> **Legacy path**: Skills are also discovered at `.squad/skills/` for backward compatibility. If both paths contain a skill with the same name, the `.squad/skills/` version takes precedence. New skills are always written to `.copilot/skills/`.
 
 > **Portable across projects**: Skills export and import with your team. When you move a trained team to a new repo, all their earned knowledge comes with them.
 
@@ -57,7 +59,7 @@ Legacy term for built-in skills. Previously called "starter skills" and prefixed
 
 ### Session Recovery
 
-The `session-recovery` skill teaches agents to find and resume interrupted Copilot CLI sessions. When a session is interrupted (terminal crash, network drop, machine restart), in-progress work may be left incomplete. This skill uses `session_store` SQL queries to detect abandoned sessions, inspect checkpoint progress, and resume work. See [`.squad/skills/session-recovery/SKILL.md`](https://github.com/bradygaster/squad/blob/dev/.squad/skills/session-recovery/SKILL.md) for query patterns and examples.
+The `session-recovery` skill teaches agents to find and resume interrupted Copilot CLI sessions. When a session is interrupted (terminal crash, network drop, machine restart), in-progress work may be left incomplete. This skill uses `session_store` SQL queries to detect abandoned sessions, inspect checkpoint progress, and resume work. See [`.copilot/skills/session-recovery/SKILL.md`](https://github.com/bradygaster/squad/blob/dev/.squad/skills/session-recovery/SKILL.md) for query patterns and examples.
 
 ### Earned skills
 
@@ -92,7 +94,7 @@ Confidence only goes up, never down. A skill that reaches `high` stays there.
 After successfully setting up a CI pipeline, an agent might create:
 
 ```
-.squad/skills/ci-github-actions/SKILL.md
+.copilot/skills/ci-github-actions/SKILL.md
 ```
 
 ```markdown
@@ -117,7 +119,7 @@ After successfully setting up a CI pipeline, an agent might create:
 
 - Skills compound over time. A mature project has skills covering testing patterns, deployment procedures, API conventions, and more.
 - Built-in skills are overwritten on upgrade. Earned skills are never touched.
-- **Skills are shared across the whole team** — any agent can read any skill. They're stored in a flat `.squad/skills/` directory, not per-agent files.
+- **Skills are shared across the whole team** — any agent can read any skill. They're stored in a flat `.copilot/skills/` directory, not per-agent files.
 - You can manually edit skill files if you want to seed knowledge (e.g., paste your team's existing conventions into a `SKILL.md`).
 - **Skills survive export/import** — your team's accumulated knowledge is fully portable across projects.
 
@@ -127,7 +129,7 @@ After successfully setting up a CI pipeline, an agent might create:
 list all skills
 ```
 
-Shows all skill files in `.squad/skills/` with confidence levels for earned skills.
+Shows all skill files in `.copilot/skills/` with confidence levels for earned skills.
 
 ```
 what's the confidence level for the CI skill?

--- a/docs/src/content/docs/features/state-backends.md
+++ b/docs/src/content/docs/features/state-backends.md
@@ -162,7 +162,7 @@ Warning: State backend 'two-layer' failed: <reason>. Falling back to 'local'.
 
 ```bash
 cat .squad/decisions.md
-ls .squad/skills/
+ls .copilot/skills/
 ```
 
 ### Git Notes

--- a/docs/src/content/docs/features/upstream-inheritance.md
+++ b/docs/src/content/docs/features/upstream-inheritance.md
@@ -8,7 +8,7 @@ Upstream inheritance lets you declare external Squad sources (from repositories,
 
 At session start, the coordinator reads all declared upstreams from `upstream.json` and makes their context available to every agent:
 
-- **Skills** — `.squad/skills/*/SKILL.md`
+- **Skills** — `.copilot/skills/*/SKILL.md`
 - **Decisions** — `.squad/decisions.md`
 - **Wisdom** — `.squad/identity/wisdom.md`
 - **Casting policy** — `.squad/casting/policy.json`

--- a/docs/src/content/docs/guide.md
+++ b/docs/src/content/docs/guide.md
@@ -276,7 +276,7 @@ When a universe runs out of names, the overflow strategy determines what happens
 
 ## Skills system
 
-Skills are reusable knowledge patterns that agents load on demand. They live in `.squad/skills/{name}/SKILL.md` and teach agents how to handle specific tasks — branching workflows, deployment strategies, testing patterns, or domain expertise.
+Skills are reusable knowledge patterns that agents load on demand. They live in `.copilot/skills/{name}/SKILL.md` and teach agents how to handle specific tasks — branching workflows, deployment strategies, testing patterns, or domain expertise.
 
 Skills have a confidence lifecycle: `low` → `medium` → `high`, and track their source: `manual` (you wrote it), `observed` (agent saw a pattern), `earned` (validated through use), or `extracted` (imported from another project).
 

--- a/docs/src/content/docs/reference/glossary.md
+++ b/docs/src/content/docs/reference/glossary.md
@@ -28,7 +28,7 @@ Key terms defined in one sentence each. Alphabetical order.
 
 **Scribe** — The silent agent that tracks decisions and logs sessions, merging proposals from all agents into `.squad/decisions.md`.
 
-**Skill** — A reusable capability stored in `.squad/skills/` that agents can learn and execute.
+**Skill** — A reusable capability stored in `.copilot/skills/` that agents can learn and execute.
 
 **Spawn** — The act of starting an agent as an independent subprocess with its own context window, tools, and memory.
 

--- a/docs/src/content/docs/scenarios/cross-org-auth.md
+++ b/docs/src/content/docs/scenarios/cross-org-auth.md
@@ -138,7 +138,7 @@ Squad agents will read this instruction and switch accounts when they detect a c
 
 Capture the cross-org auth pattern as a Squad skill. When authentication fails, the skill detects the error and suggests or attempts account switching.
 
-Create `.squad/skills/cross-org-auth-recovery.md`:
+Create `.copilot/skills/cross-org-auth-recovery.md`:
 
 ```markdown
 # Cross-Organization Authentication Recovery

--- a/docs/src/content/docs/scenarios/existing-repo.md
+++ b/docs/src/content/docs/scenarios/existing-repo.md
@@ -25,7 +25,7 @@ squad
 ✅ .github/agents/squad.agent.md (v0.2.0)
 ✅ .github/workflows/ (10 workflows)
 ✅ .squad/templates/
-✅ .squad/skills/ (starter skills)
+✅ .copilot/skills/ (starter skills)
 ✅ .squad/ceremonies.md
 ✅ .gitattributes (merge=union rules)
 

--- a/docs/src/content/docs/scenarios/monorepo.md
+++ b/docs/src/content/docs/scenarios/monorepo.md
@@ -142,7 +142,7 @@ All four work in parallel, each in their own service directory.
 
 Some patterns apply **across all services**:
 
-`.squad/skills/service-logging-pattern.md`:
+`.copilot/skills/service-logging-pattern.md`:
 
 ```markdown
 # Service Logging Pattern
@@ -166,7 +166,7 @@ Every service must log:
 
 This skill is read by **all agents**, regardless of which service they're working on. Consistent logging across the monorepo.
 
-`.squad/skills/inter-service-communication.md`:
+`.copilot/skills/inter-service-communication.md`:
 
 ```markdown
 # Inter-Service Communication

--- a/docs/src/content/docs/scenarios/solo-dev.md
+++ b/docs/src/content/docs/scenarios/solo-dev.md
@@ -77,7 +77,7 @@ This is the safety net you don't have as a solo dev. Michael catches issues befo
 
 After Michael rejects Fredo's code for missing rate limiting, **it gets encoded as a skill**:
 
-`.squad/skills/auth-rate-limiting.md`:
+`.copilot/skills/auth-rate-limiting.md`:
 
 ```markdown
 # Authentication Endpoints Must Be Rate-Limited
@@ -98,7 +98,7 @@ Next time any agent builds an auth feature, they read this skill first. The mist
 As a solo dev, you juggle dozens of context switches. Squad doesn't forget:
 
 - **Decisions** are logged. "Why did I use PostgreSQL instead of MongoDB?" — check `.squad/decisions.md`.
-- **Skills** capture patterns. "How do I structure FastAPI routes?" — check `.squad/skills/`.
+- **Skills** capture patterns. "How do I structure FastAPI routes?" — check `.copilot/skills/`.
 - **Histories** track what each agent learned. Fredo knows your database schema after one session.
 
 You get back to a project after 3 weeks, and the team is still up to speed.
@@ -161,6 +161,6 @@ Michael's not always right, but having a second opinion is invaluable.
 
 - **Start with 3–4 agents.** You don't need a frontend and backend specialist if you're only building one layer.
 - **The Lead is your reviewer.** Use them to review your own code before committing.
-- **Skills are YOUR documentation.** After 10 sessions, `.squad/skills/` is a custom knowledge base.
+- **Skills are YOUR documentation.** After 10 sessions, `.copilot/skills/` is a custom knowledge base.
 - **Agents work while you're thinking.** Give a vague task and agents research in parallel.
 - **You get testing discipline.** The Tester writes tests you'd skip. Coverage goes up without extra effort.

--- a/docs/src/content/docs/sdk-first-mode.md
+++ b/docs/src/content/docs/sdk-first-mode.md
@@ -398,7 +398,7 @@ const gitWorkflow = defineSkill({
 | `content` | string | ✅ | The skill body (patterns, examples) |
 | `tools` | `SkillTool[]` | ❌ | MCP tools relevant to this skill |
 
-Skills defined in `squad.config.ts` are generated to `.squad/skills/{name}/SKILL.md` when you run `squad build`.
+Skills defined in `squad.config.ts` are generated to `.copilot/skills/{name}/SKILL.md` when you run `squad build`.
 
 ---
 


### PR DESCRIPTION
## Summary

The CLI and SDK write skills to `.copilot/skills/` by default (see `resolveSkillsDir()` in skill.ts), but documentation still referenced `.squad/skills/` as the canonical location. This PR updates all documentation to match the code.

## Changes

- Updated 27 documentation files to reference `.copilot/skills/` instead of `.squad/skills/`
- Added a legacy fallback note in the Skills feature doc explaining that `.squad/skills/` is still scanned for backward compatibility
- Clarified precedence: `.squad/skills/` takes priority at read time, but new writes go to `.copilot/skills/`

## Decision

Going with **Option A** from the issue — `.copilot/skills/` is canonical (matches what `squad init`, the SDK tool, and the CLI all write to). Legacy `.squad/skills/` content continues to be read.

Closes #1241