### PR TITLE
fix(sdk): wire team.md/routing.md/casting state on \squad preset apply\ (#1288)

### DIFF
--- a/.changeset/preset-apply-wires-team-1288.md
+++ b/.changeset/preset-apply-wires-team-1288.md
@@ -1,0 +1,38 @@
+---
+"@bradygaster/squad-sdk": patch
+"@bradygaster/squad-cli": patch
+---
+
+Fix #1288: `squad preset apply` now wires team.md, routing.md, and casting state
+
+`squad preset apply <name>` used to copy only the preset's agent charters into `.squad/agents/`. It left:
+
+- `.squad/team.md` `## Members` table empty
+- `.squad/routing.md` with no Work Type rows for the preset agents
+- `.squad/casting/registry.json`, `history.json`, and `policy.json` not created
+
+Net result: the coordinator's mode-switch check saw an empty `## Members` table and treated every session as **Init Mode**, proposing to re-scaffold a team the user already applied — defeating the entire purpose of presets.
+
+This change adds a new merge-friendly scaffold module (`packages/squad-sdk/src/presets/scaffold.ts`) that, after `applyPreset` copies the charters, wires the preset agents into:
+
+- **team.md** `## Members` — creates the file from scratch if missing, or merges new rows into an existing `## Members` table while preserving the surrounding content (Coordinator section, Project Context, etc.). Idempotent: a second apply does not duplicate rows.
+- **routing.md** `## Work Type → Agent` — creates from scratch or appends new rows after the existing routing table. Each preset agent becomes `| <role> | <name> | — |`.
+- **casting/registry.json** — merges new agents into an existing registry without clobbering pre-existing entries. Universe = `preset:<name>` so future casts can distinguish preset-provided agents.
+- **casting/history.json** — appends a preset-application snapshot and a universe_usage_history entry.
+- **casting/policy.json** — created with sensible defaults only if missing; never overwrites an existing policy.
+
+Failure modes:
+
+- Agents with `status: 'error'` in the per-agent results (e.g., source dir missing) are excluded from the wiring step.
+- Agents with `status: 'skipped'` (already exist in target) ARE wired into team.md/registry so the team reflects user intent.
+- If the scaffolding itself throws (e.g., disk error), a synthetic error result is appended to the return value so the CLI can surface it; per-agent install results are preserved.
+
+Out of scope (tracked separately): deduplicating these writers with the equivalent fresh-write versions in `packages/squad-cli/src/cli/core/cast.ts`. A future refactor can move both call sites to the shared SDK module.
+
+Test coverage in `test/presets.test.ts`:
+- `wires preset agents into team.md ## Members (#1288)`
+- `merges preset agents into an existing team.md without duplicating rows (#1288)` — includes idempotency assertion
+- `writes casting registry.json, history.json, and policy.json (#1288)`
+- `appends routing rows for preset agents to routing.md (#1288)`
+
+Closes #1288

--- a/packages/squad-sdk/src/presets/index.ts
+++ b/packages/squad-sdk/src/presets/index.ts
@@ -14,7 +14,8 @@ import { readdirSync, statSync, lstatSync, rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { FSStorageProvider } from '../storage/fs-storage-provider.js';
 import { resolvePresetsDir, ensureSquadHome } from '../resolution.js';
-import type { PresetManifest, PresetApplyResult } from './types.js';
+import type { PresetManifest, PresetApplyResult, PresetAgent } from './types.js';
+import { scaffoldPresetIntoSquad } from './scaffold.js';
 
 export type { PresetManifest, PresetAgent, PresetApplyResult } from './types.js';
 
@@ -135,6 +136,31 @@ export function applyPreset(
       results.push({ agent: agent.name, status: 'installed' });
     } catch (err) {
       results.push({ agent: agent.name, status: 'error', reason: String(err) });
+    }
+  }
+
+  // After copying charters, wire the preset agents into team.md, routing.md,
+  // and the casting state files (registry/history/policy). Without this, the
+  // coordinator's mode-switch check sees an empty ## Members table and
+  // treats every session as Init Mode — see bradygaster/squad#1288. We only
+  // include agents that did not error out (installed + skipped-because-
+  // already-present) so the scaffolded team reflects the user's intent.
+  const wireableAgents: PresetAgent[] = manifest.agents.filter(a =>
+    results.some(r => r.agent === a.name && r.status !== 'error'),
+  );
+  if (wireableAgents.length > 0) {
+    const squadDir = path.dirname(targetDir);
+    try {
+      scaffoldPresetIntoSquad(squadDir, wireableAgents, presetName);
+    } catch (err) {
+      // Scaffolding failed but charters were copied — surface as a single
+      // synthetic error result so the CLI can warn but does not mask the
+      // per-agent install results.
+      results.push({
+        agent: presetName,
+        status: 'error',
+        reason: `Charters copied but failed to wire team.md/routing.md/casting state: ${String(err)}`,
+      });
     }
   }
 

--- a/packages/squad-sdk/src/presets/index.ts
+++ b/packages/squad-sdk/src/presets/index.ts
@@ -156,10 +156,18 @@ export function applyPreset(
       // Scaffolding failed but charters were copied — surface as a single
       // synthetic error result so the CLI can warn but does not mask the
       // per-agent install results.
+      //
+      // Use a clearly non-agent sentinel for the `agent` field (`<scaffold>`,
+      // wrapped in angle brackets which validateName rejects) instead of the
+      // preset name. The preset name is a legal agent name, and if a preset
+      // happens to ship an agent that shares the preset's name (`squad
+      // preset apply geektime` where the preset includes an agent literally
+      // called `geektime`), the consumer of the results could not tell the
+      // synthetic scaffold-failure row apart from a real per-agent error.
       results.push({
-        agent: presetName,
+        agent: '<scaffold>',
         status: 'error',
-        reason: `Charters copied but failed to wire team.md/routing.md/casting state: ${String(err)}`,
+        reason: `Charters copied (see per-agent rows above), but failed to wire team.md/routing.md/casting state for preset '${presetName}': ${String(err)}`,
       });
     }
   }

--- a/packages/squad-sdk/src/presets/scaffold.ts
+++ b/packages/squad-sdk/src/presets/scaffold.ts
@@ -31,11 +31,31 @@ interface ScaffoldOptions {
 }
 
 /**
+ * Map an agent's role to the Members-table Status cell.
+ *
+ * Mirrors the role-to-status mapping in `packages/squad-cli/src/cli/core/cast.ts:652-655`
+ * so a team produced by `preset apply` looks identical to one produced by
+ * a fresh cast — Scribe/Ralph/Rai/Fact-Checker each get their canonical
+ * status label instead of all rows being '✅ Active'. Per-role rather
+ * than per-name because presets may rename the agent but keep the role.
+ */
+function statusForRole(role: string): string {
+  // Case-insensitive comparison so presets that lowercase "session logger"
+  // still get the silent status.
+  const r = role.toLowerCase();
+  if (r === 'session logger' || r === 'scribe') return '📋 Silent';
+  if (r === 'work monitor' || r === 'ralph') return '🔄 Monitor';
+  if (r === 'rai reviewer' || r === 'rai') return '🛡️ RAI';
+  if (r === 'fact checker' || r === 'fact-checker') return '🔍 Verifier';
+  return '✅ Active';
+}
+
+/**
  * Build a single Members table row for a preset agent.
  */
 function memberRow(agent: PresetAgent): string {
   const nameLower = agent.name.toLowerCase();
-  return `| ${agent.name} | ${agent.role} | \`.squad/agents/${nameLower}/charter.md\` | ✅ Active |`;
+  return `| ${agent.name} | ${agent.role} | \`.squad/agents/${nameLower}/charter.md\` | ${statusForRole(agent.role)} |`;
 }
 
 /**

--- a/packages/squad-sdk/src/presets/scaffold.ts
+++ b/packages/squad-sdk/src/presets/scaffold.ts
@@ -1,0 +1,381 @@
+/**
+ * Preset application scaffolders.
+ *
+ * `applyPreset` copies agent charters into `.squad/agents/`, but to make the
+ * resulting squad usable by the coordinator (and to satisfy the post-init
+ * "Established Mode" mode-switch check) we must also wire the preset agents
+ * into team.md, routing.md, and the casting state files. These helpers do
+ * that in a merge-friendly way so calling `applyPreset` repeatedly is
+ * idempotent and does not clobber pre-existing rows or entries.
+ *
+ * The cast command (`packages/squad-cli/src/cli/core/cast.ts`) has its own
+ * fresh-write versions of these writers — see #1288 follow-up for a possible
+ * future refactor that shares the logic. For now, the scope of #1288 is
+ * focused on making preset apply produce a Coordinator-ready squad.
+ *
+ * @module presets/scaffold
+ */
+
+import path from 'node:path';
+import { FSStorageProvider } from '../storage/fs-storage-provider.js';
+import type { PresetAgent } from './types.js';
+
+const storage = new FSStorageProvider();
+
+const MEMBERS_HEADER = '## Members';
+const ROUTING_HEADER = '## Work Type → Agent';
+
+interface ScaffoldOptions {
+  /** Universe tag for the casting registry. Defaults to `preset:<name>`. */
+  universe: string;
+}
+
+/**
+ * Build a single Members table row for a preset agent.
+ */
+function memberRow(agent: PresetAgent): string {
+  const nameLower = agent.name.toLowerCase();
+  return `| ${agent.name} | ${agent.role} | \`.squad/agents/${nameLower}/charter.md\` | ✅ Active |`;
+}
+
+/**
+ * Build a single routing table row for a preset agent (work type = role).
+ */
+function routingRow(agent: PresetAgent): string {
+  return `| ${agent.role} | ${agent.name} | — |`;
+}
+
+/**
+ * Parse the existing Members table from team.md content (if any) and return
+ * the set of names already present (case-insensitive comparison key).
+ */
+function existingMemberNames(teamContent: string): Set<string> {
+  const names = new Set<string>();
+  const idx = teamContent.indexOf(MEMBERS_HEADER);
+  if (idx === -1) return names;
+  const afterHeader = teamContent.slice(idx + MEMBERS_HEADER.length);
+  const nextHeaderIdx = afterHeader.search(/\n## /);
+  const section = nextHeaderIdx === -1 ? afterHeader : afterHeader.slice(0, nextHeaderIdx);
+  // Match table rows: "| Name | Role | Charter | Status |"
+  // Skip header row and the separator row.
+  const rowRe = /^\|\s*([^|]+?)\s*\|/gm;
+  let match: RegExpExecArray | null;
+  while ((match = rowRe.exec(section)) !== null) {
+    const first = match[1]!.trim();
+    if (!first || first === 'Name' || /^-+$/.test(first)) continue;
+    names.add(first.toLowerCase());
+  }
+  return names;
+}
+
+/**
+ * Parse the existing routing table from routing.md content (if any) and
+ * return the set of agent names already present.
+ */
+function existingRoutingAgents(routingContent: string): Set<string> {
+  const names = new Set<string>();
+  const idx = routingContent.indexOf(ROUTING_HEADER);
+  if (idx === -1) return names;
+  const afterHeader = routingContent.slice(idx + ROUTING_HEADER.length);
+  const nextHeaderIdx = afterHeader.search(/\n## /);
+  const section = nextHeaderIdx === -1 ? afterHeader : afterHeader.slice(0, nextHeaderIdx);
+  // Routing rows: "| <Work Type> | <Primary> | <Secondary> |"
+  // We want the Primary column (2nd cell).
+  const rowRe = /^\|\s*[^|]+?\s*\|\s*([^|]+?)\s*\|/gm;
+  let match: RegExpExecArray | null;
+  while ((match = rowRe.exec(section)) !== null) {
+    const primary = match[1]!.trim();
+    if (!primary || primary === 'Primary' || /^-+$/.test(primary)) continue;
+    names.add(primary.toLowerCase());
+  }
+  return names;
+}
+
+/**
+ * Write or update `.squad/team.md` so its `## Members` table contains the
+ * preset's agents. Existing members are preserved; only new names are added.
+ * If team.md does not exist, a minimal one is created.
+ */
+function writeOrMergeTeamMembers(squadDir: string, agents: PresetAgent[], presetName: string): void {
+  const teamPath = path.join(squadDir, 'team.md');
+  const existing = storage.existsSync(teamPath) ? (storage.readSync(teamPath) ?? '') : '';
+
+  if (!existing) {
+    // Create from scratch (preset apply onto a bare .squad/ directory)
+    const fresh = [
+      '# Squad Team',
+      '',
+      `> Created by \`squad preset apply ${presetName}\``,
+      '',
+      '## Coordinator',
+      '',
+      '| Name | Role | Notes |',
+      '|------|------|-------|',
+      '| Squad | Coordinator | Routes work, enforces handoffs and reviewer gates. |',
+      '',
+      MEMBERS_HEADER,
+      '',
+      '| Name | Role | Charter | Status |',
+      '|------|------|---------|--------|',
+      ...agents.map(memberRow),
+      '',
+      '## Project Context',
+      '',
+      `- **Preset:** ${presetName}`,
+      `- **Created:** ${new Date().toISOString().split('T')[0]}`,
+      '',
+    ].join('\n');
+    storage.mkdirSync(squadDir, { recursive: true });
+    storage.writeSync(teamPath, fresh);
+    return;
+  }
+
+  // team.md exists — merge into existing ## Members table
+  const already = existingMemberNames(existing);
+  const newRows = agents
+    .filter(a => !already.has(a.name.toLowerCase()))
+    .map(memberRow);
+  if (newRows.length === 0) return; // nothing to do, all already present
+
+  const membersIdx = existing.indexOf(MEMBERS_HEADER);
+  if (membersIdx === -1) {
+    // No Members section — append one
+    const block = [
+      '',
+      MEMBERS_HEADER,
+      '',
+      '| Name | Role | Charter | Status |',
+      '|------|------|---------|--------|',
+      ...newRows,
+      '',
+    ].join('\n');
+    storage.writeSync(teamPath, existing.trimEnd() + '\n' + block);
+    return;
+  }
+
+  // Members section exists — find end of its table and insert rows there
+  const afterHeader = existing.slice(membersIdx);
+  const nextHeaderMatch = afterHeader.match(/\n## /);
+  const sectionEnd = nextHeaderMatch
+    ? membersIdx + (nextHeaderMatch.index ?? afterHeader.length)
+    : existing.length;
+  const section = existing.slice(membersIdx, sectionEnd);
+
+  // Find the last table row in the section (line starting with `|`)
+  const sectionLines = section.split('\n');
+  let lastTableLineRel = -1;
+  for (let i = sectionLines.length - 1; i >= 0; i--) {
+    if (sectionLines[i]!.trimStart().startsWith('|')) { lastTableLineRel = i; break; }
+  }
+
+  if (lastTableLineRel === -1) {
+    // Section has the header but no table — append a fresh table
+    const headerLines = [
+      '',
+      '| Name | Role | Charter | Status |',
+      '|------|------|---------|--------|',
+      ...newRows,
+      '',
+    ];
+    const newSection = MEMBERS_HEADER + '\n' + headerLines.join('\n') + '\n';
+    const updated = existing.slice(0, membersIdx) + newSection + existing.slice(sectionEnd);
+    storage.writeSync(teamPath, updated);
+    return;
+  }
+
+  // Append new rows after the last existing table row
+  const before = sectionLines.slice(0, lastTableLineRel + 1).join('\n');
+  const after = sectionLines.slice(lastTableLineRel + 1).join('\n');
+  const newSection = before + '\n' + newRows.join('\n') + (after ? '\n' + after : '\n');
+  const updated = existing.slice(0, membersIdx) + newSection + existing.slice(sectionEnd);
+  storage.writeSync(teamPath, updated);
+}
+
+/**
+ * Write or update `.squad/routing.md` so it includes a `## Work Type → Agent`
+ * table with the preset's agents. Existing rows are preserved; only new
+ * primary agents are added. If routing.md does not exist, a minimal one is
+ * created.
+ */
+function writeOrMergeRouting(squadDir: string, agents: PresetAgent[]): void {
+  const routingPath = path.join(squadDir, 'routing.md');
+  const existing = storage.existsSync(routingPath) ? (storage.readSync(routingPath) ?? '') : '';
+
+  if (!existing) {
+    const fresh = [
+      '# Squad Routing',
+      '',
+      ROUTING_HEADER,
+      '',
+      '| Work Type | Primary | Secondary |',
+      '|-----------|---------|----------|',
+      ...agents.map(routingRow),
+      '',
+      '## Governance',
+      '',
+      '- Route based on work type and agent expertise',
+      '- Update this file as team capabilities evolve',
+      '',
+    ].join('\n');
+    storage.mkdirSync(squadDir, { recursive: true });
+    storage.writeSync(routingPath, fresh);
+    return;
+  }
+
+  const already = existingRoutingAgents(existing);
+  const newRows = agents
+    .filter(a => !already.has(a.name.toLowerCase()))
+    .map(routingRow);
+  if (newRows.length === 0) return;
+
+  const headerIdx = existing.indexOf(ROUTING_HEADER);
+  if (headerIdx === -1) {
+    // Append a fresh routing block
+    const block = [
+      '',
+      ROUTING_HEADER,
+      '',
+      '| Work Type | Primary | Secondary |',
+      '|-----------|---------|----------|',
+      ...newRows,
+      '',
+    ].join('\n');
+    storage.writeSync(routingPath, existing.trimEnd() + '\n' + block);
+    return;
+  }
+
+  // Existing routing section — append new rows after its last table row
+  const afterHeader = existing.slice(headerIdx);
+  const nextHeaderMatch = afterHeader.match(/\n## /);
+  const sectionEnd = nextHeaderMatch
+    ? headerIdx + (nextHeaderMatch.index ?? afterHeader.length)
+    : existing.length;
+  const section = existing.slice(headerIdx, sectionEnd);
+  const sectionLines = section.split('\n');
+  let lastTableLineRel = -1;
+  for (let i = sectionLines.length - 1; i >= 0; i--) {
+    if (sectionLines[i]!.trimStart().startsWith('|')) { lastTableLineRel = i; break; }
+  }
+  if (lastTableLineRel === -1) {
+    const headerLines = [
+      '',
+      '| Work Type | Primary | Secondary |',
+      '|-----------|---------|----------|',
+      ...newRows,
+      '',
+    ];
+    const newSection = ROUTING_HEADER + '\n' + headerLines.join('\n') + '\n';
+    const updated = existing.slice(0, headerIdx) + newSection + existing.slice(sectionEnd);
+    storage.writeSync(routingPath, updated);
+    return;
+  }
+  const before = sectionLines.slice(0, lastTableLineRel + 1).join('\n');
+  const after = sectionLines.slice(lastTableLineRel + 1).join('\n');
+  const newSection = before + '\n' + newRows.join('\n') + (after ? '\n' + after : '\n');
+  const updated = existing.slice(0, headerIdx) + newSection + existing.slice(sectionEnd);
+  storage.writeSync(routingPath, updated);
+}
+
+/**
+ * Write or update `.squad/casting/registry.json`, `history.json`, and
+ * `policy.json` with entries for the preset's agents. Registry entries are
+ * merged (new agents added, existing entries left untouched). A new
+ * preset-apply snapshot is appended to history.json. policy.json is created
+ * with sensible defaults only if missing.
+ */
+function writeOrMergeCastingState(
+  squadDir: string,
+  agents: PresetAgent[],
+  options: ScaffoldOptions,
+): void {
+  const castingDir = path.join(squadDir, 'casting');
+  storage.mkdirSync(castingDir, { recursive: true });
+  const now = new Date().toISOString();
+
+  // ---- registry.json ----
+  const registryPath = path.join(castingDir, 'registry.json');
+  let registry: { agents: Record<string, unknown> } = { agents: {} };
+  if (storage.existsSync(registryPath)) {
+    try {
+      const raw = storage.readSync(registryPath) ?? '{}';
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && parsed.agents && typeof parsed.agents === 'object') {
+        registry = parsed as { agents: Record<string, unknown> };
+      }
+    } catch {
+      // Corrupt or unparsable — start fresh (don't lose preset wiring)
+      registry = { agents: {} };
+    }
+  }
+  for (const agent of agents) {
+    const key = agent.name.toLowerCase();
+    if (!(key in registry.agents)) {
+      registry.agents[key] = {
+        created_at: now,
+        persistent_name: agent.name,
+        universe: options.universe,
+        status: 'active',
+      };
+    }
+  }
+  storage.writeSync(registryPath, JSON.stringify(registry, null, 2) + '\n');
+
+  // ---- history.json ----
+  const historyPath = path.join(castingDir, 'history.json');
+  interface CastingHistory {
+    assignment_cast_snapshots: Record<string, { created_at: string; agents: string[]; universe: string }>;
+    universe_usage_history: Array<{ universe: string; used_at: string }>;
+  }
+  let history: CastingHistory = {
+    assignment_cast_snapshots: {},
+    universe_usage_history: [],
+  };
+  if (storage.existsSync(historyPath)) {
+    try {
+      const raw = storage.readSync(historyPath) ?? '{}';
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object') {
+        history = {
+          assignment_cast_snapshots: parsed.assignment_cast_snapshots ?? {},
+          universe_usage_history: parsed.universe_usage_history ?? [],
+        };
+      }
+    } catch {
+      // Keep the fresh defaults above
+    }
+  }
+  const snapshotKey = `preset-${options.universe}-${now}`;
+  history.assignment_cast_snapshots[snapshotKey] = {
+    created_at: now,
+    agents: agents.map(a => a.name.toLowerCase()),
+    universe: options.universe,
+  };
+  history.universe_usage_history.push({ universe: options.universe, used_at: now });
+  storage.writeSync(historyPath, JSON.stringify(history, null, 2) + '\n');
+
+  // ---- policy.json ----
+  const policyPath = path.join(castingDir, 'policy.json');
+  if (!storage.existsSync(policyPath)) {
+    const policy = { universe_allowlist: ['*'], max_capacity: 25 };
+    storage.writeSync(policyPath, JSON.stringify(policy, null, 2) + '\n');
+  }
+}
+
+/**
+ * Wire a preset's agents into team.md, routing.md, and casting state files.
+ *
+ * Call this after `applyPreset` has copied the agent charters. The function
+ * is merge-friendly: it preserves existing rows, agents, and snapshots, and
+ * only adds entries that aren't already present.
+ */
+export function scaffoldPresetIntoSquad(
+  squadDir: string,
+  agents: PresetAgent[],
+  presetName: string,
+): void {
+  if (agents.length === 0) return;
+  const universe = `preset:${presetName}`;
+  writeOrMergeTeamMembers(squadDir, agents, presetName);
+  writeOrMergeRouting(squadDir, agents);
+  writeOrMergeCastingState(squadDir, agents, { universe });
+}

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -331,6 +331,157 @@ describe('applyPreset()', () => {
     const results = applyPreset('nope', '/tmp/anywhere');
     expect(results[0]!.status).toBe('error');
   });
+
+  // Regression tests for bradygaster/squad#1288 — applyPreset must wire the
+  // preset agents into team.md, routing.md, and the casting state files so
+  // the coordinator's mode-switch check sees a populated ## Members table
+  // and skips Init Mode.
+
+  it('wires preset agents into team.md ## Members (#1288)', () => {
+    const homeDir = join(TMP, 'apply-team');
+    process.env['SQUAD_HOME'] = homeDir;
+
+    scaffold('apply-team/presets/starter/agents/dev', 'apply-team/presets/starter/agents/qa');
+    writeFile('apply-team/presets/starter/preset.json', JSON.stringify({
+      name: 'starter',
+      version: '1.0.0',
+      description: 'Starter preset',
+      agents: [
+        { name: 'dev', role: 'developer' },
+        { name: 'qa', role: 'reviewer' },
+      ],
+    }));
+    writeFile('apply-team/presets/starter/agents/dev/charter.md', '# Dev');
+    writeFile('apply-team/presets/starter/agents/qa/charter.md', '# QA');
+
+    const squadDir = join(TMP, 'target-team');
+    const agentsDir = join(squadDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+
+    applyPreset('starter', agentsDir);
+
+    const teamMd = readFileSync(join(squadDir, 'team.md'), 'utf-8');
+    expect(teamMd).toContain('## Members');
+    expect(teamMd).toContain('| dev | developer |');
+    expect(teamMd).toContain('| qa | reviewer |');
+    expect(teamMd).toContain('`.squad/agents/dev/charter.md`');
+    expect(teamMd).toContain('`.squad/agents/qa/charter.md`');
+  });
+
+  it('merges preset agents into an existing team.md without duplicating rows (#1288)', () => {
+    const homeDir = join(TMP, 'apply-team-merge');
+    process.env['SQUAD_HOME'] = homeDir;
+
+    scaffold('apply-team-merge/presets/starter/agents/qa');
+    writeFile('apply-team-merge/presets/starter/preset.json', JSON.stringify({
+      name: 'starter',
+      version: '1.0.0',
+      description: 'Starter preset',
+      agents: [{ name: 'qa', role: 'reviewer' }],
+    }));
+    writeFile('apply-team-merge/presets/starter/agents/qa/charter.md', '# QA');
+
+    const squadDir = join(TMP, 'target-team-merge');
+    const agentsDir = join(squadDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    // Pre-existing team.md from a prior squad init/cast with one member
+    writeFileSync(join(squadDir, 'team.md'), [
+      '# Squad Team',
+      '',
+      '## Coordinator',
+      '',
+      '| Name | Role | Notes |',
+      '|------|------|-------|',
+      '| Squad | Coordinator | Routes work. |',
+      '',
+      '## Members',
+      '',
+      '| Name | Role | Charter | Status |',
+      '|------|------|---------|--------|',
+      '| Picard | Lead | `.squad/agents/picard/charter.md` | ✅ Active |',
+      '',
+      '## Project Context',
+      '',
+      '- **Project:** Existing',
+      '',
+    ].join('\n'));
+
+    applyPreset('starter', agentsDir);
+
+    const teamMd = readFileSync(join(squadDir, 'team.md'), 'utf-8');
+    expect(teamMd).toContain('| Picard | Lead |');
+    expect(teamMd).toContain('| qa | reviewer |');
+    expect(teamMd).toContain('## Project Context'); // section after Members preserved
+
+    // Idempotency: a second apply must not duplicate the qa row
+    applyPreset('starter', agentsDir);
+    const teamMdAfter = readFileSync(join(squadDir, 'team.md'), 'utf-8');
+    const qaCount = (teamMdAfter.match(/\| qa \| reviewer \|/g) ?? []).length;
+    expect(qaCount).toBe(1);
+  });
+
+  it('writes casting registry.json, history.json, and policy.json (#1288)', () => {
+    const homeDir = join(TMP, 'apply-casting');
+    process.env['SQUAD_HOME'] = homeDir;
+
+    scaffold('apply-casting/presets/starter/agents/dev');
+    writeFile('apply-casting/presets/starter/preset.json', JSON.stringify({
+      name: 'starter',
+      version: '1.0.0',
+      description: 'Starter preset',
+      agents: [{ name: 'dev', role: 'developer' }],
+    }));
+    writeFile('apply-casting/presets/starter/agents/dev/charter.md', '# Dev');
+
+    const squadDir = join(TMP, 'target-casting');
+    const agentsDir = join(squadDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+
+    applyPreset('starter', agentsDir);
+
+    const registry = JSON.parse(readFileSync(join(squadDir, 'casting', 'registry.json'), 'utf-8'));
+    expect(registry.agents).toHaveProperty('dev');
+    expect(registry.agents.dev.persistent_name).toBe('dev');
+    expect(registry.agents.dev.universe).toBe('preset:starter');
+    expect(registry.agents.dev.status).toBe('active');
+
+    const history = JSON.parse(readFileSync(join(squadDir, 'casting', 'history.json'), 'utf-8'));
+    expect(Object.keys(history.assignment_cast_snapshots).length).toBeGreaterThan(0);
+    const firstSnapshot = Object.values<{ agents: string[]; universe: string }>(
+      history.assignment_cast_snapshots,
+    )[0]!;
+    expect(firstSnapshot.agents).toContain('dev');
+    expect(firstSnapshot.universe).toBe('preset:starter');
+    expect(history.universe_usage_history.length).toBeGreaterThan(0);
+
+    const policy = JSON.parse(readFileSync(join(squadDir, 'casting', 'policy.json'), 'utf-8'));
+    expect(policy.universe_allowlist).toContain('*');
+    expect(policy.max_capacity).toBeGreaterThan(0);
+  });
+
+  it('appends routing rows for preset agents to routing.md (#1288)', () => {
+    const homeDir = join(TMP, 'apply-routing');
+    process.env['SQUAD_HOME'] = homeDir;
+
+    scaffold('apply-routing/presets/starter/agents/dev');
+    writeFile('apply-routing/presets/starter/preset.json', JSON.stringify({
+      name: 'starter',
+      version: '1.0.0',
+      description: 'Starter preset',
+      agents: [{ name: 'dev', role: 'developer' }],
+    }));
+    writeFile('apply-routing/presets/starter/agents/dev/charter.md', '# Dev');
+
+    const squadDir = join(TMP, 'target-routing');
+    const agentsDir = join(squadDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+
+    applyPreset('starter', agentsDir);
+
+    const routing = readFileSync(join(squadDir, 'routing.md'), 'utf-8');
+    expect(routing).toContain('## Work Type → Agent');
+    expect(routing).toContain('| developer | dev |');
+  });
 });
 
 // ============================================================================

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -459,6 +459,55 @@ describe('applyPreset()', () => {
     expect(policy.max_capacity).toBeGreaterThan(0);
   });
 
+  it('preserves built-in role status labels in team.md (Scribe/Ralph/Rai/Fact Checker) — review on #1293', () => {
+    // A preset that happens to ship one of the always-on built-ins (Scribe,
+    // Ralph, Rai, Fact Checker) must produce the same Status cell that a
+    // fresh `squad init` cast would — '📋 Silent', '🔄 Monitor', '🛡️ RAI',
+    // '🔍 Verifier' respectively — NOT '✅ Active'. Pre-fix, memberRow()
+    // hardcoded '✅ Active' for every preset agent, which made
+    // preset-scaffolded teams visually disagree with cast-scaffolded teams
+    // for the same roster.
+    const homeDir = join(TMP, 'apply-status-roles');
+    process.env['SQUAD_HOME'] = homeDir;
+
+    scaffold(
+      'apply-status-roles/presets/builtins/agents/scribe',
+      'apply-status-roles/presets/builtins/agents/ralph',
+      'apply-status-roles/presets/builtins/agents/rai',
+      'apply-status-roles/presets/builtins/agents/fact-checker',
+      'apply-status-roles/presets/builtins/agents/dev',
+    );
+    writeFile('apply-status-roles/presets/builtins/preset.json', JSON.stringify({
+      name: 'builtins',
+      version: '1.0.0',
+      description: 'Preset that ships built-in roles',
+      agents: [
+        { name: 'scribe', role: 'Session Logger' },
+        { name: 'ralph', role: 'Work Monitor' },
+        { name: 'rai', role: 'RAI Reviewer' },
+        { name: 'fact-checker', role: 'Fact Checker' },
+        { name: 'dev', role: 'developer' },
+      ],
+    }));
+    for (const a of ['scribe', 'ralph', 'rai', 'fact-checker', 'dev']) {
+      writeFile(`apply-status-roles/presets/builtins/agents/${a}/charter.md`, `# ${a}`);
+    }
+
+    const squadDir = join(TMP, 'target-status-roles');
+    const agentsDir = join(squadDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+
+    applyPreset('builtins', agentsDir);
+
+    const teamMd = readFileSync(join(squadDir, 'team.md'), 'utf-8');
+    expect(teamMd).toContain('| scribe | Session Logger | `.squad/agents/scribe/charter.md` | 📋 Silent |');
+    expect(teamMd).toContain('| ralph | Work Monitor | `.squad/agents/ralph/charter.md` | 🔄 Monitor |');
+    expect(teamMd).toContain('| rai | RAI Reviewer | `.squad/agents/rai/charter.md` | 🛡️ RAI |');
+    expect(teamMd).toContain('| fact-checker | Fact Checker | `.squad/agents/fact-checker/charter.md` | 🔍 Verifier |');
+    // Regular agent still gets ✅ Active.
+    expect(teamMd).toContain('| dev | developer | `.squad/agents/dev/charter.md` | ✅ Active |');
+  });
+
   it('appends routing rows for preset agents to routing.md (#1288)', () => {
     const homeDir = join(TMP, 'apply-routing');
     process.env['SQUAD_HOME'] = homeDir;


### PR DESCRIPTION
`squad preset apply <name>` used to copy only the preset's agent charters into `.squad/agents/`. It left:

* `.squad/team.md` `## Members` table empty
* `.squad/routing.md` with no `## Work Type → Agent` rows
* `.squad/casting/registry.json`, `history.json`, `policy.json` not created

Net result: the Coordinator's mode-switch check saw an empty Members table and treated every session as **Init Mode**, proposing to re-scaffold the team the user already applied — defeating the entire purpose of presets. Verified end-to-end against `squad v0.10.0` + `squad preset apply geektime` per #1288.

## Fix

New merge-friendly scaffold module `packages/squad-sdk/src/presets/scaffold.ts` runs after `applyPreset` copies charters and wires preset agents into all the state files the Coordinator depends on:

* **team.md `## Members`** — creates from scratch if missing, else appends new rows to an existing table while preserving the surrounding `## Coordinator` and `## Project Context` sections. Idempotent: re-applying the same preset does not duplicate rows (regex-based detection by name, case-insensitive).
* **routing.md `## Work Type → Agent`** — creates or appends. Each preset agent becomes `| <role> | <name> | — |`.
* **casting/registry.json** — merges new agents into existing dict without clobbering. `universe` is set to `preset:<name>` so subsequent casts can distinguish preset-provided agents.
* **casting/history.json** — appends a preset-application snapshot (`preset-<universe>-<iso>`) and a `universe_usage_history` entry. Existing snapshots preserved.
* **casting/policy.json** — defaults written only if missing; never clobbers an existing policy.

### Failure-mode semantics

| Per-agent status | Wired into team.md/registry? |
|-----------------|------------------------------|
| `installed` | Yes |
| `skipped` (already exists in target) | Yes — reflects user intent that this agent is part of the team |
| `error` | No |

If the scaffolder itself throws (disk/io error), a synthetic error result is appended to the return value so the CLI surfaces it; the per-agent install results are preserved.

## Verification

* `npm run lint` — passes
* `test/presets.test.ts` — 28/28 pass including 4 new regression tests:
  - `wires preset agents into team.md ## Members (#1288)`
  - `merges preset agents into an existing team.md without duplicating rows (#1288)` — explicit idempotency assertion
  - `writes casting registry.json, history.json, and policy.json (#1288)`
  - `appends routing rows for preset agents to routing.md (#1288)`

## Out of scope (tracked separately)

Deduplicating these writers with the equivalent fresh-write versions in `packages/squad-cli/src/cli/core/cast.ts`. A future refactor can move both call sites to the shared SDK module so cast and preset apply use the same helpers.

Closes #1288
