### PR TITLE
fix(bump-build): also update package-lock workspace entries (root cause of #1266)

### DIFF
--- a/scripts/bump-build.mjs
+++ b/scripts/bump-build.mjs
@@ -76,4 +76,42 @@ for (const pkgPath of PACKAGE_PATHS) {
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
 }
 
+// Update package-lock.json workspace entries to match the new version.
+// Without this, every build that runs bump-build.mjs produces a lockfile
+// drift where package.json says X.Y.Z-build.N but lockfile workspace entries
+// still say the previous version → npm ci fails in CI with EUSAGE.
+//
+// We only touch the two workspace entries (packages/squad-cli and
+// packages/squad-sdk) and their cross-dependency reference. No npm
+// install is run, so the dependency tree is not touched.
+const LOCKFILE_PATH = join(root, 'package-lock.json');
+try {
+  const lockRaw = readFileSync(LOCKFILE_PATH, 'utf8');
+  const lock = JSON.parse(lockRaw);
+  if (lock.packages) {
+    let lockChanged = false;
+    for (const key of ['packages/squad-sdk', 'packages/squad-cli']) {
+      const entry = lock.packages[key];
+      if (entry && entry.version !== newVersion) {
+        entry.version = newVersion;
+        lockChanged = true;
+      }
+      // Also bump the CLI's @bradygaster/squad-sdk dependency floor so it
+      // resolves the freshly-built SDK rather than the previous version.
+      if (key === 'packages/squad-cli' && entry?.dependencies?.['@bradygaster/squad-sdk']) {
+        const desired = `>=${newVersion}`;
+        if (entry.dependencies['@bradygaster/squad-sdk'] !== desired) {
+          entry.dependencies['@bradygaster/squad-sdk'] = desired;
+          lockChanged = true;
+        }
+      }
+    }
+    if (lockChanged) {
+      writeFileSync(LOCKFILE_PATH, JSON.stringify(lock, null, 2) + '\n', 'utf8');
+    }
+  }
+} catch (err) {
+  console.warn(`⚠ Could not update package-lock.json: ${err.message}`);
+}
+
 console.log(`Build ${parsed.build}: ${rootPkg.version} → ${newVersion}`);


### PR DESCRIPTION
## Summary

Fixes the **root cause** of the recurring `npm ci --ignore-scripts` failures in the `sdk-exports-validation` CI job. [PR #1266](https://github.com/bradygaster/squad/pull/1266) patched the symptom on dev for v0.10.0 — this is the structural fix that prevents recurrence.

## Root cause

`scripts/bump-build.mjs` updates 3 `package.json` files on every build but **never touches `package-lock.json`**. After each bump, `package.json` says `X.Y.Z-build.N` but the lockfile workspace entries still say the previous version. Every PR's fresh CI run then fails:

```
npm error Missing: @bradygaster/squad-sdk@0.10.0-build.4 from lock file
```

Currently affecting [#1250](https://github.com/bradygaster/squad/pull/1250) and [#1257](https://github.com/bradygaster/squad/pull/1257) — both blocked on this CI step.

## Fix

After the existing `package.json` writes, the script now also:

1. Updates the two workspace entries in `package-lock.json` (`packages/squad-cli` and `packages/squad-sdk`) so their `version` field matches the new bumped version
2. Bumps the CLI's `@bradygaster/squad-sdk` dependency floor in the lockfile so it resolves the freshly-built SDK rather than the previous version
3. Best-effort: warns rather than throws on lockfile parse/write failure (corrupted lockfile won't break the build)

**No `npm install` is run** — the dependency tree is not touched. Only the two workspace metadata entries change.

## Test

- Manual: `node scripts/bump-build.mjs` bumps both `package.json` AND lockfile in lockstep (squad-cli 0.10.0 → 0.10.0-build.1, lockfile updated to match)
- ✅ All 6 existing `bump-build.test.ts` tests pass

## Unblocks

Once this merges, the 3 currently-blocked PRs (#1250, #1257, and any future PR with bumped versions) will auto-resolve on next rebase onto dev. No more recurring lockfile drift.

## Files

`scripts/bump-build.mjs` (+38 / -0)
