### PR TITLE
docs: sync state documentation with current .squad/ directory structure

### DIFF
--- a/docs/src/content/blog/021-the-migration.md
+++ b/docs/src/content/blog/021-the-migration.md
@@ -83,7 +83,7 @@ npm install -g @bradygaster/squad-cli
 
 ### Step 3: In your existing project, upgrade Squad files
 
-If you have a `.squad/` directory (or the old `.ai-team/`), run:
+If you have a `.squad/` directory (or the old `.squad/`), run:
 
 ```bash
 squad upgrade
@@ -91,7 +91,7 @@ squad upgrade
 
 This updates Squad-owned files (templates, core configs) **without touching your team state** (agents, history, decisions). Your custom changes are preserved.
 
-**Optional:** If you're migrating from `.ai-team/` to `.squad/`, use:
+**Optional:** If you're migrating from `.squad/` to `.squad/`, use:
 
 ```bash
 squad upgrade --migrate-directory

--- a/docs/src/content/blog/022-welcome-to-the-new-squad.md
+++ b/docs/src/content/blog/022-welcome-to-the-new-squad.md
@@ -719,13 +719,13 @@ The [Migration Guide](../get-started/migration.md) covers 9 scenarios:
 4. Was using `@bradygaster/create-squad`
 5. Was using `npx github:` distribution
 6. `.squad/` directory broke after upgrading
-7. Have `.ai-team/` from an older version
+7. Have `.squad/` from an older version
 8. Using Squad in CI/CD
 9. Using Squad SDK programmatically
 
 **Key changes to watch for:**
 - Package name: `@bradygaster/create-squad` → `@bradygaster/squad-cli`
-- Directory: `.ai-team/` → `.squad/` (auto-migrated with `--migrate-directory`)
+- Directory: `.squad/` → `.squad/` (auto-migrated with `--migrate-directory`)
 - Config: JSON → Markdown (`.squad/team.md`, `.squad/decisions.md`)
 - Commands: Some were renamed or merged (check `squad help`)
 

--- a/docs/src/content/docs/get-started/migration.md
+++ b/docs/src/content/docs/get-started/migration.md
@@ -11,7 +11,7 @@
 - [Scenario 4: Was Using @bradygaster/create-squad](#scenario-4-was-using-bradygastercreate-squad)
 - [Scenario 5: Was Using npx github: Distribution](#scenario-5-was-using-npx-github-distribution)
 - [Scenario 6: My .squad/ Directory Broke After Upgrading](#scenario-6-my-squad-directory-broke-after-upgrading)
-- [Scenario 7: I Have .ai-team/ from an Older Version](#scenario-7-i-have-ai-team-from-an-older-version)
+- [Scenario 7: I Have .squad/ from an Older Version](#scenario-7-i-have-ai-team-from-an-older-version)
 - [Scenario 8: Using Squad in CI/CD](#scenario-8-using-squad-in-cicd)
 - [Scenario 9: Using Squad SDK Programmatically](#scenario-9-using-squad-sdk-programmatically)
 - [Troubleshooting](#troubleshooting)
@@ -26,7 +26,7 @@
 |--------|-------|
 | `npx github:bradygaster/squad` | `npm install -g @bradygaster/squad-cli` |
 | `@bradygaster/create-squad` | `@bradygaster/squad-cli` |
-| `.ai-team/` directory | `.squad/` directory |
+| `.squad/` directory | `.squad/` directory |
 | v0.5.4 (beta) | v0.8.x (latest) |
 
 ---
@@ -251,16 +251,16 @@ If `squad doctor` still fails, see [Troubleshooting](#troubleshooting) below.
 
 ---
 
-## Scenario 7: I Have .ai-team/ from an Older Version
+## Scenario 7: I Have .squad/ from an Older Version
 
-Very early versions of Squad used `.ai-team/` instead of `.squad/`. This directory name is no longer recognized.
+Very early versions of Squad used `.squad/` instead of `.squad/`. This directory name is no longer recognized.
 
 ### Migrate
 
 1. **Back up:**
 
    ```bash
-   mv .ai-team .ai-team-backup
+   mv .squad .squad-backup
    ```
 
 2. **Initialize the new directory:**
@@ -269,12 +269,12 @@ Very early versions of Squad used `.ai-team/` instead of `.squad/`. This directo
    squad init
    ```
 
-3. **Manually migrate** any custom configuration from `.ai-team-backup/` into `.squad/`.
+3. **Manually migrate** any custom configuration from `.squad-backup/` into `.squad/`.
 
-4. **Update `.gitignore`** if it references `.ai-team/`:
+4. **Update `.gitignore`** if it references `.squad/`:
 
    ```bash
-   # Remove .ai-team references, add .squad if needed
+   # Remove .squad references, add .squad if needed
    ```
 
 5. **Verify:**

--- a/docs/src/content/docs/guide.md
+++ b/docs/src/content/docs/guide.md
@@ -459,13 +459,13 @@ squad doctor
 
 Doctor runs 9 checks — Node.js version, `gh` CLI auth, `.squad/` directory structure, team state, and more. It reports issues with clear fix instructions.
 
-**Migrating from `.ai-team/` to `.squad/`:**
+**Migrating from `.squad/` to `.squad/`:**
 
 ```bash
 squad migrate --from ai-team
 ```
 
-This renames `.ai-team/` to `.squad/` and updates all internal references.
+This renames `.squad/` to `.squad/` and updates all internal references.
 
 ---
 
@@ -557,7 +557,7 @@ Squad maintains a clear ownership model:
 | `squad plugin install <name>` | Install a plugin from the marketplace |
 | `squad plugin list` | List installed plugins |
 | `squad migrate --to sdk` | Convert existing squad to SDK-first config |
-| `squad migrate --from ai-team` | Migrate from `.ai-team/` to `.squad/` |
+| `squad migrate --from ai-team` | Migrate from `.squad/` to `.squad/` |
 | `squad subsquads` | Manage SubSquads |
 | `squad status` | Show team status and global config |
 | `squad --version` | Show installed version |

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -40,7 +40,7 @@ squad init
 | `squad doctor` | Validate squad setup integrity and diagnose issues (alias: `heartbeat`) | Yes |
 | `squad upgrade` | Upgrade Squad-owned files to latest version | Yes |
 | `squad upgrade --state-backend <type>` | Migrate state backend (`orphan`, `two-layer`); installs git hooks automatically | Yes |
-| `squad upgrade --migrate-directory` | Rename legacy `.ai-team/` directory to `.squad/` | Yes |
+| `squad upgrade --migrate-directory` | Rename legacy `.squad/` directory to `.squad/` | Yes |
 | `squad triage` | Auto-triage issues and assign to team (primary name; `watch` is an alias) | Yes |
 | `squad triage --interval <min>` | Continuous triage (default: every 10 min) | Yes |
 | `squad watch --execute` | Enable work execution (spawn Copilot to work on issues) | Yes |

--- a/docs/src/content/docs/scenarios/client-compatibility.md
+++ b/docs/src/content/docs/scenarios/client-compatibility.md
@@ -14,8 +14,8 @@ Squad runs on multiple Copilot surfaces — each with its own agent spawning mec
 | **Background/async execution** | ✅ `mode: "background"` (fire-and-forget) | ⚠️ Sync only (parallel concurrent) | ? | ? |
 | **Parallel fan-out** | ✅ Background tasks + `read_agent` | ✅ Multiple subagents in one turn | ? | ? |
 | **File discovery (.github/agents/)** | ✅ Automatic | ✅ Automatic | ? | ? |
-| **`.ai-team/` file access (read)** | ✅ Full | ✅ Full (workspace-scoped) | ? | ? |
-| **`.ai-team/` file access (write)** | ✅ Full | ✅ Full (with approval prompt) | ? | ? |
+| **`.squad/` file access (read)** | ✅ Full | ✅ Full (workspace-scoped) | ? | ? |
+| **`.squad/` file access (write)** | ✅ Full | ✅ Full (with approval prompt) | ? | ? |
 | **SQL tool** | ✅ Available | ❌ Not available | ❌ Not available | ❌ Not available |
 | **MCP server access** | ✅ Full | ✅ Full (inherited) | ⚠️ Limited | ⚠️ Limited |
 
@@ -69,7 +69,7 @@ Squad's **primary platform**. All features are fully supported.
 ### File Discovery & Access
 
 - **Auto-discovery:** `.github/agents/squad.agent.md` is discovered automatically
-- **`.ai-team/` access:** Unrestricted (full filesystem)
+- **`.squad/` access:** Unrestricted (full filesystem)
 - **Parallel reads:** Multiple file operations in one turn supported
 - **Parallel writes:** Multiple file creates/edits in one turn supported
 
@@ -123,8 +123,8 @@ Squad runs on VS Code with **conditional support**. Key differences from CLI:
 
 - **Auto-discovery:** `.github/agents/squad.agent.md` auto-discovered from workspace on load (file watchers enabled — no restart needed on changes)
 - **Scope:** Workspace-scoped (cannot access outside workspace directory)
-- **`.ai-team/` read:** ✅ Full access via `readFile` tool
-- **`.ai-team/` write:** ✅ Full access via `createFile` / `editFiles` tools
+- **`.squad/` read:** ✅ Full access via `readFile` tool
+- **`.squad/` write:** ✅ Full access via `createFile` / `editFiles` tools
 - **First-time approval:** VS Code may prompt for file modification approval on first write (security feature)
   - **User experience:** "Always allow in this workspace" option available
   - Subsequent writes in same workspace are automatic
@@ -160,7 +160,7 @@ Squad runs on VS Code with **conditional support**. Key differences from CLI:
 ### Questions to Answer
 
 - Does JetBrains Copilot support agent spawning via a tool equivalent to `task` or `runSubagent`?
-- Can agents access workspace files and `.ai-team/` directories?
+- Can agents access workspace files and `.squad/` directories?
 - What model selection mechanisms exist?
 - Is there a background/async mode?
 
@@ -179,7 +179,7 @@ Squad runs on VS Code with **conditional support**. Key differences from CLI:
 ### Questions to Answer
 
 - Can GitHub Copilot spawn agents for background work?
-- Can agents read `.ai-team/` files from the repository?
+- Can agents read `.squad/` files from the repository?
 - Is there a GitHub-specific command protocol for delegation?
 
 ---
@@ -203,7 +203,7 @@ Squad runs on VS Code with **conditional support**. Key differences from CLI:
 **Using Both:**
 - CLI is recommended for initial Squad setup and learning
 - VS Code works for day-to-day development once Squad is established
-- They share the same `.ai-team/` state — both can read/write the same team files
+- They share the same `.squad/` state — both can read/write the same team files
 - Team state is portable — init in CLI, use in VS Code, export/import across repos
 
 ### For Squad Developers
@@ -252,7 +252,7 @@ This document is based on active research spikes (#32, #33, #34) conducted in Fe
 
 - **Proposal 032a** (Strausz): `runSubagent` API research — agent spawning mechanics on VS Code
 - **Proposal 032b** (Kujan): CLI spawn parity analysis — all 5 Squad spawn patterns mapped
-- **Proposal 033a** (Strausz): VS Code file discovery — `.ai-team/` access and workspace scoping
+- **Proposal 033a** (Strausz): VS Code file discovery — `.squad/` access and workspace scoping
 - **Proposal 034a** (Kujan): Model selection & background mode — per-agent model routing and async execution
 
 **Next steps:**

--- a/docs/src/content/docs/scenarios/disaster-recovery.md
+++ b/docs/src/content/docs/scenarios/disaster-recovery.md
@@ -2,7 +2,7 @@
 
 **Try this to recover from data loss:**
 ```
-My .ai-team/ directory was deleted — help me recover the team state
+My .squad/ directory was deleted — help me recover the team state
 ```
 
 **Try this to revert bad code:**
@@ -15,18 +15,18 @@ An agent wrote bad code — how do I revert it?
 The squad is confused — reset their context
 ```
 
-Recovery procedures for deleted `.ai-team/`, bad agent code, confused squads, and upgrade issues. Most problems are fixable with Git or re-init.
+Recovery procedures for deleted `.squad/`, bad agent code, confused squads, and upgrade issues. Most problems are fixable with Git or re-init.
 
 ---
 
-## 1. "I accidentally deleted `.ai-team/`"
+## 1. "I accidentally deleted `.squad/`"
 
-Recovery scenarios: deleted `.ai-team/`, bad agent code, confused squad, upgrade issues.
+Recovery scenarios: deleted `.squad/`, bad agent code, confused squad, upgrade issues.
 
 **Solution:** It's in Git. Restore it.
 
 ```bash
-git checkout .ai-team/
+git checkout .squad/
 ```
 
 If you haven't committed `.squad/` yet, it's gone. Rebuild:
@@ -42,7 +42,7 @@ Start from scratch. If you exported your squad before, import the export:
 squad import squad-export-2025-07-15.zip
 ```
 
-**Prevention:** Commit `.ai-team/` early. Don't let it stay uncommitted for long.
+**Prevention:** Commit `.squad/` early. Don't let it stay uncommitted for long.
 
 ---
 
@@ -86,7 +86,7 @@ Sonny reads the code, fixes the issue, commits.
 
 ## 3. "An agent made a wrong decision"
 
-**What happened:** Neo decided to use REST when GraphQL was the better choice. The decision is logged in `.ai-team/decisions.md`.
+**What happened:** Neo decided to use REST when GraphQL was the better choice. The decision is logged in `.squad/decisions.md`.
 
 **Solution:** Add a directive to override it.
 
@@ -126,7 +126,7 @@ Agents now read the new decision and build accordingly.
 ```
 📋 Scribe — archiving recent session histories
 
-Moved to .ai-team/history-archive/:
+Moved to .squad/history-archive/:
   - Neo's session from 2025-07-14
   - Morpheus's session from 2025-07-14
   - Trinity's session from 2025-07-14
@@ -163,11 +163,11 @@ You're back to day one. Clean slate.
 
 **What happened:** You upgraded Squad to a new version, and now something doesn't work.
 
-**Solution:** Squad upgrades **never touch** `.ai-team/`. The issue is likely in:
+**Solution:** Squad upgrades **never touch** `.squad/`. The issue is likely in:
 
-1. **Workflow templates** — check `.ai-team-templates/`
+1. **Workflow templates** — check `.squad-templates/`
 2. **Squad agent definition** — check `.github/agents/squad.agent.md`
-3. **Model configuration** — check `.ai-team/model-config.json`
+3. **Model configuration** — check `.squad/model-config.json`
 
 Roll back the Squad agent definition:
 
@@ -181,7 +181,7 @@ Or reinstall a previous version:
 npm install -g @bradygaster/squad-cli@0.1.5
 ```
 
-**Your team's knowledge is safe.** `.ai-team/` is untouched.
+**Your team's knowledge is safe.** `.squad/` is untouched.
 
 **Prevention:** Check the CHANGELOG before upgrading. If the upgrade is major, test in a branch first.
 
@@ -212,17 +212,17 @@ Or just close the Copilot session (Ctrl+C) and start a new one.
 
 ## 8. "Skills are outdated or wrong"
 
-**What happened:** A skill file in `.ai-team/skills/` contains outdated information. Agents are following bad advice.
+**What happened:** A skill file in `.squad/skills/` contains outdated information. Agents are following bad advice.
 
 **Solution:** Edit or delete the skill file.
 
 ```bash
 # Edit the skill
-code .ai-team/skills/auth-rate-limiting.md
+code .squad/skills/auth-rate-limiting.md
 
 # Or delete it
-rm .ai-team/skills/auth-rate-limiting.md
-git add .ai-team/skills/
+rm .squad/skills/auth-rate-limiting.md
+git add .squad/skills/
 git commit -m "Remove outdated auth rate limiting skill"
 ```
 
@@ -232,13 +232,13 @@ git commit -m "Remove outdated auth rate limiting skill"
 
 ## 9. "Decisions.md is a mess"
 
-**What happened:** `.ai-team/decisions.md` has 200 entries and it's hard to find anything.
+**What happened:** `.squad/decisions.md` has 200 entries and it's hard to find anything.
 
 **Solution:** Archive old decisions.
 
 ```
 > Scribe, archive decisions older than 3 months. Move them to
-> .ai-team/decisions-archive.md.
+> .squad/decisions-archive.md.
 ```
 
 ```
@@ -285,10 +285,10 @@ Each agent logs what they did in their `history.md`.
 
 ## Tips
 
-- **`.ai-team/` is in Git.** If you delete it, restore from Git. If it's uncommitted, it's gone.
+- **`.squad/` is in Git.** If you delete it, restore from Git. If it's uncommitted, it's gone.
 - **Code review catches bad agent code.** Use the Lead to review before merging.
 - **Override bad decisions with directives.** If an agent made the wrong call, tell the team the correct one.
 - **Archive confused histories.** If a session went badly, archive the learnings so agents forget.
-- **Upgrades don't touch `.ai-team/`.** Your team's knowledge is safe across upgrades.
+- **Upgrades don't touch `.squad/`.** Your team's knowledge is safe across upgrades.
 - **Edit skill files directly.** They're just markdown. If a skill is wrong, fix it or delete it.
 - **Agent histories are the audit log.** Check them to see what each agent did.

--- a/docs/src/content/docs/scenarios/keep-my-squad.md
+++ b/docs/src/content/docs/scenarios/keep-my-squad.md
@@ -25,12 +25,12 @@ Squad persistence and portability. Your squad remembers skills, casting, and kno
 
 After working on a project for a few weeks, your squad has learned:
 
-- **Skills** — patterns, conventions, best practices (23 skill files in `.ai-team/skills/`)
-- **Decisions** — architectural choices, why you picked X over Y (`.ai-team/decisions.md`)
-- **Histories** — project-specific context each agent accumulated (`.ai-team/agents/{name}/history.md`)
-- **Casting state** — the chosen agent names, roles, universe (`.ai-team/casting-state.json`)
+- **Skills** — patterns, conventions, best practices (23 skill files in `.squad/skills/`)
+- **Decisions** — architectural choices, why you picked X over Y (`.squad/decisions.md`)
+- **Histories** — project-specific context each agent accumulated (`.squad/agents/{name}/history.md`)
+- **Casting state** — the chosen agent names, roles, universe (`.squad/casting-state.json`)
 
-All of this lives in `.ai-team/`. Commit it, and anyone who clones your repo gets the full team.
+All of this lives in `.squad/`. Commit it, and anyone who clones your repo gets the full team.
 
 ---
 
@@ -147,17 +147,17 @@ squad upgrade
 🔄 Upgrading Squad from v0.1.5 to v0.2.0
 
 ✅ .github/agents/squad.agent.md (updated to v0.2.0)
-✅ .ai-team-templates/ (new workflow templates)
+✅ .squad-templates/ (new workflow templates)
 ✅ .gitattributes (merge=union rules verified)
 
-⚠️  Your .ai-team/ directory was NOT modified.
+⚠️  Your .squad/ directory was NOT modified.
    Your team's memory, skills, and decisions are untouched.
 ```
 
 Upgrades only change:
 
 - The Squad agent definition (`.github/agents/squad.agent.md`)
-- Workflow templates (`.ai-team-templates/`)
+- Workflow templates (`.squad-templates/`)
 - The installer itself
 
 Your **team's knowledge is safe**.
@@ -166,10 +166,10 @@ Your **team's knowledge is safe**.
 
 ## 6. Git Commit Means Everyone Gets the Team
 
-You commit `.ai-team/`:
+You commit `.squad/`:
 
 ```bash
-git add .ai-team/
+git add .squad/
 git commit -m "Add Squad team with 3 weeks of accumulated knowledge"
 git push
 ```

--- a/docs/src/content/docs/scenarios/large-codebase.md
+++ b/docs/src/content/docs/scenarios/large-codebase.md
@@ -54,7 +54,7 @@ Your **codebase size doesn't matter** — agents aren't loading all 500K lines.
 
 ## 3. Routing Directs Work to the Right Agent
 
-Routing rules in `.ai-team/routing.md` keep agents focused:
+Routing rules in `.squad/routing.md` keep agents focused:
 
 ```markdown
 # Routing Rules
@@ -94,12 +94,12 @@ After 10 sessions, agent histories can grow large. The Scribe **archives old lea
 ```
 📋 Scribe — archiving agent histories
 
-Old learnings moved to .ai-team/history-archive/:
+Old learnings moved to .squad/history-archive/:
   - Neo's session logs from June
   - Trinity's session logs from July
 
 Current histories now cover the last 3 sessions only.
-Skills extracted from old sessions remain in .ai-team/skills/.
+Skills extracted from old sessions remain in .squad/skills/.
 ```
 
 Agents don't forget — they just move old details to the archive. **Generic knowledge becomes skills**, and **specific session logs are archived**.
@@ -110,7 +110,7 @@ Agents don't forget — they just move old details to the archive. **Generic kno
 
 After an agent solves a problem, it writes a skill file:
 
-`.ai-team/skills/stripe-webhook-verification.md`:
+`.squad/skills/stripe-webhook-verification.md`:
 
 ```markdown
 # Stripe Webhook Verification
@@ -124,7 +124,7 @@ const event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
 
 Next time **any agent** handles Stripe webhooks, they read this skill first. No rediscovery. No re-exploration.
 
-Over time, your `.ai-team/skills/` directory becomes a **compressed knowledge base** — 50 skill files instead of 10,000 lines of history.
+Over time, your `.squad/skills/` directory becomes a **compressed knowledge base** — 50 skill files instead of 10,000 lines of history.
 
 ---
 
@@ -146,7 +146,7 @@ Agents will focus on:
   payment-service/package.json
 ```
 
-Or route by service in `.ai-team/routing.md`:
+Or route by service in `.squad/routing.md`:
 
 ```markdown
 **Payment service work** → Morpheus

--- a/docs/src/content/docs/scenarios/mid-project.md
+++ b/docs/src/content/docs/scenarios/mid-project.md
@@ -34,9 +34,9 @@ squad init
 
 ```
 ✅ .github/agents/squad.agent.md (v0.2.0)
-✅ .ai-team-templates/
-✅ .ai-team/skills/ (starter skills)
-✅ .ai-team/ceremonies.md
+✅ .squad-templates/
+✅ .squad/skills/ (starter skills)
+✅ .squad/ceremonies.md
 ✅ .gitattributes (merge=union rules)
 
 Squad is ready.

--- a/docs/src/content/docs/scenarios/multiple-squads.md
+++ b/docs/src/content/docs/scenarios/multiple-squads.md
@@ -100,8 +100,8 @@ Extract the other two exports and copy skill files:
 unzip squad-export-mobile-app.zip -d /tmp/mobile-squad
 
 # Copy specific skills you want
-cp /tmp/mobile-squad/.ai-team/skills/react-native-debugging.md .ai-team/skills/
-cp /tmp/mobile-squad/.ai-team/skills/mobile-testing-patterns.md .ai-team/skills/
+cp /tmp/mobile-squad/.squad/skills/react-native-debugging.md .squad/skills/
+cp /tmp/mobile-squad/.squad/skills/mobile-testing-patterns.md .squad/skills/
 ```
 
 Repeat for the API gateway squad:
@@ -109,8 +109,8 @@ Repeat for the API gateway squad:
 ```bash
 unzip squad-export-api-gateway.zip -d /tmp/gateway-squad
 
-cp /tmp/gateway-squad/.ai-team/skills/rate-limiting-patterns.md .ai-team/skills/
-cp /tmp/gateway-squad/.ai-team/skills/auth-middleware-testing.md .ai-team/skills/
+cp /tmp/gateway-squad/.squad/skills/rate-limiting-patterns.md .squad/skills/
+cp /tmp/gateway-squad/.squad/skills/auth-middleware-testing.md .squad/skills/
 ```
 
 Skills are standalone markdown files. Agents load them automatically.
@@ -121,7 +121,7 @@ Skills are standalone markdown files. Agents load them automatically.
 
 If another squad learned something critical that isn't in a skill file, you can manually append it to an agent's history.
 
-Open `.ai-team/agents/{agent-name}/history.md` and add the knowledge as a session entry:
+Open `.squad/agents/{agent-name}/history.md` and add the knowledge as a session entry:
 
 ```markdown
 ## Session: 2025-07-15
@@ -173,5 +173,5 @@ This **overwrites** the existing squad. Use only if you're sure.
 - **One full import, then cherry-pick.** Import the squad with the closest domain match, then manually copy skills from the others.
 - **Skills are modular.** Each skill file is independent. Copy the ones you need, ignore the rest.
 - **Histories are context-heavy.** Don't import histories from unrelated projects — they contain project-specific details that will confuse agents.
-- **Decisions can be manually merged.** If another squad made architectural decisions you want to preserve, copy them into `.ai-team/decisions.md` as new entries.
+- **Decisions can be manually merged.** If another squad made architectural decisions you want to preserve, copy them into `.squad/decisions.md` as new entries.
 - **Skill files are the cleanest transfer.** They're generic, portable, and immediately useful across projects.

--- a/docs/src/content/docs/scenarios/new-project.md
+++ b/docs/src/content/docs/scenarios/new-project.md
@@ -34,9 +34,9 @@ squad init
 ```
 ✅ .github/agents/squad.agent.md (v0.2.0)
 ✅ .github/workflows/ (10 workflows)
-✅ .ai-team-templates/
-✅ .ai-team/skills/ (starter skills)
-✅ .ai-team/ceremonies.md
+✅ .squad-templates/
+✅ .squad/skills/ (starter skills)
+✅ .squad/ceremonies.md
 ✅ .gitattributes (merge=union rules)
 
 Squad is ready.
@@ -93,7 +93,7 @@ You can adjust the team or skip straight to work (which is implicit confirmation
 > Yes. Rusty, set up the Go module and project structure.
 ```
 
-Squad creates `.ai-team/` (roster, charters, histories, routing rules, casting state) and spawns Rusty:
+Squad creates `.squad/` (roster, charters, histories, routing rules, casting state) and spawns Rusty:
 
 ```
 🔧 Rusty — setting up Go module and project structure
@@ -154,11 +154,11 @@ Every agent reads these decisions before their next task. As the list grows, the
 ## 7. Commit Your Team
 
 ```bash
-git add .ai-team/ .ai-team-templates/ .github/ .gitattributes
+git add .squad/ .squad-templates/ .github/ .gitattributes
 git commit -m "Add Squad team"
 ```
 
-Commit `.ai-team/` — it's your team's brain. Anyone who clones the repo gets the full team with all their accumulated knowledge.
+Commit `.squad/` — it's your team's brain. Anyone who clones the repo gets the full team with all their accumulated knowledge.
 
 ---
 

--- a/docs/src/content/docs/scenarios/open-source.md
+++ b/docs/src/content/docs/scenarios/open-source.md
@@ -29,7 +29,7 @@ Squad helps:
 - **Triage incoming issues** automatically
 - **Guide contributors** with documented patterns
 - **Handle good-first-issue tasks** autonomously
-- **Keep architecture decisions visible** in `.ai-team/decisions.md`
+- **Keep architecture decisions visible** in `.squad/decisions.md`
 
 ---
 
@@ -44,7 +44,7 @@ squad init
 Enable the Ralph heartbeat workflow:
 
 ```bash
-cp .ai-team-templates/squad-heartbeat.yml .github/workflows/
+cp .squad-templates/squad-heartbeat.yml .github/workflows/
 git add .github/workflows/squad-heartbeat.yml
 git commit -m "Enable Squad auto-triage"
 git push
@@ -90,7 +90,7 @@ You review triaged issues and add `go:morpheus` if you approve.
 Enable the auto-assign workflow:
 
 ```bash
-cp .ai-team-templates/copilot-auto-assign.yml .github/workflows/
+cp .squad-templates/copilot-auto-assign.yml .github/workflows/
 git add .github/workflows/copilot-auto-assign.yml
 git commit -m "Enable Squad auto-assign"
 git push
@@ -112,9 +112,9 @@ You review PR #145, approve, merge. Issue #144 closed.
 
 ## 5. Skills Document Your Project's Patterns
 
-After Squad works on your project for a few weeks, `.ai-team/skills/` becomes a **living contributor guide**:
+After Squad works on your project for a few weeks, `.squad/skills/` becomes a **living contributor guide**:
 
-`.ai-team/skills/testing-conventions.md`:
+`.squad/skills/testing-conventions.md`:
 
 ```markdown
 # Testing Conventions
@@ -128,7 +128,7 @@ Mock external dependencies with `jest.mock()`
 
 Contributors can **read this file** to understand your testing norms. No need to repeat it in every PR review.
 
-`.ai-team/skills/api-design-patterns.md`:
+`.squad/skills/api-design-patterns.md`:
 
 ```markdown
 # API Design Patterns
@@ -154,7 +154,7 @@ Use HTTP status codes correctly:
 
 ## 6. Decisions.md is Your Architecture Decision Record (ADR)
 
-`.ai-team/decisions.md` becomes your **public ADR**:
+`.squad/decisions.md` becomes your **public ADR**:
 
 ```markdown
 ### 2025-07-10: Use esbuild instead of Webpack
@@ -258,8 +258,8 @@ Add a badge to your README:
 This project uses [Squad](https://github.com/bradygaster/squad) for AI-assisted development.
 
 - **Triaging:** Issues are auto-labeled by Squad's Ralph agent
-- **Patterns:** See `.ai-team/skills/` for coding conventions
-- **Decisions:** See `.ai-team/decisions.md` for architectural rationale
+- **Patterns:** See `.squad/skills/` for coding conventions
+- **Decisions:** See `.squad/decisions.md` for architectural rationale
 - **Import the squad:** `squad import squad-export.zip`
 ```
 
@@ -270,7 +270,7 @@ Contributors know what to expect.
 ## Tips
 
 - **Ralph triages issues for you.** Run the heartbeat workflow every 6 hours to auto-label new issues.
-- **Skills are living contributor docs.** As your squad learns, `.ai-team/skills/` becomes a knowledge base contributors can read.
+- **Skills are living contributor docs.** As your squad learns, `.squad/skills/` becomes a knowledge base contributors can read.
 - **Decisions.md is your ADR.** Architectural decisions are visible and explained, not hidden in Git history.
 - **Export your squad for forks.** Forkers get your team's accumulated knowledge — skills, conventions, decisions.
 - **good-first-issue + go:* = autonomous processing.** Mark issues as safe to auto-process, and Squad handles them.

--- a/docs/src/content/docs/scenarios/private-repos.md
+++ b/docs/src/content/docs/scenarios/private-repos.md
@@ -40,12 +40,12 @@ And select **Squad** from the `/agent` list (CLI) or `/agents` (VS Code), Squad 
 
 ---
 
-## 2. What's Stored in `.ai-team/`
+## 2. What's Stored in `.squad/`
 
-Squad writes everything to `.ai-team/` in your repository:
+Squad writes everything to `.squad/` in your repository:
 
 ```
-.ai-team/
+.squad/
 ├── team.md              # Roster (agent names, roles)
 ├── routing.md           # Work routing rules
 ├── decisions.md         # Architectural decisions
@@ -64,7 +64,7 @@ Squad writes everything to `.ai-team/` in your repository:
 **You control what's committed.** If you don't want agent histories in your repo, add them to `.gitignore`:
 
 ```gitignore
-.ai-team/agents/*/history.md
+.squad/agents/*/history.md
 ```
 
 Now histories stay local. Charters, skills, and decisions are still committed.
@@ -90,9 +90,9 @@ This is **project-specific knowledge**. If your repo is private and you want to 
 
 ## 4. Skills Are Generic — Safe to Share
 
-Skill files in `.ai-team/skills/` are **intentionally generic**:
+Skill files in `.squad/skills/` are **intentionally generic**:
 
-`.ai-team/skills/auth-rate-limiting.md`:
+`.squad/skills/auth-rate-limiting.md`:
 
 ```markdown
 # Authentication Endpoints Must Be Rate-Limited
@@ -164,12 +164,12 @@ Squad is **entirely local**. It's a GitHub Copilot agent, not a standalone servi
 
 If your repository is private and you're security-conscious:
 
-- [ ] **Review `.ai-team/agents/*/history.md`** — make sure no secrets or sensitive details are logged
+- [ ] **Review `.squad/agents/*/history.md`** — make sure no secrets or sensitive details are logged
 - [ ] **Add `history.md` to `.gitignore`** if you don't want histories committed
 - [ ] **Review exports before sharing** — check `squad-export-*.zip` for project-specific details
-- [ ] **Audit `.ai-team/decisions.md`** — remove any decisions that reference internal systems or secrets
+- [ ] **Audit `.squad/decisions.md`** — remove any decisions that reference internal systems or secrets
 - [ ] **Use GitHub token permissions wisely** — don't give Actions more permissions than needed
-- [ ] **Skills are public-safe** — feel free to share `.ai-team/skills/` publicly
+- [ ] **Skills are public-safe** — feel free to share `.squad/skills/` publicly
 
 ---
 
@@ -192,7 +192,7 @@ If your repository is private and you're security-conscious:
 **Exclude histories from Git:**
 
 ```
-> Add .ai-team/agents/*/history.md to .gitignore. I don't want
+> Add .squad/agents/*/history.md to .gitignore. I don't want
 > agent histories committed.
 ```
 

--- a/docs/src/content/docs/scenarios/release-process.md
+++ b/docs/src/content/docs/scenarios/release-process.md
@@ -31,9 +31,9 @@ Complete step-by-step guide for Squad maintainers: three-branch model (dev/previ
 
 | Branch | Purpose | Who Commits | Guard Active? | Files Allowed |
 |--------|---------|------------|---------------|---------------|
-| **dev** | Development — all work happens here | All team members | ❌ No | Everything (`.ai-team/`, team-docs, etc.) |
-| **preview** | Staging/testing — validated product only | Release coordinator | ✅ Yes | Distribution files only (`.ai-team/` blocked) |
-| **main** | Production — npm release source | Release coordinator | ✅ Yes | Distribution files only (`.ai-team/` blocked) |
+| **dev** | Development — all work happens here | All team members | ❌ No | Everything (`.squad/`, team-docs, etc.) |
+| **preview** | Staging/testing — validated product only | Release coordinator | ✅ Yes | Distribution files only (`.squad/` blocked) |
+| **main** | Production — npm release source | Release coordinator | ✅ Yes | Distribution files only (`.squad/` blocked) |
 
 ---
 
@@ -53,7 +53,7 @@ git reset --hard dev
 Remove forbidden paths:
 
 ```bash
-git rm --cached -r .ai-team/
+git rm --cached -r .squad/
 git rm --cached -r team-docs/
 ```
 
@@ -244,7 +244,7 @@ Use `.gitignore` rules and verify `git status` before pushing:
 
 ```bash
 git status
-git rm --cached -r .ai-team/
+git rm --cached -r .squad/
 git commit -m "chore: remove runtime state files"
 git push
 ```
@@ -266,15 +266,15 @@ ssh -T git@github.com
 
 ---
 
-### Issue: .ai-team/ Files Keep Getting Committed
+### Issue: .squad/ Files Keep Getting Committed
 
 **Fix:**
 
 ```bash
-git rm --cached -r .ai-team/
-grep ".ai-team" .gitignore || echo ".ai-team/" >> .gitignore
+git rm --cached -r .squad/
+grep ".squad" .gitignore || echo ".squad/" >> .gitignore
 git add .gitignore
-git commit -m "chore: ensure .ai-team/ is untracked"
+git commit -m "chore: ensure .squad/ is untracked"
 git push origin dev
 ```
 
@@ -336,13 +336,13 @@ Kobayashi, create a chore/sync-from-main branch, merge main into it, create and 
 ### To Test the Guard
 
 ```
-Kobayashi, test the guard workflow by creating a test branch with .ai-team/ content, creating a PR to main (should fail), removing the file (should pass), and cleaning up
+Kobayashi, test the guard workflow by creating a test branch with .squad/ content, creating a PR to main (should fail), removing the file (should pass), and cleaning up
 ```
 
 ### To Fix a Blocked PR
 
 ```
-Kobayashi, fetch the current PR state, remove all .ai-team/ and team-docs/ files, commit, push to update the PR, and wait for guard to pass
+Kobayashi, fetch the current PR state, remove all .squad/ and team-docs/ files, commit, push to update the PR, and wait for guard to pass
 ```
 
 ---

--- a/docs/src/content/docs/scenarios/switching-models.md
+++ b/docs/src/content/docs/scenarios/switching-models.md
@@ -49,7 +49,7 @@ All agents now use claude-haiku-4.5 (fast/cheap tier)
 Agents will be faster but may need more guidance on complex tasks.
 ```
 
-This is written to `.ai-team/model-config.json`:
+This is written to `.squad/model-config.json`:
 
 ```json
 {
@@ -80,7 +80,7 @@ All other agents → claude-sonnet-4.5 (standard tier)
 Neo will give higher-quality code reviews and architectural guidance.
 ```
 
-This is written to `.ai-team/model-config.json`:
+This is written to `.squad/model-config.json`:
 
 ```json
 {
@@ -230,4 +230,4 @@ You don't have to configure this — it's automatic.
 - **Use Opus for the Lead.** Code reviews benefit most from premium reasoning. Opus catches edge cases Sonnet misses.
 - **Haiku is underrated for tests.** Test writing doesn't require deep reasoning — Haiku is fast and accurate enough.
 - **Per-agent overrides are cheap.** Put Opus on the Lead, Haiku on the Tester, Sonnet on everyone else. Balanced budget.
-- **Model config is in `.ai-team/model-config.json`.** Commit it so your team uses the same models.
+- **Model config is in `.squad/model-config.json`.** Commit it so your team uses the same models.

--- a/docs/src/content/docs/scenarios/team-portability.md
+++ b/docs/src/content/docs/scenarios/team-portability.md
@@ -52,9 +52,9 @@ squad init
 
 ```
 ✅ .github/agents/squad.agent.md (v0.2.0)
-✅ .ai-team-templates/
-✅ .ai-team/skills/ (starter skills)
-✅ .ai-team/ceremonies.md
+✅ .squad-templates/
+✅ .squad/skills/ (starter skills)
+✅ .squad/ceremonies.md
 ✅ .gitattributes (merge=union rules)
 
 Squad is ready.
@@ -85,7 +85,7 @@ Next steps:
 
 ## 4. Handle Collisions
 
-If `.ai-team/` already exists (e.g., this repo already had a team), import will fail:
+If `.squad/` already exists (e.g., this repo already had a team), import will fail:
 
 ```bash
 squad import squad-export.json
@@ -101,7 +101,7 @@ Use `--force` to archive the existing team and replace it:
 squad import squad-export.json --force
 ```
 
-The existing `.ai-team/` is moved to `.ai-team-archive-2025-07-15-14-30-00/`. Nothing is deleted.
+The existing `.squad/` is moved to `.squad-archive-2025-07-15-14-30-00/`. Nothing is deleted.
 
 ---
 
@@ -142,5 +142,5 @@ During import, agent histories are automatically split:
 - **Review histories before sharing.** Agent histories may contain project-specific information — file paths, API keys mentioned in context, internal architecture details. Review `squad-export.json` before sending it to someone outside your organization.
 - **Import starts fresh decisions.** The imported team gets an empty `decisions.md`. Old decisions lived in the source project's context. Tell agents your conventions for the new project — they'll capture them.
 - **Casting universe is preserved.** Agents keep their names and the fictional universe they were drawn from. Danny is still Danny.
-- **Archives are cheap insurance.** When using `--force`, the old team is archived, not deleted. If the import doesn't work out, rename the archive back to `.ai-team/`.
+- **Archives are cheap insurance.** When using `--force`, the old team is archived, not deleted. If the import doesn't work out, rename the archive back to `.squad/`.
 - **Skills carry over.** Earned skills (with confidence levels) transfer with the team. Agents don't lose expertise when they move.

--- a/docs/src/content/docs/scenarios/team-state-storage.md
+++ b/docs/src/content/docs/scenarios/team-state-storage.md
@@ -1,15 +1,15 @@
 # Keeping Your Squad Where You Want It
 
-Your `.ai-team/` directory contains everything—team rosters, skills, decisions, agent histories. The question isn't whether to track it, but *how* and *where* to track it. Here are the real options, with honest tradeoffs.
+Your `.squad/` directory contains everything—team rosters, skills, decisions, agent histories. The question isn't whether to track it, but *how* and *where* to track it. Here are the real options, with honest tradeoffs.
 
 ---
 
 ## 1. Committed to Main (The Default)
 
-**What it is:** `.ai-team/` is tracked in git, committed alongside your code. Anyone who clones the repo gets the full team with all accumulated knowledge.
+**What it is:** `.squad/` is tracked in git, committed alongside your code. Anyone who clones the repo gets the full team with all accumulated knowledge.
 
 ```bash
-git add .ai-team/
+git add .squad/
 git commit -m "Add Squad team"
 ```
 
@@ -19,7 +19,7 @@ git commit -m "Add Squad team"
 - **Portable.** Clone the repo anywhere, and the team knowledge travels with it.
 - **Shared context.** Every collaborator sees the same team definitions, skills, and decisions.
 - **Git history.** You can trace how decisions evolved, view old skills, recover deleted files.
-- **GitHub Actions work out of the box.** Workflows (heartbeat, triage, label sync) access `.ai-team/` immediately.
+- **GitHub Actions work out of the box.** Workflows (heartbeat, triage, label sync) access `.squad/` immediately.
 
 ### Cons
 
@@ -37,10 +37,10 @@ git commit -m "Add Squad team"
 
 ## 2. Gitignored (Local-Only)
 
-**What it is:** Add `.ai-team/` to `.gitignore`. Team state lives locally on each dev machine, never committed.
+**What it is:** Add `.squad/` to `.gitignore`. Team state lives locally on each dev machine, never committed.
 
 ```bash
-echo ".ai-team/" >> .gitignore
+echo ".squad/" >> .gitignore
 git add .gitignore
 git commit -m "Gitignore squad team state"
 ```
@@ -53,10 +53,10 @@ git commit -m "Gitignore squad team state"
 
 ### Cons
 
-- **Team knowledge is not portable.** If you delete `.ai-team/`, it's gone. No git history to recover it.
-- **Collaborators don't share state.** Your teammate clones the repo and gets a fresh, empty `.ai-team/`. Their team doesn't match yours.
+- **Team knowledge is not portable.** If you delete `.squad/`, it's gone. No git history to recover it.
+- **Collaborators don't share state.** Your teammate clones the repo and gets a fresh, empty `.squad/`. Their team doesn't match yours.
 - **No git history for recovery.** You can't `git log` to find an old decision or see when a skill was added.
-- **⚠️ GitHub Actions workflows can't access `.ai-team/`.** Actions only see committed files. Triage routing rules in `team.md` won't work in CI/CD. (Label sync and other API-based workflows still function, but the team-based routing logic is silent.)
+- **⚠️ GitHub Actions workflows can't access `.squad/`.** Actions only see committed files. Triage routing rules in `team.md` won't work in CI/CD. (Label sync and other API-based workflows still function, but the team-based routing logic is silent.)
 
 ### When to Use This
 
@@ -68,7 +68,7 @@ git commit -m "Gitignore squad team state"
 
 ## 3. Separate Branch (e.g., `squad-state`)
 
-**What it is:** Keep `.ai-team/` on a dedicated branch (`squad-state`, `team-config`, etc.), not on `main`. Use `git worktree` to mount it locally.
+**What it is:** Keep `.squad/` on a dedicated branch (`squad-state`, `team-config`, etc.), not on `main`. Use `git worktree` to mount it locally.
 
 ### Setup
 
@@ -76,7 +76,7 @@ git commit -m "Gitignore squad team state"
 # Create and push the squad-state branch (if it doesn't exist)
 git checkout --orphan squad-state
 git rm -rf .
-echo "# Squad State Branch\nThis branch tracks .ai-team/ configuration." > README.md
+echo "# Squad State Branch\nThis branch tracks .squad/ configuration." > README.md
 git add README.md
 git commit -m "Initial squad-state branch"
 git push origin squad-state
@@ -85,10 +85,10 @@ git push origin squad-state
 git checkout main
 
 # Mount squad-state in a worktree
-git worktree add .ai-team-worktree squad-state
-ln -s .ai-team-worktree/.ai-team .ai-team
+git worktree add .squad-worktree squad-state
+ln -s .squad-worktree/.squad .squad
 git add .gitignore
-echo ".ai-team-worktree/" >> .gitignore
+echo ".squad-worktree/" >> .gitignore
 git commit -m "Add squad worktree"
 ```
 
@@ -96,13 +96,13 @@ On Windows:
 
 ```bash
 # Use mklink instead of ln -s (requires admin or Developer Mode)
-git worktree add .ai-team-worktree squad-state
-mklink /D .ai-team .ai-team-worktree\.ai-team
+git worktree add .squad-worktree squad-state
+mklink /D .squad .squad-worktree\.squad
 ```
 
 ### Pros
 
-- **Clean main branch.** `.ai-team/` never appears in `main` or in PR diffs.
+- **Clean main branch.** `.squad/` never appears in `main` or in PR diffs.
 - **Full git history.** The `squad-state` branch has complete history of all team changes.
 - **Shareable with collaborators.** They can check out `squad-state` and pull your team setup.
 - **GitHub Actions can access it.** Workflows can check out both `main` and `squad-state` if needed.
@@ -124,14 +124,14 @@ mklink /D .ai-team .ai-team-worktree\.ai-team
 
 ## 4. Git Submodule
 
-**What it is:** `.ai-team/` as a separate Git repository, added as a submodule to your main repo.
+**What it is:** `.squad/` as a separate Git repository, added as a submodule to your main repo.
 
 ### Setup
 
 ```bash
 # Create a separate repository for your squad (e.g., on GitHub)
 # Then add it as a submodule
-git submodule add https://github.com/you/my-squad-state .ai-team
+git submodule add https://github.com/you/my-squad-state .squad
 git commit -m "Add squad state as submodule"
 git push
 ```
@@ -153,13 +153,13 @@ git submodule update
 
 - **Completely separate history.** The submodule repo has its own git log, independent of your main project.
 - **Shareable across repos.** Use the same submodule in multiple projects.
-- **Clean main branch.** `.ai-team/` is external; no PR diffs in your project.
+- **Clean main branch.** `.squad/` is external; no PR diffs in your project.
 - **Full git features.** Submodule repo has branches, tags, and full history.
 
 ### Cons
 
 - **Submodules are complex.** Widely disliked by the git community. Conflicts, merge issues, and confusion are common.
-- **Everyone must remember `--recurse-submodules`.** Collaborators who forget get an empty `.ai-team/` directory.
+- **Everyone must remember `--recurse-submodules`.** Collaborators who forget get an empty `.squad/` directory.
 - **CI/CD needs extra setup.** Your workflows must initialize submodules explicitly:
   ```bash
   git submodule init && git submodule update
@@ -178,7 +178,7 @@ git submodule update
 
 ## 5. Symlink to External Directory
 
-**What it is:** Keep `.ai-team/` somewhere else on your filesystem (e.g., `~/my-squads/my-project-squad/`), then symlink it into your repo.
+**What it is:** Keep `.squad/` somewhere else on your filesystem (e.g., `~/my-squads/my-project-squad/`), then symlink it into your repo.
 
 ### Setup
 
@@ -186,26 +186,26 @@ On macOS/Linux:
 
 ```bash
 mkdir -p ~/my-squads/my-project-squad
-ln -s ~/my-squads/my-project-squad .ai-team
+ln -s ~/my-squads/my-project-squad .squad
 ```
 
 On Windows (requires admin or Developer Mode):
 
 ```bash
 mkdir C:\Users\you\my-squads\my-project-squad
-mklink /D .ai-team C:\Users\you\my-squads\my-project-squad
+mklink /D .squad C:\Users\you\my-squads\my-project-squad
 ```
 
-Add `.ai-team` to `.gitignore`:
+Add `.squad` to `.gitignore`:
 
 ```bash
-echo ".ai-team" >> .gitignore
+echo ".squad" >> .gitignore
 ```
 
 ### Pros
 
 - **Share state across repos.** Point multiple projects to the same squad directory.
-- **No git noise.** The symlink itself isn't tracked; `.ai-team/` is ignored.
+- **No git noise.** The symlink itself isn't tracked; `.squad/` is ignored.
 - **Maximum flexibility.** You can move the squad, reorganize it, or swap it out.
 
 ### Cons
@@ -227,14 +227,14 @@ echo ".ai-team" >> .gitignore
 
 ## 6. Dev Branch Only (The Squad Project's Own Approach)
 
-**What it is:** `.ai-team/` is committed, but *only* on dev/feature branches. On `main`, it's gitignored. When you create a feature branch, you remove `.ai-team/` from `.gitignore` so the team travels with your work.
+**What it is:** `.squad/` is committed, but *only* on dev/feature branches. On `main`, it's gitignored. When you create a feature branch, you remove `.squad/` from `.gitignore` so the team travels with your work.
 
 ### Setup
 
 On `main`:
 
 ```bash
-echo ".ai-team/" >> .gitignore
+echo ".squad/" >> .gitignore
 git add .gitignore
 git commit -m "Ignore squad team on main"
 ```
@@ -243,29 +243,29 @@ When you start a feature branch:
 
 ```bash
 git checkout -b feature/my-feature
-git rm .ai-team/  # if it exists from a previous branch
-# Remove .ai-team/ from .gitignore
+git rm .squad/  # if it exists from a previous branch
+# Remove .squad/ from .gitignore
 git edit .gitignore
-# (remove the .ai-team/ line)
+# (remove the .squad/ line)
 git add .gitignore
 git commit -m "Track squad team on this branch"
 ```
 
-Agents work with the full `.ai-team/` context while you develop. When you merge back to `main`, the PR shows the `.ai-team/` changes, but `main` stays clean.
+Agents work with the full `.squad/` context while you develop. When you merge back to `main`, the PR shows the `.squad/` changes, but `main` stays clean.
 
 ### Pros
 
 - **Clean main branch.** `main` is pure code, no squad artifacts.
 - **Full context on feature branches.** Agents have the team history while you work.
 - **Git history preserved.** Team changes are committed on feature branches and visible in git log.
-- **Collaborators get team state.** Anyone checking out your feature branch gets `.ai-team/`.
+- **Collaborators get team state.** Anyone checking out your feature branch gets `.squad/`.
 - **GitHub Actions can work both ways.** On `main`, workflows use GitHub API (label sync, heartbeat). On feature branches, they can use team-based routing if needed.
 
 ### Cons
 
-- **Merge conflicts when syncing branches.** If `main` has `.ai-team/` gitignored but your branch commits it, merging is messy.
-- **Easy to forget the pattern.** Developers forget to remove `.ai-team/` from `.gitignore` when creating feature branches (or forget to add it back when switching back to `main`).
-- **PR diffs include team changes.** PRs from feature branches show all `.ai-team/` modifications, which some teams find noisy.
+- **Merge conflicts when syncing branches.** If `main` has `.squad/` gitignored but your branch commits it, merging is messy.
+- **Easy to forget the pattern.** Developers forget to remove `.squad/` from `.gitignore` when creating feature branches (or forget to add it back when switching back to `main`).
+- **PR diffs include team changes.** PRs from feature branches show all `.squad/` modifications, which some teams find noisy.
 
 ### When to Use This
 
@@ -291,11 +291,11 @@ Agents work with the full `.ai-team/` context while you develop. When you merge 
 
 ## Tips
 
-- **GitHub Actions and Gitignored `.ai-team/`:** If you choose option 2 (gitignore), remember that Actions workflows see committed files only. Label sync and heartbeat workflows (which use GitHub API) still work. But `squad.agent.md` triage rules won't see `.ai-team/decisions.md` during automated runs. Workaround: Copy critical decisions to a committed file or pass them as workflow env vars.
-- **Merge conflicts on `decisions.md`:** If multiple people are committing to `.ai-team/` at the same time, `decisions.md` and agent histories conflict frequently. Use the `.gitattributes merge=union` rules that Squad sets up. Check the file after merge to ensure it looks reasonable.
-- **Backup your team.** If you're gitignoring `.ai-team/`, make sure you have backups. A deleted `.ai-team/` directory with no git history is gone forever.
+- **GitHub Actions and Gitignored `.squad/`:** If you choose option 2 (gitignore), remember that Actions workflows see committed files only. Label sync and heartbeat workflows (which use GitHub API) still work. But `squad.agent.md` triage rules won't see `.squad/decisions.md` during automated runs. Workaround: Copy critical decisions to a committed file or pass them as workflow env vars.
+- **Merge conflicts on `decisions.md`:** If multiple people are committing to `.squad/` at the same time, `decisions.md` and agent histories conflict frequently. Use the `.gitattributes merge=union` rules that Squad sets up. Check the file after merge to ensure it looks reasonable.
+- **Backup your team.** If you're gitignoring `.squad/`, make sure you have backups. A deleted `.squad/` directory with no git history is gone forever.
 - **Communicate the pattern to your team.** Whatever you choose, document it. Add a line to your `CONTRIBUTING.md` or `README.md` explaining where the squad lives and how to interact with it.
-- **Start simple, migrate later.** Commit `.ai-team/` initially (option 1). If PR noise becomes a real problem, migrate to option 2 or 3. Changing strategies later is possible but requires care.
+- **Start simple, migrate later.** Commit `.squad/` initially (option 1). If PR noise becomes a real problem, migrate to option 2 or 3. Changing strategies later is possible but requires care.
 
 ---
 
@@ -303,20 +303,20 @@ Agents work with the full `.ai-team/` context while you develop. When you merge 
 
 Use these prompts with Squad to implement specific strategies:
 
-- **"Keep .ai-team/ out of my main branch."**
+- **"Keep .squad/ out of my main branch."**
   - Directs you toward option 3 (separate branch) or option 6 (dev-only).
 
 - **"I want to share my squad across three repos without duplicating the team state."**
   - Points to option 4 (submodule) or option 5 (symlink).
 
-- **"Add .ai-team to .gitignore but make sure GitHub Actions can still route based on team.md."**
+- **"Add .squad to .gitignore but make sure GitHub Actions can still route based on team.md."**
   - Hybrid: gitignore but keep a committed `squad-routing.md` that Actions reads.
 
 - **"My enterprise doesn't allow AI artifacts in the main repository."**
   - Option 2 (gitignore) or option 4 (submodule in a separate org-controlled repo).
 
-- **"I deleted .ai-team by accident. How do I recover it?"**
-  - If committed: `git checkout HEAD~5 .ai-team/` (restore from history).
+- **"I deleted .squad by accident. How do I recover it?"**
+  - If committed: `git checkout HEAD~5 .squad/` (restore from history).
   - If gitignored: No recovery from git. Restore from backup or rebuild the team.
 
 ---

--- a/docs/src/content/docs/scenarios/upgrading.md
+++ b/docs/src/content/docs/scenarios/upgrading.md
@@ -32,14 +32,14 @@ That's it.
 | File | Updated? | Notes |
 |------|----------|-------|
 | `.github/agents/squad.agent.md` | ✅ Yes | Overwritten with latest coordinator logic |
-| `.ai-team-templates/` | ✅ Yes | Overwritten with latest templates |
+| `.squad-templates/` | ✅ Yes | Overwritten with latest templates |
 | `.github/workflows/squad-*.yml` | ✅ Yes | Overwritten with latest squad workflows |
 | `.github/copilot-instructions.md` | ⚡ Conditional | Updated only if @copilot is enabled on the team |
-| `.ai-team/` | ❌ Never | Your team's knowledge, decisions, casting state, skills |
+| `.squad/` | ❌ Never | Your team's knowledge, decisions, casting state, skills |
 
-Squad-owned files (`squad.agent.md` and `.ai-team-templates/`) are replaced entirely. Don't put custom changes in them — they'll be lost on upgrade.
+Squad-owned files (`squad.agent.md` and `.squad-templates/`) are replaced entirely. Don't put custom changes in them — they'll be lost on upgrade.
 
-Your team state in `.ai-team/` is never touched. Agent charters, histories, decisions, casting state, skills, and session logs are all safe.
+Your team state in `.squad/` is never touched. Agent charters, histories, decisions, casting state, skills, and session logs are all safe.
 
 ---
 
@@ -51,13 +51,13 @@ Migrations are:
 - **Additive** — they only create new files or directories, never modify existing ones
 - **Idempotent** — safe to re-run; if the change already exists, it's skipped
 
-Example: upgrading to v0.2.0 creates `.ai-team/skills/` if it doesn't already exist.
+Example: upgrading to v0.2.0 creates `.squad/skills/` if it doesn't already exist.
 
 ---
 
-## Migrating .ai-team/ → .squad/ (v0.5.0+)
+## Migrating .squad/ → .squad/ (v0.5.0+)
 
-In Squad v0.5.0, the team state directory was renamed from `.ai-team/` to `.squad/`. Existing repos continue to work — Squad detects both. If you're still on `.ai-team/`, you'll see a deprecation warning.
+In Squad v0.5.0, the team state directory was renamed from `.squad/` to `.squad/`. Existing repos continue to work — Squad detects both. If you're still on `.squad/`, you'll see a deprecation warning.
 
 **To migrate your repo:**
 
@@ -73,15 +73,15 @@ Then commit:
 
 ```bash
 git add -A
-git commit -m "chore: migrate .ai-team/ → .squad/"
+git commit -m "chore: migrate .squad/ → .squad/"
 ```
 
 **What the migration does:**
-- Renames `.ai-team/` → `.squad/`
+- Renames `.squad/` → `.squad/`
 - Updates `.gitignore` and `.gitattributes` references
 - Scrubs email addresses from migrated files (PII cleanup)
 
-**Timeline:** `.ai-team/` support continues through v0.6.0. Migration becomes required in v1.0.0.
+**Timeline:** `.squad/` support continues through v0.6.0. Migration becomes required in v1.0.0.
 
 **Full details:** See the [Migration Guide](../get-started/migration.md).
 
@@ -140,11 +140,11 @@ Squad still runs any missing migrations in case a prior upgrade was interrupted.
 ## 2. Commit the Upgrade
 
 ```bash
-git add .github/agents/squad.agent.md .ai-team-templates/
+git add .github/agents/squad.agent.md .squad-templates/
 git commit -m "Upgrade Squad to v0.2.0"
 ```
 
-No changes to `.ai-team/` — the diff is limited to Squad-owned files.
+No changes to `.squad/` — the diff is limited to Squad-owned files.
 
 ---
 

--- a/docs/src/content/docs/sdk-first-mode.md
+++ b/docs/src/content/docs/sdk-first-mode.md
@@ -152,7 +152,7 @@ This runs `squad build` to ensure `.squad/` is current, then removes `squad.conf
 ### Legacy Migration
 
 ```bash
-squad migrate --from ai-team   # rename .ai-team/ → .squad/
+squad migrate --from ai-team   # rename .squad/ → .squad/
 ```
 
 This replaces the old `squad upgrade --migrate-directory` command.

--- a/docs/src/content/docs/tips-and-tricks.md
+++ b/docs/src/content/docs/tips-and-tricks.md
@@ -320,7 +320,7 @@ If Frontend does something one way and Backend does it another way, the decision
 Agent A: "I used kebab-case for the file names"
 Agent B: "I used PascalCase for the file names"
 
-[You check .ai-team/decisions.md]
+[You check .squad/decisions.md]
 [No decision about file naming conventions]
 
 > Here's the permanent rule: all component files are PascalCase.
@@ -332,7 +332,7 @@ Now it's in the shared brain. Next agent to work on components will see this.
 
 When a decision no longer applies, move it to a "Superseded" section.
 
-You can edit `.ai-team/decisions.md` directly:
+You can edit `.squad/decisions.md` directly:
 
 ```markdown
 ## Superseded Decisions
@@ -366,7 +366,7 @@ This happens automatically in mature teams, but you can force it anytime.
 
 ### 6. Personal History Files Build Over Time
 
-Each agent's `.ai-team/agents/{name}/history.md` grows with every session. Check it when an agent seems lost.
+Each agent's `.squad/agents/{name}/history.md` grows with every session. Check it when an agent seems lost.
 
 ```
 [Dallas's history shows]
@@ -449,14 +449,14 @@ Ralph handles the backlog, you handle the critical path.
 ❌ "I want Lead, Frontend, Backend, Tester, DevOps, Data Engineer, Designer, and a Scribe."
 ```
 
-### Pitfall 6: Lost Work Because You Didn't Commit `.ai-team/`
+### Pitfall 6: Lost Work Because You Didn't Commit `.squad/`
 
 **Problem:** You deleted the repo and lost all your team knowledge.
 
-**Solution:** **Commit `.ai-team/` to git.** It's permanent team memory.
+**Solution:** **Commit `.squad/` to git.** It's permanent team memory.
 
 ```bash
-git add .ai-team/
+git add .squad/
 git commit -m "Add squad team state"
 git push
 ```
@@ -518,7 +518,7 @@ Squad 1: "Team A, build the admin dashboard. You own features/admin/."
 Squad 2: "Team B, build the mobile app. You own features/mobile/."
 
 [Both teams work in parallel]
-[Shared decisions in .ai-team/decisions.md prevent conflicts]
+[Shared decisions in .squad/decisions.md prevent conflicts]
 ```
 
 Requires good routing rules and clear ownership, but it works.
@@ -616,7 +616,7 @@ A typical high-performing session:
 3. **Parallel execution:** Let agents work (don't interrupt)
 4. **Check logs:** Ask Scribe what happened while you were reading code
 5. **Next round:** Based on what Scribe told you, give follow-up work or start Ralph
-6. **Wrap up:** Ask Ralph for status, commit `.ai-team/`, go home
+6. **Wrap up:** Ask Ralph for status, commit `.squad/`, go home
 
 **Time to productive work: usually < 2 minutes.**
 

--- a/docs/src/content/docs/tour-first-session.md
+++ b/docs/src/content/docs/tour-first-session.md
@@ -74,7 +74,7 @@ You can say "yes" or skip straight to a task (which is implicit confirmation):
 > Yes. Dallas, set up the Express server with basic routing.
 ```
 
-Squad creates the `.ai-team/` directory structure (team roster, routing rules, casting state, ceremony config, agent charters and histories — all seeded with your project context). Then it spawns Dallas.
+Squad creates the `.squad/` directory structure (team roster, routing rules, casting state, ceremony config, agent charters and histories — all seeded with your project context). Then it spawns Dallas.
 
 ```
 🔧 Dallas — setting up Express server with routing
@@ -267,7 +267,7 @@ squad import ../my-app/squad-export.json
 ## Tips
 
 - **First session is the slowest.** Agents have no history yet. After 2–3 sessions, they know your conventions and stop asking questions they've answered before.
-- **Commit `.ai-team/`.** It's your team's brain. Anyone who clones gets the team with all their knowledge.
+- **Commit `.squad/`.** It's your team's brain. Anyone who clones gets the team with all their knowledge.
 - **Say "team" for big tasks.** The word "team" triggers parallel fan-out across multiple agents.
 - **Name an agent for focused work.** `"Dallas, fix the login bug"` sends work to one specific agent.
 - **Directives are sticky.** Once captured, they persist across all future sessions.


### PR DESCRIPTION
## Summary

The state/team-storage documentation referenced the deprecated `.ai-team/` and `.ai-team-templates/` directory names throughout. The actual implementation uses `.squad/` and `.squad-templates/`.

## Changes

Updated 22 documentation files to replace:
- `.ai-team/` → `.squad/`
- `.ai-team-templates/` → `.squad-templates/`
- `.ai-team-archive` → `.squad-archive`
- `.ai-team-backup` → `.squad-backup`

Closes #1194