### PR TITLE
chore(lockfile): sync package-lock with package.json after v0.10.0 bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8527,11 +8527,11 @@
     },
     "packages/squad-cli": {
       "name": "@bradygaster/squad-cli",
-      "version": "0.9.6-preview.15",
+      "version": "0.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@bradygaster/squad-sdk": ">=0.9.6-preview",
+        "@bradygaster/squad-sdk": ">=0.10.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ink": "^6.8.0",
         "react": "^19.2.4",
@@ -8558,7 +8558,7 @@
     },
     "packages/squad-sdk": {
       "name": "@bradygaster/squad-sdk",
-      "version": "0.9.6-preview.13",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",


### PR DESCRIPTION
## Summary

After the v0.10.0 stable release on 2026-06-07, the root `package-lock.json` still recorded `packages/squad-cli@0.9.6-preview.15` and `packages/squad-sdk@0.9.6-preview.13` for the workspace entries. The package.json files were updated correctly during the release, but the lockfile workspace metadata was not regenerated.

This causes `npm ci --ignore-scripts` to fail in the `sdk-exports-validation` CI job whenever package.json versions diverge from these stale lockfile entries — happens on every build that runs `scripts/bump-build.mjs`. Confirmed on [PR #1257](https://github.com/bradygaster/squad/pull/1257).

## Change

Regenerated only the workspace version metadata (`packages/squad-cli` and `packages/squad-sdk` entries inside `package-lock.json`). **No dependency trees touched.** 3 lines changed.

```
-      "version": "0.9.6-preview.15",
+      "version": "0.10.0",
        ...
-        "@bradygaster/squad-sdk": ">=0.9.6-preview",
+        "@bradygaster/squad-sdk": ">=0.10.0",
        ...
-      "version": "0.9.6-preview.13",
+      "version": "0.10.0",
```

## Verification

Verified locally on Windows + Node v23.5.0:

- ✅ `npm ci --ignore-scripts` at repo root — exit 0 (passes both before and after this commit at root level; the failure mode is workspace-entry mismatch surfacing under specific build conditions)
- ✅ `npm install --ignore-scripts` — no further drift produced
- ✅ Full `npm test` suite — 6535 passed / 134 failed / 60 skipped. The 134 failures are **all pre-existing Windows file-locking flakiness** (`EBUSY`, `ENOTEMPTY`, hook timeouts); identical failure mode at `cc37a2f7` (the commit immediately before my recent merge batch) showed 125 failures with the same patterns. Diff is within the flake noise band.
- ✅ Targeted re-run of the 5 "newly failing" files in isolation — **93/93 passing**. Confirms the bulk-run failures are concurrency-induced flakes, not regressions from the recent merges (#1251, #1258, #1260, #1262, #1249).

## Unblocks

- PR #1257 (CHANGELOG in tarball) — should re-trigger CI cleanly once this lands
- PR #1250 (release pipeline) — same reason

## Test failure comparison

| Snapshot | Tests | Failed | Passed | Skipped |
|----------|-------|--------|--------|---------|
| `cc37a2f7` (pre-merge baseline) | 6776 | 125 | 6341 | 263 |
| Current dev (post-merge + lockfile fix) | 6776 | 134 | 6535 | 60 |

The pass-count INCREASED by ~200 because Windows flake skip ratios shifted between runs.
