### PR TITLE
fix(cli): stop writing squad_state to ~/.copilot/mcp-config.json on every init/upgrade (#1296)

### DIFF
--- a/.changeset/fix-1296-stop-mcp-home-pollution.md
+++ b/.changeset/fix-1296-stop-mcp-home-pollution.md
@@ -1,0 +1,40 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+Fix #1296: stop writing `squad_state_<hash>` to `~/.copilot/mcp-config.json` on every `squad init` / `squad upgrade`
+
+`squad init` (line 408 of `packages/squad-cli/src/cli/core/init.ts`) and `squad upgrade` (line 738 of `upgrade.ts`) unconditionally called `ensureSquadStateMcpInUserConfig`, which wrote a `squad_state_<hash>` entry to `~/.copilot/mcp-config.json` keyed by a stable hash of the project path. Every new `squad init` accumulated another entry in HOME with no garbage collection.
+
+This contradicted the explicit iter-8 design intent documented at `packages/squad-cli/src/cli/core/mcp-root.ts:1-27`:
+
+> *iter-7: wrote `squad_state_<hash>` into the user's HOME `~/.copilot/mcp-config.json`. That polluted HOME with one entry per Squad project and required a stale-entry GC that we never built. It also touched a file outside the project, which is surprising for `squad init` / `squad upgrade`.*
+>
+> *iter-8 flips it back inside the project: we write `squad_state` to a repo-root `.mcp.json` ... **No HOME modifications.***
+
+The repo-root `.mcp.json` writes (init.ts:403 / upgrade.ts:728) already cover all documented Copilot CLI launch modes:
+
+- ``copilot`` from the project root → walks up from cwd to git root, auto-loads `.mcp.json`
+- ``copilot -p`` from the project root → same `.mcp.json` is found
+
+For ``copilot -p`` invocations launched from **outside** the project root, the right pattern is `--additional-mcp-config @.mcp.json` (already documented as the recommended pattern at init.ts:494).
+
+**Changes**
+
+- Removed the unconditional `ensureSquadStateMcpInUserConfig` call from `init.ts:408` and `upgrade.ts:738`. Replaced both with comments explaining the iter-8 design and pointing at #1296.
+- Removed the now-unused import from both files.
+- The function definition itself (`mcp-root.ts:178-228`) is **kept** — a future `squad doctor --mcp-prune` cleanup helper may want to inspect HOME for orphan entries. It's just no longer called from the init/upgrade auto-flow.
+
+**Tests**
+
+New regression test in `test/cli/init.test.ts`:
+
+> `should NOT write any squad_state entries to ~/.copilot/mcp-config.json (regression: #1296)`
+
+Isolates the developer's real HOME by setting `USERPROFILE`/`HOME` to a temp dir before init, then asserts no `squad_state*` keys appear under that temp HOME after init. The test passes only because the unconditional write is gone — previously this assertion would have failed.
+
+All 40 existing init tests still pass; `npm run lint` clean.
+
+**Cleanup**
+
+A follow-up could add `squad doctor --mcp-prune` to walk `~/.copilot/mcp-config.json`, find `squad_state_<hash>` entries whose target directory no longer exists, and remove them. Out of scope for this fix.

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -367,7 +367,8 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
         // leaving the bridge unwired. Force-insert/pin the squad_state entry so
         // the MCP server is reachable regardless of pre-existing config.
         // iter-8: write squad_state to repo-root `.mcp.json` (auto-loaded by
-        // Copilot CLI 5.3+ walking up from cwd to git root) and tombstone any
+        // Copilot CLI ≥1.0.59, which walks up from cwd to git root finding
+        // .mcp.json files — see sdk/index.js loader) and tombstone any
         // stale project-level entry left by the SDK init writer in
         // `.copilot/mcp-config.json`. No HOME modifications.
         try {
@@ -400,8 +401,8 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
       success(`installed squad_state MCP server to .mcp.json (${describeMcpSpec(mcpSpec)}) — Copilot CLI will auto-load on next invocation`);
     }
     // iter-8: do NOT write to ~/.copilot/mcp-config.json. The repo-root
-    // .mcp.json write above is sufficient for Copilot CLI 5.3+ (which
-    // auto-loads .mcp.json walking up from cwd to git root) AND for
+    // .mcp.json write above is sufficient for Copilot CLI ≥1.0.59 (which
+    // walks up from cwd to git root looking for .mcp.json) AND for
     // `copilot -p` invocations launched from the project root. Users who
     // launch `copilot -p` from outside the project root should use
     // `--additional-mcp-config @.mcp.json` (already documented at the end

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -490,7 +490,7 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
   console.log(`${GREEN}${BOLD}Squad initialized.${RESET} Run ${CYAN}${BOLD}copilot --agent squad${RESET} and tell it what you're building.`);
   console.log();
   console.log(`${DIM}Tip: for non-interactive scripts that need squad_state tools, add to package.json:${RESET}`);
-  console.log(`${DIM}  "squad:copilot": "copilot --additional-mcp-config @.mcp.json"${RESET}`);
+  console.log(`${DIM}  "squad:copilot": "copilot --agent squad --additional-mcp-config @.mcp.json"${RESET}`);
   console.log();
 
   // ── Personal squad bridge ───────────────────────────────────────────

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -16,7 +16,7 @@ import { installGitHooks } from '../commands/install-hooks.js';
 import { liftInitMutableStateOntoOrphan } from '../commands/migrate-backend.js';
 import { resolveSquadStateMcpSpec } from './mcp-spec.js';
 import { describeMcpSpec } from './upgrade.js';
-import { ensureSquadStateMcpInRoot, ensureSquadStateMcpInUserConfig, tombstoneStaleSquadStateInProjectMcp } from './mcp-root.js';
+import { ensureSquadStateMcpInRoot, tombstoneStaleSquadStateInProjectMcp } from './mcp-root.js';
 import {
   readTeamMd,
   writeTeamMd,
@@ -399,11 +399,13 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
     if (rootResult.written) {
       success(`installed squad_state MCP server to .mcp.json (${describeMcpSpec(mcpSpec)}) — Copilot CLI will auto-load on next invocation`);
     }
-    // Also pin to user-level config for external `copilot -p` compatibility
-    const userResult = ensureSquadStateMcpInUserConfig(dest, mcpSpec);
-    if (userResult.written) {
-      success(`pinned squad_state to ~/.copilot/mcp-config.json for \`copilot -p\` mode compatibility`);
-    }
+    // iter-8: do NOT write to ~/.copilot/mcp-config.json. The repo-root
+    // .mcp.json write above is sufficient for Copilot CLI 5.3+ (which
+    // auto-loads .mcp.json walking up from cwd to git root) AND for
+    // `copilot -p` invocations launched from the project root. Users who
+    // launch `copilot -p` from outside the project root should use
+    // `--additional-mcp-config @.mcp.json` (already documented at the end
+    // of this command). See bradygaster/squad#1296.
     const tomb = tombstoneStaleSquadStateInProjectMcp(dest);
     if (tomb.removed) {
       success(`removed stale squad_state from ${tomb.path} (now lives in .mcp.json)`);

--- a/packages/squad-cli/src/cli/core/mcp-root.ts
+++ b/packages/squad-cli/src/cli/core/mcp-root.ts
@@ -9,7 +9,7 @@
  *
  * iter-8 flips it back inside the project: we write `squad_state` to a
  * repo-root `.mcp.json` under the plain (un-namespaced) `squad_state`
- * key. Copilot CLI 5.3+ auto-loads `.mcp.json` walking up from cwd to
+ * key. Copilot CLI ≥1.0.59 auto-loads `.mcp.json` walking up from cwd to
  * the git root, so the entry is picked up by bare
  * `copilot --yolo --autopilot --agent squad ...` invocations with no
  * wrapper script and no HOME modifications.

--- a/packages/squad-cli/src/cli/core/upgrade.ts
+++ b/packages/squad-cli/src/cli/core/upgrade.ts
@@ -720,9 +720,10 @@ async function runEnsureChecks(dest: string, templatesDir: string, filesUpdated:
   filesUpdated.push('.squad/templates/');
 
   // iter-8: write squad_state MCP entry to repo-root `.mcp.json`
-  // (auto-loaded by Copilot CLI 5.3+ walking up from cwd to git root)
-  // and tombstone any stale project-level entry left by older Squad
-  // versions in `.copilot/mcp-config.json`. No HOME modifications.
+  // (auto-loaded by Copilot CLI ≥1.0.59, which walks up from cwd to the
+  // git root looking for .mcp.json) and tombstone any stale project-level
+  // entry left by older Squad versions in `.copilot/mcp-config.json`.
+  // No HOME modifications.
   const pinnedSpec = await resolveSquadStateMcpSpec(getPackageVersion());
   try {
     const rootResult = ensureSquadStateMcpInRoot(dest, getPackageVersion(), pinnedSpec);
@@ -734,9 +735,9 @@ async function runEnsureChecks(dest: string, templatesDir: string, filesUpdated:
     warn(`Could not write .mcp.json: ${err instanceof Error ? err.message : err}`);
   }
   // iter-8: do NOT write to ~/.copilot/mcp-config.json on upgrade. The
-  // repo-root .mcp.json write above is sufficient for Copilot CLI 5.3+
-  // (auto-loads .mcp.json from cwd up) AND for `copilot -p` from the
-  // project root. Out-of-tree `copilot -p` should use
+  // repo-root .mcp.json write above is sufficient for Copilot CLI ≥1.0.59
+  // (walks from cwd up looking for .mcp.json) AND for `copilot -p` from
+  // the project root. Out-of-tree `copilot -p` should use
   // `--additional-mcp-config @.mcp.json`. See bradygaster/squad#1296.
   const tomb = tombstoneStaleSquadStateInProjectMcp(dest);
   if (tomb.removed) {

--- a/packages/squad-cli/src/cli/core/upgrade.ts
+++ b/packages/squad-cli/src/cli/core/upgrade.ts
@@ -16,7 +16,7 @@ import { scrubEmails } from './email-scrub.js';
 import { getPackageVersion, stampVersion, readInstalledVersion } from './version.js';
 import { resolveSquadStateMcpSpec, type SquadStateMcpSpec } from './mcp-spec.js';
 export { resolveSquadStateMcpSpec } from './mcp-spec.js';
-import { ensureSquadStateMcpInRoot, ensureSquadStateMcpInUserConfig, tombstoneStaleSquadStateInProjectMcp } from './mcp-root.js';
+import { ensureSquadStateMcpInRoot, tombstoneStaleSquadStateInProjectMcp } from './mcp-root.js';
 
 const storage = new FSStorageProvider();
 
@@ -733,15 +733,11 @@ async function runEnsureChecks(dest: string, templatesDir: string, filesUpdated:
   } catch (err) {
     warn(`Could not write .mcp.json: ${err instanceof Error ? err.message : err}`);
   }
-  // Also pin to user-level config for external `copilot -p` compatibility
-  try {
-    const userResult = ensureSquadStateMcpInUserConfig(dest, pinnedSpec);
-    if (userResult.written) {
-      success(`pinned squad_state to ~/.copilot/mcp-config.json for \`copilot -p\` mode compatibility`);
-    }
-  } catch {
-    // best-effort: user-level config write failure does not block upgrade
-  }
+  // iter-8: do NOT write to ~/.copilot/mcp-config.json on upgrade. The
+  // repo-root .mcp.json write above is sufficient for Copilot CLI 5.3+
+  // (auto-loads .mcp.json from cwd up) AND for `copilot -p` from the
+  // project root. Out-of-tree `copilot -p` should use
+  // `--additional-mcp-config @.mcp.json`. See bradygaster/squad#1296.
   const tomb = tombstoneStaleSquadStateInProjectMcp(dest);
   if (tomb.removed) {
     success(`removed stale squad_state from ${tomb.path} (now lives in .mcp.json)`);

--- a/test/cli/init.test.ts
+++ b/test/cli/init.test.ts
@@ -98,10 +98,13 @@ describe('CLI: init command', () => {
 
   it('should NOT write any squad_state entries to ~/.copilot/mcp-config.json (regression: #1296)', async () => {
     // iter-8 design: init writes squad_state to repo-root .mcp.json ONLY.
-    // The unconditional ensureSquadStateMcpInUserConfig call at init.ts:408
-    // (and upgrade.ts:738) used to write squad_state_<hash> to HOME on every
-    // init, accumulating one entry per project with no GC and contradicting
-    // the iter-8 docstring's stated "No HOME modifications" intent.
+    // Pre-fix, the unconditional `ensureSquadStateMcpInUserConfig` call
+    // inside both `initSquad` (SDK) and the `upgrade` command used to
+    // write squad_state_<hash> to HOME on every init, accumulating one
+    // entry per project with no GC and contradicting the iter-8
+    // docstring's stated "No HOME modifications" intent. (Referencing the
+    // function name rather than line numbers keeps this comment durable
+    // against unrelated edits in init.ts / upgrade.ts.)
     //
     // This test isolates the developer's real HOME by setting USERPROFILE
     // (Windows) and HOME (POSIX) to a temp dir before init, then asserting

--- a/test/cli/init.test.ts
+++ b/test/cli/init.test.ts
@@ -96,6 +96,44 @@ describe('CLI: init command', () => {
     expect(wisdomContent).toContain('Team Wisdom');
   });
 
+  it('should NOT write any squad_state entries to ~/.copilot/mcp-config.json (regression: #1296)', async () => {
+    // iter-8 design: init writes squad_state to repo-root .mcp.json ONLY.
+    // The unconditional ensureSquadStateMcpInUserConfig call at init.ts:408
+    // (and upgrade.ts:738) used to write squad_state_<hash> to HOME on every
+    // init, accumulating one entry per project with no GC and contradicting
+    // the iter-8 docstring's stated "No HOME modifications" intent.
+    //
+    // This test isolates the developer's real HOME by setting USERPROFILE
+    // (Windows) and HOME (POSIX) to a temp dir before init, then asserting
+    // no squad_state* entries appear under that temp HOME.
+    const fakeHome = join(tmpdir(), `.test-fake-home-${randomBytes(4).toString('hex')}`);
+    await mkdir(fakeHome, { recursive: true });
+    const originalUserprofile = process.env.USERPROFILE;
+    const originalHome = process.env.HOME;
+    process.env.USERPROFILE = fakeHome;
+    process.env.HOME = fakeHome;
+    try {
+      await runInit(TEST_ROOT);
+
+      const fakeHomeMcp = join(fakeHome, '.copilot', 'mcp-config.json');
+      if (existsSync(fakeHomeMcp)) {
+        const content = await readFile(fakeHomeMcp, 'utf-8');
+        const config = JSON.parse(content);
+        const servers = (config.mcpServers as Record<string, unknown> | undefined) ?? {};
+        const offending = Object.keys(servers).filter(k => k.startsWith('squad_state'));
+        expect(offending, `init must not write squad_state entries to HOME; found: ${offending.join(', ')}`).toEqual([]);
+      }
+      // (If the file doesn't exist at all, that's also a pass — init touched
+      // nothing under HOME, which is the iter-8 ideal.)
+    } finally {
+      if (originalUserprofile === undefined) { delete process.env.USERPROFILE; } else { process.env.USERPROFILE = originalUserprofile; }
+      if (originalHome === undefined) { delete process.env.HOME; } else { process.env.HOME = originalHome; }
+      if (existsSync(fakeHome)) {
+        await rm(fakeHome, { recursive: true, force: true });
+      }
+    }
+  });
+
   it('should create .copilot/mcp-config.json without squad_state (iter-7: lives in ~/.copilot)', async () => {
     await runInit(TEST_ROOT);
 


### PR DESCRIPTION
Fixes #1296.

## Symptom

`squad init` (line 408 of `init.ts`) and `squad upgrade` (line 738 of `upgrade.ts`) unconditionally call `ensureSquadStateMcpInUserConfig`, writing `squad_state_<hash>` to `~/.copilot/mcp-config.json` keyed by a stable hash of the project path. Every new `squad init` accumulates another entry in HOME with no garbage collection.

Verified live on 2026-06-13: a user's HOME mcp-config had two stale `squad_state_*` entries from two different project paths (only one of which still exists on disk).

## Why this is wrong

Contradicts the explicit iter-8 design intent at `packages/squad-cli/src/cli/core/mcp-root.ts:1-27`:

> *iter-7: wrote `squad_state_<hash>` into the user's HOME `~/.copilot/mcp-config.json`. That polluted HOME with one entry per Squad project and required a stale-entry GC that we never built. It also touched a file outside the project, which is surprising for `squad init` / `squad upgrade`.*
>
> *iter-8 flips it back inside the project: we write `squad_state` to a repo-root `.mcp.json` ... **No HOME modifications.***

The repo-root writes (init.ts:403 / upgrade.ts:728) already cover all documented Copilot CLI launch modes. Out-of-tree `copilot -p` invocations should use `--additional-mcp-config @.mcp.json` (already documented at init.ts:494 as the recommended pattern).

## Changes

- Removed the unconditional `ensureSquadStateMcpInUserConfig` call from `init.ts:408` and `upgrade.ts:738`. Replaced both with comments explaining the iter-8 design and pointing at #1296.
- Removed the now-unused import from both files.
- The function definition itself (`mcp-root.ts:178-228`) is **kept** — a future `squad doctor --mcp-prune` cleanup helper may want to inspect HOME for orphan entries. It's just no longer called from the init/upgrade auto-flow.

## Test coverage

New regression test in `test/cli/init.test.ts`:

> `should NOT write any squad_state entries to ~/.copilot/mcp-config.json (regression: #1296)`

Isolates the developer's real HOME by setting `USERPROFILE`/`HOME` to a temp dir before init, then asserts no `squad_state*` keys appear under that temp HOME after init.

All 40 existing init tests still pass; `npm run lint` clean.

## Cleanup follow-up (out of scope)

Add `squad doctor --mcp-prune` to walk `~/.copilot/mcp-config.json`, find `squad_state_<hash>` entries whose target directory no longer exists, and remove them.
