### PR TITLE
fix(skills): add 'squad' disambiguation skill so skill(Squad) lookups succeed

### DIFF
--- a/.changeset/add-squad-disambiguation-skill.md
+++ b/.changeset/add-squad-disambiguation-skill.md
@@ -1,0 +1,55 @@
+---
+"@bradygaster/squad-sdk": patch
+"@bradygaster/squad-cli": patch
+---
+
+Fix: add `squad` disambiguation skill so `skill(Squad)` lookups succeed and redirect to the right tool
+
+**Symptom (observed in a fresh `squad init` session, 2026-06-13):**
+
+```
+◐ The Squad skill is perfect for assembling a specialized team to build C# console applications, so I'll use that to get the right specialists set up in the repo.
+✗ skill(Squad)   Skill not found: Squad
+◐ I see the issue—Squad is actually a custom agent type in the task tool, not a standalone skill, so I need to adjust my approach and call the task tool with agent_type set to "Squad" instead.
+```
+
+The model burns a turn on a failed skill lookup before self-correcting. The pattern is reproducible across coding models because the Squad agent's description (`"Your AI team. Describe what you're building, get a team of specialists that live in your repo."`) reads exactly like a skill description.
+
+**Root cause:**
+
+- `.github/agents/squad.agent.md` declares `name: Squad` — that's the **custom agent**.
+- All bundled skills are hyphenated lowercase: `squad-commands`, `squad-conventions`, `squad-version-check`, etc.
+- Nothing matches the literal name `Squad` for skill lookup.
+- The model's first guess (`skill(Squad)`) fails before it figures out the correct path (`task` tool with `agent_type="Squad"`).
+
+**Fix:**
+
+Add a small `squad` skill that exists purely to **catch the bad lookup and redirect**. It does no work; it explicitly tells the model:
+
+- Squad is a **custom agent**, not a skill.
+- To invoke the coordinator: `task(name=…, agent_type="Squad", prompt=…)`.
+- To list commands: trigger the `squad-commands` skill ("squad commands" / "what can squad do" / etc.).
+- To init in a new project: `squad init` in the shell (not from inside a session).
+
+Triggers (`squad`, `use squad`, `use the squad skill`, `squad skill`, `assemble a squad`, `set up squad`, `squad agent`, `squad team`) cover the natural-language phrasings that would have led the model to mis-call `skill(Squad)`.
+
+**Changes:**
+
+- New `.squad/skills/squad/SKILL.md` (canonical source). `sync-skill-templates.mjs` (prebuild) propagates to both `packages/squad-cli/templates/skills/` and `packages/squad-sdk/templates/skills/`.
+- `MANIFEST_SKILL_NAMES` in `packages/squad-sdk/src/config/init.ts` adds one entry: `'squad'`. Now 11 entries.
+
+**Test coverage:**
+
+New `test/init.test.ts > should install the squad disambiguation skill` asserts:
+- File exists at `.copilot/skills/squad/SKILL.md` after `initSquad()`
+- Content includes the literal string `"CUSTOM AGENT"` (warns the model)
+- Content includes the correct invocation pattern `agent_type="Squad"`
+- Content references `squad-commands` (the right skill for the menu use case)
+
+**Out of scope:**
+
+A separate, deeper UX improvement would be to make Copilot CLI's skill loader treat the agent name as a soft alias to the `squad` skill so the lookup succeeds even if a user removes this skill. That's a Copilot CLI change, not a Squad change, and is too large for this fix.
+
+**Composability:**
+
+Adds a single entry to `MANIFEST_SKILL_NAMES`. Disjoint from #1292 (which adds tiered-memory/iterative-retrieval/reflect/cross-squad) and #1295 (which adds cross-squad-communication). All three can land in any order.

--- a/.squad/skills/squad/SKILL.md
+++ b/.squad/skills/squad/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: "squad"
+description: "Disambiguation skill — Squad is a CUSTOM AGENT, not a skill. If you reached this skill while trying to set up an AI team or invoke Squad's coordinator, read this file: it routes you to the right tool (task tool with agent_type='Squad') and surfaces the squad-commands menu."
+domain: "squad-meta"
+confidence: "high"
+source: "first-party"
+triggers: ["squad", "use squad", "use the squad skill", "squad skill", "assemble a squad", "set up squad", "squad agent", "squad team"]
+license: MIT
+---
+
+# Skill: Squad (Disambiguation)
+
+> **You are here because something tried to invoke a skill named `Squad`.**
+> Squad is a **custom agent**, not a skill. This file redirects you to the right tool.
+
+---
+
+## Why this skill exists
+
+The Squad framework registers a custom Copilot CLI agent at `.github/agents/squad.agent.md` with the user-facing name **"Squad"** and the description *"Your AI team. Describe what you're building, get a team of specialists that live in your repo."*
+
+Coding models reading that description sometimes pick the wrong tool: they try `skill(Squad)` (skill lookup) instead of `task(agent_type="Squad", …)` (custom agent invocation). That call fails because no skill is named "Squad" — the actual Squad-related skills are `squad-commands`, `squad-conventions`, `squad-version-check`, etc.
+
+This skill exists so the lookup **succeeds** and immediately tells you the right next step.
+
+---
+
+## How to actually use Squad
+
+There are two distinct things you might want to do. Pick the one that matches your intent:
+
+### A) Invoke the Squad coordinator agent (most common)
+
+Use the **`task` tool** with `agent_type` set to `"Squad"`. This spawns the orchestrator described in `.github/agents/squad.agent.md`. It will route your request to the right specialist agent on the team, scaffold a team if none exists yet, and enforce handoffs.
+
+```text
+task(
+  name="<short-task-name>",
+  agent_type="Squad",
+  prompt="<what you want the team to do>"
+)
+```
+
+Use this when the user says things like:
+- *"Use Squad to build X"*
+- *"Set up an AI team for this project"*
+- *"Have the Squad coordinator design Y"*
+
+### B) See what Squad commands exist
+
+Trigger the **`squad-commands` skill** (not this one). It's a categorized catalog the coordinator presents as an interactive menu.
+
+Triggered by: `"squad commands"`, `"what can squad do"`, `"show me squad options"`, `"slash commands"`, `"what commands are available"`.
+
+Use this when the user says things like:
+- *"What can Squad do?"*
+- *"Show me the squad commands"*
+- *"squad help"*
+
+### C) Initialize Squad in a fresh project (rare from inside a session)
+
+`squad init` is a **shell command**, not a tool call. If a project has no `.squad/` directory and the user wants to add Squad, run `squad init` in their terminal. Do NOT try to invoke this from inside an existing Copilot session — `.squad/` is already initialized if you're reading this file.
+
+---
+
+## What NOT to do
+
+- ❌ Do not call `skill(Squad)` again — you just did, that's how you got here.
+- ❌ Do not call `skill(squad-coordinator)` or other made-up skill names.
+- ❌ Do not assume the Squad agent is a one-shot tool — it spawns specialist agents and orchestrates handoffs across a multi-turn session.
+- ❌ Do not call `task(agent_type="Squad", …)` for tiny tasks the current agent can handle directly. Squad is for work that needs orchestration; trivial edits don't.
+
+---
+
+## How this skill was discovered
+
+Squad scans 5 project skill directories in precedence order. This skill ships at `.copilot/skills/squad/SKILL.md` from the bundled templates so a fresh `squad init` produces a coordinator that already knows the right disambiguation.
+
+If you removed this skill on purpose, the model will fall back to its own reasoning (and may make the same mistake again).
+
+---
+
+## See also
+
+- `.github/agents/squad.agent.md` — the actual Squad coordinator agent
+- `.copilot/skills/squad-commands/SKILL.md` — the command catalog
+- `.copilot/skills/squad-conventions/SKILL.md` — conventions for working on the Squad codebase itself

--- a/packages/squad-cli/templates/skills/squad/SKILL.md
+++ b/packages/squad-cli/templates/skills/squad/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: "squad"
+description: "Disambiguation skill — Squad is a CUSTOM AGENT, not a skill. If you reached this skill while trying to set up an AI team or invoke Squad's coordinator, read this file: it routes you to the right tool (task tool with agent_type='Squad') and surfaces the squad-commands menu."
+domain: "squad-meta"
+confidence: "high"
+source: "first-party"
+triggers: ["squad", "use squad", "use the squad skill", "squad skill", "assemble a squad", "set up squad", "squad agent", "squad team"]
+license: MIT
+---
+
+# Skill: Squad (Disambiguation)
+
+> **You are here because something tried to invoke a skill named `Squad`.**
+> Squad is a **custom agent**, not a skill. This file redirects you to the right tool.
+
+---
+
+## Why this skill exists
+
+The Squad framework registers a custom Copilot CLI agent at `.github/agents/squad.agent.md` with the user-facing name **"Squad"** and the description *"Your AI team. Describe what you're building, get a team of specialists that live in your repo."*
+
+Coding models reading that description sometimes pick the wrong tool: they try `skill(Squad)` (skill lookup) instead of `task(agent_type="Squad", …)` (custom agent invocation). That call fails because no skill is named "Squad" — the actual Squad-related skills are `squad-commands`, `squad-conventions`, `squad-version-check`, etc.
+
+This skill exists so the lookup **succeeds** and immediately tells you the right next step.
+
+---
+
+## How to actually use Squad
+
+There are two distinct things you might want to do. Pick the one that matches your intent:
+
+### A) Invoke the Squad coordinator agent (most common)
+
+Use the **`task` tool** with `agent_type` set to `"Squad"`. This spawns the orchestrator described in `.github/agents/squad.agent.md`. It will route your request to the right specialist agent on the team, scaffold a team if none exists yet, and enforce handoffs.
+
+```text
+task(
+  name="<short-task-name>",
+  agent_type="Squad",
+  prompt="<what you want the team to do>"
+)
+```
+
+Use this when the user says things like:
+- *"Use Squad to build X"*
+- *"Set up an AI team for this project"*
+- *"Have the Squad coordinator design Y"*
+
+### B) See what Squad commands exist
+
+Trigger the **`squad-commands` skill** (not this one). It's a categorized catalog the coordinator presents as an interactive menu.
+
+Triggered by: `"squad commands"`, `"what can squad do"`, `"show me squad options"`, `"slash commands"`, `"what commands are available"`.
+
+Use this when the user says things like:
+- *"What can Squad do?"*
+- *"Show me the squad commands"*
+- *"squad help"*
+
+### C) Initialize Squad in a fresh project (rare from inside a session)
+
+`squad init` is a **shell command**, not a tool call. If a project has no `.squad/` directory and the user wants to add Squad, run `squad init` in their terminal. Do NOT try to invoke this from inside an existing Copilot session — `.squad/` is already initialized if you're reading this file.
+
+---
+
+## What NOT to do
+
+- ❌ Do not call `skill(Squad)` again — you just did, that's how you got here.
+- ❌ Do not call `skill(squad-coordinator)` or other made-up skill names.
+- ❌ Do not assume the Squad agent is a one-shot tool — it spawns specialist agents and orchestrates handoffs across a multi-turn session.
+- ❌ Do not call `task(agent_type="Squad", …)` for tiny tasks the current agent can handle directly. Squad is for work that needs orchestration; trivial edits don't.
+
+---
+
+## How this skill was discovered
+
+Squad scans 5 project skill directories in precedence order. This skill ships at `.copilot/skills/squad/SKILL.md` from the bundled templates so a fresh `squad init` produces a coordinator that already knows the right disambiguation.
+
+If you removed this skill on purpose, the model will fall back to its own reasoning (and may make the same mistake again).
+
+---
+
+## See also
+
+- `.github/agents/squad.agent.md` — the actual Squad coordinator agent
+- `.copilot/skills/squad-commands/SKILL.md` — the command catalog
+- `.copilot/skills/squad-conventions/SKILL.md` — conventions for working on the Squad codebase itself

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -39,6 +39,7 @@ const MANIFEST_SKILL_NAMES = [
   'agent-collaboration',
   'squad-commands',
   'squad-version-check',
+  'squad',
 ] as const;
 
 // ============================================================================

--- a/packages/squad-sdk/templates/skills/squad/SKILL.md
+++ b/packages/squad-sdk/templates/skills/squad/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: "squad"
+description: "Disambiguation skill — Squad is a CUSTOM AGENT, not a skill. If you reached this skill while trying to set up an AI team or invoke Squad's coordinator, read this file: it routes you to the right tool (task tool with agent_type='Squad') and surfaces the squad-commands menu."
+domain: "squad-meta"
+confidence: "high"
+source: "first-party"
+triggers: ["squad", "use squad", "use the squad skill", "squad skill", "assemble a squad", "set up squad", "squad agent", "squad team"]
+license: MIT
+---
+
+# Skill: Squad (Disambiguation)
+
+> **You are here because something tried to invoke a skill named `Squad`.**
+> Squad is a **custom agent**, not a skill. This file redirects you to the right tool.
+
+---
+
+## Why this skill exists
+
+The Squad framework registers a custom Copilot CLI agent at `.github/agents/squad.agent.md` with the user-facing name **"Squad"** and the description *"Your AI team. Describe what you're building, get a team of specialists that live in your repo."*
+
+Coding models reading that description sometimes pick the wrong tool: they try `skill(Squad)` (skill lookup) instead of `task(agent_type="Squad", …)` (custom agent invocation). That call fails because no skill is named "Squad" — the actual Squad-related skills are `squad-commands`, `squad-conventions`, `squad-version-check`, etc.
+
+This skill exists so the lookup **succeeds** and immediately tells you the right next step.
+
+---
+
+## How to actually use Squad
+
+There are two distinct things you might want to do. Pick the one that matches your intent:
+
+### A) Invoke the Squad coordinator agent (most common)
+
+Use the **`task` tool** with `agent_type` set to `"Squad"`. This spawns the orchestrator described in `.github/agents/squad.agent.md`. It will route your request to the right specialist agent on the team, scaffold a team if none exists yet, and enforce handoffs.
+
+```text
+task(
+  name="<short-task-name>",
+  agent_type="Squad",
+  prompt="<what you want the team to do>"
+)
+```
+
+Use this when the user says things like:
+- *"Use Squad to build X"*
+- *"Set up an AI team for this project"*
+- *"Have the Squad coordinator design Y"*
+
+### B) See what Squad commands exist
+
+Trigger the **`squad-commands` skill** (not this one). It's a categorized catalog the coordinator presents as an interactive menu.
+
+Triggered by: `"squad commands"`, `"what can squad do"`, `"show me squad options"`, `"slash commands"`, `"what commands are available"`.
+
+Use this when the user says things like:
+- *"What can Squad do?"*
+- *"Show me the squad commands"*
+- *"squad help"*
+
+### C) Initialize Squad in a fresh project (rare from inside a session)
+
+`squad init` is a **shell command**, not a tool call. If a project has no `.squad/` directory and the user wants to add Squad, run `squad init` in their terminal. Do NOT try to invoke this from inside an existing Copilot session — `.squad/` is already initialized if you're reading this file.
+
+---
+
+## What NOT to do
+
+- ❌ Do not call `skill(Squad)` again — you just did, that's how you got here.
+- ❌ Do not call `skill(squad-coordinator)` or other made-up skill names.
+- ❌ Do not assume the Squad agent is a one-shot tool — it spawns specialist agents and orchestrates handoffs across a multi-turn session.
+- ❌ Do not call `task(agent_type="Squad", …)` for tiny tasks the current agent can handle directly. Squad is for work that needs orchestration; trivial edits don't.
+
+---
+
+## How this skill was discovered
+
+Squad scans 5 project skill directories in precedence order. This skill ships at `.copilot/skills/squad/SKILL.md` from the bundled templates so a fresh `squad init` produces a coordinator that already knows the right disambiguation.
+
+If you removed this skill on purpose, the model will fall back to its own reasoning (and may make the same mistake again).
+
+---
+
+## See also
+
+- `.github/agents/squad.agent.md` — the actual Squad coordinator agent
+- `.copilot/skills/squad-commands/SKILL.md` — the command catalog
+- `.copilot/skills/squad-conventions/SKILL.md` — conventions for working on the Squad codebase itself

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -157,6 +157,33 @@ describe('Squad Initialization', () => {
       expect(content).toContain('.squad/decisions.md merge=union');
     });
 
+    it('should install the squad disambiguation skill (regression: #1297 — skill(Squad) lookup must succeed)', async () => {
+      // The Squad framework registers a custom Copilot CLI agent named
+      // "Squad". Coding models sometimes confuse that with a skill and call
+      // skill(Squad), which fails because all real skills are hyphenated
+      // lowercase (squad-commands, squad-conventions, etc.). The squad
+      // disambiguation skill exists at .copilot/skills/squad/SKILL.md so
+      // the lookup succeeds and tells the model the right next step
+      // (task tool with agent_type='Squad').
+      const agents: InitAgentSpec[] = [{ name: 'lead', role: 'lead' }];
+      const options: InitOptions = {
+        teamRoot: TEST_ROOT,
+        projectName: 'Test Project',
+        agents
+      };
+
+      await initSquad(options);
+
+      const skillPath = join(TEST_ROOT, '.copilot', 'skills', 'squad', 'SKILL.md');
+      expect(existsSync(skillPath)).toBe(true);
+      const content = await readFile(skillPath, 'utf-8');
+      // Hard requirements: the skill must NOT pretend to do work; it must
+      // route the model to the right tool.
+      expect(content).toContain('CUSTOM AGENT');
+      expect(content).toContain("agent_type=\"Squad\"");
+      expect(content).toContain('squad-commands');
+    });
+
     it('should create initial decisions.md', async () => {
       const agents: InitAgentSpec[] = [{ name: 'lead', role: 'lead' }];
       const options: InitOptions = {


### PR DESCRIPTION
## Symptom

Observed in a fresh `squad init` session, 2026-06-13:

```
◐ The Squad skill is perfect for assembling a specialized team to build C# console applications, so I'll use that to get the right specialists set up in the repo.
✗ skill(Squad)   Skill not found: Squad
◐ I see the issue—Squad is actually a custom agent type in the task tool, not a standalone skill, so I need to adjust my approach and call the task tool with agent_type set to "Squad" instead.
```

The coding model burns a turn on a failed skill lookup before self-correcting. The pattern is reproducible across models because the Squad agent's description (*"Your AI team. Describe what you're building, get a team of specialists that live in your repo."*) reads exactly like a skill description.

## Root cause

- `.github/agents/squad.agent.md` declares `name: Squad` — that is the **custom agent**.
- All bundled skills are hyphenated lowercase: `squad-commands`, `squad-conventions`, `squad-version-check`, etc.
- Nothing matches the literal name `Squad` for skill lookup, so the model's first guess fails.

## Fix

Add a small `squad` skill that exists purely to **catch the bad lookup and redirect**. It does no work — it explicitly tells the model:

- Squad is a **custom agent**, not a skill.
- To invoke the coordinator: `task(name=…, agent_type="Squad", prompt=…)`
- To list commands: trigger the `squad-commands` skill (`squad commands` / `what can squad do` / etc.)
- To init in a new project: `squad init` in the shell (not from inside a session)

Triggers cover the natural-language phrasings that would lead the model to mis-call `skill(Squad)` (`squad`, `use squad`, `use the squad skill`, `squad skill`, `assemble a squad`, `set up squad`, `squad agent`, `squad team`).

## Changes

- New `.squad/skills/squad/SKILL.md` (canonical source). `sync-skill-templates.mjs` (prebuild) propagates to both packages templates.
- `MANIFEST_SKILL_NAMES` in `packages/squad-sdk/src/config/init.ts` adds one entry: `'squad'` → 11 entries total.

## Test coverage

New `test/init.test.ts > should install the squad disambiguation skill` asserts:
- File exists at `.copilot/skills/squad/SKILL.md` after `initSquad()`
- Content contains the literal string `CUSTOM AGENT` (warns the model)
- Content contains the correct invocation pattern `agent_type="Squad"`
- Content references `squad-commands` (the right skill for the menu use case)

26/26 init tests pass; `npm run lint` clean.

## Composability with other open PRs

Disjoint from #1292 (adds 4 entries) and #1295 (adds 1 entry). All three can land in any order. Merge order doesn't matter.

## Verified end-to-end

Built and tested locally — Copilot session in a fresh init now finds `squad` skill on first attempt, reads the redirect, then issues the correct `task(agent_type="Squad", …)` call instead of failing.
