### PR TITLE
feat(init): prompt to add @copilot as a team member during squad init

### DIFF
--- a/.changeset/init-prompt-copilot-member.md
+++ b/.changeset/init-prompt-copilot-member.md
@@ -1,0 +1,10 @@
+---
+"@bradygaster/squad-cli": minor
+---
+
+Add @copilot team member prompt during `squad init`
+
+During interactive `squad init`, users are now prompted to add @copilot
+as an autonomous team member. Answering yes adds the Coding Agent section
+to team.md and copies copilot-instructions.md into the project. Non-interactive
+mode skips silently with a hint to run `squad copilot enable` later.

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -17,6 +17,12 @@ import { liftInitMutableStateOntoOrphan } from '../commands/migrate-backend.js';
 import { resolveSquadStateMcpSpec } from './mcp-spec.js';
 import { describeMcpSpec } from './upgrade.js';
 import { ensureSquadStateMcpInRoot, ensureSquadStateMcpInUserConfig, tombstoneStaleSquadStateInProjectMcp } from './mcp-root.js';
+import {
+  readTeamMd,
+  writeTeamMd,
+  hasCopilot,
+  insertCopilotSection,
+} from './team-md.js';
 
 const storage = new FSStorageProvider();
 
@@ -421,6 +427,48 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
   for (const file of result.skippedFiles) {
     // Files are already relative to teamRoot, just display as-is
     console.log(`${DIM}${file} already exists — skipping${RESET}`);
+  }
+
+  // ── Copilot agent prompt ───────────────────────────────────────────
+  // Ask if the user wants to add @copilot as an autonomous team member.
+  // This enables .github/copilot-instructions.md and adds Coding Agent
+  // to the team roster, allowing squad-labeled issues to be auto-assigned.
+  const teamContent = readTeamMd(squadDir);
+  if (!hasCopilot(teamContent)) {
+    if (process.stdin.isTTY) {
+      const { createInterface } = await import('node:readline/promises');
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      try {
+        console.log();
+        const answer = (await rl.question(`  Add ${BOLD}@copilot${RESET} as an autonomous team member? [Y/n]: `)).trim().toLowerCase();
+        if (answer === '' || answer === 'y' || answer === 'yes') {
+          const updated = insertCopilotSection(teamContent, false);
+          writeTeamMd(squadDir, updated);
+          success('Added @copilot (Coding Agent) to team roster');
+
+          // Copy copilot-instructions.md from templates
+          const currentFileUrl = new URL(import.meta.url);
+          const currentFilePath = currentFileUrl.pathname.startsWith('/') && process.platform === 'win32'
+            ? currentFileUrl.pathname.substring(1)
+            : currentFileUrl.pathname;
+          const templatesSrc = path.resolve(path.dirname(currentFilePath), '..', '..', '..', 'templates');
+          const instructionsSrc = path.join(templatesSrc, 'copilot-instructions.md');
+          const instructionsDest = path.join(dest, '.github', 'copilot-instructions.md');
+
+          if (storage.existsSync(instructionsSrc) && !storage.existsSync(instructionsDest)) {
+            storage.mkdirSync(path.dirname(instructionsDest), { recursive: true });
+            storage.copySync(instructionsSrc, instructionsDest);
+            success('.github/copilot-instructions.md');
+          }
+        } else {
+          console.log(`${DIM}  Skipped — add later with: squad copilot enable${RESET}`);
+        }
+      } finally {
+        rl.close();
+      }
+    } else {
+      console.log(`${DIM}  Non-interactive mode — skipping @copilot setup. Add later with: squad copilot enable${RESET}`);
+    }
   }
 
   // ── Celebration ceremony ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

During interactive `squad init`, users are now prompted to add `@copilot` as an autonomous team member. This closes the UX gap where users had to know about `squad copilot enable` as a separate step.

## Behavior

- **Interactive (TTY):** After scaffolding completes, prompts: `Add @copilot as an autonomous team member? [Y/n]:`
  - **Yes (default):** Adds Coding Agent section to `team.md` and copies `copilot-instructions.md` template to `.github/`
  - **No:** Skips with a hint message about `squad copilot enable`
- **Non-interactive:** Skips silently with guidance message
- **Existing @copilot:** Skips entirely (idempotent)

## Testing

- Build passes (`npm run build`)
- Follows existing prompt patterns (same readline/promises approach as worktree strategy prompt)
- Uses same `insertCopilotSection`/`writeTeamMd` helpers as `squad copilot enable`

Closes #1147