### PR TITLE
chore: simplify workflow files by removing .ai-team fallback logic

### DIFF
--- a/.squad-templates/workflows/squad-heartbeat.yml
+++ b/.squad-templates/workflows/squad-heartbeat.yml
@@ -106,10 +106,7 @@ jobs:
           script: |
             const fs = require('fs');
 
-            let teamFile = '.squad/team.md';
-            if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) return;
 
             const content = fs.readFileSync(teamFile, 'utf8');
@@ -154,7 +151,7 @@ jobs:
                     agent_assignment: {
                       target_repo: `${context.repo.owner}/${context.repo.repo}`,
                       base_branch: repoData.default_branch,
-                      custom_instructions: `Read .squad/team.md (or .ai-team/team.md) for team context and .squad/routing.md (or .ai-team/routing.md) for routing rules.`
+                      custom_instructions: `Read .squad/team.md for team context and .squad/routing.md for routing rules.`
                     }
                   });
                   core.info(`Assigned copilot-swe-agent[bot] to #${issue.number}`);

--- a/.squad-templates/workflows/squad-issue-assign.yml
+++ b/.squad-templates/workflows/squad-issue-assign.yml
@@ -27,13 +27,9 @@ jobs:
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
 
-            // Read team roster — check .squad/ first, fall back to .ai-team/
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-            if (!fs.existsSync(teamFile)) {
-              core.warning('No .squad/team.md or .ai-team/team.md found — cannot assign work');
+              core.warning('No .squad/team.md found — cannot assign work');
               return;
             }
 
@@ -72,7 +68,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` (or \`.ai-team/team.md\`) for valid member names.`
+                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` for valid member names.`
               });
               return;
             }

--- a/.squad-templates/workflows/squad-triage.yml
+++ b/.squad-templates/workflows/squad-triage.yml
@@ -22,13 +22,9 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
 
-            // Read team roster — check .squad/ first, fall back to .ai-team/
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-            if (!fs.existsSync(teamFile)) {
-              core.warning('No .squad/team.md or .ai-team/team.md found — cannot triage');
+              core.warning('No .squad/team.md found — cannot triage');
               return;
             }
 
@@ -88,11 +84,7 @@ jobs:
               }
             }
 
-            // Read routing rules — check .squad/ first, fall back to .ai-team/
-            let routingFile = '.squad/routing.md';
-            if (!fs.existsSync(routingFile)) {
-              routingFile = '.ai-team/routing.md';
-            }
+            const routingFile = '.squad/routing.md';
             let routingContent = '';
             if (fs.existsSync(routingFile)) {
               routingContent = fs.readFileSync(routingFile, 'utf8');

--- a/.squad-templates/workflows/sync-squad-labels.yml
+++ b/.squad-templates/workflows/sync-squad-labels.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - '.squad/team.md'
-      - '.ai-team/team.md'
   workflow_dispatch:
 
 permissions:
@@ -22,13 +21,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-
-            if (!fs.existsSync(teamFile)) {
-              core.info('No .squad/team.md or .ai-team/team.md found — skipping label sync');
+              core.info('No .squad/team.md found — skipping label sync');
               return;
             }
 

--- a/packages/squad-cli/templates/workflows/squad-heartbeat.yml
+++ b/packages/squad-cli/templates/workflows/squad-heartbeat.yml
@@ -106,10 +106,7 @@ jobs:
           script: |
             const fs = require('fs');
 
-            let teamFile = '.squad/team.md';
-            if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) return;
 
             const content = fs.readFileSync(teamFile, 'utf8');
@@ -154,7 +151,7 @@ jobs:
                     agent_assignment: {
                       target_repo: `${context.repo.owner}/${context.repo.repo}`,
                       base_branch: repoData.default_branch,
-                      custom_instructions: `Read .squad/team.md (or .ai-team/team.md) for team context and .squad/routing.md (or .ai-team/routing.md) for routing rules.`
+                      custom_instructions: `Read .squad/team.md for team context and .squad/routing.md for routing rules.`
                     }
                   });
                   core.info(`Assigned copilot-swe-agent[bot] to #${issue.number}`);

--- a/packages/squad-cli/templates/workflows/squad-issue-assign.yml
+++ b/packages/squad-cli/templates/workflows/squad-issue-assign.yml
@@ -27,13 +27,9 @@ jobs:
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
 
-            // Read team roster — check .squad/ first, fall back to .ai-team/
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-            if (!fs.existsSync(teamFile)) {
-              core.warning('No .squad/team.md or .ai-team/team.md found — cannot assign work');
+              core.warning('No .squad/team.md found — cannot assign work');
               return;
             }
 
@@ -72,7 +68,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` (or \`.ai-team/team.md\`) for valid member names.`
+                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` for valid member names.`
               });
               return;
             }

--- a/packages/squad-cli/templates/workflows/squad-triage.yml
+++ b/packages/squad-cli/templates/workflows/squad-triage.yml
@@ -22,13 +22,9 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
 
-            // Read team roster — check .squad/ first, fall back to .ai-team/
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-            if (!fs.existsSync(teamFile)) {
-              core.warning('No .squad/team.md or .ai-team/team.md found — cannot triage');
+              core.warning('No .squad/team.md found — cannot triage');
               return;
             }
 
@@ -88,11 +84,7 @@ jobs:
               }
             }
 
-            // Read routing rules — check .squad/ first, fall back to .ai-team/
-            let routingFile = '.squad/routing.md';
-            if (!fs.existsSync(routingFile)) {
-              routingFile = '.ai-team/routing.md';
-            }
+            const routingFile = '.squad/routing.md';
             let routingContent = '';
             if (fs.existsSync(routingFile)) {
               routingContent = fs.readFileSync(routingFile, 'utf8');

--- a/packages/squad-cli/templates/workflows/sync-squad-labels.yml
+++ b/packages/squad-cli/templates/workflows/sync-squad-labels.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - '.squad/team.md'
-      - '.ai-team/team.md'
   workflow_dispatch:
 
 permissions:
@@ -22,13 +21,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-
-            if (!fs.existsSync(teamFile)) {
-              core.info('No .squad/team.md or .ai-team/team.md found — skipping label sync');
+              core.info('No .squad/team.md found — skipping label sync');
               return;
             }
 

--- a/packages/squad-sdk/templates/workflows/squad-heartbeat.yml
+++ b/packages/squad-sdk/templates/workflows/squad-heartbeat.yml
@@ -106,10 +106,7 @@ jobs:
           script: |
             const fs = require('fs');
 
-            let teamFile = '.squad/team.md';
-            if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) return;
 
             const content = fs.readFileSync(teamFile, 'utf8');
@@ -154,7 +151,7 @@ jobs:
                     agent_assignment: {
                       target_repo: `${context.repo.owner}/${context.repo.repo}`,
                       base_branch: repoData.default_branch,
-                      custom_instructions: `Read .squad/team.md (or .ai-team/team.md) for team context and .squad/routing.md (or .ai-team/routing.md) for routing rules.`
+                      custom_instructions: `Read .squad/team.md for team context and .squad/routing.md for routing rules.`
                     }
                   });
                   core.info(`Assigned copilot-swe-agent[bot] to #${issue.number}`);

--- a/packages/squad-sdk/templates/workflows/squad-issue-assign.yml
+++ b/packages/squad-sdk/templates/workflows/squad-issue-assign.yml
@@ -27,13 +27,9 @@ jobs:
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
 
-            // Read team roster — check .squad/ first, fall back to .ai-team/
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-            if (!fs.existsSync(teamFile)) {
-              core.warning('No .squad/team.md or .ai-team/team.md found — cannot assign work');
+              core.warning('No .squad/team.md found — cannot assign work');
               return;
             }
 
@@ -72,7 +68,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` (or \`.ai-team/team.md\`) for valid member names.`
+                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` for valid member names.`
               });
               return;
             }

--- a/packages/squad-sdk/templates/workflows/squad-triage.yml
+++ b/packages/squad-sdk/templates/workflows/squad-triage.yml
@@ -22,13 +22,9 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
 
-            // Read team roster — check .squad/ first, fall back to .ai-team/
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-            if (!fs.existsSync(teamFile)) {
-              core.warning('No .squad/team.md or .ai-team/team.md found — cannot triage');
+              core.warning('No .squad/team.md found — cannot triage');
               return;
             }
 
@@ -88,11 +84,7 @@ jobs:
               }
             }
 
-            // Read routing rules — check .squad/ first, fall back to .ai-team/
-            let routingFile = '.squad/routing.md';
-            if (!fs.existsSync(routingFile)) {
-              routingFile = '.ai-team/routing.md';
-            }
+            const routingFile = '.squad/routing.md';
             let routingContent = '';
             if (fs.existsSync(routingFile)) {
               routingContent = fs.readFileSync(routingFile, 'utf8');

--- a/packages/squad-sdk/templates/workflows/sync-squad-labels.yml
+++ b/packages/squad-sdk/templates/workflows/sync-squad-labels.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - '.squad/team.md'
-      - '.ai-team/team.md'
   workflow_dispatch:
 
 permissions:
@@ -22,13 +21,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-
-            if (!fs.existsSync(teamFile)) {
-              core.info('No .squad/team.md or .ai-team/team.md found — skipping label sync');
+              core.info('No .squad/team.md found — skipping label sync');
               return;
             }
 

--- a/templates/workflows/squad-heartbeat.yml
+++ b/templates/workflows/squad-heartbeat.yml
@@ -106,10 +106,7 @@ jobs:
           script: |
             const fs = require('fs');
 
-            let teamFile = '.squad/team.md';
-            if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) return;
 
             const content = fs.readFileSync(teamFile, 'utf8');
@@ -154,7 +151,7 @@ jobs:
                     agent_assignment: {
                       target_repo: `${context.repo.owner}/${context.repo.repo}`,
                       base_branch: repoData.default_branch,
-                      custom_instructions: `Read .squad/team.md (or .ai-team/team.md) for team context and .squad/routing.md (or .ai-team/routing.md) for routing rules.`
+                      custom_instructions: `Read .squad/team.md for team context and .squad/routing.md for routing rules.`
                     }
                   });
                   core.info(`Assigned copilot-swe-agent[bot] to #${issue.number}`);

--- a/templates/workflows/squad-issue-assign.yml
+++ b/templates/workflows/squad-issue-assign.yml
@@ -27,13 +27,9 @@ jobs:
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
 
-            // Read team roster — check .squad/ first, fall back to .ai-team/
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-            if (!fs.existsSync(teamFile)) {
-              core.warning('No .squad/team.md or .ai-team/team.md found — cannot assign work');
+              core.warning('No .squad/team.md found — cannot assign work');
               return;
             }
 
@@ -72,7 +68,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` (or \`.ai-team/team.md\`) for valid member names.`
+                body: `⚠️ No squad member found matching label \`${label}\`. Check \`.squad/team.md\` for valid member names.`
               });
               return;
             }

--- a/templates/workflows/squad-triage.yml
+++ b/templates/workflows/squad-triage.yml
@@ -22,13 +22,9 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
 
-            // Read team roster — check .squad/ first, fall back to .ai-team/
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-            if (!fs.existsSync(teamFile)) {
-              core.warning('No .squad/team.md or .ai-team/team.md found — cannot triage');
+              core.warning('No .squad/team.md found — cannot triage');
               return;
             }
 
@@ -88,11 +84,7 @@ jobs:
               }
             }
 
-            // Read routing rules — check .squad/ first, fall back to .ai-team/
-            let routingFile = '.squad/routing.md';
-            if (!fs.existsSync(routingFile)) {
-              routingFile = '.ai-team/routing.md';
-            }
+            const routingFile = '.squad/routing.md';
             let routingContent = '';
             if (fs.existsSync(routingFile)) {
               routingContent = fs.readFileSync(routingFile, 'utf8');

--- a/templates/workflows/sync-squad-labels.yml
+++ b/templates/workflows/sync-squad-labels.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - '.squad/team.md'
-      - '.ai-team/team.md'
   workflow_dispatch:
 
 permissions:
@@ -22,13 +21,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            let teamFile = '.squad/team.md';
+            const teamFile = '.squad/team.md';
             if (!fs.existsSync(teamFile)) {
-              teamFile = '.ai-team/team.md';
-            }
-
-            if (!fs.existsSync(teamFile)) {
-              core.info('No .squad/team.md or .ai-team/team.md found — skipping label sync');
+              core.info('No .squad/team.md found — skipping label sync');
               return;
             }
 


### PR DESCRIPTION
## Summary

Removes dead `.ai-team/` fallback code from workflow templates. The `.squad/` directory has been the canonical location since the rename — these fallback paths were never triggered and added unnecessary complexity to every workflow file.

## Changes

- Removed `.ai-team/` fallback branches from 4 workflow templates (triage, issue-assign, heartbeat, sync-squad-labels)
- Cleaned up empty if-blocks left by the removal
- Simplified warning messages to reference only `.squad/team.md`
- Changed `let` → `const` for file paths that are no longer reassigned
- Synced all template copies (`.squad-templates/`, `packages/squad-cli/templates/`, `packages/squad-sdk/templates/`)

## Not Changed

Guard rail checks in `squad-preview.yml` and `squad-promote.yml` are intentionally preserved — they legitimately prevent legacy `.ai-team/` files from being shipped to production.

## Scope Note

The broader simplification (moving workflow logic into CLI commands like `squad workflow <name>`) is a larger architectural change tracked separately. This PR focuses on the quick win: removing dead code paths that add complexity without value.

Closes #1167