### PR TITLE
Squad.Agents.AI 0.4.0: default-on subagent observability + Aspire-style connection-string lookup

### DIFF
--- a/src/Squad.Agents.AI/README.md
+++ b/src/Squad.Agents.AI/README.md
@@ -132,7 +132,14 @@ Use `GitHubTokenProvider` only when the host owns token retrieval, such as Key V
 
 `AddSquadAgent()` reads `ConnectionStrings:squad` through `IConfiguration.GetConnectionString("squad")`. In environment variables, use `ConnectionStrings__squad`.
 
-Named registrations select a named connection string. For example, `AddSquadAgent("research")` reads `ConnectionStrings:squad-research`; in environment variables, use `ConnectionStrings__squad-research`.
+Named registrations support both connection-string conventions:
+
+| Style | Example | Looks up |
+|---|---|---|
+| **Aspire-style direct** (tried first) | `AddSquadAgent("research-squad")` | `ConnectionStrings:research-squad` |
+| **Legacy prefixed fallback** | `AddSquadAgent("research")` | `ConnectionStrings:squad-research` |
+
+So when an Aspire AppHost registers a Squad resource via `builder.AddSquad("research-squad", ...)` and a downstream project does `.WithReference(researchSquad)`, the consumer can resolve the agent with a single `builder.Services.AddKeyedSquadAgent("research-squad")` call — the SDK finds the Aspire-injected connection string automatically. Existing consumers using the prefixed form continue to work; the SDK tries the literal name first and falls back to `squad-{name}` if the direct lookup is empty.
 
 Supported connection string forms:
 
@@ -142,6 +149,39 @@ squad://localhost?teamRoot=C%3A%5Cteam&cliPath=C%3A%5Ctools%5Ccopilot.exe&cliArg
 ```
 
 Parsed URI query keys: `teamRoot`, `cliPath`, `cwd`, `cliArgs` (semicolon-separated), and `env` (`key=value;key2=value2`). Unknown URI host/protocol values are reserved for future use.
+
+## Subagent observability — first-class OpenTelemetry
+
+`Squad.Agents.AI` emits one OpenTelemetry `Activity` per subagent dispatch out of the box. Hosts that subscribe to the activity source see one `squad.subagent {Name}` span per spawn, with the subagent name as a tag and timeline annotations (`squad.subagent.start`, `squad.subagent.message`, `squad.subagent.completed`, `squad.subagent.failed`) marking every state transition.
+
+Two-line wiring is all that is required — no manual callback plumbing:
+
+```csharp
+using OpenTelemetry.Trace;
+using Squad.Agents.AI;
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(t => t.AddSource(SquadAgentDiagnostics.ActivitySourceName));
+
+builder.Services.AddSquadAgent(o => o.SquadFolderPath = @"C:\team");
+```
+
+When the coordinator's `task` tool spawns specialists, the host's tracer (Jaeger, Zipkin, Application Insights, or the Aspire dashboard's **Traces** view) shows one `squad.subagent` span per spawn, each tagged with `squad.subagent.name`, `squad.subagent.display_name`, `squad.subagent.sdk_agent_id`, and `squad.subagent.reply_preview` — plus timeline events for every lifecycle transition.
+
+**Turning telemetry off.** Set `EmitSubagentActivities = false` to suppress Squad's built-in spans (for example, when you want to drive observability entirely from your own callback or avoid double-counting). The `OnSubagentTrace` callback continues to fire either way — it is the customization seam, independent of telemetry.
+
+```csharp
+builder.Services.AddSquadAgent(o =>
+{
+    o.SquadFolderPath = @"C:\team";
+    o.EmitSubagentActivities = false;          // disable built-in OTel emission
+    o.OnSubagentTrace = trace =>               // handle telemetry yourself
+    {
+        if (trace.Kind == SquadAgentTraceEventKind.SubagentStarted)
+            MyMetrics.IncrementSpawn(trace.SubagentName!);
+    };
+});
+```
 
 ## Key options
 
@@ -157,6 +197,8 @@ Parsed URI query keys: `teamRoot`, `cliPath`, `cwd`, `cliArgs` (semicolon-separa
 | `TraceEvents` | Enables verbose SDK logging and emits a startup warning when enabled. |
 | `AgentName` | Display name for the resulting `AIAgent`; defaults to `Squad`. |
 | `Instructions` | Optional system instructions passed to the inner Copilot agent. |
+| `EmitSubagentActivities` | Whether the SDK opens an OpenTelemetry `Activity` per subagent dispatch and annotates lifecycle events. Defaults to `true`. Set to `false` to handle telemetry from your own `OnSubagentTrace` callback. |
+| `OnSubagentTrace` | Optional callback invoked for every typed `SquadAgentTraceEvent`. Independent of `EmitSubagentActivities` — both can be on simultaneously. |
 
 ## Security
 

--- a/src/Squad.Agents.AI/Squad.Agents.AI.csproj
+++ b/src/Squad.Agents.AI/Squad.Agents.AI.csproj
@@ -17,7 +17,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="samples/**/*.cs" />

--- a/src/Squad.Agents.AI/SquadAgent.cs
+++ b/src/Squad.Agents.AI/SquadAgent.cs
@@ -139,13 +139,16 @@ public sealed class SquadAgent : DelegatingAIAgent, IAsyncDisposable
             sessionConfig.SystemMessage = new SystemMessageConfig { Content = options.Instructions };
         }
 
-        // Wire OnSubagentTrace before ConfigureSession so consumer-supplied ConfigureSession
-        // callbacks can still override or chain behind our defaults (e.g. compose multiple OnEvent
-        // handlers, replace IncludeSubAgentStreamingEvents, etc.).
+        // Install the subagent trace mapper when EITHER:
+        //   - EmitSubagentActivities is on (default true) — to emit OTel spans + events
+        //   - OnSubagentTrace is set — to forward typed events to the consumer
+        // The two concerns are independent; the mapper handles whichever combination is active.
         SquadSubagentTraceMapper? traceMapper = null;
-        if (options.OnSubagentTrace is not null)
+        if (options.EmitSubagentActivities || options.OnSubagentTrace is not null)
         {
-            traceMapper = new SquadSubagentTraceMapper(options.OnSubagentTrace);
+            traceMapper = new SquadSubagentTraceMapper(
+                options.OnSubagentTrace,
+                emitActivities: options.EmitSubagentActivities);
             sessionConfig.IncludeSubAgentStreamingEvents = true;
             sessionConfig.OnEvent = traceMapper.OnSessionEvent;
         }

--- a/src/Squad.Agents.AI/SquadAgentOptions.cs
+++ b/src/Squad.Agents.AI/SquadAgentOptions.cs
@@ -144,22 +144,23 @@ public sealed class SquadAgentOptions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Setting this callback has three side effects:
+    /// Setting this callback has two side effects:
     /// </para>
     /// <list type="number">
     /// <item><see cref="GitHub.Copilot.SessionConfigBase.IncludeSubAgentStreamingEvents"/> is forced to
     /// <see langword="true"/> so subagent assistant messages flow up to the parent session (otherwise
     /// the subagent's reply stays inside its own session and never reaches the callback).</item>
-    /// <item>An <see cref="System.Diagnostics.ActivitySource"/> named
-    /// <see cref="SquadAgentDiagnostics.ActivitySourceName"/> emits one <see cref="System.Diagnostics.Activity"/>
-    /// per subagent dispatch, tagged with <c>squad.subagent.name</c> and a preview of the subagent's
-    /// reply. Hosts that <c>.AddSource(SquadAgentDiagnostics.ActivitySourceName)</c> on their
-    /// OpenTelemetry tracer get these spans in their backend (e.g. the Aspire dashboard).</item>
     /// <item><see cref="ConfigureSession"/> may still override <see cref="GitHub.Copilot.SessionConfigBase.OnEvent"/>
     /// or <see cref="GitHub.Copilot.SessionConfigBase.IncludeSubAgentStreamingEvents"/>; consumers
     /// that need a stacked event handler should call <c>OnSubagentTrace</c> from inside their
     /// <see cref="ConfigureSession"/> callback to compose the two.</item>
     /// </list>
+    /// <para>
+    /// OpenTelemetry telemetry is independent — it is controlled by
+    /// <see cref="EmitSubagentActivities"/> (default <see langword="true"/>) and emits whether or
+    /// not this callback is set. Use <c>OnSubagentTrace</c> when you want to layer extra behaviour
+    /// (custom logging, dashboards, audit trails) on top of the built-in spans.
+    /// </para>
     /// <para>
     /// Consumer callback exceptions are caught and swallowed so a misbehaving subscriber cannot tear
     /// down the SDK event loop. Add your own try/catch + logging inside the callback if you need to
@@ -179,6 +180,53 @@ public sealed class SquadAgentOptions
     /// </example>
     [JsonIgnore]
     public Action<SquadAgentTraceEvent>? OnSubagentTrace { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether to emit OpenTelemetry <see cref="System.Diagnostics.Activity"/> spans
+    /// and lifecycle events for each subagent dispatch. Defaults to <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When <see langword="true"/>, an <see cref="System.Diagnostics.ActivitySource"/> named
+    /// <see cref="SquadAgentDiagnostics.ActivitySourceName"/> opens one
+    /// <see cref="System.Diagnostics.Activity"/> per subagent dispatch (tagged with
+    /// <c>squad.subagent.name</c>, <c>squad.subagent.display_name</c>, <c>squad.subagent.sdk_agent_id</c>,
+    /// and <c>squad.subagent.reply_preview</c>). Each subagent lifecycle phase
+    /// (<c>squad.subagent.start</c>, <c>squad.subagent.message</c>, <c>squad.subagent.completed</c>,
+    /// <c>squad.subagent.failed</c>) is also added as a <see cref="System.Diagnostics.ActivityEvent"/>
+    /// on the live subagent span so the timeline view in dashboards (e.g. Aspire) shows annotated
+    /// timestamps for every state transition.
+    /// </para>
+    /// <para>
+    /// Hosts that <c>.AddSource(SquadAgentDiagnostics.ActivitySourceName)</c> on their OpenTelemetry
+    /// tracer get these spans in their backend automatically — no need to set
+    /// <see cref="OnSubagentTrace"/>.
+    /// </para>
+    /// <para>
+    /// Set this to <see langword="false"/> to disable Squad's built-in telemetry (e.g. when you
+    /// want to handle observability entirely from your own <see cref="OnSubagentTrace"/> callback,
+    /// or to avoid double-counting if another layer in your stack is already emitting equivalent
+    /// spans).
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// // Default (recommended): just AddSource and the dashboard lights up.
+    /// builder.Services.AddOpenTelemetry()
+    ///     .WithTracing(t => t.AddSource(SquadAgentDiagnostics.ActivitySourceName));
+    ///
+    /// builder.Services.AddSquadAgent(opts => opts.SquadFolderPath = "/team");
+    ///
+    /// // Opt out (custom telemetry):
+    /// builder.Services.AddSquadAgent(opts =>
+    /// {
+    ///     opts.SquadFolderPath = "/team";
+    ///     opts.EmitSubagentActivities = false;
+    ///     opts.OnSubagentTrace = trace => MyMetrics.Increment(trace.Kind.ToString());
+    /// });
+    /// </code>
+    /// </example>
+    public bool EmitSubagentActivities { get; set; } = true;
 
     private static readonly string[] TokenPatterns = { "TOKEN", "KEY", "SECRET", "HMAC", "PASSWORD", "CREDENTIAL" };
 

--- a/src/Squad.Agents.AI/SquadAgentOptionsConfigurator.cs
+++ b/src/Squad.Agents.AI/SquadAgentOptionsConfigurator.cs
@@ -7,14 +7,22 @@ namespace Squad.Agents.AI;
 /// Binds SquadAgentOptions from a configured connection string.
 /// Runs before user-supplied configure lambda; user settings always win.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Resolves the connection string by trying each candidate name in order and using the first
+/// one that returns a non-empty value. This lets a single registration accept both the
+/// Aspire-style direct name (e.g. <c>ConnectionStrings:research-squad</c>) and the legacy
+/// prefixed name (<c>ConnectionStrings:squad-research</c>) without breaking either convention.
+/// </para>
+/// </remarks>
 internal sealed class SquadAgentOptionsConfigurator : IConfigureNamedOptions<SquadAgentOptions>
 {
     private readonly IConfiguration _configuration;
     private readonly string _optionsName;
-    private readonly string _connectionStringName;
+    private readonly string[] _connectionStringNames;
 
     public SquadAgentOptionsConfigurator(IConfiguration configuration)
-        : this(configuration, Options.DefaultName, SquadServiceCollectionExtensions.DefaultConnectionStringName)
+        : this(configuration, Options.DefaultName, new[] { SquadServiceCollectionExtensions.DefaultConnectionStringName })
     {
     }
 
@@ -22,10 +30,23 @@ internal sealed class SquadAgentOptionsConfigurator : IConfigureNamedOptions<Squ
         IConfiguration configuration,
         string optionsName,
         string connectionStringName)
+        : this(
+            configuration,
+            optionsName,
+            new[] { connectionStringName ?? throw new ArgumentNullException(nameof(connectionStringName)) })
+    {
+    }
+
+    internal SquadAgentOptionsConfigurator(
+        IConfiguration configuration,
+        string optionsName,
+        string[] connectionStringNames)
     {
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _optionsName = optionsName ?? Options.DefaultName;
-        _connectionStringName = connectionStringName ?? throw new ArgumentNullException(nameof(connectionStringName));
+        _connectionStringNames = connectionStringNames ?? throw new ArgumentNullException(nameof(connectionStringNames));
+        if (_connectionStringNames.Length == 0)
+            throw new ArgumentException("At least one connection string name must be supplied.", nameof(connectionStringNames));
     }
 
     public void Configure(SquadAgentOptions options) => Configure(Options.DefaultName, options);
@@ -35,7 +56,19 @@ internal sealed class SquadAgentOptionsConfigurator : IConfigureNamedOptions<Squ
         if (!string.Equals(name ?? Options.DefaultName, _optionsName, StringComparison.Ordinal))
             return;
 
-        var connectionString = _configuration.GetConnectionString(_connectionStringName);
+        // Try each candidate name in order; first non-empty wins. This lets a single
+        // AddSquadAgent("research") call resolve either ConnectionStrings:research
+        // (Aspire-style) or ConnectionStrings:squad-research (legacy SDK convention).
+        string? connectionString = null;
+        foreach (var candidate in _connectionStringNames)
+        {
+            var value = _configuration.GetConnectionString(candidate);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                connectionString = value;
+                break;
+            }
+        }
 
         if (string.IsNullOrWhiteSpace(connectionString))
             return;

--- a/src/Squad.Agents.AI/SquadServiceCollectionExtensions.cs
+++ b/src/Squad.Agents.AI/SquadServiceCollectionExtensions.cs
@@ -166,9 +166,9 @@ public static class SquadServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         var optionsName = GetOptionsName(name);
-        var connectionStringName = GetConnectionStringName(name);
+        var connectionStringNames = GetConnectionStringNames(name);
 
-        RegisterOptionsInfrastructure(services, optionsName, connectionStringName, configure);
+        RegisterOptionsInfrastructure(services, optionsName, connectionStringNames, configure);
 
         // Register SquadAgent with specified lifetime
         services.Add(new ServiceDescriptor(
@@ -208,9 +208,9 @@ public static class SquadServiceCollectionExtensions
 
         // Use the serviceKey as the options name when no explicit name is given
         var optionsName = GetOptionsName(name ?? serviceKey);
-        var connectionStringName = GetConnectionStringName(name ?? serviceKey);
+        var connectionStringNames = GetConnectionStringNames(name ?? serviceKey);
 
-        RegisterOptionsInfrastructure(services, optionsName, connectionStringName, configure);
+        RegisterOptionsInfrastructure(services, optionsName, connectionStringNames, configure);
 
         // Register keyed SquadAgent
         services.Add(new ServiceDescriptor(
@@ -243,7 +243,7 @@ public static class SquadServiceCollectionExtensions
     private static void RegisterOptionsInfrastructure(
         IServiceCollection services,
         string optionsName,
-        string connectionStringName,
+        string[] connectionStringNames,
         Action<SquadAgentOptions>? configure)
     {
         // Register connection string configurator FIRST (runs before user callback)
@@ -251,7 +251,7 @@ public static class SquadServiceCollectionExtensions
             new SquadAgentOptionsConfigurator(
                 sp.GetRequiredService<IConfiguration>(),
                 optionsName,
-                connectionStringName));
+                connectionStringNames));
 
         if (configure is not null)
         {
@@ -277,8 +277,31 @@ public static class SquadServiceCollectionExtensions
         return string.IsNullOrWhiteSpace(name) ? Options.DefaultName : name;
     }
 
-    private static string GetConnectionStringName(string? name)
+    /// <summary>
+    /// Returns the candidate IConfiguration ConnectionStrings: keys to try for a logical name.
+    /// Tried in order; first non-empty value wins.
+    /// </summary>
+    /// <remarks>
+    /// For a bare registration (<paramref name="name"/> null or whitespace) we look up the
+    /// historical default key <c>squad</c>.
+    /// <para>
+    /// For a named registration we try the literal name first
+    /// (e.g. <c>ConnectionStrings:research-squad</c> — the Aspire convention where the
+    /// resource name IS the connection string key), then fall back to the legacy prefixed
+    /// form (<c>ConnectionStrings:squad-research</c>) so existing consumers continue to work
+    /// without changes.
+    /// </para>
+    /// </remarks>
+    private static string[] GetConnectionStringNames(string? name)
     {
-        return string.IsNullOrWhiteSpace(name) ? DefaultConnectionStringName : $"{DefaultConnectionStringName}-{name}";
+        if (string.IsNullOrWhiteSpace(name))
+            return new[] { DefaultConnectionStringName };
+
+        var prefixed = $"{DefaultConnectionStringName}-{name}";
+        // Avoid duplicate lookups when the caller passes a name that's already prefixed
+        // (e.g. AddSquadAgent("squad-research") → just look up "squad-research" once).
+        return string.Equals(name, prefixed, StringComparison.Ordinal)
+            ? new[] { name }
+            : new[] { name, prefixed };
     }
 }

--- a/src/Squad.Agents.AI/SquadSubagentTraceMapper.cs
+++ b/src/Squad.Agents.AI/SquadSubagentTraceMapper.cs
@@ -20,11 +20,13 @@ namespace Squad.Agents.AI;
 internal sealed class SquadSubagentTraceMapper : IDisposable
 {
     private readonly Action<SquadAgentTraceEvent>? _onTrace;
+    private readonly bool _emitActivities;
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Activity> _liveSubagentActivities = new(StringComparer.Ordinal);
 
-    public SquadSubagentTraceMapper(Action<SquadAgentTraceEvent>? onTrace)
+    public SquadSubagentTraceMapper(Action<SquadAgentTraceEvent>? onTrace, bool emitActivities = true)
     {
         _onTrace = onTrace;
+        _emitActivities = emitActivities;
     }
 
     /// <summary>Hook to set on <see cref="SessionConfigBase.OnEvent"/>.</summary>
@@ -47,45 +49,74 @@ internal sealed class SquadSubagentTraceMapper : IDisposable
 
         if (envelope is null) return;
 
-        // OpenTelemetry: open/close an Activity per subagent run.
-        if (envelope.Kind == SquadAgentTraceEventKind.SubagentStarted &&
-            !string.IsNullOrEmpty(envelope.SdkAgentId))
+        // OpenTelemetry: open/annotate/close one Activity per subagent run when activity emission is on.
+        // Lifecycle events (start / message / completed / failed) are added as ActivityEvents on the live
+        // subagent span so backends with timeline views (e.g. Aspire dashboard) show one annotated marker
+        // per state transition.
+        if (_emitActivities)
         {
-            var activity = SquadAgentDiagnostics.ActivitySource.StartActivity(
-                $"squad.subagent {envelope.SubagentName ?? envelope.SdkAgentId}",
-                ActivityKind.Internal);
-            if (activity is not null)
+            if (envelope.Kind == SquadAgentTraceEventKind.SubagentStarted &&
+                !string.IsNullOrEmpty(envelope.SdkAgentId))
             {
-                activity.SetTag("squad.subagent.name", envelope.SubagentName);
-                activity.SetTag("squad.subagent.display_name", envelope.SubagentDisplayName);
-                activity.SetTag("squad.subagent.sdk_agent_id", envelope.SdkAgentId);
-                _liveSubagentActivities[envelope.SdkAgentId!] = activity;
+                var activity = SquadAgentDiagnostics.ActivitySource.StartActivity(
+                    $"squad.subagent {envelope.SubagentName ?? envelope.SdkAgentId}",
+                    ActivityKind.Internal);
+                if (activity is not null)
+                {
+                    activity.SetTag("squad.subagent.name", envelope.SubagentName);
+                    activity.SetTag("squad.subagent.display_name", envelope.SubagentDisplayName);
+                    activity.SetTag("squad.subagent.sdk_agent_id", envelope.SdkAgentId);
+                    activity.AddEvent(new ActivityEvent(
+                        "squad.subagent.start",
+                        tags: new ActivityTagsCollection
+                        {
+                            ["squad.subagent.name"] = envelope.SubagentName,
+                            ["squad.subagent.display_name"] = envelope.SubagentDisplayName,
+                            ["squad.subagent.sdk_agent_id"] = envelope.SdkAgentId,
+                        }));
+                    _liveSubagentActivities[envelope.SdkAgentId!] = activity;
+                }
             }
-        }
-        else if (envelope.Kind == SquadAgentTraceEventKind.AssistantMessage &&
-                 !string.IsNullOrEmpty(envelope.SdkAgentId) &&
-                 _liveSubagentActivities.TryGetValue(envelope.SdkAgentId!, out var liveActivity))
-        {
-            // The subagent's assistant message is the substantive output of that dispatch. Tag the span
-            // with a short preview so backends can group spans by subagent and show the reply at a glance.
-            // We bound the preview to a sane length even though backends are free to truncate further.
-            if (!string.IsNullOrEmpty(envelope.Content))
+            else if (envelope.Kind == SquadAgentTraceEventKind.AssistantMessage &&
+                     !string.IsNullOrEmpty(envelope.SdkAgentId) &&
+                     _liveSubagentActivities.TryGetValue(envelope.SdkAgentId!, out var liveActivity))
             {
-                var preview = envelope.Content!.Length > 512
-                    ? envelope.Content.Substring(0, 512) + "..."
-                    : envelope.Content;
-                liveActivity.SetTag("squad.subagent.reply_preview", preview);
+                // The subagent's assistant message is the substantive output of that dispatch. Tag the
+                // span with a short preview so backends can group spans by subagent and show the reply at
+                // a glance. We bound the preview to a sane length even though backends are free to
+                // truncate further. Also raise an ActivityEvent so the timeline shows when the reply was
+                // produced (useful for streaming subagents that emit multiple messages).
+                if (!string.IsNullOrEmpty(envelope.Content))
+                {
+                    var preview = envelope.Content!.Length > 512
+                        ? envelope.Content.Substring(0, 512) + "..."
+                        : envelope.Content;
+                    liveActivity.SetTag("squad.subagent.reply_preview", preview);
+                    liveActivity.AddEvent(new ActivityEvent(
+                        "squad.subagent.message",
+                        tags: new ActivityTagsCollection
+                        {
+                            ["squad.subagent.name"] = envelope.SubagentName,
+                            ["squad.subagent.sdk_agent_id"] = envelope.SdkAgentId,
+                            ["squad.subagent.message_preview"] = preview,
+                        }));
+                }
             }
-        }
-        else if (envelope.Kind is SquadAgentTraceEventKind.SubagentCompleted or SquadAgentTraceEventKind.SubagentFailed &&
-                 !string.IsNullOrEmpty(envelope.SdkAgentId) &&
-                 _liveSubagentActivities.TryRemove(envelope.SdkAgentId!, out var completedActivity))
-        {
-            completedActivity.SetStatus(
-                envelope.Kind == SquadAgentTraceEventKind.SubagentFailed
-                    ? ActivityStatusCode.Error
-                    : ActivityStatusCode.Ok);
-            completedActivity.Dispose();
+            else if (envelope.Kind is SquadAgentTraceEventKind.SubagentCompleted or SquadAgentTraceEventKind.SubagentFailed &&
+                     !string.IsNullOrEmpty(envelope.SdkAgentId) &&
+                     _liveSubagentActivities.TryRemove(envelope.SdkAgentId!, out var completedActivity))
+            {
+                var isFailure = envelope.Kind == SquadAgentTraceEventKind.SubagentFailed;
+                completedActivity.AddEvent(new ActivityEvent(
+                    isFailure ? "squad.subagent.failed" : "squad.subagent.completed",
+                    tags: new ActivityTagsCollection
+                    {
+                        ["squad.subagent.name"] = envelope.SubagentName,
+                        ["squad.subagent.sdk_agent_id"] = envelope.SdkAgentId,
+                    }));
+                completedActivity.SetStatus(isFailure ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
+                completedActivity.Dispose();
+            }
         }
 
         // Deliver the typed event to the consumer last so any consumer-side side effects (logging,

--- a/test/Squad.Agents.AI.Tests/SquadAgentDefaultObservabilityTests.cs
+++ b/test/Squad.Agents.AI.Tests/SquadAgentDefaultObservabilityTests.cs
@@ -1,0 +1,286 @@
+using System.Diagnostics;
+using GitHub.Copilot;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Squad.Agents.AI.Tests;
+
+/// <summary>
+/// Tests for the 0.4.0 behaviours added on top of 0.3.0's typed-trace surface:
+///   - EmitSubagentActivities option (default-on telemetry, opt-out without losing callback)
+///   - ActivityEvents on the live subagent span (start / message / completed / failed)
+///   - Aspire-style direct connection-string name lookup (ConnectionStrings:{name})
+///     with a legacy fallback to ConnectionStrings:squad-{name}
+/// </summary>
+[Collection("SquadActivityListeners")]
+public class SquadAgentDefaultObservabilityTests
+{
+    private static SubagentStartedData StartedData(string name) => new()
+    {
+        AgentName = name,
+        AgentDisplayName = name,
+        AgentDescription = $"{name} test agent",
+        ToolCallId = $"toolu_{name.ToLowerInvariant()}",
+    };
+
+    private static SubagentCompletedData CompletedData(string name) => new()
+    {
+        AgentName = name,
+        AgentDisplayName = name,
+        ToolCallId = $"toolu_{name.ToLowerInvariant()}",
+    };
+
+    private static SubagentFailedData FailedData(string name) => new()
+    {
+        AgentName = name,
+        AgentDisplayName = name,
+        ToolCallId = $"toolu_{name.ToLowerInvariant()}",
+        Error = "test failure",
+    };
+
+    private static AssistantMessageData AssistantData(string content) => new()
+    {
+        Content = content,
+        MessageId = Guid.NewGuid().ToString("n"),
+    };
+
+    // ── EmitSubagentActivities option ───────────────────────────────────────
+
+    [Fact]
+    public void Mapper_EmitsActivities_ByDefault_EvenWhenOnTraceIsNull()
+    {
+        Activity? started = null;
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a => started = a,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var mapper = new SquadSubagentTraceMapper(onTrace: null, emitActivities: true);
+        mapper.OnSessionEvent(new SubagentStartedEvent
+        {
+            AgentId = "toolu_default_1",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = StartedData("Morpheus"),
+        });
+
+        Assert.NotNull(started);
+        Assert.Equal("squad.subagent Morpheus", started!.OperationName);
+    }
+
+    [Fact]
+    public void Mapper_DoesNotEmitActivities_WhenEmitActivitiesIsFalse_ButStillFiresCallback()
+    {
+        var callbackInvoked = false;
+        var activityStarted = false;
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = _ => activityStarted = true,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var mapper = new SquadSubagentTraceMapper(
+            onTrace: _ => callbackInvoked = true,
+            emitActivities: false);
+
+        mapper.OnSessionEvent(new SubagentStartedEvent
+        {
+            AgentId = "toolu_optout_1",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = StartedData("Trinity"),
+        });
+
+        Assert.True(callbackInvoked, "Consumer callback must still fire when activities are disabled.");
+        Assert.False(activityStarted, "No span should be created when EmitSubagentActivities is false.");
+    }
+
+    [Fact]
+    public void Options_EmitSubagentActivities_DefaultsToTrue()
+    {
+        var options = new SquadAgentOptions();
+        Assert.True(options.EmitSubagentActivities);
+    }
+
+    // ── ActivityEvents at every lifecycle boundary ──────────────────────────
+
+    [Fact]
+    public void Mapper_AddsStartEvent_OnSubagentStarted()
+    {
+        var events = CollectEvents(() =>
+        {
+            using var mapper = new SquadSubagentTraceMapper(onTrace: null, emitActivities: true);
+            mapper.OnSessionEvent(new SubagentStartedEvent
+            {
+                AgentId = "toolu_evt_start",
+                Timestamp = DateTimeOffset.UtcNow,
+                Data = StartedData("Oracle"),
+            });
+            mapper.Dispose();
+        });
+
+        Assert.Contains(events, e => e.Name == "squad.subagent.start");
+    }
+
+    [Fact]
+    public void Mapper_AddsMessageEvent_OnAssistantMessage_WithPreviewTag()
+    {
+        var events = CollectEvents(() =>
+        {
+            using var mapper = new SquadSubagentTraceMapper(onTrace: null, emitActivities: true);
+            mapper.OnSessionEvent(new SubagentStartedEvent
+            {
+                AgentId = "toolu_evt_msg",
+                Timestamp = DateTimeOffset.UtcNow,
+                Data = StartedData("Tank"),
+            });
+            mapper.OnSessionEvent(new AssistantMessageEvent
+            {
+                AgentId = "toolu_evt_msg",
+                Timestamp = DateTimeOffset.UtcNow,
+                Data = AssistantData("running the program now"),
+            });
+            mapper.OnSessionEvent(new SubagentCompletedEvent
+            {
+                AgentId = "toolu_evt_msg",
+                Timestamp = DateTimeOffset.UtcNow,
+                Data = CompletedData("Tank"),
+            });
+        });
+
+        var msgEvent = events.FirstOrDefault(e => e.Name == "squad.subagent.message");
+        Assert.NotEqual(default, msgEvent);
+        var preview = msgEvent.Tags.FirstOrDefault(kv => kv.Key == "squad.subagent.message_preview").Value;
+        Assert.Equal("running the program now", preview);
+    }
+
+    [Fact]
+    public void Mapper_AddsCompletedEvent_OnSubagentCompleted()
+    {
+        var events = CollectEvents(() =>
+        {
+            using var mapper = new SquadSubagentTraceMapper(onTrace: null, emitActivities: true);
+            mapper.OnSessionEvent(new SubagentStartedEvent
+            {
+                AgentId = "toolu_evt_ok",
+                Timestamp = DateTimeOffset.UtcNow,
+                Data = StartedData("Picard"),
+            });
+            mapper.OnSessionEvent(new SubagentCompletedEvent
+            {
+                AgentId = "toolu_evt_ok",
+                Timestamp = DateTimeOffset.UtcNow,
+                Data = CompletedData("Picard"),
+            });
+        });
+
+        Assert.Contains(events, e => e.Name == "squad.subagent.completed");
+    }
+
+    [Fact]
+    public void Mapper_AddsFailedEvent_OnSubagentFailed()
+    {
+        var events = CollectEvents(() =>
+        {
+            using var mapper = new SquadSubagentTraceMapper(onTrace: null, emitActivities: true);
+            mapper.OnSessionEvent(new SubagentStartedEvent
+            {
+                AgentId = "toolu_evt_fail",
+                Timestamp = DateTimeOffset.UtcNow,
+                Data = StartedData("Worf"),
+            });
+            mapper.OnSessionEvent(new SubagentFailedEvent
+            {
+                AgentId = "toolu_evt_fail",
+                Timestamp = DateTimeOffset.UtcNow,
+                Data = FailedData("Worf"),
+            });
+        });
+
+        Assert.Contains(events, e => e.Name == "squad.subagent.failed");
+    }
+
+    private static List<ActivityEvent> CollectEvents(Action action)
+    {
+        var allEvents = new List<ActivityEvent>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = a => allEvents.AddRange(a.Events),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        action();
+        return allEvents;
+    }
+
+    // ── Connection-string lookup chain ──────────────────────────────────────
+
+    [Fact]
+    public void Configurator_PrefersDirectNameOverPrefixedName_AspireStyle()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:research-squad"] = @"C:\aspire-research",
+                ["ConnectionStrings:squad-research-squad"] = @"C:\legacy-fallback",
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSquadAgent("research-squad");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<SquadAgentOptions>>().Get("research-squad");
+
+        Assert.Equal(@"C:\aspire-research", options.SquadFolderPath);
+    }
+
+    [Fact]
+    public void Configurator_FallsBackToLegacyPrefixedName_WhenDirectNameMissing()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:squad-research"] = @"C:\legacy-team",
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSquadAgent("research");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<SquadAgentOptions>>().Get("research");
+
+        Assert.Equal(@"C:\legacy-team", options.SquadFolderPath);
+    }
+
+    [Fact]
+    public void KeyedConfigurator_PrefersDirectNameOverPrefixedName_AspireStyle()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:dev-squad"] = @"C:\aspire-dev",
+                ["ConnectionStrings:squad-dev-squad"] = @"C:\should-not-win",
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddKeyedSquadAgent("dev-squad");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<SquadAgentOptions>>().Get("dev-squad");
+
+        Assert.Equal(@"C:\aspire-dev", options.SquadFolderPath);
+    }
+}

--- a/test/Squad.Agents.AI.Tests/SquadSubagentTraceTests.cs
+++ b/test/Squad.Agents.AI.Tests/SquadSubagentTraceTests.cs
@@ -9,6 +9,7 @@ namespace Squad.Agents.AI.Tests;
 /// Mapper is exercised directly via InternalsVisibleTo so tests stay hermetic
 /// (no live CLI session); a real end-to-end smoke test runs through the sample.
 /// </summary>
+[Collection("SquadActivityListeners")]
 public class SquadSubagentTraceTests
 {
     private static SubagentStartedData MakeStartedData(string name, string? displayName = null) => new()


### PR DESCRIPTION
## Summary

Two small but high-impact changes that remove ~30 lines of boilerplate from every consumer (Aspire and otherwise) and make the OpenTelemetry story self-explanatory.

### 1. `EmitSubagentActivities` (default `true`) — telemetry independent of callback

Today the per-subagent OTel `Activity` emission is a side-effect of setting `OnSubagentTrace`. A host that just wants `squad.subagent {Name}` spans in their backend has to wire a callback they don't need. `Microsoft.Agents.AI.Squad` is silent until then.

**0.4.0 makes activity emission the default:**

- New `SquadAgentOptions.EmitSubagentActivities` (defaults to `true`).
- `SquadAgent` installs `SquadSubagentTraceMapper` whenever `EmitSubagentActivities || OnSubagentTrace != null`, so spans flow with zero extra wiring.
- `OnSubagentTrace` becomes a pure customisation hook (logging, dashboards, metrics) — independent of telemetry. Set `EmitSubagentActivities = false` to opt out of built-in spans.

**Richer span shape**: every lifecycle phase is now an `ActivityEvent` on the live subagent span (visible as annotated markers on the timeline in Aspire / Jaeger / etc.):

- `squad.subagent.start`     — on SubagentStarted
- `squad.subagent.message`   — on AssistantMessage (with `message_preview` tag)
- `squad.subagent.completed` — on SubagentCompleted
- `squad.subagent.failed`    — on SubagentFailed

Net effect for a consumer:

```csharp
builder.Services.AddOpenTelemetry()
    .WithTracing(t => t.AddSource(SquadAgentDiagnostics.ActivitySourceName));
builder.Services.AddSquadAgent(o => o.SquadFolderPath = "/team");
```

…and the dashboard lights up. No callback wiring, no `Activity.Current?.AddEvent` plumbing in the host.

### 2. Aspire-style connection-string lookup (with legacy fallback)

Aspire injects connection strings under the literal resource name — e.g. `builder.AddSquad("research-squad", ...)` exposes `ConnectionStrings:research-squad` to the consumer. The 0.3.0 SDK only looked at `ConnectionStrings:squad-research-squad` (prefixed), so Aspire consumers had to manually call `Configuration.GetConnectionString(name)`, parse the URI, and feed `SquadFolderPath` into the configure callback themselves.

**0.4.0 tries the literal name first and falls back to the legacy prefixed form:**

| Style | Example | Looks up |
|---|---|---|
| **Aspire-style direct** (tried first) | `AddSquadAgent("research-squad")` | `ConnectionStrings:research-squad` |
| **Legacy prefixed fallback** | `AddSquadAgent("research")` | `ConnectionStrings:squad-research` |

Both work. Existing consumers using `ConnectionStrings:squad-{name}` continue unchanged; new Aspire consumers get the natural one-line registration.

## Tests

54 → 64 tests, all passing on `net8.0`/`net9.0`/`net10.0`.

New `SquadAgentDefaultObservabilityTests` covers:

- Default-on activity emission (without consumer callback)
- Opt-out path (`EmitSubagentActivities = false`) — span suppression + callback still fires
- Each `ActivityEvent` name (`start` / `message` / `completed` / `failed`)
- Connection-string precedence: Aspire-direct preferred, prefixed fallback used, same rule applies for keyed registrations

Existing `SquadSubagentTraceTests` and the new class share an `[Collection(""SquadActivityListeners"")]` so they run serially — process-global `ActivityListener` state caused cross-test pollution otherwise.

## Backward compatibility

**Fully backward compatible.** The two-arg `SquadSubagentTraceMapper` constructor defaults `emitActivities` to `true`, `EmitSubagentActivities` defaults to `true`, and the legacy `ConnectionStrings:squad-{name}` lookup still resolves.

- Existing consumer with `OnSubagentTrace` set → no change in behaviour (mapper runs in both 0.3.0 and 0.4.0 because `OnSubagentTrace` is non-null).
- Existing consumer with `AddSource(...)` but no `OnSubagentTrace` → **gains** the spans they always asked for.

## Real-world motivation

This came out of building the `CommunityToolkit.Aspire.Hosting.Squad` example (https://github.com/CommunityToolkit/Aspire/pull/1394). The 0.3.0 consumer code needed:

```csharp
var cs = builder.Configuration.GetConnectionString(""research-squad"")
    ?? throw new InvalidOperationException(""Missing connection string ..."");
var root = ParseSquadTeamRoot(cs)
    ?? throw new InvalidOperationException(""Could not parse teamRoot ..."");
builder.Services.AddKeyedSquadAgent(""research"", opts =>
{
    opts.SquadFolderPath = root;
    opts.OnSubagentTrace = trace => { /* needed just to enable spans */ };
});
```

With 0.4.0 this collapses to:

```csharp
builder.Services.AddKeyedSquadAgent(""research-squad"");
```

…and the OTel spans appear in the Aspire dashboard automatically.