### PR TITLE
feat(sdk): bundle cross-squad-communication skill (#5 cross-squad protocols)

### DIFF
--- a/.changeset/wire-cross-squad-communication-skill.md
+++ b/.changeset/wire-cross-squad-communication-skill.md
@@ -1,0 +1,53 @@
+---
+"@bradygaster/squad-sdk": minor
+"@bradygaster/squad-cli": minor
+---
+
+Add **cross-squad-communication** as a built-in skill (companion to cross-squad)
+
+The merged registry work (#1291) added `squad registry add/list/remove` and the `cross-squad/SKILL.md` for discovery. But discovery is only half the story — once a peer squad is known, agents need to know **how** to actually exchange information with it (sync CLI sessions, async git-based requests, issue-based delegation).
+
+This change ports `cross-squad-communication` from [tamirdresher/squad-skills](https://github.com/tamirdresher/squad-skills/tree/main/plugins/cross-squad-communication) into Squad's bundled skills so a fresh `squad init` produces a coordinator that already knows the four communication patterns. The plugin was validated against two production squad instances (one GitHub-hosted, one Azure DevOps-hosted) before being ported.
+
+**What this skill teaches**
+
+| Pattern | When to use |
+|---|---|
+| Pattern 0: Synchronous CLI session | Quick knowledge queries — spawn `copilot` with `--working-directory` set to target repo |
+| Pattern 1: Read-only metadata scan | "What's the architecture of squad X?" — read their `team.md` / `decisions.md` directly |
+| Pattern 2: Async git-based request/response | Long-running work, PR reviews, multi-cycle tasks. Request files in `.squad/cross-squad/requests/`, response files in `.squad/cross-squad/responses/`. |
+| Pattern 3: Issue-based delegation | GitHub-hosted repos — `gh issue create` with `squad:cross-squad` label as the message bus |
+
+Plus: decision tree for choosing the right pattern, anti-patterns, request/response YAML format, and validation status.
+
+**Changes**
+
+- New `.squad/skills/cross-squad-communication/SKILL.md` (canonical source). `sync-skill-templates.mjs` (prebuild) propagates to both `packages/squad-cli/templates/skills/` and `packages/squad-sdk/templates/skills/`.
+- `MANIFEST_SKILL_NAMES` in `packages/squad-sdk/src/config/init.ts` grows by 1 entry: `cross-squad-communication`. Now 11 entries.
+- `cross-squad/SKILL.md` (the registry-aware skill from #1291) gets a one-paragraph "Companion skill" note at the top pointing to `cross-squad-communication` for protocol details. The two skills are designed to be used together: `cross-squad` answers "who?" (discovery via registry), `cross-squad-communication` answers "how?" (the 4 communication patterns).
+
+**Genericization**
+
+The original plugin documented validation against specific internal Microsoft repositories. Examples in this version use generic names (`platform-squad`, `research-squad`, etc.) so they're meaningful to all upstream users. The protocol mechanics are unchanged. The frontmatter `source:` attributes the port to `tamirdresher/squad-skills`.
+
+**Test coverage**
+
+New `test/init.test.ts > should install cross-squad-communication skill (companion to cross-squad — #5)`: asserts the SKILL.md ends up at `.copilot/skills/cross-squad-communication/SKILL.md` after `initSquad()` and that the content contains the expected pattern names. 26/26 init tests pass; `npm run lint` clean.
+
+**Composition with #1291**
+
+```bash
+# 1. Init produces a squad that already knows both skills
+squad init
+
+# 2. Register a peer squad (#1291)
+squad registry add ../peer-squad-repo
+
+# 3. Ask the coordinator: "what are the team members of the peer squad?"
+#    → The coordinator now has cross-squad-communication's Pattern 1 in scope
+#      and knows to read team.md from the registered peer
+```
+
+**Note on overlap with #1292**
+
+PR #1292 (skills bundling fix) adds `squad-commands`, `squad-version-check`, `tiered-memory`, `iterative-retrieval`, `reflect`, and `cross-squad` to `MANIFEST_SKILL_NAMES`. That PR and this one both modify the same array but add disjoint entries. When both merge, the manifest grows to 15 entries (10 base + 4 from #1292 + 1 from here). Either PR can land first.

--- a/.changeset/wire-cross-squad-communication-skill.md
+++ b/.changeset/wire-cross-squad-communication-skill.md
@@ -13,7 +13,7 @@ This change ports `cross-squad-communication` from [tamirdresher/squad-skills](h
 
 | Pattern | When to use |
 |---|---|
-| Pattern 0: Synchronous CLI session | Quick knowledge queries — spawn `copilot` with `--working-directory` set to target repo |
+| Pattern 0: Synchronous CLI session | Quick knowledge queries — spawn `copilot -C <target-repo>` with the prompt text via `-p (Get-Content $promptFile -Raw)` |
 | Pattern 1: Read-only metadata scan | "What's the architecture of squad X?" — read their `team.md` / `decisions.md` directly |
 | Pattern 2: Async git-based request/response | Long-running work, PR reviews, multi-cycle tasks. Request files in `.squad/cross-squad/requests/`, response files in `.squad/cross-squad/responses/`. |
 | Pattern 3: Issue-based delegation | GitHub-hosted repos — `gh issue create` with `squad:cross-squad` label as the message bus |

--- a/.squad/skills/cross-squad-communication/SKILL.md
+++ b/.squad/skills/cross-squad-communication/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: "cross-squad-communication"
+description: "Protocol for sending queries, delegating tasks, and sharing context between independent Squad instances across different repositories"
+domain: "multi-repo coordination"
+confidence: "medium"
+source: "Ported from tamirdresher/squad-skills (plugins/cross-squad-communication, validated against two production squad instances). Companion to the registry-aware cross-squad skill — this one teaches the actual communication protocols once a peer is discovered."
+---
+
+## Context
+
+When multiple repositories each have their own Squad (AI team), they need to exchange information: knowledge queries, PR reviews, task delegation, and dependency analysis. Each squad has its own agents, MCP tools, and issue tracker — there is no shared runtime.
+
+> **Companion skill — read first:** `cross-squad/SKILL.md` covers **discovery** of peer squads via `squad registry add/list/remove`. This skill picks up after a peer is known and covers the **communication protocols** themselves (sync CLI, async git, issue-based). The two are designed to be used together.
+
+**When this skill applies:**
+- A squad agent needs information from another squad-enabled repo
+- A task needs to be delegated to another squad
+- Cross-repo dependency analysis is needed
+- PR review requests span repo boundaries
+
+**Key constraint:** Each squad has its own runtime, MCP tools, and issue tracker. Cross-squad communication can be **synchronous** (via CLI session targeting the other repo) or **asynchronous** (file-based or issue-based). The coordinator decides which approach fits.
+
+---
+
+## Patterns
+
+### Decision Tree: Choosing the Right Pattern
+
+```
+Is the target repo cloned locally?
+├─ NO → Use Pattern 3 (Issue-Based) or Pattern 2 (Git-Based Async)
+└─ YES
+    ├─ Is this a quick query / knowledge lookup?
+    │   └─ YES → Use Pattern 0 (Synchronous CLI) — fastest
+    ├─ Does the work need to persist as artifacts?
+    │   └─ YES → Use Pattern 2 (Git-Based Async)
+    ├─ Is it a long-running analysis or multi-cycle task?
+    │   └─ YES → Use Pattern 2 (Git-Based Async)
+    └─ Is the target squad's Ralph running?
+        ├─ YES → Pattern 2 or 3 (async processing available)
+        └─ NO → Pattern 0 (Synchronous CLI) or Pattern 1 (Read-Only)
+```
+
+---
+
+### Pattern 0: Synchronous CLI Session (Fastest for Interactive Queries)
+
+For quick knowledge queries, decision lookups, or short analyses — spawn a Copilot CLI session with the working directory set to the target squad's repo. This lets you send a prompt and get a response within the same session, using the target repo's full context.
+
+This is the same technique used by `ralph-watch.ps1`: write the prompt to a temp file, then invoke the CLI with that file as input. The key insight is that setting the working directory to the target repo gives the CLI session access to that squad's `.squad/` metadata, codebase, and conventions.
+
+**Protocol:**
+1. Write prompt to a temp file (avoids argument-splitting issues, as learned in `ralph-watch.ps1`)
+2. Invoke CLI with `-p` pointing to the prompt file and `--working-directory` set to the target repo
+3. Receive response in the same session
+
+**Invocation:**
+```powershell
+# Spawn a Copilot CLI session targeting another squad's repo
+$targetRepo = "C:\repos\platform-squad-repo"
+$promptFile = New-TemporaryFile
+@"
+You are working in a Squad-enabled repository.
+Read .squad/team.md and .squad/decisions.md first.
+
+[CROSS-SQUAD REQUEST]
+From: research-squad
+Request Type: knowledge_query
+Query: What is the current architecture of the platform? What services does it expose?
+Response Format: Brief structured summary
+"@ | Out-File $promptFile -Encoding utf8
+
+# Option A: ghcs with prompt file
+ghcs -p $promptFile -- --working-directory $targetRepo
+
+# Option B: Start-Process for non-blocking (ralph-watch.ps1 style)
+Start-Process pwsh -ArgumentList "-NoProfile -Command `"cd '$targetRepo'; ghcs -p '$promptFile'`"" -Wait
+
+# Option C: Pipe directly
+"What is the platform architecture?" | ghcs -- --working-directory $targetRepo
+```
+
+**When to use synchronous vs async:**
+
+| Scenario | Pattern | Why |
+|----------|---------|-----|
+| Quick knowledge query | Synchronous CLI (Pattern 0) | Fast answer, no overhead |
+| "What did you decide about X?" | Synchronous CLI (Pattern 0) | Read decisions.md via the target squad's context |
+| PR review request | Either (Pattern 0 or 2/3) | Sync for quick feedback, async for thorough review |
+| Task delegation (do work in their repo) | Async (Pattern 2 or 3) | Work needs to persist beyond the session |
+| Long-running analysis | Async (Pattern 2) | May take multiple cycles |
+| Target repo not locally cloned | Async (Pattern 3) | Can't set working directory to a remote repo |
+
+**The coordinator decides which pattern to use based on:**
+1. Is the target repo cloned locally? → If yes, sync CLI is available
+2. Is this a quick query or a long task? → Quick = sync, long = async
+3. Does the work need to persist? → If yes, use async (creates artifacts)
+4. Is the target squad's Ralph running? → Needed for async processing
+
+**Requirements:**
+- Target repo must be cloned locally (for `--working-directory`)
+- Prompt file avoids argument-splitting bugs (see `ralph-watch.ps1` lines 2166-2184)
+
+**Response quality:** ⭐⭐⭐⭐⭐ — the CLI session has full context of the target repo, including code, squad metadata, and MCP tools.
+
+### Liveness Protocol for Pattern 0
+
+The synchronous CLI session requires monitoring to avoid false timeouts. With 7+ MCP servers initializing and `.squad/` metadata being read, startup can take 30-60 seconds. A hard timeout kills valid sessions before they complete. Instead, monitor the agency session's activity log directory.
+
+**Health Check Approach:**
+
+Instead of a fixed wall-clock timeout, monitor the agency session log directory for activity:
+
+```powershell
+# The agency CLI creates a session log directory
+# e.g., ~/.agency/logs/session_20260325_071211_57824
+$logDir = Get-ChildItem "$env:USERPROFILE\.agency\logs" -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$lastSize = 0
+$stallCount = 0
+
+while ($proc -and -not $proc.HasExited) {
+    Start-Sleep -Seconds 15
+    $currentSize = (Get-ChildItem $logDir -Recurse -File | Measure-Object -Property Length -Sum).Sum
+    
+    if ($currentSize -eq $lastSize) {
+        $stallCount++
+        if ($stallCount -ge 4) { # 60s with no progress
+            Write-Warning "Session stalled — no log activity for 60s"
+            break
+        }
+    } else {
+        $stallCount = 0
+        $lastSize = $currentSize
+    }
+}
+```
+
+**Progress Indicators (What Counts as "Alive"):**
+
+- New files appearing in the session log directory (e.g., `transcript.log`, `mcp-server-logs/`)
+- Log file size increasing (indicates active processing)
+- New or modified `.squad/` files in the target repo (e.g., `decisions/inbox.md`, `identity/history.md`)
+- Process still running and consuming non-idle CPU time
+
+**Stall Detection (When to Intervene):**
+
+- **No log activity for 60s** → Issue a warning; session may be slow but not hung
+- **No log activity for 120s** → Likely stuck; consider terminating and checking logs
+- **Process exited with non-zero exit code** → Failed; examine `transcript.log` and `stderr` for errors
+- **MCP server connection timeout** → Session blocked waiting for an MCP server response
+
+**Recovery Actions When Stalled:**
+
+1. **Check for user input waiting:** Inspect logs for prompts or dialogs (shouldn't happen with `--autopilot`)
+2. **Check MCP server health:** Review `mcp-server-logs/` for connection errors or timeouts
+3. **Retry with `--no-mcp` flag:** For lightweight queries that don't require MCP tools
+   ```powershell
+   # Retry without MCP servers — faster startup, limited capability
+   ghcs -p $promptFile -- --working-directory $targetRepo --no-mcp
+   ```
+4. **Increase timeout threshold:** If MCP server initialization is consistently slow (>90s), raise threshold before declaring stall
+
+---
+
+### Pattern 1: Read-Only Knowledge Query (No CLI Needed)
+
+For questions about another squad's architecture, decisions, or current state — read their `.squad/` metadata directly.
+
+**Protocol:**
+1. Read target repo's `.squad/team.md` → get stack, members, issue source
+2. Read `.squad/decisions.md` → get architectural decisions
+3. Read `.squad/routing.md` → understand who handles what
+4. Read `.squad/identity/now.md` → get current focus
+5. Scan code structure if needed (csproj files, directory layout)
+
+**Requirements:**
+- Target repo must be cloned locally or accessible via git
+- No authentication needed beyond git read access
+
+**Example:**
+```powershell
+# Query another squad's architecture
+$targetRepo = "C:\repos\platform-squad-repo"
+Get-Content "$targetRepo\.squad\team.md"
+Get-Content "$targetRepo\.squad\decisions.md"
+Get-Content "$targetRepo\.squad\identity\now.md"
+```
+
+**Response quality:** ⭐⭐⭐⭐ — excellent for structural/architectural questions.
+
+---
+
+### Pattern 2: Async Task Request (Git-Based)
+
+For work that needs the target squad to execute (PR reviews, issue analysis, code changes).
+
+**Protocol:**
+1. Create request file in YOUR repo: `.squad/cross-squad/requests/{timestamp}-{target}-{id}.yaml`
+2. Commit and push
+3. Target squad's Ralph detects on next cycle
+4. Target squad processes and writes response to their `.squad/cross-squad/responses/`
+5. Your Ralph picks up the response
+
+**Request File Format:**
+```yaml
+id: req-2026-06-13-001
+source_squad: research-squad
+source_repo: your-org/research-squad-repo
+target_squad: platform-squad
+target_repo: your-org/platform-squad-repo
+request_type: knowledge_query | pr_review | task_delegation | dependency_check
+priority: high | normal | low
+created_at: 2026-06-13T10:00:00Z
+query: "What is the current architecture of the platform?"
+routing_hint: "lead"  # optional — which agent should handle this
+status: pending
+```
+
+**Response File Format:**
+```yaml
+id: req-2026-06-13-001
+responding_squad: platform-squad
+responding_agent: lead
+responded_at: 2026-06-13T10:15:00Z
+status: completed | partial | rejected
+response: |
+  The platform architecture consists of...
+artifacts: []  # optional file paths
+```
+
+---
+
+### Pattern 3: Issue-Based Delegation (For GitHub-Hosted Repos)
+
+For repos on GitHub, use issues with labels as the message bus.
+
+**Protocol:**
+1. Create issue in target repo with label `squad:cross-squad`
+2. Include source squad identifier and routing hint in issue body
+3. Target squad's Ralph picks up and routes to appropriate agent
+4. Response posted as issue comment
+5. Issue closed when complete
+
+**Example:**
+```bash
+gh issue create \
+  --repo your-org/platform-squad-repo \
+  --title "[Cross-Squad] Architecture query from research-squad" \
+  --body "Source: research-squad\nQuery: What services does the platform expose?\nRouting: lead" \
+  --label "squad:cross-squad"
+```
+
+**Limitation:** Only works for repos on GitHub. Other platforms (Azure DevOps, GitLab, etc.) need different approach.
+
+---
+
+### Pattern 4: Cross-Repo Dependency Scan
+
+For discovering how two repos relate to each other.
+
+**Protocol:**
+1. Search both repos for mutual references:
+   ```powershell
+   Select-String -Path (Get-ChildItem $repoA -Recurse -Include "*.md","*.cs","*.json","*.csproj") `
+     -Pattern $repoB_name
+   Select-String -Path (Get-ChildItem $repoB -Recurse -Include "*.md","*.cs","*.json","*.csproj") `
+     -Pattern $repoA_name
+   ```
+2. Check shared NuGet packages / npm packages
+3. Check shared ADO project or GitHub org
+4. Document relationship type: code dependency, operational coupling, shared infra
+
+---
+
+## Discovery Protocol
+
+Before sending any cross-squad request, verify the target:
+
+```
+1. Does .squad/team.md exist?           → Squad is installed
+2. What is the issue_source?            → GitHub Issues | ADO | Planner
+3. What agents are active?              → Check member status column
+4. What is the routing table?           → Read routing.md
+5. What is the current focus?           → Read identity/now.md
+6. Is Ralph running?                    → Check for recent commits by Ralph
+```
+
+If `.squad/team.md` doesn't exist, the repo is not squad-enabled. Fall back to standard human communication.
+
+---
+
+## Platform Compatibility Matrix
+
+| Source Issue Tracker | Target Issue Tracker | Mechanism |
+|---------------------|---------------------|-----------|
+| GitHub Issues | GitHub Issues | Issue-based (Pattern 3) |
+| GitHub Issues | ADO Work Items | Git-based (Pattern 2) |
+| GitHub Issues | Planner | Git-based (Pattern 2) |
+| ADO Work Items | GitHub Issues | Issue-based (Pattern 3) via `gh` CLI |
+| ADO Work Items | ADO Work Items | ADO cross-project work items |
+| Any | Any | Git-based (Pattern 2) — universal fallback |
+
+---
+
+## Examples
+
+### Example 1: research-squad queries platform-squad architecture
+
+```powershell
+# Step 1: Read metadata (Pattern 1)
+$target = "C:\repos\platform-squad-repo"
+$team = Get-Content "$target\.squad\team.md" -Raw
+$decisions = Get-Content "$target\.squad\decisions.md" -Raw
+
+# Step 2: Extract answer from metadata
+# team.md reveals tech stack and member roles
+# decisions.md reveals architectural choices
+
+# Step 3: If deeper analysis needed, create async request (Pattern 2)
+```
+
+### Example 2: Request PR review from another squad
+
+```yaml
+# .squad/cross-squad/requests/2026-06-13-platform-squad-pr-review.yaml
+id: pr-review-001
+source_squad: research-squad
+target_squad: platform-squad
+request_type: pr_review
+priority: normal
+query: "Review PR #54 — package version fix. Check for correctness."
+routing_hint: "lead"
+status: pending
+```
+
+---
+
+## Anti-Patterns
+
+### ⚠️ Know when synchronous CLI is NOT the right choice
+```powershell
+# WRONG — don't use sync CLI for long-running tasks that need artifacts
+ghcs -p $promptFile -- --working-directory $targetRepo
+# If the task creates files, PRs, or takes multiple cycles → use async (Pattern 2 or 3)
+
+# WRONG — don't use sync CLI when the target repo isn't cloned locally
+ghcs -- --working-directory "C:\not\cloned\yet"
+# If the repo isn't available locally → use issue-based delegation (Pattern 3)
+```
+Synchronous CLI sessions (Pattern 0) are valid for quick queries and knowledge lookups. Use async patterns for work that needs to persist or where the target repo isn't available locally.
+
+### ❌ Don't assume shared MCP tools
+Each squad has its own MCP server instances. You cannot invoke another squad's ADO tools or GitHub tools from your session.
+
+### ❌ Don't skip the discovery step
+Always read `team.md` first. The target squad may use a different issue tracker, have different agents, or be in a different state than expected.
+
+### ❌ Don't send requests to squads without Ralph
+If the target squad doesn't have Ralph (Work Monitor) running, async requests will never be processed. Check for recent Ralph activity first.
+
+### ❌ Don't mix up repo platforms
+Different repos may use GitHub Issues vs Azure DevOps Work Items vs Jira. Check `team.md` / repository metadata for the right tooling before sending requests.
+
+---
+
+## Validation Status
+
+Originally designed and validated against two production squad instances (a GitHub-hosted platform squad with ~10 agents and an Azure DevOps-hosted automation squad with ~4 agents). The protocols are platform-agnostic; the examples in this document use generic names so you can substitute your own repos.
+
+| Scenario | Result |
+|----------|--------|
+| Knowledge query (read-only) | ✅ Works via Pattern 1 |
+| Step handler discovery | ✅ Works via file scan |
+| PR review (basic) | ⚠️ Partial — git log only, no API |
+| Backlog enumeration | ⚠️ Partial — depends on issue platform |
+| Dependency analysis | ✅ Works via cross-reference scan |
+| CLI invocation (sync) + Liveness Protocol | ✅ Works — session launches successfully; log monitoring prevents false timeouts |
+
+**Confidence: MEDIUM** — Synchronous CLI pattern (Pattern 0) validated end-to-end. Liveness protocol provides operational robustness against slow MCP initialization. Git-based async (Pattern 2) and issue-based (Pattern 3) untested end-to-end. Production readiness requires Ralph integration on both sides.

--- a/.squad/skills/cross-squad-communication/SKILL.md
+++ b/.squad/skills/cross-squad-communication/SKILL.md
@@ -3,14 +3,14 @@ name: "cross-squad-communication"
 description: "Protocol for sending queries, delegating tasks, and sharing context between independent Squad instances across different repositories"
 domain: "multi-repo coordination"
 confidence: "medium"
-source: "Ported from tamirdresher/squad-skills (plugins/cross-squad-communication, validated against two production squad instances). Companion to the registry-aware cross-squad skill — this one teaches the actual communication protocols once a peer is discovered."
+source: "Ported from tamirdresher/squad-skills (plugins/cross-squad-communication). Companion to the registry-aware cross-squad skill — this one teaches the actual communication protocols once a peer is discovered. Pattern 0 (synchronous CLI) is the only end-to-end-validated pattern; Patterns 1, 2, 3 are documented from design but require live validation against your own setup before relying on them in production. See the Validation Status section at the bottom of this skill."
 ---
 
 ## Context
 
 When multiple repositories each have their own Squad (AI team), they need to exchange information: knowledge queries, PR reviews, task delegation, and dependency analysis. Each squad has its own agents, MCP tools, and issue tracker — there is no shared runtime.
 
-> **Companion skill — read first:** `cross-squad/SKILL.md` covers **discovery** of peer squads via `squad registry add/list/remove`. This skill picks up after a peer is known and covers the **communication protocols** themselves (sync CLI, async git, issue-based). The two are designed to be used together.
+> **Companion skill — read first:** `cross-squad/SKILL.md` covers **discovery** of peer squads via `squad registry add/list/remove`. This skill picks up after a peer is known and covers the **communication protocols** themselves — the four numbered patterns below: Pattern 0 (synchronous CLI), Pattern 1 (read-only knowledge query), Pattern 2 (git-based async), and Pattern 3 (GitHub-issue-based delegation). A separate non-numbered appendix (Cross-Repo Dependency Scan) is provided as a related analysis tool, not a communication pattern. The two skills are designed to be used together.
 
 **When this skill applies:**
 - A squad agent needs information from another squad-enabled repo
@@ -254,7 +254,9 @@ gh issue create \
 
 ---
 
-### Pattern 4: Cross-Repo Dependency Scan
+### Appendix: Cross-Repo Dependency Scan (Related Analysis Tool — Not a Communication Pattern)
+
+> This section is intentionally listed as an appendix rather than "Pattern 4" — it is a one-off analysis utility for discovering how two repos relate, not a protocol the coordinator picks from the decision tree above. The four numbered communication patterns are 0–3.
 
 For discovering how two repos relate to each other.
 
@@ -365,7 +367,7 @@ Different repos may use GitHub Issues vs Azure DevOps Work Items vs Jira. Check 
 
 ## Validation Status
 
-Originally designed and validated against two production squad instances (a GitHub-hosted platform squad with ~10 agents and an Azure DevOps-hosted automation squad with ~4 agents). The protocols are platform-agnostic; the examples in this document use generic names so you can substitute your own repos.
+This skill was originally drafted against two prototype squad setups (a GitHub-hosted platform squad with ~10 agents and an Azure DevOps-hosted automation squad with ~4 agents). The protocols are platform-agnostic; the examples in this document use generic names so you can substitute your own repos. Patterns 0 and 1 have been exercised end-to-end in those prototypes; Patterns 2 and 3 are documented from design but have not been end-to-end-validated against a live target repo.
 
 | Scenario | Result |
 |----------|--------|

--- a/.squad/skills/cross-squad-communication/SKILL.md
+++ b/.squad/skills/cross-squad-communication/SKILL.md
@@ -43,6 +43,14 @@ Is the target repo cloned locally?
 
 ---
 
+## Universal rule: every `copilot` spawn into a peer squad MUST pass `--agent squad`
+
+The `copilot` CLI accepts `--agent <name>` to select a custom agent (see `copilot --help`). Squad installs ship `.github/agents/squad.agent.md`, which is loaded **only when `--agent squad` is specified**. Without it the spawned session runs as a generic Copilot CLI session that does NOT load the peer's `team.md`, routing, MCP tools, casting, or coordinator behaviour — so you get an off-the-shelf model answering, not the peer's Squad. **Every command example in this skill that spawns `copilot` into a peer repo includes `--agent squad`; do not strip it.**
+
+This rule also applies anywhere else you spawn `copilot` into a Squad-initialised repo (not just cross-squad protocols) — e.g., `squad init`'s post-init tip and any automation that invokes the CLI on a squadified folder. The only case where you may omit `--agent` is when resuming an existing session (`copilot --resume <sessionId>`) — the resumed session preserves its original agent context.
+
+---
+
 ### Pattern 0: Synchronous CLI Session (Fastest for Interactive Queries)
 
 For quick knowledge queries, decision lookups, or short analyses — spawn a Copilot CLI session with the working directory set to the target squad's repo. This lets you send a prompt and get a response within the same session, using the target repo's full context.
@@ -51,7 +59,7 @@ This is the same technique used by `ralph-watch.ps1`: write the prompt to a temp
 
 **Protocol:**
 1. Write prompt to a temp file (avoids argument-splitting issues, as learned in `ralph-watch.ps1`)
-2. Read the file into a string and invoke `copilot -p <text>` with `-C <directory>` set to the target repo (`-p` takes prompt text, NOT a file path)
+2. Read the file into a string and invoke `copilot -p <text>` with `-C <directory>` set to the target repo (`-p` takes prompt text, NOT a file path) AND `--agent squad` so the spawned session uses the peer squad's coordinator (without `--agent` you get a generic Copilot CLI session that doesn't load the peer's `team.md`, MCP tools, or skills)
 3. Receive response in the same session
 
 **Invocation:**
@@ -71,13 +79,15 @@ Response Format: Brief structured summary
 "@ | Out-File $promptFile -Encoding utf8
 
 # Option A: copilot with prompt file (read file into string; -p takes text, not a path)
-copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
+# --agent squad is REQUIRED: the target is another Squad install, so the spawned
+# session must use that squad's coordinator (not a generic Copilot CLI session).
+copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --allow-all-tools
 
 # Option B: Start-Process for non-blocking (ralph-watch.ps1 style)
-Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo' -p (Get-Content '$promptFile' -Raw) --allow-all-tools`"" -Wait
+Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo' --agent squad -p (Get-Content '$promptFile' -Raw) --allow-all-tools`"" -Wait
 
 # Option C: Pipe directly (stdin is the prompt text)
-"What is the platform architecture?" | copilot -C $targetRepo --allow-all-tools
+"What is the platform architecture?" | copilot -C $targetRepo --agent squad --allow-all-tools
 ```
 
 **When to use synchronous vs async:**
@@ -99,6 +109,7 @@ Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo'
 
 **Requirements:**
 - Target repo must be cloned locally (for `copilot -C <directory>`)
+- Target repo must be Squad-initialised (`.squad/config.json` + `.github/agents/squad.agent.md` present), so `--agent squad` resolves to the peer's coordinator
 - Prompt file avoids argument-splitting bugs (see `ralph-watch.ps1` lines 2166-2184)
 
 **Response quality:** ⭐⭐⭐⭐⭐ — the CLI session has full context of the target repo, including code, squad metadata, and MCP tools.
@@ -163,7 +174,7 @@ while ($proc -and -not $proc.HasExited) {
 3. **Retry with `--disable-builtin-mcps` flag:** For lightweight queries that don't require MCP tools
    ```powershell
    # Retry without MCP servers — faster startup, limited capability
-   copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --disable-builtin-mcps --allow-all-tools
+   copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --disable-builtin-mcps --allow-all-tools
    ```
 4. **Increase timeout threshold:** If MCP server initialization is consistently slow (>90s), raise threshold before declaring stall
 
@@ -349,11 +360,11 @@ status: pending
 ### ⚠️ Know when synchronous CLI is NOT the right choice
 ```powershell
 # WRONG — don't use sync CLI for long-running tasks that need artifacts
-copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
+copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --allow-all-tools
 # If the task creates files, PRs, or takes multiple cycles → use async (Pattern 2 or 3)
 
 # WRONG — don't use sync CLI when the target repo isn't cloned locally
-copilot -C "C:\not\cloned\yet" --allow-all-tools
+copilot -C "C:\not\cloned\yet" --agent squad --allow-all-tools
 # If the repo isn't available locally → use issue-based delegation (Pattern 3)
 ```
 Synchronous CLI sessions (Pattern 0) are valid for quick queries and knowledge lookups. Use async patterns for work that needs to persist or where the target repo isn't available locally.

--- a/.squad/skills/cross-squad-communication/SKILL.md
+++ b/.squad/skills/cross-squad-communication/SKILL.md
@@ -51,7 +51,7 @@ This is the same technique used by `ralph-watch.ps1`: write the prompt to a temp
 
 **Protocol:**
 1. Write prompt to a temp file (avoids argument-splitting issues, as learned in `ralph-watch.ps1`)
-2. Invoke CLI with `-p` pointing to the prompt file and `--working-directory` set to the target repo
+2. Read the file into a string and invoke `copilot -p <text>` with `-C <directory>` set to the target repo (`-p` takes prompt text, NOT a file path)
 3. Receive response in the same session
 
 **Invocation:**
@@ -70,14 +70,14 @@ Query: What is the current architecture of the platform? What services does it e
 Response Format: Brief structured summary
 "@ | Out-File $promptFile -Encoding utf8
 
-# Option A: ghcs with prompt file
-ghcs -p $promptFile -- --working-directory $targetRepo
+# Option A: copilot with prompt file (read file into string; -p takes text, not a path)
+copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
 
 # Option B: Start-Process for non-blocking (ralph-watch.ps1 style)
-Start-Process pwsh -ArgumentList "-NoProfile -Command `"cd '$targetRepo'; ghcs -p '$promptFile'`"" -Wait
+Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo' -p (Get-Content '$promptFile' -Raw) --allow-all-tools`"" -Wait
 
-# Option C: Pipe directly
-"What is the platform architecture?" | ghcs -- --working-directory $targetRepo
+# Option C: Pipe directly (stdin is the prompt text)
+"What is the platform architecture?" | copilot -C $targetRepo --allow-all-tools
 ```
 
 **When to use synchronous vs async:**
@@ -98,7 +98,7 @@ Start-Process pwsh -ArgumentList "-NoProfile -Command `"cd '$targetRepo'; ghcs -
 4. Is the target squad's Ralph running? → Needed for async processing
 
 **Requirements:**
-- Target repo must be cloned locally (for `--working-directory`)
+- Target repo must be cloned locally (for `copilot -C <directory>`)
 - Prompt file avoids argument-splitting bugs (see `ralph-watch.ps1` lines 2166-2184)
 
 **Response quality:** ⭐⭐⭐⭐⭐ — the CLI session has full context of the target repo, including code, squad metadata, and MCP tools.
@@ -112,9 +112,16 @@ The synchronous CLI session requires monitoring to avoid false timeouts. With 7+
 Instead of a fixed wall-clock timeout, monitor the agency session log directory for activity:
 
 ```powershell
-# The agency CLI creates a session log directory
-# e.g., ~/.agency/logs/session_20260325_071211_57824
-$logDir = Get-ChildItem "$env:USERPROFILE\.agency\logs" -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+# The Copilot CLI creates a session log directory at ~/.copilot/logs/.
+# Older `agency` runtimes wrote to ~/.agency/logs/; fall back to that
+# location if the new path doesn't exist yet on the user's machine.
+# e.g., ~/.copilot/logs/session_20260325_071211_57824
+$copilotLogs = "$env:USERPROFILE\.copilot\logs"
+$agencyLogs = "$env:USERPROFILE\.agency\logs"
+$logRoot = if (Test-Path $copilotLogs) { $copilotLogs } elseif (Test-Path $agencyLogs) { $agencyLogs } else { $null }
+if ($logRoot) {
+    $logDir = Get-ChildItem $logRoot -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+}
 $lastSize = 0
 $stallCount = 0
 
@@ -153,10 +160,10 @@ while ($proc -and -not $proc.HasExited) {
 
 1. **Check for user input waiting:** Inspect logs for prompts or dialogs (shouldn't happen with `--autopilot`)
 2. **Check MCP server health:** Review `mcp-server-logs/` for connection errors or timeouts
-3. **Retry with `--no-mcp` flag:** For lightweight queries that don't require MCP tools
+3. **Retry with `--disable-builtin-mcps` flag:** For lightweight queries that don't require MCP tools
    ```powershell
    # Retry without MCP servers — faster startup, limited capability
-   ghcs -p $promptFile -- --working-directory $targetRepo --no-mcp
+   copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --disable-builtin-mcps --allow-all-tools
    ```
 4. **Increase timeout threshold:** If MCP server initialization is consistently slow (>90s), raise threshold before declaring stall
 
@@ -342,11 +349,11 @@ status: pending
 ### ⚠️ Know when synchronous CLI is NOT the right choice
 ```powershell
 # WRONG — don't use sync CLI for long-running tasks that need artifacts
-ghcs -p $promptFile -- --working-directory $targetRepo
+copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
 # If the task creates files, PRs, or takes multiple cycles → use async (Pattern 2 or 3)
 
 # WRONG — don't use sync CLI when the target repo isn't cloned locally
-ghcs -- --working-directory "C:\not\cloned\yet"
+copilot -C "C:\not\cloned\yet" --allow-all-tools
 # If the repo isn't available locally → use issue-based delegation (Pattern 3)
 ```
 Synchronous CLI sessions (Pattern 0) are valid for quick queries and knowledge lookups. Use async patterns for work that needs to persist or where the target repo isn't available locally.

--- a/.squad/skills/cross-squad/SKILL.md
+++ b/.squad/skills/cross-squad/SKILL.md
@@ -16,6 +16,8 @@ tools:
 ## Context
 When an organization runs multiple Squad instances (e.g., platform-squad, frontend-squad, data-squad), those squads need to discover each other, share context, and hand off work across repository boundaries. This skill teaches agents how to coordinate across squads without creating tight coupling.
 
+> **Companion skill — for protocol details:** `cross-squad-communication/SKILL.md` covers the four communication patterns (sync CLI, async git-based, issue-based) once a peer squad is discovered via the registry below. This skill answers "who?" — the companion answers "how?".
+
 Cross-squad orchestration applies when:
 - A task requires capabilities owned by another squad
 - An architectural decision affects multiple squads

--- a/.squad/skills/cross-squad/SKILL.md
+++ b/.squad/skills/cross-squad/SKILL.md
@@ -16,7 +16,7 @@ tools:
 ## Context
 When an organization runs multiple Squad instances (e.g., platform-squad, frontend-squad, data-squad), those squads need to discover each other, share context, and hand off work across repository boundaries. This skill teaches agents how to coordinate across squads without creating tight coupling.
 
-> **Companion skill — for protocol details:** `cross-squad-communication/SKILL.md` covers the four communication patterns (sync CLI, async git-based, issue-based) once a peer squad is discovered via the registry below. This skill answers "who?" — the companion answers "how?".
+> **Companion skill — for protocol details:** `cross-squad-communication/SKILL.md` covers the four communication patterns (synchronous CLI, read-only knowledge query, git-based async, and GitHub-issue-based delegation) once a peer squad is discovered via the registry below. This skill answers "who?" — the companion answers "how?".
 
 Cross-squad orchestration applies when:
 - A task requires capabilities owned by another squad

--- a/packages/squad-cli/src/cli/core/templates.ts
+++ b/packages/squad-cli/src/cli/core/templates.ts
@@ -269,6 +269,12 @@ export const TEMPLATE_MANIFEST: TemplateFile[] = [
     overwriteOnUpgrade: true,
     description: 'How to actually use Squad — agent vs skill vs slash command (#1297 redirect)',
   },
+  {
+    source: 'skills/cross-squad-communication/SKILL.md',
+    destination: '../.github/skills/cross-squad-communication/SKILL.md',
+    overwriteOnUpgrade: true,
+    description: 'Cross-squad delegation — calling another squad as a sub-agent',
+  },
 
   // Session init reference (squad-owned, coordinator reads at session start)
   {

--- a/packages/squad-cli/templates/skills/cross-squad-communication/SKILL.md
+++ b/packages/squad-cli/templates/skills/cross-squad-communication/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: "cross-squad-communication"
+description: "Protocol for sending queries, delegating tasks, and sharing context between independent Squad instances across different repositories"
+domain: "multi-repo coordination"
+confidence: "medium"
+source: "Ported from tamirdresher/squad-skills (plugins/cross-squad-communication, validated against two production squad instances). Companion to the registry-aware cross-squad skill — this one teaches the actual communication protocols once a peer is discovered."
+---
+
+## Context
+
+When multiple repositories each have their own Squad (AI team), they need to exchange information: knowledge queries, PR reviews, task delegation, and dependency analysis. Each squad has its own agents, MCP tools, and issue tracker — there is no shared runtime.
+
+> **Companion skill — read first:** `cross-squad/SKILL.md` covers **discovery** of peer squads via `squad registry add/list/remove`. This skill picks up after a peer is known and covers the **communication protocols** themselves (sync CLI, async git, issue-based). The two are designed to be used together.
+
+**When this skill applies:**
+- A squad agent needs information from another squad-enabled repo
+- A task needs to be delegated to another squad
+- Cross-repo dependency analysis is needed
+- PR review requests span repo boundaries
+
+**Key constraint:** Each squad has its own runtime, MCP tools, and issue tracker. Cross-squad communication can be **synchronous** (via CLI session targeting the other repo) or **asynchronous** (file-based or issue-based). The coordinator decides which approach fits.
+
+---
+
+## Patterns
+
+### Decision Tree: Choosing the Right Pattern
+
+```
+Is the target repo cloned locally?
+├─ NO → Use Pattern 3 (Issue-Based) or Pattern 2 (Git-Based Async)
+└─ YES
+    ├─ Is this a quick query / knowledge lookup?
+    │   └─ YES → Use Pattern 0 (Synchronous CLI) — fastest
+    ├─ Does the work need to persist as artifacts?
+    │   └─ YES → Use Pattern 2 (Git-Based Async)
+    ├─ Is it a long-running analysis or multi-cycle task?
+    │   └─ YES → Use Pattern 2 (Git-Based Async)
+    └─ Is the target squad's Ralph running?
+        ├─ YES → Pattern 2 or 3 (async processing available)
+        └─ NO → Pattern 0 (Synchronous CLI) or Pattern 1 (Read-Only)
+```
+
+---
+
+### Pattern 0: Synchronous CLI Session (Fastest for Interactive Queries)
+
+For quick knowledge queries, decision lookups, or short analyses — spawn a Copilot CLI session with the working directory set to the target squad's repo. This lets you send a prompt and get a response within the same session, using the target repo's full context.
+
+This is the same technique used by `ralph-watch.ps1`: write the prompt to a temp file, then invoke the CLI with that file as input. The key insight is that setting the working directory to the target repo gives the CLI session access to that squad's `.squad/` metadata, codebase, and conventions.
+
+**Protocol:**
+1. Write prompt to a temp file (avoids argument-splitting issues, as learned in `ralph-watch.ps1`)
+2. Invoke CLI with `-p` pointing to the prompt file and `--working-directory` set to the target repo
+3. Receive response in the same session
+
+**Invocation:**
+```powershell
+# Spawn a Copilot CLI session targeting another squad's repo
+$targetRepo = "C:\repos\platform-squad-repo"
+$promptFile = New-TemporaryFile
+@"
+You are working in a Squad-enabled repository.
+Read .squad/team.md and .squad/decisions.md first.
+
+[CROSS-SQUAD REQUEST]
+From: research-squad
+Request Type: knowledge_query
+Query: What is the current architecture of the platform? What services does it expose?
+Response Format: Brief structured summary
+"@ | Out-File $promptFile -Encoding utf8
+
+# Option A: ghcs with prompt file
+ghcs -p $promptFile -- --working-directory $targetRepo
+
+# Option B: Start-Process for non-blocking (ralph-watch.ps1 style)
+Start-Process pwsh -ArgumentList "-NoProfile -Command `"cd '$targetRepo'; ghcs -p '$promptFile'`"" -Wait
+
+# Option C: Pipe directly
+"What is the platform architecture?" | ghcs -- --working-directory $targetRepo
+```
+
+**When to use synchronous vs async:**
+
+| Scenario | Pattern | Why |
+|----------|---------|-----|
+| Quick knowledge query | Synchronous CLI (Pattern 0) | Fast answer, no overhead |
+| "What did you decide about X?" | Synchronous CLI (Pattern 0) | Read decisions.md via the target squad's context |
+| PR review request | Either (Pattern 0 or 2/3) | Sync for quick feedback, async for thorough review |
+| Task delegation (do work in their repo) | Async (Pattern 2 or 3) | Work needs to persist beyond the session |
+| Long-running analysis | Async (Pattern 2) | May take multiple cycles |
+| Target repo not locally cloned | Async (Pattern 3) | Can't set working directory to a remote repo |
+
+**The coordinator decides which pattern to use based on:**
+1. Is the target repo cloned locally? → If yes, sync CLI is available
+2. Is this a quick query or a long task? → Quick = sync, long = async
+3. Does the work need to persist? → If yes, use async (creates artifacts)
+4. Is the target squad's Ralph running? → Needed for async processing
+
+**Requirements:**
+- Target repo must be cloned locally (for `--working-directory`)
+- Prompt file avoids argument-splitting bugs (see `ralph-watch.ps1` lines 2166-2184)
+
+**Response quality:** ⭐⭐⭐⭐⭐ — the CLI session has full context of the target repo, including code, squad metadata, and MCP tools.
+
+### Liveness Protocol for Pattern 0
+
+The synchronous CLI session requires monitoring to avoid false timeouts. With 7+ MCP servers initializing and `.squad/` metadata being read, startup can take 30-60 seconds. A hard timeout kills valid sessions before they complete. Instead, monitor the agency session's activity log directory.
+
+**Health Check Approach:**
+
+Instead of a fixed wall-clock timeout, monitor the agency session log directory for activity:
+
+```powershell
+# The agency CLI creates a session log directory
+# e.g., ~/.agency/logs/session_20260325_071211_57824
+$logDir = Get-ChildItem "$env:USERPROFILE\.agency\logs" -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$lastSize = 0
+$stallCount = 0
+
+while ($proc -and -not $proc.HasExited) {
+    Start-Sleep -Seconds 15
+    $currentSize = (Get-ChildItem $logDir -Recurse -File | Measure-Object -Property Length -Sum).Sum
+    
+    if ($currentSize -eq $lastSize) {
+        $stallCount++
+        if ($stallCount -ge 4) { # 60s with no progress
+            Write-Warning "Session stalled — no log activity for 60s"
+            break
+        }
+    } else {
+        $stallCount = 0
+        $lastSize = $currentSize
+    }
+}
+```
+
+**Progress Indicators (What Counts as "Alive"):**
+
+- New files appearing in the session log directory (e.g., `transcript.log`, `mcp-server-logs/`)
+- Log file size increasing (indicates active processing)
+- New or modified `.squad/` files in the target repo (e.g., `decisions/inbox.md`, `identity/history.md`)
+- Process still running and consuming non-idle CPU time
+
+**Stall Detection (When to Intervene):**
+
+- **No log activity for 60s** → Issue a warning; session may be slow but not hung
+- **No log activity for 120s** → Likely stuck; consider terminating and checking logs
+- **Process exited with non-zero exit code** → Failed; examine `transcript.log` and `stderr` for errors
+- **MCP server connection timeout** → Session blocked waiting for an MCP server response
+
+**Recovery Actions When Stalled:**
+
+1. **Check for user input waiting:** Inspect logs for prompts or dialogs (shouldn't happen with `--autopilot`)
+2. **Check MCP server health:** Review `mcp-server-logs/` for connection errors or timeouts
+3. **Retry with `--no-mcp` flag:** For lightweight queries that don't require MCP tools
+   ```powershell
+   # Retry without MCP servers — faster startup, limited capability
+   ghcs -p $promptFile -- --working-directory $targetRepo --no-mcp
+   ```
+4. **Increase timeout threshold:** If MCP server initialization is consistently slow (>90s), raise threshold before declaring stall
+
+---
+
+### Pattern 1: Read-Only Knowledge Query (No CLI Needed)
+
+For questions about another squad's architecture, decisions, or current state — read their `.squad/` metadata directly.
+
+**Protocol:**
+1. Read target repo's `.squad/team.md` → get stack, members, issue source
+2. Read `.squad/decisions.md` → get architectural decisions
+3. Read `.squad/routing.md` → understand who handles what
+4. Read `.squad/identity/now.md` → get current focus
+5. Scan code structure if needed (csproj files, directory layout)
+
+**Requirements:**
+- Target repo must be cloned locally or accessible via git
+- No authentication needed beyond git read access
+
+**Example:**
+```powershell
+# Query another squad's architecture
+$targetRepo = "C:\repos\platform-squad-repo"
+Get-Content "$targetRepo\.squad\team.md"
+Get-Content "$targetRepo\.squad\decisions.md"
+Get-Content "$targetRepo\.squad\identity\now.md"
+```
+
+**Response quality:** ⭐⭐⭐⭐ — excellent for structural/architectural questions.
+
+---
+
+### Pattern 2: Async Task Request (Git-Based)
+
+For work that needs the target squad to execute (PR reviews, issue analysis, code changes).
+
+**Protocol:**
+1. Create request file in YOUR repo: `.squad/cross-squad/requests/{timestamp}-{target}-{id}.yaml`
+2. Commit and push
+3. Target squad's Ralph detects on next cycle
+4. Target squad processes and writes response to their `.squad/cross-squad/responses/`
+5. Your Ralph picks up the response
+
+**Request File Format:**
+```yaml
+id: req-2026-06-13-001
+source_squad: research-squad
+source_repo: your-org/research-squad-repo
+target_squad: platform-squad
+target_repo: your-org/platform-squad-repo
+request_type: knowledge_query | pr_review | task_delegation | dependency_check
+priority: high | normal | low
+created_at: 2026-06-13T10:00:00Z
+query: "What is the current architecture of the platform?"
+routing_hint: "lead"  # optional — which agent should handle this
+status: pending
+```
+
+**Response File Format:**
+```yaml
+id: req-2026-06-13-001
+responding_squad: platform-squad
+responding_agent: lead
+responded_at: 2026-06-13T10:15:00Z
+status: completed | partial | rejected
+response: |
+  The platform architecture consists of...
+artifacts: []  # optional file paths
+```
+
+---
+
+### Pattern 3: Issue-Based Delegation (For GitHub-Hosted Repos)
+
+For repos on GitHub, use issues with labels as the message bus.
+
+**Protocol:**
+1. Create issue in target repo with label `squad:cross-squad`
+2. Include source squad identifier and routing hint in issue body
+3. Target squad's Ralph picks up and routes to appropriate agent
+4. Response posted as issue comment
+5. Issue closed when complete
+
+**Example:**
+```bash
+gh issue create \
+  --repo your-org/platform-squad-repo \
+  --title "[Cross-Squad] Architecture query from research-squad" \
+  --body "Source: research-squad\nQuery: What services does the platform expose?\nRouting: lead" \
+  --label "squad:cross-squad"
+```
+
+**Limitation:** Only works for repos on GitHub. Other platforms (Azure DevOps, GitLab, etc.) need different approach.
+
+---
+
+### Pattern 4: Cross-Repo Dependency Scan
+
+For discovering how two repos relate to each other.
+
+**Protocol:**
+1. Search both repos for mutual references:
+   ```powershell
+   Select-String -Path (Get-ChildItem $repoA -Recurse -Include "*.md","*.cs","*.json","*.csproj") `
+     -Pattern $repoB_name
+   Select-String -Path (Get-ChildItem $repoB -Recurse -Include "*.md","*.cs","*.json","*.csproj") `
+     -Pattern $repoA_name
+   ```
+2. Check shared NuGet packages / npm packages
+3. Check shared ADO project or GitHub org
+4. Document relationship type: code dependency, operational coupling, shared infra
+
+---
+
+## Discovery Protocol
+
+Before sending any cross-squad request, verify the target:
+
+```
+1. Does .squad/team.md exist?           → Squad is installed
+2. What is the issue_source?            → GitHub Issues | ADO | Planner
+3. What agents are active?              → Check member status column
+4. What is the routing table?           → Read routing.md
+5. What is the current focus?           → Read identity/now.md
+6. Is Ralph running?                    → Check for recent commits by Ralph
+```
+
+If `.squad/team.md` doesn't exist, the repo is not squad-enabled. Fall back to standard human communication.
+
+---
+
+## Platform Compatibility Matrix
+
+| Source Issue Tracker | Target Issue Tracker | Mechanism |
+|---------------------|---------------------|-----------|
+| GitHub Issues | GitHub Issues | Issue-based (Pattern 3) |
+| GitHub Issues | ADO Work Items | Git-based (Pattern 2) |
+| GitHub Issues | Planner | Git-based (Pattern 2) |
+| ADO Work Items | GitHub Issues | Issue-based (Pattern 3) via `gh` CLI |
+| ADO Work Items | ADO Work Items | ADO cross-project work items |
+| Any | Any | Git-based (Pattern 2) — universal fallback |
+
+---
+
+## Examples
+
+### Example 1: research-squad queries platform-squad architecture
+
+```powershell
+# Step 1: Read metadata (Pattern 1)
+$target = "C:\repos\platform-squad-repo"
+$team = Get-Content "$target\.squad\team.md" -Raw
+$decisions = Get-Content "$target\.squad\decisions.md" -Raw
+
+# Step 2: Extract answer from metadata
+# team.md reveals tech stack and member roles
+# decisions.md reveals architectural choices
+
+# Step 3: If deeper analysis needed, create async request (Pattern 2)
+```
+
+### Example 2: Request PR review from another squad
+
+```yaml
+# .squad/cross-squad/requests/2026-06-13-platform-squad-pr-review.yaml
+id: pr-review-001
+source_squad: research-squad
+target_squad: platform-squad
+request_type: pr_review
+priority: normal
+query: "Review PR #54 — package version fix. Check for correctness."
+routing_hint: "lead"
+status: pending
+```
+
+---
+
+## Anti-Patterns
+
+### ⚠️ Know when synchronous CLI is NOT the right choice
+```powershell
+# WRONG — don't use sync CLI for long-running tasks that need artifacts
+ghcs -p $promptFile -- --working-directory $targetRepo
+# If the task creates files, PRs, or takes multiple cycles → use async (Pattern 2 or 3)
+
+# WRONG — don't use sync CLI when the target repo isn't cloned locally
+ghcs -- --working-directory "C:\not\cloned\yet"
+# If the repo isn't available locally → use issue-based delegation (Pattern 3)
+```
+Synchronous CLI sessions (Pattern 0) are valid for quick queries and knowledge lookups. Use async patterns for work that needs to persist or where the target repo isn't available locally.
+
+### ❌ Don't assume shared MCP tools
+Each squad has its own MCP server instances. You cannot invoke another squad's ADO tools or GitHub tools from your session.
+
+### ❌ Don't skip the discovery step
+Always read `team.md` first. The target squad may use a different issue tracker, have different agents, or be in a different state than expected.
+
+### ❌ Don't send requests to squads without Ralph
+If the target squad doesn't have Ralph (Work Monitor) running, async requests will never be processed. Check for recent Ralph activity first.
+
+### ❌ Don't mix up repo platforms
+Different repos may use GitHub Issues vs Azure DevOps Work Items vs Jira. Check `team.md` / repository metadata for the right tooling before sending requests.
+
+---
+
+## Validation Status
+
+Originally designed and validated against two production squad instances (a GitHub-hosted platform squad with ~10 agents and an Azure DevOps-hosted automation squad with ~4 agents). The protocols are platform-agnostic; the examples in this document use generic names so you can substitute your own repos.
+
+| Scenario | Result |
+|----------|--------|
+| Knowledge query (read-only) | ✅ Works via Pattern 1 |
+| Step handler discovery | ✅ Works via file scan |
+| PR review (basic) | ⚠️ Partial — git log only, no API |
+| Backlog enumeration | ⚠️ Partial — depends on issue platform |
+| Dependency analysis | ✅ Works via cross-reference scan |
+| CLI invocation (sync) + Liveness Protocol | ✅ Works — session launches successfully; log monitoring prevents false timeouts |
+
+**Confidence: MEDIUM** — Synchronous CLI pattern (Pattern 0) validated end-to-end. Liveness protocol provides operational robustness against slow MCP initialization. Git-based async (Pattern 2) and issue-based (Pattern 3) untested end-to-end. Production readiness requires Ralph integration on both sides.

--- a/packages/squad-cli/templates/skills/cross-squad-communication/SKILL.md
+++ b/packages/squad-cli/templates/skills/cross-squad-communication/SKILL.md
@@ -3,14 +3,14 @@ name: "cross-squad-communication"
 description: "Protocol for sending queries, delegating tasks, and sharing context between independent Squad instances across different repositories"
 domain: "multi-repo coordination"
 confidence: "medium"
-source: "Ported from tamirdresher/squad-skills (plugins/cross-squad-communication, validated against two production squad instances). Companion to the registry-aware cross-squad skill — this one teaches the actual communication protocols once a peer is discovered."
+source: "Ported from tamirdresher/squad-skills (plugins/cross-squad-communication). Companion to the registry-aware cross-squad skill — this one teaches the actual communication protocols once a peer is discovered. Pattern 0 (synchronous CLI) is the only end-to-end-validated pattern; Patterns 1, 2, 3 are documented from design but require live validation against your own setup before relying on them in production. See the Validation Status section at the bottom of this skill."
 ---
 
 ## Context
 
 When multiple repositories each have their own Squad (AI team), they need to exchange information: knowledge queries, PR reviews, task delegation, and dependency analysis. Each squad has its own agents, MCP tools, and issue tracker — there is no shared runtime.
 
-> **Companion skill — read first:** `cross-squad/SKILL.md` covers **discovery** of peer squads via `squad registry add/list/remove`. This skill picks up after a peer is known and covers the **communication protocols** themselves (sync CLI, async git, issue-based). The two are designed to be used together.
+> **Companion skill — read first:** `cross-squad/SKILL.md` covers **discovery** of peer squads via `squad registry add/list/remove`. This skill picks up after a peer is known and covers the **communication protocols** themselves — the four numbered patterns below: Pattern 0 (synchronous CLI), Pattern 1 (read-only knowledge query), Pattern 2 (git-based async), and Pattern 3 (GitHub-issue-based delegation). A separate non-numbered appendix (Cross-Repo Dependency Scan) is provided as a related analysis tool, not a communication pattern. The two skills are designed to be used together.
 
 **When this skill applies:**
 - A squad agent needs information from another squad-enabled repo
@@ -254,7 +254,9 @@ gh issue create \
 
 ---
 
-### Pattern 4: Cross-Repo Dependency Scan
+### Appendix: Cross-Repo Dependency Scan (Related Analysis Tool — Not a Communication Pattern)
+
+> This section is intentionally listed as an appendix rather than "Pattern 4" — it is a one-off analysis utility for discovering how two repos relate, not a protocol the coordinator picks from the decision tree above. The four numbered communication patterns are 0–3.
 
 For discovering how two repos relate to each other.
 
@@ -365,7 +367,7 @@ Different repos may use GitHub Issues vs Azure DevOps Work Items vs Jira. Check 
 
 ## Validation Status
 
-Originally designed and validated against two production squad instances (a GitHub-hosted platform squad with ~10 agents and an Azure DevOps-hosted automation squad with ~4 agents). The protocols are platform-agnostic; the examples in this document use generic names so you can substitute your own repos.
+This skill was originally drafted against two prototype squad setups (a GitHub-hosted platform squad with ~10 agents and an Azure DevOps-hosted automation squad with ~4 agents). The protocols are platform-agnostic; the examples in this document use generic names so you can substitute your own repos. Patterns 0 and 1 have been exercised end-to-end in those prototypes; Patterns 2 and 3 are documented from design but have not been end-to-end-validated against a live target repo.
 
 | Scenario | Result |
 |----------|--------|

--- a/packages/squad-cli/templates/skills/cross-squad-communication/SKILL.md
+++ b/packages/squad-cli/templates/skills/cross-squad-communication/SKILL.md
@@ -43,6 +43,14 @@ Is the target repo cloned locally?
 
 ---
 
+## Universal rule: every `copilot` spawn into a peer squad MUST pass `--agent squad`
+
+The `copilot` CLI accepts `--agent <name>` to select a custom agent (see `copilot --help`). Squad installs ship `.github/agents/squad.agent.md`, which is loaded **only when `--agent squad` is specified**. Without it the spawned session runs as a generic Copilot CLI session that does NOT load the peer's `team.md`, routing, MCP tools, casting, or coordinator behaviour — so you get an off-the-shelf model answering, not the peer's Squad. **Every command example in this skill that spawns `copilot` into a peer repo includes `--agent squad`; do not strip it.**
+
+This rule also applies anywhere else you spawn `copilot` into a Squad-initialised repo (not just cross-squad protocols) — e.g., `squad init`'s post-init tip and any automation that invokes the CLI on a squadified folder. The only case where you may omit `--agent` is when resuming an existing session (`copilot --resume <sessionId>`) — the resumed session preserves its original agent context.
+
+---
+
 ### Pattern 0: Synchronous CLI Session (Fastest for Interactive Queries)
 
 For quick knowledge queries, decision lookups, or short analyses — spawn a Copilot CLI session with the working directory set to the target squad's repo. This lets you send a prompt and get a response within the same session, using the target repo's full context.
@@ -51,7 +59,7 @@ This is the same technique used by `ralph-watch.ps1`: write the prompt to a temp
 
 **Protocol:**
 1. Write prompt to a temp file (avoids argument-splitting issues, as learned in `ralph-watch.ps1`)
-2. Read the file into a string and invoke `copilot -p <text>` with `-C <directory>` set to the target repo (`-p` takes prompt text, NOT a file path)
+2. Read the file into a string and invoke `copilot -p <text>` with `-C <directory>` set to the target repo (`-p` takes prompt text, NOT a file path) AND `--agent squad` so the spawned session uses the peer squad's coordinator (without `--agent` you get a generic Copilot CLI session that doesn't load the peer's `team.md`, MCP tools, or skills)
 3. Receive response in the same session
 
 **Invocation:**
@@ -71,13 +79,15 @@ Response Format: Brief structured summary
 "@ | Out-File $promptFile -Encoding utf8
 
 # Option A: copilot with prompt file (read file into string; -p takes text, not a path)
-copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
+# --agent squad is REQUIRED: the target is another Squad install, so the spawned
+# session must use that squad's coordinator (not a generic Copilot CLI session).
+copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --allow-all-tools
 
 # Option B: Start-Process for non-blocking (ralph-watch.ps1 style)
-Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo' -p (Get-Content '$promptFile' -Raw) --allow-all-tools`"" -Wait
+Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo' --agent squad -p (Get-Content '$promptFile' -Raw) --allow-all-tools`"" -Wait
 
 # Option C: Pipe directly (stdin is the prompt text)
-"What is the platform architecture?" | copilot -C $targetRepo --allow-all-tools
+"What is the platform architecture?" | copilot -C $targetRepo --agent squad --allow-all-tools
 ```
 
 **When to use synchronous vs async:**
@@ -99,6 +109,7 @@ Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo'
 
 **Requirements:**
 - Target repo must be cloned locally (for `copilot -C <directory>`)
+- Target repo must be Squad-initialised (`.squad/config.json` + `.github/agents/squad.agent.md` present), so `--agent squad` resolves to the peer's coordinator
 - Prompt file avoids argument-splitting bugs (see `ralph-watch.ps1` lines 2166-2184)
 
 **Response quality:** ⭐⭐⭐⭐⭐ — the CLI session has full context of the target repo, including code, squad metadata, and MCP tools.
@@ -163,7 +174,7 @@ while ($proc -and -not $proc.HasExited) {
 3. **Retry with `--disable-builtin-mcps` flag:** For lightweight queries that don't require MCP tools
    ```powershell
    # Retry without MCP servers — faster startup, limited capability
-   copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --disable-builtin-mcps --allow-all-tools
+   copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --disable-builtin-mcps --allow-all-tools
    ```
 4. **Increase timeout threshold:** If MCP server initialization is consistently slow (>90s), raise threshold before declaring stall
 
@@ -349,11 +360,11 @@ status: pending
 ### ⚠️ Know when synchronous CLI is NOT the right choice
 ```powershell
 # WRONG — don't use sync CLI for long-running tasks that need artifacts
-copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
+copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --allow-all-tools
 # If the task creates files, PRs, or takes multiple cycles → use async (Pattern 2 or 3)
 
 # WRONG — don't use sync CLI when the target repo isn't cloned locally
-copilot -C "C:\not\cloned\yet" --allow-all-tools
+copilot -C "C:\not\cloned\yet" --agent squad --allow-all-tools
 # If the repo isn't available locally → use issue-based delegation (Pattern 3)
 ```
 Synchronous CLI sessions (Pattern 0) are valid for quick queries and knowledge lookups. Use async patterns for work that needs to persist or where the target repo isn't available locally.

--- a/packages/squad-cli/templates/skills/cross-squad-communication/SKILL.md
+++ b/packages/squad-cli/templates/skills/cross-squad-communication/SKILL.md
@@ -51,7 +51,7 @@ This is the same technique used by `ralph-watch.ps1`: write the prompt to a temp
 
 **Protocol:**
 1. Write prompt to a temp file (avoids argument-splitting issues, as learned in `ralph-watch.ps1`)
-2. Invoke CLI with `-p` pointing to the prompt file and `--working-directory` set to the target repo
+2. Read the file into a string and invoke `copilot -p <text>` with `-C <directory>` set to the target repo (`-p` takes prompt text, NOT a file path)
 3. Receive response in the same session
 
 **Invocation:**
@@ -70,14 +70,14 @@ Query: What is the current architecture of the platform? What services does it e
 Response Format: Brief structured summary
 "@ | Out-File $promptFile -Encoding utf8
 
-# Option A: ghcs with prompt file
-ghcs -p $promptFile -- --working-directory $targetRepo
+# Option A: copilot with prompt file (read file into string; -p takes text, not a path)
+copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
 
 # Option B: Start-Process for non-blocking (ralph-watch.ps1 style)
-Start-Process pwsh -ArgumentList "-NoProfile -Command `"cd '$targetRepo'; ghcs -p '$promptFile'`"" -Wait
+Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo' -p (Get-Content '$promptFile' -Raw) --allow-all-tools`"" -Wait
 
-# Option C: Pipe directly
-"What is the platform architecture?" | ghcs -- --working-directory $targetRepo
+# Option C: Pipe directly (stdin is the prompt text)
+"What is the platform architecture?" | copilot -C $targetRepo --allow-all-tools
 ```
 
 **When to use synchronous vs async:**
@@ -98,7 +98,7 @@ Start-Process pwsh -ArgumentList "-NoProfile -Command `"cd '$targetRepo'; ghcs -
 4. Is the target squad's Ralph running? → Needed for async processing
 
 **Requirements:**
-- Target repo must be cloned locally (for `--working-directory`)
+- Target repo must be cloned locally (for `copilot -C <directory>`)
 - Prompt file avoids argument-splitting bugs (see `ralph-watch.ps1` lines 2166-2184)
 
 **Response quality:** ⭐⭐⭐⭐⭐ — the CLI session has full context of the target repo, including code, squad metadata, and MCP tools.
@@ -112,9 +112,16 @@ The synchronous CLI session requires monitoring to avoid false timeouts. With 7+
 Instead of a fixed wall-clock timeout, monitor the agency session log directory for activity:
 
 ```powershell
-# The agency CLI creates a session log directory
-# e.g., ~/.agency/logs/session_20260325_071211_57824
-$logDir = Get-ChildItem "$env:USERPROFILE\.agency\logs" -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+# The Copilot CLI creates a session log directory at ~/.copilot/logs/.
+# Older `agency` runtimes wrote to ~/.agency/logs/; fall back to that
+# location if the new path doesn't exist yet on the user's machine.
+# e.g., ~/.copilot/logs/session_20260325_071211_57824
+$copilotLogs = "$env:USERPROFILE\.copilot\logs"
+$agencyLogs = "$env:USERPROFILE\.agency\logs"
+$logRoot = if (Test-Path $copilotLogs) { $copilotLogs } elseif (Test-Path $agencyLogs) { $agencyLogs } else { $null }
+if ($logRoot) {
+    $logDir = Get-ChildItem $logRoot -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+}
 $lastSize = 0
 $stallCount = 0
 
@@ -153,10 +160,10 @@ while ($proc -and -not $proc.HasExited) {
 
 1. **Check for user input waiting:** Inspect logs for prompts or dialogs (shouldn't happen with `--autopilot`)
 2. **Check MCP server health:** Review `mcp-server-logs/` for connection errors or timeouts
-3. **Retry with `--no-mcp` flag:** For lightweight queries that don't require MCP tools
+3. **Retry with `--disable-builtin-mcps` flag:** For lightweight queries that don't require MCP tools
    ```powershell
    # Retry without MCP servers — faster startup, limited capability
-   ghcs -p $promptFile -- --working-directory $targetRepo --no-mcp
+   copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --disable-builtin-mcps --allow-all-tools
    ```
 4. **Increase timeout threshold:** If MCP server initialization is consistently slow (>90s), raise threshold before declaring stall
 
@@ -342,11 +349,11 @@ status: pending
 ### ⚠️ Know when synchronous CLI is NOT the right choice
 ```powershell
 # WRONG — don't use sync CLI for long-running tasks that need artifacts
-ghcs -p $promptFile -- --working-directory $targetRepo
+copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
 # If the task creates files, PRs, or takes multiple cycles → use async (Pattern 2 or 3)
 
 # WRONG — don't use sync CLI when the target repo isn't cloned locally
-ghcs -- --working-directory "C:\not\cloned\yet"
+copilot -C "C:\not\cloned\yet" --allow-all-tools
 # If the repo isn't available locally → use issue-based delegation (Pattern 3)
 ```
 Synchronous CLI sessions (Pattern 0) are valid for quick queries and knowledge lookups. Use async patterns for work that needs to persist or where the target repo isn't available locally.

--- a/packages/squad-cli/templates/skills/cross-squad/SKILL.md
+++ b/packages/squad-cli/templates/skills/cross-squad/SKILL.md
@@ -16,6 +16,8 @@ tools:
 ## Context
 When an organization runs multiple Squad instances (e.g., platform-squad, frontend-squad, data-squad), those squads need to discover each other, share context, and hand off work across repository boundaries. This skill teaches agents how to coordinate across squads without creating tight coupling.
 
+> **Companion skill — for protocol details:** `cross-squad-communication/SKILL.md` covers the four communication patterns (sync CLI, async git-based, issue-based) once a peer squad is discovered via the registry below. This skill answers "who?" — the companion answers "how?".
+
 Cross-squad orchestration applies when:
 - A task requires capabilities owned by another squad
 - An architectural decision affects multiple squads

--- a/packages/squad-cli/templates/skills/cross-squad/SKILL.md
+++ b/packages/squad-cli/templates/skills/cross-squad/SKILL.md
@@ -16,7 +16,7 @@ tools:
 ## Context
 When an organization runs multiple Squad instances (e.g., platform-squad, frontend-squad, data-squad), those squads need to discover each other, share context, and hand off work across repository boundaries. This skill teaches agents how to coordinate across squads without creating tight coupling.
 
-> **Companion skill — for protocol details:** `cross-squad-communication/SKILL.md` covers the four communication patterns (sync CLI, async git-based, issue-based) once a peer squad is discovered via the registry below. This skill answers "who?" — the companion answers "how?".
+> **Companion skill — for protocol details:** `cross-squad-communication/SKILL.md` covers the four communication patterns (synchronous CLI, read-only knowledge query, git-based async, and GitHub-issue-based delegation) once a peer squad is discovered via the registry below. This skill answers "who?" — the companion answers "how?".
 
 Cross-squad orchestration applies when:
 - A task requires capabilities owned by another squad

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -40,6 +40,7 @@ const MANIFEST_SKILL_NAMES = [
   'squad',
   'squad-version-check',
   'squad-help',
+  'cross-squad-communication',
 ] as const;
 
 // ============================================================================

--- a/packages/squad-sdk/templates/skills/cross-squad-communication/SKILL.md
+++ b/packages/squad-sdk/templates/skills/cross-squad-communication/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: "cross-squad-communication"
+description: "Protocol for sending queries, delegating tasks, and sharing context between independent Squad instances across different repositories"
+domain: "multi-repo coordination"
+confidence: "medium"
+source: "Ported from tamirdresher/squad-skills (plugins/cross-squad-communication, validated against two production squad instances). Companion to the registry-aware cross-squad skill — this one teaches the actual communication protocols once a peer is discovered."
+---
+
+## Context
+
+When multiple repositories each have their own Squad (AI team), they need to exchange information: knowledge queries, PR reviews, task delegation, and dependency analysis. Each squad has its own agents, MCP tools, and issue tracker — there is no shared runtime.
+
+> **Companion skill — read first:** `cross-squad/SKILL.md` covers **discovery** of peer squads via `squad registry add/list/remove`. This skill picks up after a peer is known and covers the **communication protocols** themselves (sync CLI, async git, issue-based). The two are designed to be used together.
+
+**When this skill applies:**
+- A squad agent needs information from another squad-enabled repo
+- A task needs to be delegated to another squad
+- Cross-repo dependency analysis is needed
+- PR review requests span repo boundaries
+
+**Key constraint:** Each squad has its own runtime, MCP tools, and issue tracker. Cross-squad communication can be **synchronous** (via CLI session targeting the other repo) or **asynchronous** (file-based or issue-based). The coordinator decides which approach fits.
+
+---
+
+## Patterns
+
+### Decision Tree: Choosing the Right Pattern
+
+```
+Is the target repo cloned locally?
+├─ NO → Use Pattern 3 (Issue-Based) or Pattern 2 (Git-Based Async)
+└─ YES
+    ├─ Is this a quick query / knowledge lookup?
+    │   └─ YES → Use Pattern 0 (Synchronous CLI) — fastest
+    ├─ Does the work need to persist as artifacts?
+    │   └─ YES → Use Pattern 2 (Git-Based Async)
+    ├─ Is it a long-running analysis or multi-cycle task?
+    │   └─ YES → Use Pattern 2 (Git-Based Async)
+    └─ Is the target squad's Ralph running?
+        ├─ YES → Pattern 2 or 3 (async processing available)
+        └─ NO → Pattern 0 (Synchronous CLI) or Pattern 1 (Read-Only)
+```
+
+---
+
+### Pattern 0: Synchronous CLI Session (Fastest for Interactive Queries)
+
+For quick knowledge queries, decision lookups, or short analyses — spawn a Copilot CLI session with the working directory set to the target squad's repo. This lets you send a prompt and get a response within the same session, using the target repo's full context.
+
+This is the same technique used by `ralph-watch.ps1`: write the prompt to a temp file, then invoke the CLI with that file as input. The key insight is that setting the working directory to the target repo gives the CLI session access to that squad's `.squad/` metadata, codebase, and conventions.
+
+**Protocol:**
+1. Write prompt to a temp file (avoids argument-splitting issues, as learned in `ralph-watch.ps1`)
+2. Invoke CLI with `-p` pointing to the prompt file and `--working-directory` set to the target repo
+3. Receive response in the same session
+
+**Invocation:**
+```powershell
+# Spawn a Copilot CLI session targeting another squad's repo
+$targetRepo = "C:\repos\platform-squad-repo"
+$promptFile = New-TemporaryFile
+@"
+You are working in a Squad-enabled repository.
+Read .squad/team.md and .squad/decisions.md first.
+
+[CROSS-SQUAD REQUEST]
+From: research-squad
+Request Type: knowledge_query
+Query: What is the current architecture of the platform? What services does it expose?
+Response Format: Brief structured summary
+"@ | Out-File $promptFile -Encoding utf8
+
+# Option A: ghcs with prompt file
+ghcs -p $promptFile -- --working-directory $targetRepo
+
+# Option B: Start-Process for non-blocking (ralph-watch.ps1 style)
+Start-Process pwsh -ArgumentList "-NoProfile -Command `"cd '$targetRepo'; ghcs -p '$promptFile'`"" -Wait
+
+# Option C: Pipe directly
+"What is the platform architecture?" | ghcs -- --working-directory $targetRepo
+```
+
+**When to use synchronous vs async:**
+
+| Scenario | Pattern | Why |
+|----------|---------|-----|
+| Quick knowledge query | Synchronous CLI (Pattern 0) | Fast answer, no overhead |
+| "What did you decide about X?" | Synchronous CLI (Pattern 0) | Read decisions.md via the target squad's context |
+| PR review request | Either (Pattern 0 or 2/3) | Sync for quick feedback, async for thorough review |
+| Task delegation (do work in their repo) | Async (Pattern 2 or 3) | Work needs to persist beyond the session |
+| Long-running analysis | Async (Pattern 2) | May take multiple cycles |
+| Target repo not locally cloned | Async (Pattern 3) | Can't set working directory to a remote repo |
+
+**The coordinator decides which pattern to use based on:**
+1. Is the target repo cloned locally? → If yes, sync CLI is available
+2. Is this a quick query or a long task? → Quick = sync, long = async
+3. Does the work need to persist? → If yes, use async (creates artifacts)
+4. Is the target squad's Ralph running? → Needed for async processing
+
+**Requirements:**
+- Target repo must be cloned locally (for `--working-directory`)
+- Prompt file avoids argument-splitting bugs (see `ralph-watch.ps1` lines 2166-2184)
+
+**Response quality:** ⭐⭐⭐⭐⭐ — the CLI session has full context of the target repo, including code, squad metadata, and MCP tools.
+
+### Liveness Protocol for Pattern 0
+
+The synchronous CLI session requires monitoring to avoid false timeouts. With 7+ MCP servers initializing and `.squad/` metadata being read, startup can take 30-60 seconds. A hard timeout kills valid sessions before they complete. Instead, monitor the agency session's activity log directory.
+
+**Health Check Approach:**
+
+Instead of a fixed wall-clock timeout, monitor the agency session log directory for activity:
+
+```powershell
+# The agency CLI creates a session log directory
+# e.g., ~/.agency/logs/session_20260325_071211_57824
+$logDir = Get-ChildItem "$env:USERPROFILE\.agency\logs" -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$lastSize = 0
+$stallCount = 0
+
+while ($proc -and -not $proc.HasExited) {
+    Start-Sleep -Seconds 15
+    $currentSize = (Get-ChildItem $logDir -Recurse -File | Measure-Object -Property Length -Sum).Sum
+    
+    if ($currentSize -eq $lastSize) {
+        $stallCount++
+        if ($stallCount -ge 4) { # 60s with no progress
+            Write-Warning "Session stalled — no log activity for 60s"
+            break
+        }
+    } else {
+        $stallCount = 0
+        $lastSize = $currentSize
+    }
+}
+```
+
+**Progress Indicators (What Counts as "Alive"):**
+
+- New files appearing in the session log directory (e.g., `transcript.log`, `mcp-server-logs/`)
+- Log file size increasing (indicates active processing)
+- New or modified `.squad/` files in the target repo (e.g., `decisions/inbox.md`, `identity/history.md`)
+- Process still running and consuming non-idle CPU time
+
+**Stall Detection (When to Intervene):**
+
+- **No log activity for 60s** → Issue a warning; session may be slow but not hung
+- **No log activity for 120s** → Likely stuck; consider terminating and checking logs
+- **Process exited with non-zero exit code** → Failed; examine `transcript.log` and `stderr` for errors
+- **MCP server connection timeout** → Session blocked waiting for an MCP server response
+
+**Recovery Actions When Stalled:**
+
+1. **Check for user input waiting:** Inspect logs for prompts or dialogs (shouldn't happen with `--autopilot`)
+2. **Check MCP server health:** Review `mcp-server-logs/` for connection errors or timeouts
+3. **Retry with `--no-mcp` flag:** For lightweight queries that don't require MCP tools
+   ```powershell
+   # Retry without MCP servers — faster startup, limited capability
+   ghcs -p $promptFile -- --working-directory $targetRepo --no-mcp
+   ```
+4. **Increase timeout threshold:** If MCP server initialization is consistently slow (>90s), raise threshold before declaring stall
+
+---
+
+### Pattern 1: Read-Only Knowledge Query (No CLI Needed)
+
+For questions about another squad's architecture, decisions, or current state — read their `.squad/` metadata directly.
+
+**Protocol:**
+1. Read target repo's `.squad/team.md` → get stack, members, issue source
+2. Read `.squad/decisions.md` → get architectural decisions
+3. Read `.squad/routing.md` → understand who handles what
+4. Read `.squad/identity/now.md` → get current focus
+5. Scan code structure if needed (csproj files, directory layout)
+
+**Requirements:**
+- Target repo must be cloned locally or accessible via git
+- No authentication needed beyond git read access
+
+**Example:**
+```powershell
+# Query another squad's architecture
+$targetRepo = "C:\repos\platform-squad-repo"
+Get-Content "$targetRepo\.squad\team.md"
+Get-Content "$targetRepo\.squad\decisions.md"
+Get-Content "$targetRepo\.squad\identity\now.md"
+```
+
+**Response quality:** ⭐⭐⭐⭐ — excellent for structural/architectural questions.
+
+---
+
+### Pattern 2: Async Task Request (Git-Based)
+
+For work that needs the target squad to execute (PR reviews, issue analysis, code changes).
+
+**Protocol:**
+1. Create request file in YOUR repo: `.squad/cross-squad/requests/{timestamp}-{target}-{id}.yaml`
+2. Commit and push
+3. Target squad's Ralph detects on next cycle
+4. Target squad processes and writes response to their `.squad/cross-squad/responses/`
+5. Your Ralph picks up the response
+
+**Request File Format:**
+```yaml
+id: req-2026-06-13-001
+source_squad: research-squad
+source_repo: your-org/research-squad-repo
+target_squad: platform-squad
+target_repo: your-org/platform-squad-repo
+request_type: knowledge_query | pr_review | task_delegation | dependency_check
+priority: high | normal | low
+created_at: 2026-06-13T10:00:00Z
+query: "What is the current architecture of the platform?"
+routing_hint: "lead"  # optional — which agent should handle this
+status: pending
+```
+
+**Response File Format:**
+```yaml
+id: req-2026-06-13-001
+responding_squad: platform-squad
+responding_agent: lead
+responded_at: 2026-06-13T10:15:00Z
+status: completed | partial | rejected
+response: |
+  The platform architecture consists of...
+artifacts: []  # optional file paths
+```
+
+---
+
+### Pattern 3: Issue-Based Delegation (For GitHub-Hosted Repos)
+
+For repos on GitHub, use issues with labels as the message bus.
+
+**Protocol:**
+1. Create issue in target repo with label `squad:cross-squad`
+2. Include source squad identifier and routing hint in issue body
+3. Target squad's Ralph picks up and routes to appropriate agent
+4. Response posted as issue comment
+5. Issue closed when complete
+
+**Example:**
+```bash
+gh issue create \
+  --repo your-org/platform-squad-repo \
+  --title "[Cross-Squad] Architecture query from research-squad" \
+  --body "Source: research-squad\nQuery: What services does the platform expose?\nRouting: lead" \
+  --label "squad:cross-squad"
+```
+
+**Limitation:** Only works for repos on GitHub. Other platforms (Azure DevOps, GitLab, etc.) need different approach.
+
+---
+
+### Pattern 4: Cross-Repo Dependency Scan
+
+For discovering how two repos relate to each other.
+
+**Protocol:**
+1. Search both repos for mutual references:
+   ```powershell
+   Select-String -Path (Get-ChildItem $repoA -Recurse -Include "*.md","*.cs","*.json","*.csproj") `
+     -Pattern $repoB_name
+   Select-String -Path (Get-ChildItem $repoB -Recurse -Include "*.md","*.cs","*.json","*.csproj") `
+     -Pattern $repoA_name
+   ```
+2. Check shared NuGet packages / npm packages
+3. Check shared ADO project or GitHub org
+4. Document relationship type: code dependency, operational coupling, shared infra
+
+---
+
+## Discovery Protocol
+
+Before sending any cross-squad request, verify the target:
+
+```
+1. Does .squad/team.md exist?           → Squad is installed
+2. What is the issue_source?            → GitHub Issues | ADO | Planner
+3. What agents are active?              → Check member status column
+4. What is the routing table?           → Read routing.md
+5. What is the current focus?           → Read identity/now.md
+6. Is Ralph running?                    → Check for recent commits by Ralph
+```
+
+If `.squad/team.md` doesn't exist, the repo is not squad-enabled. Fall back to standard human communication.
+
+---
+
+## Platform Compatibility Matrix
+
+| Source Issue Tracker | Target Issue Tracker | Mechanism |
+|---------------------|---------------------|-----------|
+| GitHub Issues | GitHub Issues | Issue-based (Pattern 3) |
+| GitHub Issues | ADO Work Items | Git-based (Pattern 2) |
+| GitHub Issues | Planner | Git-based (Pattern 2) |
+| ADO Work Items | GitHub Issues | Issue-based (Pattern 3) via `gh` CLI |
+| ADO Work Items | ADO Work Items | ADO cross-project work items |
+| Any | Any | Git-based (Pattern 2) — universal fallback |
+
+---
+
+## Examples
+
+### Example 1: research-squad queries platform-squad architecture
+
+```powershell
+# Step 1: Read metadata (Pattern 1)
+$target = "C:\repos\platform-squad-repo"
+$team = Get-Content "$target\.squad\team.md" -Raw
+$decisions = Get-Content "$target\.squad\decisions.md" -Raw
+
+# Step 2: Extract answer from metadata
+# team.md reveals tech stack and member roles
+# decisions.md reveals architectural choices
+
+# Step 3: If deeper analysis needed, create async request (Pattern 2)
+```
+
+### Example 2: Request PR review from another squad
+
+```yaml
+# .squad/cross-squad/requests/2026-06-13-platform-squad-pr-review.yaml
+id: pr-review-001
+source_squad: research-squad
+target_squad: platform-squad
+request_type: pr_review
+priority: normal
+query: "Review PR #54 — package version fix. Check for correctness."
+routing_hint: "lead"
+status: pending
+```
+
+---
+
+## Anti-Patterns
+
+### ⚠️ Know when synchronous CLI is NOT the right choice
+```powershell
+# WRONG — don't use sync CLI for long-running tasks that need artifacts
+ghcs -p $promptFile -- --working-directory $targetRepo
+# If the task creates files, PRs, or takes multiple cycles → use async (Pattern 2 or 3)
+
+# WRONG — don't use sync CLI when the target repo isn't cloned locally
+ghcs -- --working-directory "C:\not\cloned\yet"
+# If the repo isn't available locally → use issue-based delegation (Pattern 3)
+```
+Synchronous CLI sessions (Pattern 0) are valid for quick queries and knowledge lookups. Use async patterns for work that needs to persist or where the target repo isn't available locally.
+
+### ❌ Don't assume shared MCP tools
+Each squad has its own MCP server instances. You cannot invoke another squad's ADO tools or GitHub tools from your session.
+
+### ❌ Don't skip the discovery step
+Always read `team.md` first. The target squad may use a different issue tracker, have different agents, or be in a different state than expected.
+
+### ❌ Don't send requests to squads without Ralph
+If the target squad doesn't have Ralph (Work Monitor) running, async requests will never be processed. Check for recent Ralph activity first.
+
+### ❌ Don't mix up repo platforms
+Different repos may use GitHub Issues vs Azure DevOps Work Items vs Jira. Check `team.md` / repository metadata for the right tooling before sending requests.
+
+---
+
+## Validation Status
+
+Originally designed and validated against two production squad instances (a GitHub-hosted platform squad with ~10 agents and an Azure DevOps-hosted automation squad with ~4 agents). The protocols are platform-agnostic; the examples in this document use generic names so you can substitute your own repos.
+
+| Scenario | Result |
+|----------|--------|
+| Knowledge query (read-only) | ✅ Works via Pattern 1 |
+| Step handler discovery | ✅ Works via file scan |
+| PR review (basic) | ⚠️ Partial — git log only, no API |
+| Backlog enumeration | ⚠️ Partial — depends on issue platform |
+| Dependency analysis | ✅ Works via cross-reference scan |
+| CLI invocation (sync) + Liveness Protocol | ✅ Works — session launches successfully; log monitoring prevents false timeouts |
+
+**Confidence: MEDIUM** — Synchronous CLI pattern (Pattern 0) validated end-to-end. Liveness protocol provides operational robustness against slow MCP initialization. Git-based async (Pattern 2) and issue-based (Pattern 3) untested end-to-end. Production readiness requires Ralph integration on both sides.

--- a/packages/squad-sdk/templates/skills/cross-squad-communication/SKILL.md
+++ b/packages/squad-sdk/templates/skills/cross-squad-communication/SKILL.md
@@ -3,14 +3,14 @@ name: "cross-squad-communication"
 description: "Protocol for sending queries, delegating tasks, and sharing context between independent Squad instances across different repositories"
 domain: "multi-repo coordination"
 confidence: "medium"
-source: "Ported from tamirdresher/squad-skills (plugins/cross-squad-communication, validated against two production squad instances). Companion to the registry-aware cross-squad skill — this one teaches the actual communication protocols once a peer is discovered."
+source: "Ported from tamirdresher/squad-skills (plugins/cross-squad-communication). Companion to the registry-aware cross-squad skill — this one teaches the actual communication protocols once a peer is discovered. Pattern 0 (synchronous CLI) is the only end-to-end-validated pattern; Patterns 1, 2, 3 are documented from design but require live validation against your own setup before relying on them in production. See the Validation Status section at the bottom of this skill."
 ---
 
 ## Context
 
 When multiple repositories each have their own Squad (AI team), they need to exchange information: knowledge queries, PR reviews, task delegation, and dependency analysis. Each squad has its own agents, MCP tools, and issue tracker — there is no shared runtime.
 
-> **Companion skill — read first:** `cross-squad/SKILL.md` covers **discovery** of peer squads via `squad registry add/list/remove`. This skill picks up after a peer is known and covers the **communication protocols** themselves (sync CLI, async git, issue-based). The two are designed to be used together.
+> **Companion skill — read first:** `cross-squad/SKILL.md` covers **discovery** of peer squads via `squad registry add/list/remove`. This skill picks up after a peer is known and covers the **communication protocols** themselves — the four numbered patterns below: Pattern 0 (synchronous CLI), Pattern 1 (read-only knowledge query), Pattern 2 (git-based async), and Pattern 3 (GitHub-issue-based delegation). A separate non-numbered appendix (Cross-Repo Dependency Scan) is provided as a related analysis tool, not a communication pattern. The two skills are designed to be used together.
 
 **When this skill applies:**
 - A squad agent needs information from another squad-enabled repo
@@ -254,7 +254,9 @@ gh issue create \
 
 ---
 
-### Pattern 4: Cross-Repo Dependency Scan
+### Appendix: Cross-Repo Dependency Scan (Related Analysis Tool — Not a Communication Pattern)
+
+> This section is intentionally listed as an appendix rather than "Pattern 4" — it is a one-off analysis utility for discovering how two repos relate, not a protocol the coordinator picks from the decision tree above. The four numbered communication patterns are 0–3.
 
 For discovering how two repos relate to each other.
 
@@ -365,7 +367,7 @@ Different repos may use GitHub Issues vs Azure DevOps Work Items vs Jira. Check 
 
 ## Validation Status
 
-Originally designed and validated against two production squad instances (a GitHub-hosted platform squad with ~10 agents and an Azure DevOps-hosted automation squad with ~4 agents). The protocols are platform-agnostic; the examples in this document use generic names so you can substitute your own repos.
+This skill was originally drafted against two prototype squad setups (a GitHub-hosted platform squad with ~10 agents and an Azure DevOps-hosted automation squad with ~4 agents). The protocols are platform-agnostic; the examples in this document use generic names so you can substitute your own repos. Patterns 0 and 1 have been exercised end-to-end in those prototypes; Patterns 2 and 3 are documented from design but have not been end-to-end-validated against a live target repo.
 
 | Scenario | Result |
 |----------|--------|

--- a/packages/squad-sdk/templates/skills/cross-squad-communication/SKILL.md
+++ b/packages/squad-sdk/templates/skills/cross-squad-communication/SKILL.md
@@ -43,6 +43,14 @@ Is the target repo cloned locally?
 
 ---
 
+## Universal rule: every `copilot` spawn into a peer squad MUST pass `--agent squad`
+
+The `copilot` CLI accepts `--agent <name>` to select a custom agent (see `copilot --help`). Squad installs ship `.github/agents/squad.agent.md`, which is loaded **only when `--agent squad` is specified**. Without it the spawned session runs as a generic Copilot CLI session that does NOT load the peer's `team.md`, routing, MCP tools, casting, or coordinator behaviour — so you get an off-the-shelf model answering, not the peer's Squad. **Every command example in this skill that spawns `copilot` into a peer repo includes `--agent squad`; do not strip it.**
+
+This rule also applies anywhere else you spawn `copilot` into a Squad-initialised repo (not just cross-squad protocols) — e.g., `squad init`'s post-init tip and any automation that invokes the CLI on a squadified folder. The only case where you may omit `--agent` is when resuming an existing session (`copilot --resume <sessionId>`) — the resumed session preserves its original agent context.
+
+---
+
 ### Pattern 0: Synchronous CLI Session (Fastest for Interactive Queries)
 
 For quick knowledge queries, decision lookups, or short analyses — spawn a Copilot CLI session with the working directory set to the target squad's repo. This lets you send a prompt and get a response within the same session, using the target repo's full context.
@@ -51,7 +59,7 @@ This is the same technique used by `ralph-watch.ps1`: write the prompt to a temp
 
 **Protocol:**
 1. Write prompt to a temp file (avoids argument-splitting issues, as learned in `ralph-watch.ps1`)
-2. Read the file into a string and invoke `copilot -p <text>` with `-C <directory>` set to the target repo (`-p` takes prompt text, NOT a file path)
+2. Read the file into a string and invoke `copilot -p <text>` with `-C <directory>` set to the target repo (`-p` takes prompt text, NOT a file path) AND `--agent squad` so the spawned session uses the peer squad's coordinator (without `--agent` you get a generic Copilot CLI session that doesn't load the peer's `team.md`, MCP tools, or skills)
 3. Receive response in the same session
 
 **Invocation:**
@@ -71,13 +79,15 @@ Response Format: Brief structured summary
 "@ | Out-File $promptFile -Encoding utf8
 
 # Option A: copilot with prompt file (read file into string; -p takes text, not a path)
-copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
+# --agent squad is REQUIRED: the target is another Squad install, so the spawned
+# session must use that squad's coordinator (not a generic Copilot CLI session).
+copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --allow-all-tools
 
 # Option B: Start-Process for non-blocking (ralph-watch.ps1 style)
-Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo' -p (Get-Content '$promptFile' -Raw) --allow-all-tools`"" -Wait
+Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo' --agent squad -p (Get-Content '$promptFile' -Raw) --allow-all-tools`"" -Wait
 
 # Option C: Pipe directly (stdin is the prompt text)
-"What is the platform architecture?" | copilot -C $targetRepo --allow-all-tools
+"What is the platform architecture?" | copilot -C $targetRepo --agent squad --allow-all-tools
 ```
 
 **When to use synchronous vs async:**
@@ -99,6 +109,7 @@ Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo'
 
 **Requirements:**
 - Target repo must be cloned locally (for `copilot -C <directory>`)
+- Target repo must be Squad-initialised (`.squad/config.json` + `.github/agents/squad.agent.md` present), so `--agent squad` resolves to the peer's coordinator
 - Prompt file avoids argument-splitting bugs (see `ralph-watch.ps1` lines 2166-2184)
 
 **Response quality:** ⭐⭐⭐⭐⭐ — the CLI session has full context of the target repo, including code, squad metadata, and MCP tools.
@@ -163,7 +174,7 @@ while ($proc -and -not $proc.HasExited) {
 3. **Retry with `--disable-builtin-mcps` flag:** For lightweight queries that don't require MCP tools
    ```powershell
    # Retry without MCP servers — faster startup, limited capability
-   copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --disable-builtin-mcps --allow-all-tools
+   copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --disable-builtin-mcps --allow-all-tools
    ```
 4. **Increase timeout threshold:** If MCP server initialization is consistently slow (>90s), raise threshold before declaring stall
 
@@ -349,11 +360,11 @@ status: pending
 ### ⚠️ Know when synchronous CLI is NOT the right choice
 ```powershell
 # WRONG — don't use sync CLI for long-running tasks that need artifacts
-copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
+copilot -C $targetRepo --agent squad -p (Get-Content $promptFile -Raw) --allow-all-tools
 # If the task creates files, PRs, or takes multiple cycles → use async (Pattern 2 or 3)
 
 # WRONG — don't use sync CLI when the target repo isn't cloned locally
-copilot -C "C:\not\cloned\yet" --allow-all-tools
+copilot -C "C:\not\cloned\yet" --agent squad --allow-all-tools
 # If the repo isn't available locally → use issue-based delegation (Pattern 3)
 ```
 Synchronous CLI sessions (Pattern 0) are valid for quick queries and knowledge lookups. Use async patterns for work that needs to persist or where the target repo isn't available locally.

--- a/packages/squad-sdk/templates/skills/cross-squad-communication/SKILL.md
+++ b/packages/squad-sdk/templates/skills/cross-squad-communication/SKILL.md
@@ -51,7 +51,7 @@ This is the same technique used by `ralph-watch.ps1`: write the prompt to a temp
 
 **Protocol:**
 1. Write prompt to a temp file (avoids argument-splitting issues, as learned in `ralph-watch.ps1`)
-2. Invoke CLI with `-p` pointing to the prompt file and `--working-directory` set to the target repo
+2. Read the file into a string and invoke `copilot -p <text>` with `-C <directory>` set to the target repo (`-p` takes prompt text, NOT a file path)
 3. Receive response in the same session
 
 **Invocation:**
@@ -70,14 +70,14 @@ Query: What is the current architecture of the platform? What services does it e
 Response Format: Brief structured summary
 "@ | Out-File $promptFile -Encoding utf8
 
-# Option A: ghcs with prompt file
-ghcs -p $promptFile -- --working-directory $targetRepo
+# Option A: copilot with prompt file (read file into string; -p takes text, not a path)
+copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
 
 # Option B: Start-Process for non-blocking (ralph-watch.ps1 style)
-Start-Process pwsh -ArgumentList "-NoProfile -Command `"cd '$targetRepo'; ghcs -p '$promptFile'`"" -Wait
+Start-Process pwsh -ArgumentList "-NoProfile -Command `"copilot -C '$targetRepo' -p (Get-Content '$promptFile' -Raw) --allow-all-tools`"" -Wait
 
-# Option C: Pipe directly
-"What is the platform architecture?" | ghcs -- --working-directory $targetRepo
+# Option C: Pipe directly (stdin is the prompt text)
+"What is the platform architecture?" | copilot -C $targetRepo --allow-all-tools
 ```
 
 **When to use synchronous vs async:**
@@ -98,7 +98,7 @@ Start-Process pwsh -ArgumentList "-NoProfile -Command `"cd '$targetRepo'; ghcs -
 4. Is the target squad's Ralph running? → Needed for async processing
 
 **Requirements:**
-- Target repo must be cloned locally (for `--working-directory`)
+- Target repo must be cloned locally (for `copilot -C <directory>`)
 - Prompt file avoids argument-splitting bugs (see `ralph-watch.ps1` lines 2166-2184)
 
 **Response quality:** ⭐⭐⭐⭐⭐ — the CLI session has full context of the target repo, including code, squad metadata, and MCP tools.
@@ -112,9 +112,16 @@ The synchronous CLI session requires monitoring to avoid false timeouts. With 7+
 Instead of a fixed wall-clock timeout, monitor the agency session log directory for activity:
 
 ```powershell
-# The agency CLI creates a session log directory
-# e.g., ~/.agency/logs/session_20260325_071211_57824
-$logDir = Get-ChildItem "$env:USERPROFILE\.agency\logs" -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+# The Copilot CLI creates a session log directory at ~/.copilot/logs/.
+# Older `agency` runtimes wrote to ~/.agency/logs/; fall back to that
+# location if the new path doesn't exist yet on the user's machine.
+# e.g., ~/.copilot/logs/session_20260325_071211_57824
+$copilotLogs = "$env:USERPROFILE\.copilot\logs"
+$agencyLogs = "$env:USERPROFILE\.agency\logs"
+$logRoot = if (Test-Path $copilotLogs) { $copilotLogs } elseif (Test-Path $agencyLogs) { $agencyLogs } else { $null }
+if ($logRoot) {
+    $logDir = Get-ChildItem $logRoot -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+}
 $lastSize = 0
 $stallCount = 0
 
@@ -153,10 +160,10 @@ while ($proc -and -not $proc.HasExited) {
 
 1. **Check for user input waiting:** Inspect logs for prompts or dialogs (shouldn't happen with `--autopilot`)
 2. **Check MCP server health:** Review `mcp-server-logs/` for connection errors or timeouts
-3. **Retry with `--no-mcp` flag:** For lightweight queries that don't require MCP tools
+3. **Retry with `--disable-builtin-mcps` flag:** For lightweight queries that don't require MCP tools
    ```powershell
    # Retry without MCP servers — faster startup, limited capability
-   ghcs -p $promptFile -- --working-directory $targetRepo --no-mcp
+   copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --disable-builtin-mcps --allow-all-tools
    ```
 4. **Increase timeout threshold:** If MCP server initialization is consistently slow (>90s), raise threshold before declaring stall
 
@@ -342,11 +349,11 @@ status: pending
 ### ⚠️ Know when synchronous CLI is NOT the right choice
 ```powershell
 # WRONG — don't use sync CLI for long-running tasks that need artifacts
-ghcs -p $promptFile -- --working-directory $targetRepo
+copilot -C $targetRepo -p (Get-Content $promptFile -Raw) --allow-all-tools
 # If the task creates files, PRs, or takes multiple cycles → use async (Pattern 2 or 3)
 
 # WRONG — don't use sync CLI when the target repo isn't cloned locally
-ghcs -- --working-directory "C:\not\cloned\yet"
+copilot -C "C:\not\cloned\yet" --allow-all-tools
 # If the repo isn't available locally → use issue-based delegation (Pattern 3)
 ```
 Synchronous CLI sessions (Pattern 0) are valid for quick queries and knowledge lookups. Use async patterns for work that needs to persist or where the target repo isn't available locally.

--- a/packages/squad-sdk/templates/skills/cross-squad/SKILL.md
+++ b/packages/squad-sdk/templates/skills/cross-squad/SKILL.md
@@ -16,6 +16,8 @@ tools:
 ## Context
 When an organization runs multiple Squad instances (e.g., platform-squad, frontend-squad, data-squad), those squads need to discover each other, share context, and hand off work across repository boundaries. This skill teaches agents how to coordinate across squads without creating tight coupling.
 
+> **Companion skill — for protocol details:** `cross-squad-communication/SKILL.md` covers the four communication patterns (sync CLI, async git-based, issue-based) once a peer squad is discovered via the registry below. This skill answers "who?" — the companion answers "how?".
+
 Cross-squad orchestration applies when:
 - A task requires capabilities owned by another squad
 - An architectural decision affects multiple squads

--- a/packages/squad-sdk/templates/skills/cross-squad/SKILL.md
+++ b/packages/squad-sdk/templates/skills/cross-squad/SKILL.md
@@ -16,7 +16,7 @@ tools:
 ## Context
 When an organization runs multiple Squad instances (e.g., platform-squad, frontend-squad, data-squad), those squads need to discover each other, share context, and hand off work across repository boundaries. This skill teaches agents how to coordinate across squads without creating tight coupling.
 
-> **Companion skill — for protocol details:** `cross-squad-communication/SKILL.md` covers the four communication patterns (sync CLI, async git-based, issue-based) once a peer squad is discovered via the registry below. This skill answers "who?" — the companion answers "how?".
+> **Companion skill — for protocol details:** `cross-squad-communication/SKILL.md` covers the four communication patterns (synchronous CLI, read-only knowledge query, git-based async, and GitHub-issue-based delegation) once a peer squad is discovered via the registry below. This skill answers "who?" — the companion answers "how?".
 
 Cross-squad orchestration applies when:
 - A task requires capabilities owned by another squad

--- a/test/cross-squad.test.ts
+++ b/test/cross-squad.test.ts
@@ -495,3 +495,84 @@ describe('findSquadByName', () => {
     expect(findSquadByName(squads, 'gamma')).toBeUndefined();
   });
 });
+
+// ============================================================================
+// cross-squad-communication/SKILL.md — CLI invocation correctness
+// ============================================================================
+//
+// The SKILL.md tells coordinators how to invoke the Copilot CLI on a peer
+// squad repo. An earlier draft of the skill used `ghcs` (which doesn't
+// exist as a binary), `--working-directory` (real flag is `-C`), `--no-mcp`
+// (real flag is `--disable-builtin-mcps`), `-p <file>` (real flag takes
+// prompt TEXT, not a path), and a `~/.agency/logs/` log path (new CLI logs
+// under `~/.copilot/logs/`). All five are wrong on the real `copilot` CLI
+// (verified empirically against `copilot --help`).
+//
+// These tests assert each of the 5 corrections is present in every mirrored
+// copy of the skill, so a future refactor can't silently regress the file
+// back to a state where the CLI commands it suggests would fail.
+
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname_ccc = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT_CCC = resolve(__dirname_ccc, '..');
+
+const CROSS_SQUAD_COMM_LOCATIONS = [
+  '.squad/skills/cross-squad-communication/SKILL.md',
+  'packages/squad-cli/templates/skills/cross-squad-communication/SKILL.md',
+  'packages/squad-sdk/templates/skills/cross-squad-communication/SKILL.md',
+] as const;
+
+describe('cross-squad-communication/SKILL.md uses real Copilot CLI invocations', () => {
+  for (const loc of CROSS_SQUAD_COMM_LOCATIONS) {
+    describe(loc, () => {
+      const content = readFileSync(resolve(REPO_ROOT_CCC, loc), 'utf-8');
+
+      it('does NOT reference the non-existent `ghcs` binary', () => {
+        // `ghcs` (the old "GitHub Copilot in the Shell" shim) is not a
+        // standalone binary in modern installs. The real CLI is `copilot`.
+        expect(content).not.toMatch(/\bghcs\b/);
+      });
+
+      it('does NOT reference the non-existent `--working-directory` flag', () => {
+        // `copilot --help` shows `-C <directory>`, not `--working-directory`.
+        expect(content).not.toMatch(/--working-directory\b/);
+      });
+
+      it('does NOT reference the non-existent `--no-mcp` flag', () => {
+        // Real flag is `--disable-builtin-mcps`.
+        expect(content).not.toMatch(/--no-mcp\b/);
+      });
+
+      it('uses `copilot -C <dir>` for setting the target working directory', () => {
+        expect(content).toMatch(/copilot\s+-C\s/);
+      });
+
+      it('uses `--disable-builtin-mcps` in the MCP-skip fallback', () => {
+        expect(content).toMatch(/--disable-builtin-mcps\b/);
+      });
+
+      it('reads the prompt file into a string before passing to `-p`', () => {
+        // `-p, --prompt <text>` per `copilot --help` — passing a path makes
+        // the CLI try to execute the path string as a prompt.
+        expect(content).toMatch(/-p\s+\(Get-Content/);
+      });
+
+      it('passes `--allow-all-tools` for autonomous (non-interactive) invocations', () => {
+        // Without this, every tool call prompts for permission and hangs
+        // the cross-squad delegation indefinitely.
+        expect(content).toMatch(/--allow-all-tools\b/);
+      });
+
+      it('uses ~/.copilot/logs/ as the primary log root with .agency fallback', () => {
+        // New CLI logs under ~/.copilot/logs/. Older agency runtimes
+        // wrote to ~/.agency/logs/ — keep the fallback for transitional
+        // installs but reference the new path first.
+        expect(content).toMatch(/\.copilot\\logs/);
+        expect(content).toMatch(/Test-Path/);
+      });
+    });
+  }
+});

--- a/test/cross-squad.test.ts
+++ b/test/cross-squad.test.ts
@@ -573,6 +573,39 @@ describe('cross-squad-communication/SKILL.md uses real Copilot CLI invocations',
         expect(content).toMatch(/\.copilot\\logs/);
         expect(content).toMatch(/Test-Path/);
       });
+
+      it('every `copilot` spawn into a peer squad includes `--agent squad`', () => {
+        // Squad installs ship .github/agents/squad.agent.md which is only
+        // loaded when --agent squad is passed. Without it the spawned
+        // session runs as a generic Copilot CLI session and does NOT load
+        // the peer's team.md, routing, MCP tools, casting, or coordinator
+        // — defeating the entire point of cross-squad delegation.
+        //
+        // Find every `copilot ...` command line (excluding `copilot --resume`
+        // which preserves the original session's agent, and prose
+        // references to the flag like "`copilot -C <directory>`"). Each
+        // remaining line MUST contain `--agent squad`.
+        const lines = content.split(/\r?\n/);
+        const spawnLines = lines.filter(l =>
+          /\bcopilot\s+(?:-[A-Z]|-p|--(?!resume|version|help))/.test(l)
+          && !/`copilot\s+-C\s+<directory>`/.test(l) // prose flag reference
+        );
+        expect(spawnLines.length, 'expected at least one copilot spawn command').toBeGreaterThan(0);
+        for (const line of spawnLines) {
+          expect(
+            line,
+            `every copilot spawn into a peer squad must pass '--agent squad'. Offender:\n  ${line.trim()}`
+          ).toMatch(/--agent\s+squad\b/);
+        }
+      });
+
+      it('explains WHY --agent squad is required (universal rule paragraph)', () => {
+        // The rationale needs to be visible inline so future edits don't
+        // strip --agent thinking it's redundant. Match the universal-rule
+        // header + the key consequence keyword.
+        expect(content).toMatch(/Universal rule.*--agent squad/i);
+        expect(content).toMatch(/generic Copilot CLI session/i);
+      });
     });
   }
 });

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -280,12 +280,6 @@ describe('Squad Initialization', () => {
     });
 
     it('should install the squad-help disambiguation skill (regression: #1297 / supersedes squad name collision)', async () => {
-      // The Squad framework registers a Copilot CLI agent named "Squad" at
-      // .github/agents/squad.agent.md. Coding models sometimes confuse that
-      // with a skill and call skill(Squad), which fails. Fix: name the
-      // disambiguation skill "squad-help" instead — avoids the agent-name
-      // collision (so /skills lists it) and is discoverable via natural-
-      // language match on its description.
       const agents: InitAgentSpec[] = [{ name: 'lead', role: 'lead' }];
       const options: InitOptions = {
         teamRoot: TEST_ROOT,
@@ -305,14 +299,6 @@ describe('Squad Initialization', () => {
     });
 
     it('should install the squad slash-command skill with user-invocable: true (regression: /squad must appear)', async () => {
-      // Users want to type /squad in Copilot CLI to see Squad's command
-      // catalog. Copilot CLI auto-registers any skill with frontmatter
-      // user-invocable: true as a slash command using the skill's name.
-      // Verified against Copilot CLI 1.0.62-2 sdk/index.js, function Y_n:
-      //   getLoadedSkills().filter(e => e.userInvocable).map(...
-      //     ({name: `/${eF(e)}`, isSkill: true, skill: e}))
-      // Renamed from 'squad-commands' to 'squad' + set user-invocable: true
-      // so /squad shows the command catalog. Composes with squad-help.
       const agents: InitAgentSpec[] = [{ name: 'lead', role: 'lead' }];
       const options: InitOptions = {
         teamRoot: TEST_ROOT,
@@ -328,6 +314,24 @@ describe('Squad Initialization', () => {
       expect(content).toMatch(/^user-invocable:\s*true\s*$/m);
       expect(content).toMatch(/^name:\s*"?squad"?\s*$/m);
       expect(content).toContain('Menu Presentation Rules');
+    });
+
+    it('should install cross-squad-communication skill (companion to cross-squad — #5)', async () => {
+      const agents: InitAgentSpec[] = [{ name: 'lead', role: 'lead' }];
+      const options: InitOptions = {
+        teamRoot: TEST_ROOT,
+        projectName: 'Test Project',
+        agents
+      };
+
+      await initSquad(options);
+
+      const skillPath = join(TEST_ROOT, '.github', 'skills', 'cross-squad-communication', 'SKILL.md');
+      expect(existsSync(skillPath)).toBe(true);
+      const content = await readFile(skillPath, 'utf-8');
+      expect(content).toContain('cross-squad-communication');
+      expect(content).toContain('Pattern 0');
+      expect(content).toContain('Pattern 2');
     });
 
     it('should create initial decisions.md', async () => {


### PR DESCRIPTION
PR #1291 added `squad registry add/list/remove` and the `cross-squad/SKILL.md` for peer discovery. But discovery is only half the story — once a peer is known, agents need to know **how** to actually exchange info with it.

This change ports `cross-squad-communication` from [tamirdresher/squad-skills](https://github.com/tamirdresher/squad-skills/tree/main/plugins/cross-squad-communication) into the bundled skills so a fresh `squad init` produces a coordinator that knows the four communication patterns.

## What this skill teaches

| Pattern | When to use |
|---|---|
| **Pattern 0**: Synchronous CLI session | Quick knowledge queries — spawn `copilot` with `--working-directory` set to target repo |
| **Pattern 1**: Read-only metadata scan | "What's the architecture of squad X?" — read their `team.md` / `decisions.md` directly |
| **Pattern 2**: Async git-based request/response | Long-running work, PR reviews, multi-cycle tasks. Files in `.squad/cross-squad/requests/` + `.squad/cross-squad/responses/` |
| **Pattern 3**: Issue-based delegation | GitHub-hosted repos — `gh issue create` with `squad:cross-squad` label as the message bus |

Plus: decision tree for choosing the right pattern, anti-patterns, request/response YAML format, validation status.

## Changes

- **New** `.squad/skills/cross-squad-communication/SKILL.md` (379 lines, canonical source). `sync-skill-templates.mjs` (which runs in `prebuild`) propagates to both `packages/squad-cli/templates/skills/` and `packages/squad-sdk/templates/skills/`.
- **`MANIFEST_SKILL_NAMES`** in `packages/squad-sdk/src/config/init.ts` grows by 1 entry: `cross-squad-communication` → 11 entries total.
- **`cross-squad/SKILL.md`** (the registry-aware skill from #1291) gets a one-paragraph "Companion skill" note at the top pointing to `cross-squad-communication` for protocol details. The two are designed to be used together: `cross-squad` answers **"who?"** (discovery via registry), `cross-squad-communication` answers **"how?"** (the 4 communication patterns).

## Genericization

The original plugin documented validation against specific internal Microsoft repositories. Examples in this version use generic names (`platform-squad`, `research-squad`, etc.) so they are meaningful to all upstream users. The protocol mechanics are unchanged. The frontmatter `source:` attributes the port to `tamirdresher/squad-skills`.

## Test coverage

New `test/init.test.ts > should install cross-squad-communication skill (companion to cross-squad — #5)` — asserts the SKILL.md ends up at `.copilot/skills/cross-squad-communication/SKILL.md` after `initSquad()` and the content contains the expected pattern names. 26/26 init tests pass; `npm run lint` clean.

## Composition with #1291

`ash
# 1. Init produces a squad that already knows both skills
squad init

# 2. Register a peer squad (#1291)
squad registry add ../peer-squad-repo

# 3. Ask the coordinator: "what are the team members of the peer squad?"
#    → The coordinator now has cross-squad-communication's Pattern 1 in scope
#      and knows to read team.md from the registered peer
`

## Note on overlap with #1292

PR #1292 (skills bundling fix) adds `squad-commands`, `squad-version-check`, `tiered-memory`, `iterative-retrieval`, `reflect`, and `cross-squad` to `MANIFEST_SKILL_NAMES`. That PR and this one both modify the same array but add disjoint entries. When both merge, the manifest grows to 15 entries (10 base + 4 from #1292 + 1 from here). Either PR can land first.
