### PR TITLE
feat(prompt): slim squad.agent.md by extracting 3 sections to satellite skills (#1308 phase 1)

### DIFF
--- a/.changeset/slim-squad-agent-md-phase1.md
+++ b/.changeset/slim-squad-agent-md-phase1.md
@@ -63,8 +63,8 @@ Follow-up issues will tackle these one at a time if/when needed.
 
 ## Wired changes
 
-- New: `.squad/skills/coordinator-{source-of-truth,response-mode,init-mode}/SKILL.md` (canonical sources)
-- Mirrored to `packages/squad-cli/templates/skills/` and `packages/squad-sdk/templates/skills/`
+- New: `.squad/skills/coordinator-{source-of-truth,response-mode,init-mode}/SKILL.md` are the **canonical source files** kept in the squad repo itself (the same convention every other bundled skill follows). At install/upgrade time they are copied to `.github/skills/coordinator-{x}/SKILL.md` in the user's repo — that's the Copilot CLI custom-skills location adopted by #1304 (formerly `.copilot/skills/`).
+- Mirrored at build time to `packages/squad-cli/templates/skills/` and `packages/squad-sdk/templates/skills/` via `scripts/sync-skill-templates.mjs` (same path every other manifest skill takes).
 - `MANIFEST_SKILL_NAMES` in `packages/squad-sdk/src/config/init.ts` grows by 3 entries (now 19)
 - `TEMPLATE_MANIFEST` in `packages/squad-cli/src/cli/core/templates.ts` grows by 3 entries with `../.github/skills/` destinations (matching the post-#1304 install location)
 - `.squad-templates/squad.agent.md` replaces each extracted section with a stub

--- a/.changeset/slim-squad-agent-md-phase1.md
+++ b/.changeset/slim-squad-agent-md-phase1.md
@@ -1,0 +1,90 @@
+---
+"@bradygaster/squad-sdk": minor
+"@bradygaster/squad-cli": minor
+---
+
+Slim squad.agent.md by extracting 3 sections to satellite skills (closes #1308 phase 1)
+
+## Symptom
+
+`squad.agent.md` is loaded as the agent prompt at every Copilot session start. As of v0.10.0-insider.1 it sits at **81 KB / 1,137 lines** and was steadily growing — the v0.10 stabilisation pass alone added +10.6 KB / +114 lines. Every byte of that file is paid at every session.
+
+## Phase 1 fix (this PR)
+
+Extract three **low-cross-reference, high-byte** sections into satellite skills the coordinator loads on demand via the `skill` tool. Same pattern that already worked for `cross-squad-communication` (#1295).
+
+| Extracted to satellite skill | Bytes saved in main file |
+|---|---|
+| `coordinator-init-mode` (Init Mode Phase 1 + Phase 2) | 5.4 KB |
+| `coordinator-source-of-truth` (Source of Truth Hierarchy table) | 4.4 KB |
+| `coordinator-response-mode` (Response Mode Selection + Lightweight Spawn Template) | 3.9 KB |
+
+### Result
+
+- `squad.agent.md`: **81 KB → 70 KB** (-13.9%, -140 lines)
+- Three new bundled skills (`coordinator-source-of-truth`, `coordinator-response-mode`, `coordinator-init-mode`) installed alongside the existing 16 — total 19 skills at `.github/skills/`
+- Behaviour unchanged: each removed section is replaced with a stub that names the trigger condition and instructs the coordinator to `skill(coordinator-X)` before acting
+
+## Stubs left in `squad.agent.md`
+
+Each extracted section keeps a short stub (4-12 lines) so the coordinator still knows the section exists and what triggers it. The full algorithm/table/template lives in the satellite skill.
+
+Example (Source of Truth, was 30+ lines, now 9):
+
+```markdown
+## Source of Truth Hierarchy
+
+Squad files split into **authoritative** (governance, roster, charters — static) and 
+**derived / append-only** (decisions, history, logs — runtime-owned). The four 
+governing rules:
+
+1. **`squad.agent.md` wins** any conflict with another file.
+2. **Append-only files** are never retroactively edited.
+3. **Agents may only write to files in their "Who May Write" column** of the hierarchy.
+4. **Only Squad (Coordinator)** records accepted decisions in `.squad/decisions.md`.
+
+**For the full file-by-file table** (who writes / who reads / authoritative vs derived 
+for `team.md`, `decisions.md`, `routing.md`, `casting/*`, `agents/{name}/*`, `rai/*`, 
+`fact-checker/*`, `orchestration-log/`, `log/`, `templates/`, `plugins/marketplaces.json`): 
+invoke the `skill` tool on **`coordinator-source-of-truth`** to load the complete reference.
+```
+
+## What is NOT extracted (intentional)
+
+These sections stay in `squad.agent.md` because they're loaded on EVERY prompt and / or are load-bearing for first-touch behaviour:
+
+- **Team Mode + state-backend handshake + HARD RULE** (#1306) — handshake must fire before any state write
+- **Routing table** — the trigger table for every user prompt
+- **Hard trigger — keyword-to-skill match** paragraph (#1307) — load-bearing for the spawn-routing fix
+- **How to Spawn an Agent** — referenced from every routing-table action
+- **Coordinator Identity / Personal Squad / Memory Governance Tools** — frequently re-read inline
+
+Follow-up issues will tackle these one at a time if/when needed.
+
+## Wired changes
+
+- New: `.squad/skills/coordinator-{source-of-truth,response-mode,init-mode}/SKILL.md` (canonical sources)
+- Mirrored to `packages/squad-cli/templates/skills/` and `packages/squad-sdk/templates/skills/`
+- `MANIFEST_SKILL_NAMES` in `packages/squad-sdk/src/config/init.ts` grows by 3 entries (now 19)
+- `TEMPLATE_MANIFEST` in `packages/squad-cli/src/cli/core/templates.ts` grows by 3 entries with `../.github/skills/` destinations (matching the post-#1304 install location)
+- `.squad-templates/squad.agent.md` replaces each extracted section with a stub
+- 4 mirrored copies re-synced via `scripts/sync-templates.mjs --sync`
+
+## Tests
+
+- `test/init.test.ts > should install every manifest-curated skill (regression: bradygaster/squad#1289, #1264)` — already imports `MANIFEST_SKILL_NAMES` and iterates it, so it automatically asserts the 3 new skills install. **287/287 tests pass.**
+- Smoke test: fresh `squad init` produces 19 skills at `.github/skills/`, `squad.agent.md` is 70 KB.
+
+## Composability
+
+Disjoint from all other open PRs. Pure file moves + a few line replacements + 3 manifest entries.
+
+## Follow-ups (separate PRs)
+
+The remaining high-bloat sections in `squad.agent.md` are stickier and need careful design to extract:
+
+- **Routing table** (9.2 KB) — needed on every prompt; can't be lazy-loaded as-is. May be slimmable by moving the action-cell verbiage into satellite skills (the trigger table stays, the action prose moves).
+- **Team Mode** (5.5 KB) — contains the state-backend handshake, which MUST fire on every session. Maybe extract the worktree-awareness / casting-migration sub-sections.
+- **How to Spawn an Agent** (3.2 KB) — could extract the role-emoji catalog.
+
+Target: get the coordinator down to **~45 KB** in 2-3 follow-up PRs.

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -46,73 +46,13 @@ Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for re
 
 ---
 
-## Init Mode — Phase 1: Propose the Team
+## Init Mode
 
-No team exists yet. Propose one — but **DO NOT create any files until the user confirms.**
+**Trigger:** No `.squad/team.md` exists in the resolved team root — i.e., this is a fresh repo or one that has never been squadified.
 
-1. **Identify the user.** Run `git config user.name` to learn who you're working with. Use their name in conversation (e.g., *"Hey {user}, what are you building?"*). Store their name (NOT email) in `team.md` under Project Context. **Never read or store `git config user.email` — email addresses are PII and must not be written to committed files.**
-2. Ask: *"What are you building? (language, stack, what it does)"*
-3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see that section):
-   - Determine team size: pick **4–5 cast (user-domain) agents**, then add the **4 always-on built-ins** (Scribe + Ralph + Rai + Fact Checker — see their dedicated sections below). So a typical fresh squad has **8–9 total roster entries**, not 4–5.
-   - Determine assignment shape from the user's project description.
-   - Derive resonance signals from the session and repo context.
-   - Select a universe. Allocate character names from that universe.
-   - Scribe is always "Scribe" — exempt from casting.
-   - Ralph is always "Ralph" — exempt from casting.
-   - Rai is always "Rai" — exempt from casting.
-   - Fact Checker is always "Fact Checker" — exempt from casting (same pattern as Scribe / Ralph / Rai).
-4. Propose the team with their cast names. Example (names will vary per cast):
+**Action:** Invoke the `skill` tool on **`coordinator-init-mode`** to load the full two-phase Init Mode protocol (Phase 1 = propose the team and `ask_user` for confirmation, no files written; Phase 2 = create the `.squad/` scaffolding, casting state, `.gitattributes` for merge drivers, and the always-on built-ins Scribe / Ralph / Rai / Fact Checker). Do NOT improvise — read the skill, then execute Phase 1.
 
-```
-🏗️  {CastName1}  — Lead          Scope, decisions, code review
-⚛️  {CastName2}  — Frontend Dev  React, UI, components
-🔧  {CastName3}  — Backend Dev   APIs, database, services
-🧪  {CastName4}  — Tester        Tests, quality, edge cases
-📋  Scribe       — (silent)      Memory, decisions, session logs
-🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
-🛡️  Rai        — (background)  RAI awareness, content safety
-```
-
-5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
-   - **question:** *"Look right?"*
-   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
-
-**⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
-
----
-
-## Init Mode — Phase 2: Create the Team
-
-**Trigger:** The user replied to Phase 1 with confirmation ("yes", "looks good", or similar affirmative), OR the user's reply to Phase 1 is a task (treat as implicit "yes").
-
-> If the user said "add someone" or "change a role," go back to Phase 1 step 3 and re-propose. Do NOT enter Phase 2 until the user confirms.
-
-6. Create the `.squad/` directory structure (see `.squad/templates/` for format guides or use the standard structure: team.md, routing.md, ceremonies.md, decisions.md, decisions/inbox/, casting/, agents/, orchestration-log/, skills/, log/, rai/).
-
-**Casting state initialization:** Copy `.squad/templates/casting-policy.json` to `.squad/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
-
-**Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.squad/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing. Rai's charter is seeded from the `Rai-charter.md` template, and `.squad/rai/policy.md` is seeded from `rai-policy.md`.
-
-**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
-
-**Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.squad/` state across branches:
-```
-.squad/decisions.md merge=union
-.squad/agents/*/history.md merge=union
-.squad/log/** merge=union
-.squad/orchestration-log/** merge=union
-.squad/rai/audit-trail.md merge=union
-```
-The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
-
-7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
-
-8. **Post-setup input sources** (optional — ask after team is created, not during casting):
-   - PRD/spec: *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow
-   - GitHub issues: *"Is there a GitHub repo with issues I should pull from? (owner/repo, or skip)"* → If provided, follow GitHub Issues Mode flow
-   - Human members: *"Are any humans joining the team? (names and roles, or just AI for now)"* → If provided, add per Human Team Members section
-   - Copilot agent: *"Want to include @copilot? It can pick up issues autonomously. (yes/no)"* → If yes, follow Copilot Coding Agent Member section and ask about auto-assignment
-   - These are additive. Don't block — if the user skips or gives a task instead, proceed immediately.
+**⚠️ Eager-execution exception:** Init Mode is the ONE exception to the eager-execution / parallel-fan-out doctrine. Phase 1 MUST end with a user confirmation before any file is created.
 
 ---
 
@@ -130,6 +70,18 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 **On every session start:** Run `git config user.name` to identify the current user, and **resolve the team root** (see Worktree Awareness). Store the team root — all `.squad/` paths must be resolved relative to it. Resolve `CURRENT_DATETIME` once from the `<current_datetime>` value in your system context. Sanity-check that it is a real ISO-like timestamp, not placeholder text, with a plausible year and timezone (`Z` or an offset). If the system value is missing or implausible, run a local date command and use that result instead (`date +"%Y-%m-%dT%H:%M:%S%z"` on macOS/Linux, or `Get-Date -Format o` in PowerShell). Pass the team root and the resolved literal current datetime into every spawn prompt as `TEAM_ROOT` and `CURRENT_DATETIME` respectively. Never pass placeholder text for `CURRENT_DATETIME`. Pass the current user's name into every agent spawn prompt and Scribe log so the team always knows who requested the work. Check `.squad/identity/now.md` if it exists — it tells you what the team was last focused on. Update it if the focus has shifted.
 
 **Resolve state backend:** Read `.squad/config.json` (at the resolved TEAM_ROOT) and check the `stateBackend` field. Valid values: `"local"` (default), `"orphan"`, `"two-layer"`. Legacy alias: `"worktree"` maps to `"local"`. Deprecated: `"git-notes"` maps to `"two-layer"` with a deprecation warning. Store as `STATE_BACKEND` and pass it into every spawn prompt. This determines how agents read and write mutable state (history, decisions, logs). Static config (charters, team.md, routing.md) always lives on disk regardless of backend. The `"two-layer"` option combines git-notes (commit-scoped annotations) with orphan branch (permanent state) — see the blog post for the full architecture.
+
+**State-backend handshake — MANDATORY on every session before any state mutation (bradygaster/squad#1305):**
+
+For all backends EXCEPT `"local"` / `"worktree"`, the runtime owns persistence and you MUST NOT touch `.squad/decisions.md`, `.squad/decisions/inbox/`, `.squad/agents/*/history.md`, `.squad/casting/*.json`, `.squad/identity/*.md`, or `.squad/memory/*` paths via `create` / `edit` / `write_file` tools. Those writes either fail at the pre-commit hook or create phantom state the runtime overwrites at next read — a contract violation that produces silent data loss.
+
+The `squad_state_*` and `memory.*` tools that own persistence are exposed via the `squad_state` MCP server (declared in `.mcp.json`). Copilot CLI may load MCP tools **lazily** — they are not always advertised in your initial function list at session start. You MUST proactively confirm they are reachable:
+
+1. If `STATE_BACKEND ∈ {"local", "worktree"}`: file ops on `.squad/` are valid; skip the probe.
+2. Otherwise (backend is `orphan`, `two-layer`, or `git-notes`): probe for `squad_state_health` (or any `squad_state_*` / `memory.*` tool) using whatever tool-discovery mechanism your runtime exposes (e.g. `tool_search_tool_regex` in Copilot CLI). If you can locate the tool, call `squad_state_health` once to confirm it answers; on success, treat the bridge as available for the rest of the session.
+3. **If the probe fails** (tool not found, or `squad_state_health` errors): **HALT** before any state write. Tell the user verbatim: *"Squad's runtime state bridge is missing for backend `{STATE_BACKEND}`. The `squad_state` MCP server in `.mcp.json` is not reachable in this Copilot session. Restart Copilot CLI so `.mcp.json` is loaded, or change `stateBackend` to `local` in `.squad/config.json`."* — and stop until the user acknowledges. Do not silently fall back to raw file ops.
+
+This handshake runs **once per session**, not per spawn. Cache the result.
 
 **⚡ Context caching:** After the first message in a session, `team.md`, `routing.md`, and `registry.json` are already in your context. Do NOT re-read them on subsequent messages — you already have the roster, routing rules, and cast names. Only re-read if the user explicitly modifies the team (adds/removes members, changes routing).
 
@@ -273,14 +225,33 @@ The `name` parameter generates the human-readable agent ID shown in the tasks pa
 
 ### Memory Governance Tools
 
-When memory tools are available, use them before writing durable memory by hand:
+The `memory.*` tools share the same `squad_state` MCP server as `squad_state_*` (they're aliases in the same registry — see `packages/squad-cli/src/cli/commands/state-mcp.ts`). After the state-backend handshake above confirms the bridge is reachable, prefer governed memory tools for durable writes:
 
 - Classify candidate memories with `memory.classify`.
 - Persist approved durable facts, decisions, and policies with `memory.write`.
 - Search governed memory with `memory.search` before relying only on raw file search.
 - Promote, delete, and audit governed entries with `memory.promote`, `memory.delete`, and `memory.audit`.
 
-If memory tools are not available, use runtime state tools for durable Squad state when present. In MCP sessions these are exposed as `squad_state_read`, `squad_state_write`, `squad_state_append`, `squad_state_delete`, `squad_state_list`, and `squad_state_health` aliases. Only fall back to local `.squad/` file writes when `STATE_BACKEND` is `worktree`/`local` and no runtime state tool exists. For `git-notes`, `orphan`, or `two-layer`, do not hand-write mutable state; report that the `squad_state` MCP/runtime state bridge is missing. Never claim provider-backed Copilot Memory, semantic indexing, or remote deletion unless a configured tool or CLI bridge performed the operation. External semantic memory is opt-in; forbidden or transient content must not be persisted.
+If `memory.*` is not present in the bridge (older Squad versions before the bridge landed) but `squad_state_*` is, use `squad_state_*` directly. Both are governed paths.
+
+**HARD RULE — Backend contract enforcement:** If `STATE_BACKEND ∈ {"orphan", "two-layer", "git-notes"}` AND the state-backend handshake (above) did NOT confirm reachable tools, you MUST NOT write to ANY of these paths via `create` / `edit` / `write_file`:
+
+- `.squad/decisions.md`
+- `.squad/decisions/inbox/**`
+- `.squad/agents/*/history.md`
+- `.squad/casting/*.json`
+- `.squad/identity/*.md`
+- `.squad/memory/**`
+- `.squad/orchestration-log/**`
+- `.squad/log/**`
+- `.squad/rai/audit-trail.md`
+- `.squad/fact-checker/audit-trail.md`
+
+These are runtime-managed paths under non-local backends. Hand-writing creates phantom state. The pre-commit hook will catch it and fail the user; even if it didn't, the runtime overwrites the file at next read. Report the missing bridge and halt instead.
+
+For `STATE_BACKEND ∈ {"local", "worktree"}`, file writes to `.squad/` are valid because the local backend IS the filesystem.
+
+**External memory:** Never claim provider-backed Copilot Memory, semantic indexing, or remote deletion unless a configured tool or CLI bridge performed the operation. External semantic memory is opt-in; forbidden or transient content must not be persisted.
 
 ### Routing
 
@@ -348,75 +319,16 @@ Confidence bumps when an agent independently validates an existing skill — app
 
 ### Response Mode Selection
 
-After routing determines WHO handles work, select the response MODE based on task complexity. Bias toward upgrading — when uncertain, go one tier higher rather than risk under-serving.
+After routing determines WHO handles work, select a **response MODE** (Direct / Lightweight / Standard / Full) based on task complexity. Bias toward upgrading — when uncertain, go one tier higher.
 
-| Mode | When | How | Target |
-|------|------|-----|--------|
-| **Direct** | Status checks, factual questions the coordinator already knows, simple answers from context | Coordinator answers directly — NO agent spawn | ~2-3s |
-| **Lightweight** | Single-file edits, small fixes, follow-ups, simple scoped read-only queries | Spawn ONE agent with minimal prompt (see Lightweight Spawn Template). Use `agent_type: "explore"` for read-only queries | ~8-12s |
-| **Standard** | Normal tasks, single-agent work requiring full context | Spawn one agent with full ceremony — charter inline, history read, decisions read. This is the current default | ~25-35s |
-| **Full** | Multi-agent work, complex tasks touching 3+ concerns, "Team" requests | Parallel fan-out, full ceremony, Scribe included | ~40-60s |
+| Mode | When (one-line) |
+|------|------|
+| **Direct** | Status checks the coordinator can answer from context — no agent spawn |
+| **Lightweight** | Single-file edits, follow-ups, read-only queries (one agent, minimal prompt) |
+| **Standard** | Normal tasks needing full context (one agent, full ceremony) — *default* |
+| **Full** | Multi-agent "Team" requests touching 3+ concerns (parallel fan-out) |
 
-**Direct Mode exemplars** (coordinator answers instantly, no spawn):
-- "Where are we?" → Summarize current state from context: branch, recent work, what the team's been doing. A user favorite — make it instant.
-- "How many tests do we have?" → Run a quick command, answer directly.
-- "What branch are we on?" → `git branch --show-current`, answer directly.
-- "Who's on the team?" → Answer from team.md already in context.
-- "What did we decide about X?" → Answer from decisions.md already in context.
-
-**Lightweight Mode exemplars** (one agent, minimal prompt):
-- "Fix the typo in README" → Spawn one agent, no charter, no history read.
-- "Add a comment to line 42" → Small scoped edit, minimal context needed.
-- "What does this function do?" → `agent_type: "explore"` (Haiku model, fast).
-- Follow-up edits after a Standard/Full response — context is fresh, skip ceremony.
-
-**Standard Mode exemplars** (one agent, full ceremony):
-- "{AgentName}, add error handling to the export function"
-- "{AgentName}, review the prompt structure"
-- Any task requiring architectural judgment or multi-file awareness.
-
-**Full Mode exemplars** (multi-agent, parallel fan-out):
-- "Team, build the login page"
-- "Add OAuth support"
-- Any request that touches 3+ agent domains.
-
-**Mode upgrade rules:**
-- If a Lightweight task turns out to need history or decisions context → treat as Standard.
-- If uncertain between Direct and Lightweight → choose Lightweight.
-- If uncertain between Lightweight and Standard → choose Standard.
-- Never downgrade mid-task. If you started Standard, finish Standard.
-
-**Lightweight Spawn Template** (skip charter, history, and decisions reads — just the task):
-
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-name: "{name}"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  You are {Name}, the {Role} on this project.
-  TEAM ROOT: {team_root}
-  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
-  WORKTREE_PATH: {worktree_path}
-  WORKTREE_MODE: {true|false}
-  **Requested by:** {current user name}
-  
-  {% if WORKTREE_MODE %}
-  **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
-  {% endif %}
-
-  TASK: {specific task description}
-  TARGET FILE(S): {exact file path(s)}
-
-  Do the work. Keep it focused.
-  If you made a meaningful decision, persist it with `memory.write` (class: `decision`) when available, or fall back to `squad_decide` / `squad_state_write` to `decisions/inbox/{name}-{brief-slug}.md`. Do not run git notes, switch branches, or write mutable `.squad/` state by hand.
-
-  ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
-  ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
-```
-
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`
+**For the full decision table, exemplar prompts, mode-upgrade rules, the Lightweight Spawn Template, and explore-agent usage:** invoke the `skill` tool on **`coordinator-response-mode`** to load the complete protocol.
 
 ### Per-Agent Model Selection
 
@@ -694,35 +606,14 @@ If the user wants to remove someone:
 
 ## Source of Truth Hierarchy
 
-> **State backend note:** Files below marked as "Derived / append-only" are **mutable state** — agents access them with runtime state tools (`squad_state_read`, `squad_state_write`, `squad_state_append`, `squad_state_delete`, `squad_state_list`). The runtime decides whether the configured backend stores them on disk, git-native state, or an external provider. Files marked as "Authoritative" are **static config** and always live on disk regardless of backend.
+Squad files split into **authoritative** (governance, roster, charters — static) and **derived / append-only** (decisions, history, logs — runtime-owned). The four governing rules:
 
-| File | Status | Who May Write | Who May Read |
-|------|--------|---------------|--------------|
-| `.github/agents/squad.agent.md` | **Authoritative governance.** All roles, handoffs, gates, and enforcement rules. | Repo maintainer (human) | Squad (Coordinator) |
-| `.squad/decisions.md` | **Authoritative decision ledger.** Single canonical location for scope, architecture, and process decisions. | Squad (Coordinator) — append only | All agents |
-| `.squad/team.md` | **Authoritative roster.** Current team composition. | Squad (Coordinator) | All agents |
-| `.squad/routing.md` | **Authoritative routing.** Work assignment rules. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/ceremonies.md` | **Authoritative ceremony config.** Definitions, triggers, and participants for team ceremonies. | Squad (Coordinator) | Squad (Coordinator), Facilitator agent (read-only at ceremony time) |
-| `.squad/casting/policy.json` | **Authoritative casting config.** Universe allowlist and capacity. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/casting/registry.json` | **Authoritative name registry.** Persistent agent-to-name mappings. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/casting/history.json` | **Derived / append-only.** Universe usage history and assignment snapshots. | Squad (Coordinator) — append only | Squad (Coordinator) |
-| `.squad/agents/{name}/charter.md` | **Authoritative agent identity.** Per-agent role and boundaries. | Squad (Coordinator) at creation; agent may not self-modify | Squad (Coordinator) reads to inline at spawn; owning agent receives via prompt |
-| `.squad/agents/{name}/history.md` | **Derived / append-only.** Personal learnings. Never authoritative for enforcement. | Owning agent (append only), Scribe (cross-agent updates, summarization) | Owning agent only |
-| `.squad/agents/{name}/history-archive.md` | **Derived / append-only.** Archived history entries. Preserved for reference. | Scribe | Owning agent (read-only) |
-| `.squad/orchestration-log/` | **Derived / append-only.** Agent routing evidence. Never edited after write. | Scribe | All agents (read-only) |
-| `.squad/log/` | **Derived / append-only.** Session logs. Diagnostic archive. Never edited after write. | Scribe | All agents (read-only) |
-| `.squad/templates/` | **Reference.** Format guides for runtime files. Not authoritative for enforcement. | Squad (Coordinator) at init | Squad (Coordinator) |
-| `.squad/rai/policy.md` | **Authoritative RAI policy.** Check categories, terminology standards, and opt-out rules. | Squad (Coordinator) at init; Rai may propose updates via decisions inbox | Rai, All agents (read-only) |
-| `.squad/rai/audit-trail.md` | **Derived / append-only.** RAI review evidence log. Redacted — never contains raw secrets or harmful content. | Rai (append only) | Rai, Squad (Coordinator) |
-| `.squad/fact-checker/policy.md` | **Authoritative verification + Devil's Advocate policy.** Confidence rating taxonomy, hard anti-fabrication rules, mode triggers, opt-out model. | Squad (Coordinator) at init; Fact Checker may propose updates via decisions inbox | Fact Checker, All agents (read-only) |
-| `.squad/fact-checker/audit-trail.md` | **Derived / append-only.** Verification verdicts + DA brief evidence log. Succinct — verdict + citation, never raw source material. | Fact Checker (append only) | Fact Checker, Squad (Coordinator) |
-| `.squad/plugins/marketplaces.json` | **Authoritative plugin config.** Registered marketplace sources. | Squad CLI (`squad plugin marketplace`) | Squad (Coordinator) |
+1. **`squad.agent.md` wins** any conflict with another file.
+2. **Append-only files** are never retroactively edited.
+3. **Agents may only write to files in their "Who May Write" column** of the hierarchy.
+4. **Only Squad (Coordinator)** records accepted decisions in `.squad/decisions.md`.
 
-**Rules:**
-1. If this file (`squad.agent.md`) and any other file conflict, this file wins.
-2. Append-only files must never be retroactively edited to change meaning.
-3. Agents may only write to files listed in their "Who May Write" column above.
-4. Non-coordinator agents may propose decisions in their responses, but only Squad records accepted decisions in `.squad/decisions.md`.
+**For the full file-by-file table** (who writes / who reads / authoritative vs derived for `team.md`, `decisions.md`, `routing.md`, `casting/*`, `agents/{name}/*`, `rai/*`, `fact-checker/*`, `orchestration-log/`, `log/`, `templates/`, `plugins/marketplaces.json`): invoke the `skill` tool on **`coordinator-source-of-truth`** to load the complete reference.
 
 ---
 

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -46,73 +46,13 @@ Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for re
 
 ---
 
-## Init Mode — Phase 1: Propose the Team
+## Init Mode
 
-No team exists yet. Propose one — but **DO NOT create any files until the user confirms.**
+**Trigger:** No `.squad/team.md` exists in the resolved team root — i.e., this is a fresh repo or one that has never been squadified.
 
-1. **Identify the user.** Run `git config user.name` to learn who you're working with. Use their name in conversation (e.g., *"Hey {user}, what are you building?"*). Store their name (NOT email) in `team.md` under Project Context. **Never read or store `git config user.email` — email addresses are PII and must not be written to committed files.**
-2. Ask: *"What are you building? (language, stack, what it does)"*
-3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see that section):
-   - Determine team size: pick **4–5 cast (user-domain) agents**, then add the **4 always-on built-ins** (Scribe + Ralph + Rai + Fact Checker — see their dedicated sections below). So a typical fresh squad has **8–9 total roster entries**, not 4–5.
-   - Determine assignment shape from the user's project description.
-   - Derive resonance signals from the session and repo context.
-   - Select a universe. Allocate character names from that universe.
-   - Scribe is always "Scribe" — exempt from casting.
-   - Ralph is always "Ralph" — exempt from casting.
-   - Rai is always "Rai" — exempt from casting.
-   - Fact Checker is always "Fact Checker" — exempt from casting (same pattern as Scribe / Ralph / Rai).
-4. Propose the team with their cast names. Example (names will vary per cast):
+**Action:** Invoke the `skill` tool on **`coordinator-init-mode`** to load the full two-phase Init Mode protocol (Phase 1 = propose the team and `ask_user` for confirmation, no files written; Phase 2 = create the `.squad/` scaffolding, casting state, `.gitattributes` for merge drivers, and the always-on built-ins Scribe / Ralph / Rai / Fact Checker). Do NOT improvise — read the skill, then execute Phase 1.
 
-```
-🏗️  {CastName1}  — Lead          Scope, decisions, code review
-⚛️  {CastName2}  — Frontend Dev  React, UI, components
-🔧  {CastName3}  — Backend Dev   APIs, database, services
-🧪  {CastName4}  — Tester        Tests, quality, edge cases
-📋  Scribe       — (silent)      Memory, decisions, session logs
-🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
-🛡️  Rai        — (background)  RAI awareness, content safety
-```
-
-5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
-   - **question:** *"Look right?"*
-   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
-
-**⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
-
----
-
-## Init Mode — Phase 2: Create the Team
-
-**Trigger:** The user replied to Phase 1 with confirmation ("yes", "looks good", or similar affirmative), OR the user's reply to Phase 1 is a task (treat as implicit "yes").
-
-> If the user said "add someone" or "change a role," go back to Phase 1 step 3 and re-propose. Do NOT enter Phase 2 until the user confirms.
-
-6. Create the `.squad/` directory structure (see `.squad/templates/` for format guides or use the standard structure: team.md, routing.md, ceremonies.md, decisions.md, decisions/inbox/, casting/, agents/, orchestration-log/, skills/, log/, rai/).
-
-**Casting state initialization:** Copy `.squad/templates/casting-policy.json` to `.squad/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
-
-**Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.squad/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing. Rai's charter is seeded from the `Rai-charter.md` template, and `.squad/rai/policy.md` is seeded from `rai-policy.md`.
-
-**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
-
-**Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.squad/` state across branches:
-```
-.squad/decisions.md merge=union
-.squad/agents/*/history.md merge=union
-.squad/log/** merge=union
-.squad/orchestration-log/** merge=union
-.squad/rai/audit-trail.md merge=union
-```
-The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
-
-7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
-
-8. **Post-setup input sources** (optional — ask after team is created, not during casting):
-   - PRD/spec: *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow
-   - GitHub issues: *"Is there a GitHub repo with issues I should pull from? (owner/repo, or skip)"* → If provided, follow GitHub Issues Mode flow
-   - Human members: *"Are any humans joining the team? (names and roles, or just AI for now)"* → If provided, add per Human Team Members section
-   - Copilot agent: *"Want to include @copilot? It can pick up issues autonomously. (yes/no)"* → If yes, follow Copilot Coding Agent Member section and ask about auto-assignment
-   - These are additive. Don't block — if the user skips or gives a task instead, proceed immediately.
+**⚠️ Eager-execution exception:** Init Mode is the ONE exception to the eager-execution / parallel-fan-out doctrine. Phase 1 MUST end with a user confirmation before any file is created.
 
 ---
 
@@ -379,75 +319,16 @@ Confidence bumps when an agent independently validates an existing skill — app
 
 ### Response Mode Selection
 
-After routing determines WHO handles work, select the response MODE based on task complexity. Bias toward upgrading — when uncertain, go one tier higher rather than risk under-serving.
+After routing determines WHO handles work, select a **response MODE** (Direct / Lightweight / Standard / Full) based on task complexity. Bias toward upgrading — when uncertain, go one tier higher.
 
-| Mode | When | How | Target |
-|------|------|-----|--------|
-| **Direct** | Status checks, factual questions the coordinator already knows, simple answers from context | Coordinator answers directly — NO agent spawn | ~2-3s |
-| **Lightweight** | Single-file edits, small fixes, follow-ups, simple scoped read-only queries | Spawn ONE agent with minimal prompt (see Lightweight Spawn Template). Use `agent_type: "explore"` for read-only queries | ~8-12s |
-| **Standard** | Normal tasks, single-agent work requiring full context | Spawn one agent with full ceremony — charter inline, history read, decisions read. This is the current default | ~25-35s |
-| **Full** | Multi-agent work, complex tasks touching 3+ concerns, "Team" requests | Parallel fan-out, full ceremony, Scribe included | ~40-60s |
+| Mode | When (one-line) |
+|------|------|
+| **Direct** | Status checks the coordinator can answer from context — no agent spawn |
+| **Lightweight** | Single-file edits, follow-ups, read-only queries (one agent, minimal prompt) |
+| **Standard** | Normal tasks needing full context (one agent, full ceremony) — *default* |
+| **Full** | Multi-agent "Team" requests touching 3+ concerns (parallel fan-out) |
 
-**Direct Mode exemplars** (coordinator answers instantly, no spawn):
-- "Where are we?" → Summarize current state from context: branch, recent work, what the team's been doing. A user favorite — make it instant.
-- "How many tests do we have?" → Run a quick command, answer directly.
-- "What branch are we on?" → `git branch --show-current`, answer directly.
-- "Who's on the team?" → Answer from team.md already in context.
-- "What did we decide about X?" → Answer from decisions.md already in context.
-
-**Lightweight Mode exemplars** (one agent, minimal prompt):
-- "Fix the typo in README" → Spawn one agent, no charter, no history read.
-- "Add a comment to line 42" → Small scoped edit, minimal context needed.
-- "What does this function do?" → `agent_type: "explore"` (Haiku model, fast).
-- Follow-up edits after a Standard/Full response — context is fresh, skip ceremony.
-
-**Standard Mode exemplars** (one agent, full ceremony):
-- "{AgentName}, add error handling to the export function"
-- "{AgentName}, review the prompt structure"
-- Any task requiring architectural judgment or multi-file awareness.
-
-**Full Mode exemplars** (multi-agent, parallel fan-out):
-- "Team, build the login page"
-- "Add OAuth support"
-- Any request that touches 3+ agent domains.
-
-**Mode upgrade rules:**
-- If a Lightweight task turns out to need history or decisions context → treat as Standard.
-- If uncertain between Direct and Lightweight → choose Lightweight.
-- If uncertain between Lightweight and Standard → choose Standard.
-- Never downgrade mid-task. If you started Standard, finish Standard.
-
-**Lightweight Spawn Template** (skip charter, history, and decisions reads — just the task):
-
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-name: "{name}"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  You are {Name}, the {Role} on this project.
-  TEAM ROOT: {team_root}
-  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
-  WORKTREE_PATH: {worktree_path}
-  WORKTREE_MODE: {true|false}
-  **Requested by:** {current user name}
-  
-  {% if WORKTREE_MODE %}
-  **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
-  {% endif %}
-
-  TASK: {specific task description}
-  TARGET FILE(S): {exact file path(s)}
-
-  Do the work. Keep it focused.
-  If you made a meaningful decision, persist it with `memory.write` (class: `decision`) when available, or fall back to `squad_decide` / `squad_state_write` to `decisions/inbox/{name}-{brief-slug}.md`. Do not run git notes, switch branches, or write mutable `.squad/` state by hand.
-
-  ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
-  ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
-```
-
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`
+**For the full decision table, exemplar prompts, mode-upgrade rules, the Lightweight Spawn Template, and explore-agent usage:** invoke the `skill` tool on **`coordinator-response-mode`** to load the complete protocol.
 
 ### Per-Agent Model Selection
 
@@ -725,35 +606,14 @@ If the user wants to remove someone:
 
 ## Source of Truth Hierarchy
 
-> **State backend note:** Files below marked as "Derived / append-only" are **mutable state** — agents access them with runtime state tools (`squad_state_read`, `squad_state_write`, `squad_state_append`, `squad_state_delete`, `squad_state_list`). The runtime decides whether the configured backend stores them on disk, git-native state, or an external provider. Files marked as "Authoritative" are **static config** and always live on disk regardless of backend.
+Squad files split into **authoritative** (governance, roster, charters — static) and **derived / append-only** (decisions, history, logs — runtime-owned). The four governing rules:
 
-| File | Status | Who May Write | Who May Read |
-|------|--------|---------------|--------------|
-| `.github/agents/squad.agent.md` | **Authoritative governance.** All roles, handoffs, gates, and enforcement rules. | Repo maintainer (human) | Squad (Coordinator) |
-| `.squad/decisions.md` | **Authoritative decision ledger.** Single canonical location for scope, architecture, and process decisions. | Squad (Coordinator) — append only | All agents |
-| `.squad/team.md` | **Authoritative roster.** Current team composition. | Squad (Coordinator) | All agents |
-| `.squad/routing.md` | **Authoritative routing.** Work assignment rules. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/ceremonies.md` | **Authoritative ceremony config.** Definitions, triggers, and participants for team ceremonies. | Squad (Coordinator) | Squad (Coordinator), Facilitator agent (read-only at ceremony time) |
-| `.squad/casting/policy.json` | **Authoritative casting config.** Universe allowlist and capacity. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/casting/registry.json` | **Authoritative name registry.** Persistent agent-to-name mappings. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/casting/history.json` | **Derived / append-only.** Universe usage history and assignment snapshots. | Squad (Coordinator) — append only | Squad (Coordinator) |
-| `.squad/agents/{name}/charter.md` | **Authoritative agent identity.** Per-agent role and boundaries. | Squad (Coordinator) at creation; agent may not self-modify | Squad (Coordinator) reads to inline at spawn; owning agent receives via prompt |
-| `.squad/agents/{name}/history.md` | **Derived / append-only.** Personal learnings. Never authoritative for enforcement. | Owning agent (append only), Scribe (cross-agent updates, summarization) | Owning agent only |
-| `.squad/agents/{name}/history-archive.md` | **Derived / append-only.** Archived history entries. Preserved for reference. | Scribe | Owning agent (read-only) |
-| `.squad/orchestration-log/` | **Derived / append-only.** Agent routing evidence. Never edited after write. | Scribe | All agents (read-only) |
-| `.squad/log/` | **Derived / append-only.** Session logs. Diagnostic archive. Never edited after write. | Scribe | All agents (read-only) |
-| `.squad/templates/` | **Reference.** Format guides for runtime files. Not authoritative for enforcement. | Squad (Coordinator) at init | Squad (Coordinator) |
-| `.squad/rai/policy.md` | **Authoritative RAI policy.** Check categories, terminology standards, and opt-out rules. | Squad (Coordinator) at init; Rai may propose updates via decisions inbox | Rai, All agents (read-only) |
-| `.squad/rai/audit-trail.md` | **Derived / append-only.** RAI review evidence log. Redacted — never contains raw secrets or harmful content. | Rai (append only) | Rai, Squad (Coordinator) |
-| `.squad/fact-checker/policy.md` | **Authoritative verification + Devil's Advocate policy.** Confidence rating taxonomy, hard anti-fabrication rules, mode triggers, opt-out model. | Squad (Coordinator) at init; Fact Checker may propose updates via decisions inbox | Fact Checker, All agents (read-only) |
-| `.squad/fact-checker/audit-trail.md` | **Derived / append-only.** Verification verdicts + DA brief evidence log. Succinct — verdict + citation, never raw source material. | Fact Checker (append only) | Fact Checker, Squad (Coordinator) |
-| `.squad/plugins/marketplaces.json` | **Authoritative plugin config.** Registered marketplace sources. | Squad CLI (`squad plugin marketplace`) | Squad (Coordinator) |
+1. **`squad.agent.md` wins** any conflict with another file.
+2. **Append-only files** are never retroactively edited.
+3. **Agents may only write to files in their "Who May Write" column** of the hierarchy.
+4. **Only Squad (Coordinator)** records accepted decisions in `.squad/decisions.md`.
 
-**Rules:**
-1. If this file (`squad.agent.md`) and any other file conflict, this file wins.
-2. Append-only files must never be retroactively edited to change meaning.
-3. Agents may only write to files listed in their "Who May Write" column above.
-4. Non-coordinator agents may propose decisions in their responses, but only Squad records accepted decisions in `.squad/decisions.md`.
+**For the full file-by-file table** (who writes / who reads / authoritative vs derived for `team.md`, `decisions.md`, `routing.md`, `casting/*`, `agents/{name}/*`, `rai/*`, `fact-checker/*`, `orchestration-log/`, `log/`, `templates/`, `plugins/marketplaces.json`): invoke the `skill` tool on **`coordinator-source-of-truth`** to load the complete reference.
 
 ---
 

--- a/.squad/skills/coordinator-init-mode/SKILL.md
+++ b/.squad/skills/coordinator-init-mode/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: "coordinator-init-mode"
+description: "The complete two-phase Init Mode protocol the Squad coordinator runs when no team exists yet in the current repo. Phase 1 = propose the team (no files created, wait for user confirm). Phase 2 = create .squad/ scaffolding, casting state, .gitattributes for merge drivers, and the always-on built-ins (Scribe, Ralph, Rai, Fact Checker). Loaded on demand when the coordinator detects no .squad/team.md exists."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill when init mode is detected (no .squad/team.md present)."
+---
+
+> **Load this skill when:** you detect that no `.squad/team.md` exists in the resolved team root — that means this is a fresh repo or a repo that has never been squadified, and Init Mode is the right path. The short stub in `squad.agent.md` tells you to load this skill; the full two-phase protocol lives here.
+>
+> **⚠️ Eager-execution exception:** Init Mode is the ONE exception to the eager-execution / parallel-fan-out doctrine. Phase 1 MUST end with a user confirmation before any file is created. Do not bypass.
+
+## Phase 1: Propose the Team
+
+No team exists yet. **Propose one — but DO NOT create any files until the user confirms.**
+
+1. **Identify the user.** Run `git config user.name` to learn who you're working with. Use their name in conversation (e.g., *"Hey {user}, what are you building?"*). Store their name (NOT email) in `team.md` under Project Context. **Never read or store `git config user.email`** — email addresses are PII and must not be written to committed files.
+2. Ask: *"What are you building? (language, stack, what it does)"*
+3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see the canonical Casting reference at `.squad/templates/casting-reference.md`):
+   - Determine team size: pick **4–5 cast (user-domain) agents**, then add the **4 always-on built-ins** (Scribe + Ralph + Rai + Fact Checker — see their dedicated sections in `squad.agent.md`). A typical fresh squad has **8–9 total roster entries**, not 4–5.
+   - Determine assignment shape from the user's project description.
+   - Derive resonance signals from the session and repo context.
+   - Select a universe. Allocate character names from that universe.
+   - Scribe is always "Scribe" — exempt from casting.
+   - Ralph is always "Ralph" — exempt from casting.
+   - Rai is always "Rai" — exempt from casting.
+   - Fact Checker is always "Fact Checker" — exempt from casting (same pattern as Scribe / Ralph / Rai).
+4. Propose the team with their cast names. Example (names will vary per cast):
+
+```
+🏗️  {CastName1}  — Lead          Scope, decisions, code review
+⚛️  {CastName2}  — Frontend Dev  React, UI, components
+🔧  {CastName3}  — Backend Dev   APIs, database, services
+🧪  {CastName4}  — Tester        Tests, quality, edge cases
+📋  Scribe       — (silent)      Memory, decisions, session logs
+🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
+🛡️  Rai         — (background)  RAI awareness, content safety
+🔍  Fact Checker — (verifier)    Verification + Devil's Advocate
+```
+
+5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
+   - **question:** *"Look right?"*
+   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
+
+**⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
+
+---
+
+## Phase 2: Create the Team
+
+**Trigger:** The user replied to Phase 1 with confirmation ("yes", "looks good", or similar affirmative), OR the user's reply to Phase 1 is a task (treat as implicit "yes").
+
+> If the user said "add someone" or "change a role," go back to Phase 1 step 3 and re-propose. **Do NOT enter Phase 2 until the user confirms.**
+
+6. Create the `.squad/` directory structure (see `.squad/templates/` for format guides or use the standard structure: `team.md`, `routing.md`, `ceremonies.md`, `decisions.md`, `decisions/inbox/`, `casting/`, `agents/`, `orchestration-log/`, `skills/`, `log/`, `rai/`).
+
+**Casting state initialization:** Copy `.squad/templates/casting-policy.json` to `.squad/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
+
+**Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.squad/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing. Rai's charter is seeded from the `Rai-charter.md` template, and `.squad/rai/policy.md` is seeded from `rai-policy.md`. Fact Checker's charter is seeded from `fact-checker-charter.md` and `.squad/fact-checker/policy.md` is seeded from `fact-checker-policy.md`.
+
+**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
+
+**Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.squad/` state across branches:
+
+```
+.squad/decisions.md merge=union
+.squad/agents/*/history.md merge=union
+.squad/log/** merge=union
+.squad/orchestration-log/** merge=union
+.squad/rai/audit-trail.md merge=union
+```
+
+The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
+
+7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
+
+8. **Post-setup input sources** (optional — ask after team is created, not during casting):
+   - **PRD/spec:** *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow.
+   - **GitHub issues:** *"Is there a GitHub repo with issues I should pull from? (owner/repo, or skip)"* → If provided, follow GitHub Issues Mode flow.
+   - **Human members:** *"Are any humans joining the team? (names and roles, or just AI for now)"* → If provided, add per Human Team Members section.
+   - **Copilot agent:** *"Want to include @copilot? It can pick up issues autonomously. (yes/no)"* → If yes, follow Copilot Coding Agent Member section and ask about auto-assignment.
+   - These are additive. **Don't block** — if the user skips or gives a task instead, proceed immediately.

--- a/.squad/skills/coordinator-response-mode/SKILL.md
+++ b/.squad/skills/coordinator-response-mode/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: "coordinator-response-mode"
+description: "Selecting WHO handles work is the Routing table; selecting HOW they handle it (Direct, Lightweight, Standard, Full) is Response Mode. This skill contains the complete decision table, exemplar prompts for each mode, the Lightweight spawn template, and the upgrade rules. Squad coordinator loads this on demand once routing has identified the agent — to pick the right ceremony level for the task."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill after Routing, before spawn."
+---
+
+> **Load this skill when:** you have routed work to an agent and need to pick the response mode (Direct / Lightweight / Standard / Full). The 1-line stub in `squad.agent.md` is for awareness; this skill is the full decision table + templates.
+
+## Response Mode Selection
+
+After routing determines WHO handles work, select the response MODE based on task complexity. **Bias toward upgrading** — when uncertain, go one tier higher rather than risk under-serving.
+
+| Mode | When | How | Target |
+|------|------|-----|--------|
+| **Direct** | Status checks, factual questions the coordinator already knows, simple answers from context | Coordinator answers directly — NO agent spawn | ~2-3s |
+| **Lightweight** | Single-file edits, small fixes, follow-ups, simple scoped read-only queries | Spawn ONE agent with minimal prompt (see Lightweight Spawn Template below). Use `agent_type: "explore"` for read-only queries | ~8-12s |
+| **Standard** | Normal tasks, single-agent work requiring full context | Spawn one agent with full ceremony — charter inline, history read, decisions read. This is the current default | ~25-35s |
+| **Full** | Multi-agent work, complex tasks touching 3+ concerns, "Team" requests | Parallel fan-out, full ceremony, Scribe included | ~40-60s |
+
+## Direct Mode exemplars
+
+Coordinator answers instantly, no spawn:
+
+- *"Where are we?"* → Summarize current state from context: branch, recent work, what the team's been doing. A user favorite — make it instant.
+- *"How many tests do we have?"* → Run a quick command, answer directly.
+- *"What branch are we on?"* → `git branch --show-current`, answer directly.
+- *"Who's on the team?"* → Answer from `team.md` already in context.
+- *"What did we decide about X?"* → Answer from `decisions.md` already in context.
+
+## Lightweight Mode exemplars
+
+One agent, minimal prompt:
+
+- *"Fix the typo in README"* → Spawn one agent, no charter, no history read.
+- *"Add a comment to line 42"* → Small scoped edit, minimal context needed.
+- *"What does this function do?"* → `agent_type: "explore"` (Haiku model, fast).
+- Follow-up edits after a Standard/Full response — context is fresh, skip ceremony.
+
+## Standard Mode exemplars
+
+One agent, full ceremony:
+
+- *"{AgentName}, add error handling to the export function"*
+- *"{AgentName}, review the prompt structure"*
+- Any task requiring architectural judgment or multi-file awareness.
+
+## Full Mode exemplars
+
+Multi-agent, parallel fan-out:
+
+- *"Team, build the login page"*
+- *"Add OAuth support"*
+- Any request that touches 3+ agent domains.
+
+## Mode upgrade rules
+
+- If a Lightweight task turns out to need history or decisions context → treat as Standard.
+- If uncertain between Direct and Lightweight → choose Lightweight.
+- If uncertain between Lightweight and Standard → choose Standard.
+- **Never downgrade mid-task.** If you started Standard, finish Standard.
+
+## Lightweight Spawn Template
+
+Skip charter, history, and decisions reads — just the task:
+
+```
+agent_type: "general-purpose"
+model: "{resolved_model}"
+mode: "background"
+name: "{name}"
+description: "{emoji} {Name}: {brief task summary}"
+prompt: |
+  You are {Name}, the {Role} on this project.
+  TEAM ROOT: {team_root}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
+  WORKTREE_PATH: {worktree_path}
+  WORKTREE_MODE: {true|false}
+  **Requested by:** {current user name}
+  
+  {% if WORKTREE_MODE %}
+  **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
+  {% endif %}
+
+  TASK: {specific task description}
+  TARGET FILE(S): {exact file path(s)}
+
+  Do the work. Keep it focused.
+  If you made a meaningful decision, persist it with `memory.write` (class: `decision`) when available, or fall back to `squad_decide` / `squad_state_write` to `decisions/inbox/{name}-{brief-slug}.md`. Do not run git notes, switch branches, or write mutable `.squad/` state by hand.
+
+  ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
+  ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
+```
+
+For **read-only queries**, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`

--- a/.squad/skills/coordinator-source-of-truth/SKILL.md
+++ b/.squad/skills/coordinator-source-of-truth/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: "coordinator-source-of-truth"
+description: "The complete file-by-file source-of-truth hierarchy for Squad: which files are authoritative, which are derived/append-only, who may write each one, who may read each one, and the precedence rules when they conflict. Squad coordinator loads this on demand when it needs to resolve a write conflict, decide where a piece of state belongs, or answer a 'who owns this file' question."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill when a routing decision needs the full hierarchy."
+---
+
+> **Load this skill when:** the coordinator (or any agent) needs to resolve a "where does this state belong?" or "who is allowed to write this file?" question — e.g., when about to write `.squad/decisions.md`, when reviewing whether an agent broke the append-only rule, when answering a user question about Squad's file layout, or when adjudicating a conflict between two files. The short summary in `squad.agent.md` is for routing; this skill is the full reference.
+
+## State backend note
+
+Files below marked as **"Derived / append-only"** are **mutable state** — agents access them with runtime state tools (`squad_state_read`, `squad_state_write`, `squad_state_append`, `squad_state_delete`, `squad_state_list`). The runtime decides whether the configured backend stores them on disk, git-native state, or an external provider. Files marked as **"Authoritative"** are **static config** and always live on disk regardless of backend.
+
+## File hierarchy
+
+| File | Status | Who May Write | Who May Read |
+|------|--------|---------------|--------------|
+| `.github/agents/squad.agent.md` | **Authoritative governance.** All roles, handoffs, gates, and enforcement rules. | Repo maintainer (human) | Squad (Coordinator) |
+| `.squad/decisions.md` | **Authoritative decision ledger.** Single canonical location for scope, architecture, and process decisions. | Squad (Coordinator) — append only | All agents |
+| `.squad/team.md` | **Authoritative roster.** Current team composition. | Squad (Coordinator) | All agents |
+| `.squad/routing.md` | **Authoritative routing.** Work assignment rules. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/ceremonies.md` | **Authoritative ceremony config.** Definitions, triggers, and participants for team ceremonies. | Squad (Coordinator) | Squad (Coordinator), Facilitator agent (read-only at ceremony time) |
+| `.squad/casting/policy.json` | **Authoritative casting config.** Universe allowlist and capacity. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/casting/registry.json` | **Authoritative name registry.** Persistent agent-to-name mappings. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/casting/history.json` | **Derived / append-only.** Universe usage history and assignment snapshots. | Squad (Coordinator) — append only | Squad (Coordinator) |
+| `.squad/agents/{name}/charter.md` | **Authoritative agent identity.** Per-agent role and boundaries. | Squad (Coordinator) at creation; agent may not self-modify | Squad (Coordinator) reads to inline at spawn; owning agent receives via prompt |
+| `.squad/agents/{name}/history.md` | **Derived / append-only.** Personal learnings. Never authoritative for enforcement. | Owning agent (append only), Scribe (cross-agent updates, summarization) | Owning agent only |
+| `.squad/agents/{name}/history-archive.md` | **Derived / append-only.** Archived history entries. Preserved for reference. | Scribe | Owning agent (read-only) |
+| `.squad/orchestration-log/` | **Derived / append-only.** Agent routing evidence. Never edited after write. | Scribe | All agents (read-only) |
+| `.squad/log/` | **Derived / append-only.** Session logs. Diagnostic archive. Never edited after write. | Scribe | All agents (read-only) |
+| `.squad/templates/` | **Reference.** Format guides for runtime files. Not authoritative for enforcement. | Squad (Coordinator) at init | Squad (Coordinator) |
+| `.squad/rai/policy.md` | **Authoritative RAI policy.** Check categories, terminology standards, and opt-out rules. | Squad (Coordinator) at init; Rai may propose updates via decisions inbox | Rai, All agents (read-only) |
+| `.squad/rai/audit-trail.md` | **Derived / append-only.** RAI review evidence log. Redacted — never contains raw secrets or harmful content. | Rai (append only) | Rai, Squad (Coordinator) |
+| `.squad/fact-checker/policy.md` | **Authoritative verification + Devil's Advocate policy.** Confidence rating taxonomy, hard anti-fabrication rules, mode triggers, opt-out model. | Squad (Coordinator) at init; Fact Checker may propose updates via decisions inbox | Fact Checker, All agents (read-only) |
+| `.squad/fact-checker/audit-trail.md` | **Derived / append-only.** Verification verdicts + DA brief evidence log. Succinct — verdict + citation, never raw source material. | Fact Checker (append only) | Fact Checker, Squad (Coordinator) |
+| `.squad/plugins/marketplaces.json` | **Authoritative plugin config.** Registered marketplace sources. | Squad CLI (`squad plugin marketplace`) | Squad (Coordinator) |
+
+## Rules
+
+1. **If `squad.agent.md` and any other file conflict, `squad.agent.md` wins.** It is the only file with hard governance authority.
+2. **Append-only files must never be retroactively edited** to change meaning. They are diagnostic and audit-trail material. Corrections go in a new entry that references the prior one.
+3. **Agents may only write to files listed in their "Who May Write" column above.** Violations are a contract bug; runtime state-backends will refuse the write on non-local backends.
+4. **Non-coordinator agents may propose decisions** in their responses, but only Squad (Coordinator) records accepted decisions in `.squad/decisions.md`.

--- a/docs/src/content/docs/features/skill-security-scanner.md
+++ b/docs/src/content/docs/features/skill-security-scanner.md
@@ -66,8 +66,8 @@ The scanner is markdown-aware, which means it understands when a "dangerous" pat
 
 | Where pattern appears | Action |
 |----------------------|--------|
-| Inside a fenced code block (```` ``` ````) | **Suppressed** — treated as documentation, not advice |
-| Inside an inline code span (`` ` ``) | **Suppressed** — treated as a reference |
+| Inside a fenced code block (three backticks) | **Suppressed** — treated as documentation, not advice |
+| Inside an inline code span (single backtick) | **Suppressed** — treated as a reference |
 | In prose with a placeholder token (`<your-token>`, `<api-key>`, `xxx`, `***`) | **Suppressed** — clearly an example |
 | In prose without any of the above | **Flagged** as a finding |
 

--- a/index.cjs
+++ b/index.cjs
@@ -1451,7 +1451,8 @@ function readInstalledVersion(filePath) {
     if (!fs.existsSync(filePath)) return null;
     const content = fs.readFileSync(filePath, 'utf8');
     // Try to read from HTML comment first (new format)
-    const commentMatch = content.match(/<!-- version: ([0-9.]+(?:-[a-z]+)?) -->/);
+    // Accept pre-release suffixes with optional numeric tail (e.g. `0.10.0-insider.1`)
+    const commentMatch = content.match(/<!-- version: ([0-9.]+(?:-[a-z]+(?:\.[0-9]+)?)?) -->/);
     if (commentMatch) return commentMatch[1];
     // Fallback: try old frontmatter format for backward compatibility during upgrade
     const frontmatterMatch = content.match(/^version:\s*"([^"]+)"/m);

--- a/packages/squad-cli/src/cli/core/templates.ts
+++ b/packages/squad-cli/src/cli/core/templates.ts
@@ -299,6 +299,24 @@ export const TEMPLATE_MANIFEST: TemplateFile[] = [
     overwriteOnUpgrade: true,
     description: 'Cross-squad discovery — finding peer squads via registry/upstream',
   },
+  {
+    source: 'skills/coordinator-source-of-truth/SKILL.md',
+    destination: '../.github/skills/coordinator-source-of-truth/SKILL.md',
+    overwriteOnUpgrade: true,
+    description: 'Squad file-by-file source-of-truth hierarchy (extracted from squad.agent.md, #1308)',
+  },
+  {
+    source: 'skills/coordinator-response-mode/SKILL.md',
+    destination: '../.github/skills/coordinator-response-mode/SKILL.md',
+    overwriteOnUpgrade: true,
+    description: 'Response Mode Selection (Direct/Lightweight/Standard/Full) — full decision table + Lightweight spawn template',
+  },
+  {
+    source: 'skills/coordinator-init-mode/SKILL.md',
+    destination: '../.github/skills/coordinator-init-mode/SKILL.md',
+    overwriteOnUpgrade: true,
+    description: 'Init Mode two-phase protocol — propose team (Phase 1) then create .squad/ scaffolding (Phase 2)',
+  },
 
   // Session init reference (squad-owned, coordinator reads at session start)
   {

--- a/packages/squad-cli/templates/skills/coordinator-init-mode/SKILL.md
+++ b/packages/squad-cli/templates/skills/coordinator-init-mode/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: "coordinator-init-mode"
+description: "The complete two-phase Init Mode protocol the Squad coordinator runs when no team exists yet in the current repo. Phase 1 = propose the team (no files created, wait for user confirm). Phase 2 = create .squad/ scaffolding, casting state, .gitattributes for merge drivers, and the always-on built-ins (Scribe, Ralph, Rai, Fact Checker). Loaded on demand when the coordinator detects no .squad/team.md exists."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill when init mode is detected (no .squad/team.md present)."
+---
+
+> **Load this skill when:** you detect that no `.squad/team.md` exists in the resolved team root — that means this is a fresh repo or a repo that has never been squadified, and Init Mode is the right path. The short stub in `squad.agent.md` tells you to load this skill; the full two-phase protocol lives here.
+>
+> **⚠️ Eager-execution exception:** Init Mode is the ONE exception to the eager-execution / parallel-fan-out doctrine. Phase 1 MUST end with a user confirmation before any file is created. Do not bypass.
+
+## Phase 1: Propose the Team
+
+No team exists yet. **Propose one — but DO NOT create any files until the user confirms.**
+
+1. **Identify the user.** Run `git config user.name` to learn who you're working with. Use their name in conversation (e.g., *"Hey {user}, what are you building?"*). Store their name (NOT email) in `team.md` under Project Context. **Never read or store `git config user.email`** — email addresses are PII and must not be written to committed files.
+2. Ask: *"What are you building? (language, stack, what it does)"*
+3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see the canonical Casting reference at `.squad/templates/casting-reference.md`):
+   - Determine team size: pick **4–5 cast (user-domain) agents**, then add the **4 always-on built-ins** (Scribe + Ralph + Rai + Fact Checker — see their dedicated sections in `squad.agent.md`). A typical fresh squad has **8–9 total roster entries**, not 4–5.
+   - Determine assignment shape from the user's project description.
+   - Derive resonance signals from the session and repo context.
+   - Select a universe. Allocate character names from that universe.
+   - Scribe is always "Scribe" — exempt from casting.
+   - Ralph is always "Ralph" — exempt from casting.
+   - Rai is always "Rai" — exempt from casting.
+   - Fact Checker is always "Fact Checker" — exempt from casting (same pattern as Scribe / Ralph / Rai).
+4. Propose the team with their cast names. Example (names will vary per cast):
+
+```
+🏗️  {CastName1}  — Lead          Scope, decisions, code review
+⚛️  {CastName2}  — Frontend Dev  React, UI, components
+🔧  {CastName3}  — Backend Dev   APIs, database, services
+🧪  {CastName4}  — Tester        Tests, quality, edge cases
+📋  Scribe       — (silent)      Memory, decisions, session logs
+🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
+🛡️  Rai         — (background)  RAI awareness, content safety
+🔍  Fact Checker — (verifier)    Verification + Devil's Advocate
+```
+
+5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
+   - **question:** *"Look right?"*
+   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
+
+**⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
+
+---
+
+## Phase 2: Create the Team
+
+**Trigger:** The user replied to Phase 1 with confirmation ("yes", "looks good", or similar affirmative), OR the user's reply to Phase 1 is a task (treat as implicit "yes").
+
+> If the user said "add someone" or "change a role," go back to Phase 1 step 3 and re-propose. **Do NOT enter Phase 2 until the user confirms.**
+
+6. Create the `.squad/` directory structure (see `.squad/templates/` for format guides or use the standard structure: `team.md`, `routing.md`, `ceremonies.md`, `decisions.md`, `decisions/inbox/`, `casting/`, `agents/`, `orchestration-log/`, `skills/`, `log/`, `rai/`).
+
+**Casting state initialization:** Copy `.squad/templates/casting-policy.json` to `.squad/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
+
+**Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.squad/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing. Rai's charter is seeded from the `Rai-charter.md` template, and `.squad/rai/policy.md` is seeded from `rai-policy.md`. Fact Checker's charter is seeded from `fact-checker-charter.md` and `.squad/fact-checker/policy.md` is seeded from `fact-checker-policy.md`.
+
+**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
+
+**Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.squad/` state across branches:
+
+```
+.squad/decisions.md merge=union
+.squad/agents/*/history.md merge=union
+.squad/log/** merge=union
+.squad/orchestration-log/** merge=union
+.squad/rai/audit-trail.md merge=union
+```
+
+The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
+
+7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
+
+8. **Post-setup input sources** (optional — ask after team is created, not during casting):
+   - **PRD/spec:** *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow.
+   - **GitHub issues:** *"Is there a GitHub repo with issues I should pull from? (owner/repo, or skip)"* → If provided, follow GitHub Issues Mode flow.
+   - **Human members:** *"Are any humans joining the team? (names and roles, or just AI for now)"* → If provided, add per Human Team Members section.
+   - **Copilot agent:** *"Want to include @copilot? It can pick up issues autonomously. (yes/no)"* → If yes, follow Copilot Coding Agent Member section and ask about auto-assignment.
+   - These are additive. **Don't block** — if the user skips or gives a task instead, proceed immediately.

--- a/packages/squad-cli/templates/skills/coordinator-response-mode/SKILL.md
+++ b/packages/squad-cli/templates/skills/coordinator-response-mode/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: "coordinator-response-mode"
+description: "Selecting WHO handles work is the Routing table; selecting HOW they handle it (Direct, Lightweight, Standard, Full) is Response Mode. This skill contains the complete decision table, exemplar prompts for each mode, the Lightweight spawn template, and the upgrade rules. Squad coordinator loads this on demand once routing has identified the agent — to pick the right ceremony level for the task."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill after Routing, before spawn."
+---
+
+> **Load this skill when:** you have routed work to an agent and need to pick the response mode (Direct / Lightweight / Standard / Full). The 1-line stub in `squad.agent.md` is for awareness; this skill is the full decision table + templates.
+
+## Response Mode Selection
+
+After routing determines WHO handles work, select the response MODE based on task complexity. **Bias toward upgrading** — when uncertain, go one tier higher rather than risk under-serving.
+
+| Mode | When | How | Target |
+|------|------|-----|--------|
+| **Direct** | Status checks, factual questions the coordinator already knows, simple answers from context | Coordinator answers directly — NO agent spawn | ~2-3s |
+| **Lightweight** | Single-file edits, small fixes, follow-ups, simple scoped read-only queries | Spawn ONE agent with minimal prompt (see Lightweight Spawn Template below). Use `agent_type: "explore"` for read-only queries | ~8-12s |
+| **Standard** | Normal tasks, single-agent work requiring full context | Spawn one agent with full ceremony — charter inline, history read, decisions read. This is the current default | ~25-35s |
+| **Full** | Multi-agent work, complex tasks touching 3+ concerns, "Team" requests | Parallel fan-out, full ceremony, Scribe included | ~40-60s |
+
+## Direct Mode exemplars
+
+Coordinator answers instantly, no spawn:
+
+- *"Where are we?"* → Summarize current state from context: branch, recent work, what the team's been doing. A user favorite — make it instant.
+- *"How many tests do we have?"* → Run a quick command, answer directly.
+- *"What branch are we on?"* → `git branch --show-current`, answer directly.
+- *"Who's on the team?"* → Answer from `team.md` already in context.
+- *"What did we decide about X?"* → Answer from `decisions.md` already in context.
+
+## Lightweight Mode exemplars
+
+One agent, minimal prompt:
+
+- *"Fix the typo in README"* → Spawn one agent, no charter, no history read.
+- *"Add a comment to line 42"* → Small scoped edit, minimal context needed.
+- *"What does this function do?"* → `agent_type: "explore"` (Haiku model, fast).
+- Follow-up edits after a Standard/Full response — context is fresh, skip ceremony.
+
+## Standard Mode exemplars
+
+One agent, full ceremony:
+
+- *"{AgentName}, add error handling to the export function"*
+- *"{AgentName}, review the prompt structure"*
+- Any task requiring architectural judgment or multi-file awareness.
+
+## Full Mode exemplars
+
+Multi-agent, parallel fan-out:
+
+- *"Team, build the login page"*
+- *"Add OAuth support"*
+- Any request that touches 3+ agent domains.
+
+## Mode upgrade rules
+
+- If a Lightweight task turns out to need history or decisions context → treat as Standard.
+- If uncertain between Direct and Lightweight → choose Lightweight.
+- If uncertain between Lightweight and Standard → choose Standard.
+- **Never downgrade mid-task.** If you started Standard, finish Standard.
+
+## Lightweight Spawn Template
+
+Skip charter, history, and decisions reads — just the task:
+
+```
+agent_type: "general-purpose"
+model: "{resolved_model}"
+mode: "background"
+name: "{name}"
+description: "{emoji} {Name}: {brief task summary}"
+prompt: |
+  You are {Name}, the {Role} on this project.
+  TEAM ROOT: {team_root}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
+  WORKTREE_PATH: {worktree_path}
+  WORKTREE_MODE: {true|false}
+  **Requested by:** {current user name}
+  
+  {% if WORKTREE_MODE %}
+  **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
+  {% endif %}
+
+  TASK: {specific task description}
+  TARGET FILE(S): {exact file path(s)}
+
+  Do the work. Keep it focused.
+  If you made a meaningful decision, persist it with `memory.write` (class: `decision`) when available, or fall back to `squad_decide` / `squad_state_write` to `decisions/inbox/{name}-{brief-slug}.md`. Do not run git notes, switch branches, or write mutable `.squad/` state by hand.
+
+  ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
+  ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
+```
+
+For **read-only queries**, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`

--- a/packages/squad-cli/templates/skills/coordinator-source-of-truth/SKILL.md
+++ b/packages/squad-cli/templates/skills/coordinator-source-of-truth/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: "coordinator-source-of-truth"
+description: "The complete file-by-file source-of-truth hierarchy for Squad: which files are authoritative, which are derived/append-only, who may write each one, who may read each one, and the precedence rules when they conflict. Squad coordinator loads this on demand when it needs to resolve a write conflict, decide where a piece of state belongs, or answer a 'who owns this file' question."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill when a routing decision needs the full hierarchy."
+---
+
+> **Load this skill when:** the coordinator (or any agent) needs to resolve a "where does this state belong?" or "who is allowed to write this file?" question — e.g., when about to write `.squad/decisions.md`, when reviewing whether an agent broke the append-only rule, when answering a user question about Squad's file layout, or when adjudicating a conflict between two files. The short summary in `squad.agent.md` is for routing; this skill is the full reference.
+
+## State backend note
+
+Files below marked as **"Derived / append-only"** are **mutable state** — agents access them with runtime state tools (`squad_state_read`, `squad_state_write`, `squad_state_append`, `squad_state_delete`, `squad_state_list`). The runtime decides whether the configured backend stores them on disk, git-native state, or an external provider. Files marked as **"Authoritative"** are **static config** and always live on disk regardless of backend.
+
+## File hierarchy
+
+| File | Status | Who May Write | Who May Read |
+|------|--------|---------------|--------------|
+| `.github/agents/squad.agent.md` | **Authoritative governance.** All roles, handoffs, gates, and enforcement rules. | Repo maintainer (human) | Squad (Coordinator) |
+| `.squad/decisions.md` | **Authoritative decision ledger.** Single canonical location for scope, architecture, and process decisions. | Squad (Coordinator) — append only | All agents |
+| `.squad/team.md` | **Authoritative roster.** Current team composition. | Squad (Coordinator) | All agents |
+| `.squad/routing.md` | **Authoritative routing.** Work assignment rules. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/ceremonies.md` | **Authoritative ceremony config.** Definitions, triggers, and participants for team ceremonies. | Squad (Coordinator) | Squad (Coordinator), Facilitator agent (read-only at ceremony time) |
+| `.squad/casting/policy.json` | **Authoritative casting config.** Universe allowlist and capacity. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/casting/registry.json` | **Authoritative name registry.** Persistent agent-to-name mappings. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/casting/history.json` | **Derived / append-only.** Universe usage history and assignment snapshots. | Squad (Coordinator) — append only | Squad (Coordinator) |
+| `.squad/agents/{name}/charter.md` | **Authoritative agent identity.** Per-agent role and boundaries. | Squad (Coordinator) at creation; agent may not self-modify | Squad (Coordinator) reads to inline at spawn; owning agent receives via prompt |
+| `.squad/agents/{name}/history.md` | **Derived / append-only.** Personal learnings. Never authoritative for enforcement. | Owning agent (append only), Scribe (cross-agent updates, summarization) | Owning agent only |
+| `.squad/agents/{name}/history-archive.md` | **Derived / append-only.** Archived history entries. Preserved for reference. | Scribe | Owning agent (read-only) |
+| `.squad/orchestration-log/` | **Derived / append-only.** Agent routing evidence. Never edited after write. | Scribe | All agents (read-only) |
+| `.squad/log/` | **Derived / append-only.** Session logs. Diagnostic archive. Never edited after write. | Scribe | All agents (read-only) |
+| `.squad/templates/` | **Reference.** Format guides for runtime files. Not authoritative for enforcement. | Squad (Coordinator) at init | Squad (Coordinator) |
+| `.squad/rai/policy.md` | **Authoritative RAI policy.** Check categories, terminology standards, and opt-out rules. | Squad (Coordinator) at init; Rai may propose updates via decisions inbox | Rai, All agents (read-only) |
+| `.squad/rai/audit-trail.md` | **Derived / append-only.** RAI review evidence log. Redacted — never contains raw secrets or harmful content. | Rai (append only) | Rai, Squad (Coordinator) |
+| `.squad/fact-checker/policy.md` | **Authoritative verification + Devil's Advocate policy.** Confidence rating taxonomy, hard anti-fabrication rules, mode triggers, opt-out model. | Squad (Coordinator) at init; Fact Checker may propose updates via decisions inbox | Fact Checker, All agents (read-only) |
+| `.squad/fact-checker/audit-trail.md` | **Derived / append-only.** Verification verdicts + DA brief evidence log. Succinct — verdict + citation, never raw source material. | Fact Checker (append only) | Fact Checker, Squad (Coordinator) |
+| `.squad/plugins/marketplaces.json` | **Authoritative plugin config.** Registered marketplace sources. | Squad CLI (`squad plugin marketplace`) | Squad (Coordinator) |
+
+## Rules
+
+1. **If `squad.agent.md` and any other file conflict, `squad.agent.md` wins.** It is the only file with hard governance authority.
+2. **Append-only files must never be retroactively edited** to change meaning. They are diagnostic and audit-trail material. Corrections go in a new entry that references the prior one.
+3. **Agents may only write to files listed in their "Who May Write" column above.** Violations are a contract bug; runtime state-backends will refuse the write on non-local backends.
+4. **Non-coordinator agents may propose decisions** in their responses, but only Squad (Coordinator) records accepted decisions in `.squad/decisions.md`.

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -46,73 +46,13 @@ Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for re
 
 ---
 
-## Init Mode — Phase 1: Propose the Team
+## Init Mode
 
-No team exists yet. Propose one — but **DO NOT create any files until the user confirms.**
+**Trigger:** No `.squad/team.md` exists in the resolved team root — i.e., this is a fresh repo or one that has never been squadified.
 
-1. **Identify the user.** Run `git config user.name` to learn who you're working with. Use their name in conversation (e.g., *"Hey {user}, what are you building?"*). Store their name (NOT email) in `team.md` under Project Context. **Never read or store `git config user.email` — email addresses are PII and must not be written to committed files.**
-2. Ask: *"What are you building? (language, stack, what it does)"*
-3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see that section):
-   - Determine team size: pick **4–5 cast (user-domain) agents**, then add the **4 always-on built-ins** (Scribe + Ralph + Rai + Fact Checker — see their dedicated sections below). So a typical fresh squad has **8–9 total roster entries**, not 4–5.
-   - Determine assignment shape from the user's project description.
-   - Derive resonance signals from the session and repo context.
-   - Select a universe. Allocate character names from that universe.
-   - Scribe is always "Scribe" — exempt from casting.
-   - Ralph is always "Ralph" — exempt from casting.
-   - Rai is always "Rai" — exempt from casting.
-   - Fact Checker is always "Fact Checker" — exempt from casting (same pattern as Scribe / Ralph / Rai).
-4. Propose the team with their cast names. Example (names will vary per cast):
+**Action:** Invoke the `skill` tool on **`coordinator-init-mode`** to load the full two-phase Init Mode protocol (Phase 1 = propose the team and `ask_user` for confirmation, no files written; Phase 2 = create the `.squad/` scaffolding, casting state, `.gitattributes` for merge drivers, and the always-on built-ins Scribe / Ralph / Rai / Fact Checker). Do NOT improvise — read the skill, then execute Phase 1.
 
-```
-🏗️  {CastName1}  — Lead          Scope, decisions, code review
-⚛️  {CastName2}  — Frontend Dev  React, UI, components
-🔧  {CastName3}  — Backend Dev   APIs, database, services
-🧪  {CastName4}  — Tester        Tests, quality, edge cases
-📋  Scribe       — (silent)      Memory, decisions, session logs
-🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
-🛡️  Rai        — (background)  RAI awareness, content safety
-```
-
-5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
-   - **question:** *"Look right?"*
-   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
-
-**⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
-
----
-
-## Init Mode — Phase 2: Create the Team
-
-**Trigger:** The user replied to Phase 1 with confirmation ("yes", "looks good", or similar affirmative), OR the user's reply to Phase 1 is a task (treat as implicit "yes").
-
-> If the user said "add someone" or "change a role," go back to Phase 1 step 3 and re-propose. Do NOT enter Phase 2 until the user confirms.
-
-6. Create the `.squad/` directory structure (see `.squad/templates/` for format guides or use the standard structure: team.md, routing.md, ceremonies.md, decisions.md, decisions/inbox/, casting/, agents/, orchestration-log/, skills/, log/, rai/).
-
-**Casting state initialization:** Copy `.squad/templates/casting-policy.json` to `.squad/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
-
-**Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.squad/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing. Rai's charter is seeded from the `Rai-charter.md` template, and `.squad/rai/policy.md` is seeded from `rai-policy.md`.
-
-**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
-
-**Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.squad/` state across branches:
-```
-.squad/decisions.md merge=union
-.squad/agents/*/history.md merge=union
-.squad/log/** merge=union
-.squad/orchestration-log/** merge=union
-.squad/rai/audit-trail.md merge=union
-```
-The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
-
-7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
-
-8. **Post-setup input sources** (optional — ask after team is created, not during casting):
-   - PRD/spec: *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow
-   - GitHub issues: *"Is there a GitHub repo with issues I should pull from? (owner/repo, or skip)"* → If provided, follow GitHub Issues Mode flow
-   - Human members: *"Are any humans joining the team? (names and roles, or just AI for now)"* → If provided, add per Human Team Members section
-   - Copilot agent: *"Want to include @copilot? It can pick up issues autonomously. (yes/no)"* → If yes, follow Copilot Coding Agent Member section and ask about auto-assignment
-   - These are additive. Don't block — if the user skips or gives a task instead, proceed immediately.
+**⚠️ Eager-execution exception:** Init Mode is the ONE exception to the eager-execution / parallel-fan-out doctrine. Phase 1 MUST end with a user confirmation before any file is created.
 
 ---
 
@@ -379,75 +319,16 @@ Confidence bumps when an agent independently validates an existing skill — app
 
 ### Response Mode Selection
 
-After routing determines WHO handles work, select the response MODE based on task complexity. Bias toward upgrading — when uncertain, go one tier higher rather than risk under-serving.
+After routing determines WHO handles work, select a **response MODE** (Direct / Lightweight / Standard / Full) based on task complexity. Bias toward upgrading — when uncertain, go one tier higher.
 
-| Mode | When | How | Target |
-|------|------|-----|--------|
-| **Direct** | Status checks, factual questions the coordinator already knows, simple answers from context | Coordinator answers directly — NO agent spawn | ~2-3s |
-| **Lightweight** | Single-file edits, small fixes, follow-ups, simple scoped read-only queries | Spawn ONE agent with minimal prompt (see Lightweight Spawn Template). Use `agent_type: "explore"` for read-only queries | ~8-12s |
-| **Standard** | Normal tasks, single-agent work requiring full context | Spawn one agent with full ceremony — charter inline, history read, decisions read. This is the current default | ~25-35s |
-| **Full** | Multi-agent work, complex tasks touching 3+ concerns, "Team" requests | Parallel fan-out, full ceremony, Scribe included | ~40-60s |
+| Mode | When (one-line) |
+|------|------|
+| **Direct** | Status checks the coordinator can answer from context — no agent spawn |
+| **Lightweight** | Single-file edits, follow-ups, read-only queries (one agent, minimal prompt) |
+| **Standard** | Normal tasks needing full context (one agent, full ceremony) — *default* |
+| **Full** | Multi-agent "Team" requests touching 3+ concerns (parallel fan-out) |
 
-**Direct Mode exemplars** (coordinator answers instantly, no spawn):
-- "Where are we?" → Summarize current state from context: branch, recent work, what the team's been doing. A user favorite — make it instant.
-- "How many tests do we have?" → Run a quick command, answer directly.
-- "What branch are we on?" → `git branch --show-current`, answer directly.
-- "Who's on the team?" → Answer from team.md already in context.
-- "What did we decide about X?" → Answer from decisions.md already in context.
-
-**Lightweight Mode exemplars** (one agent, minimal prompt):
-- "Fix the typo in README" → Spawn one agent, no charter, no history read.
-- "Add a comment to line 42" → Small scoped edit, minimal context needed.
-- "What does this function do?" → `agent_type: "explore"` (Haiku model, fast).
-- Follow-up edits after a Standard/Full response — context is fresh, skip ceremony.
-
-**Standard Mode exemplars** (one agent, full ceremony):
-- "{AgentName}, add error handling to the export function"
-- "{AgentName}, review the prompt structure"
-- Any task requiring architectural judgment or multi-file awareness.
-
-**Full Mode exemplars** (multi-agent, parallel fan-out):
-- "Team, build the login page"
-- "Add OAuth support"
-- Any request that touches 3+ agent domains.
-
-**Mode upgrade rules:**
-- If a Lightweight task turns out to need history or decisions context → treat as Standard.
-- If uncertain between Direct and Lightweight → choose Lightweight.
-- If uncertain between Lightweight and Standard → choose Standard.
-- Never downgrade mid-task. If you started Standard, finish Standard.
-
-**Lightweight Spawn Template** (skip charter, history, and decisions reads — just the task):
-
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-name: "{name}"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  You are {Name}, the {Role} on this project.
-  TEAM ROOT: {team_root}
-  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
-  WORKTREE_PATH: {worktree_path}
-  WORKTREE_MODE: {true|false}
-  **Requested by:** {current user name}
-  
-  {% if WORKTREE_MODE %}
-  **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
-  {% endif %}
-
-  TASK: {specific task description}
-  TARGET FILE(S): {exact file path(s)}
-
-  Do the work. Keep it focused.
-  If you made a meaningful decision, persist it with `memory.write` (class: `decision`) when available, or fall back to `squad_decide` / `squad_state_write` to `decisions/inbox/{name}-{brief-slug}.md`. Do not run git notes, switch branches, or write mutable `.squad/` state by hand.
-
-  ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
-  ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
-```
-
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`
+**For the full decision table, exemplar prompts, mode-upgrade rules, the Lightweight Spawn Template, and explore-agent usage:** invoke the `skill` tool on **`coordinator-response-mode`** to load the complete protocol.
 
 ### Per-Agent Model Selection
 
@@ -725,35 +606,14 @@ If the user wants to remove someone:
 
 ## Source of Truth Hierarchy
 
-> **State backend note:** Files below marked as "Derived / append-only" are **mutable state** — agents access them with runtime state tools (`squad_state_read`, `squad_state_write`, `squad_state_append`, `squad_state_delete`, `squad_state_list`). The runtime decides whether the configured backend stores them on disk, git-native state, or an external provider. Files marked as "Authoritative" are **static config** and always live on disk regardless of backend.
+Squad files split into **authoritative** (governance, roster, charters — static) and **derived / append-only** (decisions, history, logs — runtime-owned). The four governing rules:
 
-| File | Status | Who May Write | Who May Read |
-|------|--------|---------------|--------------|
-| `.github/agents/squad.agent.md` | **Authoritative governance.** All roles, handoffs, gates, and enforcement rules. | Repo maintainer (human) | Squad (Coordinator) |
-| `.squad/decisions.md` | **Authoritative decision ledger.** Single canonical location for scope, architecture, and process decisions. | Squad (Coordinator) — append only | All agents |
-| `.squad/team.md` | **Authoritative roster.** Current team composition. | Squad (Coordinator) | All agents |
-| `.squad/routing.md` | **Authoritative routing.** Work assignment rules. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/ceremonies.md` | **Authoritative ceremony config.** Definitions, triggers, and participants for team ceremonies. | Squad (Coordinator) | Squad (Coordinator), Facilitator agent (read-only at ceremony time) |
-| `.squad/casting/policy.json` | **Authoritative casting config.** Universe allowlist and capacity. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/casting/registry.json` | **Authoritative name registry.** Persistent agent-to-name mappings. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/casting/history.json` | **Derived / append-only.** Universe usage history and assignment snapshots. | Squad (Coordinator) — append only | Squad (Coordinator) |
-| `.squad/agents/{name}/charter.md` | **Authoritative agent identity.** Per-agent role and boundaries. | Squad (Coordinator) at creation; agent may not self-modify | Squad (Coordinator) reads to inline at spawn; owning agent receives via prompt |
-| `.squad/agents/{name}/history.md` | **Derived / append-only.** Personal learnings. Never authoritative for enforcement. | Owning agent (append only), Scribe (cross-agent updates, summarization) | Owning agent only |
-| `.squad/agents/{name}/history-archive.md` | **Derived / append-only.** Archived history entries. Preserved for reference. | Scribe | Owning agent (read-only) |
-| `.squad/orchestration-log/` | **Derived / append-only.** Agent routing evidence. Never edited after write. | Scribe | All agents (read-only) |
-| `.squad/log/` | **Derived / append-only.** Session logs. Diagnostic archive. Never edited after write. | Scribe | All agents (read-only) |
-| `.squad/templates/` | **Reference.** Format guides for runtime files. Not authoritative for enforcement. | Squad (Coordinator) at init | Squad (Coordinator) |
-| `.squad/rai/policy.md` | **Authoritative RAI policy.** Check categories, terminology standards, and opt-out rules. | Squad (Coordinator) at init; Rai may propose updates via decisions inbox | Rai, All agents (read-only) |
-| `.squad/rai/audit-trail.md` | **Derived / append-only.** RAI review evidence log. Redacted — never contains raw secrets or harmful content. | Rai (append only) | Rai, Squad (Coordinator) |
-| `.squad/fact-checker/policy.md` | **Authoritative verification + Devil's Advocate policy.** Confidence rating taxonomy, hard anti-fabrication rules, mode triggers, opt-out model. | Squad (Coordinator) at init; Fact Checker may propose updates via decisions inbox | Fact Checker, All agents (read-only) |
-| `.squad/fact-checker/audit-trail.md` | **Derived / append-only.** Verification verdicts + DA brief evidence log. Succinct — verdict + citation, never raw source material. | Fact Checker (append only) | Fact Checker, Squad (Coordinator) |
-| `.squad/plugins/marketplaces.json` | **Authoritative plugin config.** Registered marketplace sources. | Squad CLI (`squad plugin marketplace`) | Squad (Coordinator) |
+1. **`squad.agent.md` wins** any conflict with another file.
+2. **Append-only files** are never retroactively edited.
+3. **Agents may only write to files in their "Who May Write" column** of the hierarchy.
+4. **Only Squad (Coordinator)** records accepted decisions in `.squad/decisions.md`.
 
-**Rules:**
-1. If this file (`squad.agent.md`) and any other file conflict, this file wins.
-2. Append-only files must never be retroactively edited to change meaning.
-3. Agents may only write to files listed in their "Who May Write" column above.
-4. Non-coordinator agents may propose decisions in their responses, but only Squad records accepted decisions in `.squad/decisions.md`.
+**For the full file-by-file table** (who writes / who reads / authoritative vs derived for `team.md`, `decisions.md`, `routing.md`, `casting/*`, `agents/{name}/*`, `rai/*`, `fact-checker/*`, `orchestration-log/`, `log/`, `templates/`, `plugins/marketplaces.json`): invoke the `skill` tool on **`coordinator-source-of-truth`** to load the complete reference.
 
 ---
 

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -51,6 +51,9 @@ export const MANIFEST_SKILL_NAMES = [
   'iterative-retrieval',
   'reflect',
   'cross-squad',
+  'coordinator-source-of-truth',
+  'coordinator-response-mode',
+  'coordinator-init-mode',
 ] as const;
 
 // ============================================================================

--- a/packages/squad-sdk/templates/skills/coordinator-init-mode/SKILL.md
+++ b/packages/squad-sdk/templates/skills/coordinator-init-mode/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: "coordinator-init-mode"
+description: "The complete two-phase Init Mode protocol the Squad coordinator runs when no team exists yet in the current repo. Phase 1 = propose the team (no files created, wait for user confirm). Phase 2 = create .squad/ scaffolding, casting state, .gitattributes for merge drivers, and the always-on built-ins (Scribe, Ralph, Rai, Fact Checker). Loaded on demand when the coordinator detects no .squad/team.md exists."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill when init mode is detected (no .squad/team.md present)."
+---
+
+> **Load this skill when:** you detect that no `.squad/team.md` exists in the resolved team root — that means this is a fresh repo or a repo that has never been squadified, and Init Mode is the right path. The short stub in `squad.agent.md` tells you to load this skill; the full two-phase protocol lives here.
+>
+> **⚠️ Eager-execution exception:** Init Mode is the ONE exception to the eager-execution / parallel-fan-out doctrine. Phase 1 MUST end with a user confirmation before any file is created. Do not bypass.
+
+## Phase 1: Propose the Team
+
+No team exists yet. **Propose one — but DO NOT create any files until the user confirms.**
+
+1. **Identify the user.** Run `git config user.name` to learn who you're working with. Use their name in conversation (e.g., *"Hey {user}, what are you building?"*). Store their name (NOT email) in `team.md` under Project Context. **Never read or store `git config user.email`** — email addresses are PII and must not be written to committed files.
+2. Ask: *"What are you building? (language, stack, what it does)"*
+3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see the canonical Casting reference at `.squad/templates/casting-reference.md`):
+   - Determine team size: pick **4–5 cast (user-domain) agents**, then add the **4 always-on built-ins** (Scribe + Ralph + Rai + Fact Checker — see their dedicated sections in `squad.agent.md`). A typical fresh squad has **8–9 total roster entries**, not 4–5.
+   - Determine assignment shape from the user's project description.
+   - Derive resonance signals from the session and repo context.
+   - Select a universe. Allocate character names from that universe.
+   - Scribe is always "Scribe" — exempt from casting.
+   - Ralph is always "Ralph" — exempt from casting.
+   - Rai is always "Rai" — exempt from casting.
+   - Fact Checker is always "Fact Checker" — exempt from casting (same pattern as Scribe / Ralph / Rai).
+4. Propose the team with their cast names. Example (names will vary per cast):
+
+```
+🏗️  {CastName1}  — Lead          Scope, decisions, code review
+⚛️  {CastName2}  — Frontend Dev  React, UI, components
+🔧  {CastName3}  — Backend Dev   APIs, database, services
+🧪  {CastName4}  — Tester        Tests, quality, edge cases
+📋  Scribe       — (silent)      Memory, decisions, session logs
+🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
+🛡️  Rai         — (background)  RAI awareness, content safety
+🔍  Fact Checker — (verifier)    Verification + Devil's Advocate
+```
+
+5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
+   - **question:** *"Look right?"*
+   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
+
+**⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
+
+---
+
+## Phase 2: Create the Team
+
+**Trigger:** The user replied to Phase 1 with confirmation ("yes", "looks good", or similar affirmative), OR the user's reply to Phase 1 is a task (treat as implicit "yes").
+
+> If the user said "add someone" or "change a role," go back to Phase 1 step 3 and re-propose. **Do NOT enter Phase 2 until the user confirms.**
+
+6. Create the `.squad/` directory structure (see `.squad/templates/` for format guides or use the standard structure: `team.md`, `routing.md`, `ceremonies.md`, `decisions.md`, `decisions/inbox/`, `casting/`, `agents/`, `orchestration-log/`, `skills/`, `log/`, `rai/`).
+
+**Casting state initialization:** Copy `.squad/templates/casting-policy.json` to `.squad/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
+
+**Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.squad/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing. Rai's charter is seeded from the `Rai-charter.md` template, and `.squad/rai/policy.md` is seeded from `rai-policy.md`. Fact Checker's charter is seeded from `fact-checker-charter.md` and `.squad/fact-checker/policy.md` is seeded from `fact-checker-policy.md`.
+
+**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
+
+**Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.squad/` state across branches:
+
+```
+.squad/decisions.md merge=union
+.squad/agents/*/history.md merge=union
+.squad/log/** merge=union
+.squad/orchestration-log/** merge=union
+.squad/rai/audit-trail.md merge=union
+```
+
+The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
+
+7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
+
+8. **Post-setup input sources** (optional — ask after team is created, not during casting):
+   - **PRD/spec:** *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow.
+   - **GitHub issues:** *"Is there a GitHub repo with issues I should pull from? (owner/repo, or skip)"* → If provided, follow GitHub Issues Mode flow.
+   - **Human members:** *"Are any humans joining the team? (names and roles, or just AI for now)"* → If provided, add per Human Team Members section.
+   - **Copilot agent:** *"Want to include @copilot? It can pick up issues autonomously. (yes/no)"* → If yes, follow Copilot Coding Agent Member section and ask about auto-assignment.
+   - These are additive. **Don't block** — if the user skips or gives a task instead, proceed immediately.

--- a/packages/squad-sdk/templates/skills/coordinator-response-mode/SKILL.md
+++ b/packages/squad-sdk/templates/skills/coordinator-response-mode/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: "coordinator-response-mode"
+description: "Selecting WHO handles work is the Routing table; selecting HOW they handle it (Direct, Lightweight, Standard, Full) is Response Mode. This skill contains the complete decision table, exemplar prompts for each mode, the Lightweight spawn template, and the upgrade rules. Squad coordinator loads this on demand once routing has identified the agent — to pick the right ceremony level for the task."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill after Routing, before spawn."
+---
+
+> **Load this skill when:** you have routed work to an agent and need to pick the response mode (Direct / Lightweight / Standard / Full). The 1-line stub in `squad.agent.md` is for awareness; this skill is the full decision table + templates.
+
+## Response Mode Selection
+
+After routing determines WHO handles work, select the response MODE based on task complexity. **Bias toward upgrading** — when uncertain, go one tier higher rather than risk under-serving.
+
+| Mode | When | How | Target |
+|------|------|-----|--------|
+| **Direct** | Status checks, factual questions the coordinator already knows, simple answers from context | Coordinator answers directly — NO agent spawn | ~2-3s |
+| **Lightweight** | Single-file edits, small fixes, follow-ups, simple scoped read-only queries | Spawn ONE agent with minimal prompt (see Lightweight Spawn Template below). Use `agent_type: "explore"` for read-only queries | ~8-12s |
+| **Standard** | Normal tasks, single-agent work requiring full context | Spawn one agent with full ceremony — charter inline, history read, decisions read. This is the current default | ~25-35s |
+| **Full** | Multi-agent work, complex tasks touching 3+ concerns, "Team" requests | Parallel fan-out, full ceremony, Scribe included | ~40-60s |
+
+## Direct Mode exemplars
+
+Coordinator answers instantly, no spawn:
+
+- *"Where are we?"* → Summarize current state from context: branch, recent work, what the team's been doing. A user favorite — make it instant.
+- *"How many tests do we have?"* → Run a quick command, answer directly.
+- *"What branch are we on?"* → `git branch --show-current`, answer directly.
+- *"Who's on the team?"* → Answer from `team.md` already in context.
+- *"What did we decide about X?"* → Answer from `decisions.md` already in context.
+
+## Lightweight Mode exemplars
+
+One agent, minimal prompt:
+
+- *"Fix the typo in README"* → Spawn one agent, no charter, no history read.
+- *"Add a comment to line 42"* → Small scoped edit, minimal context needed.
+- *"What does this function do?"* → `agent_type: "explore"` (Haiku model, fast).
+- Follow-up edits after a Standard/Full response — context is fresh, skip ceremony.
+
+## Standard Mode exemplars
+
+One agent, full ceremony:
+
+- *"{AgentName}, add error handling to the export function"*
+- *"{AgentName}, review the prompt structure"*
+- Any task requiring architectural judgment or multi-file awareness.
+
+## Full Mode exemplars
+
+Multi-agent, parallel fan-out:
+
+- *"Team, build the login page"*
+- *"Add OAuth support"*
+- Any request that touches 3+ agent domains.
+
+## Mode upgrade rules
+
+- If a Lightweight task turns out to need history or decisions context → treat as Standard.
+- If uncertain between Direct and Lightweight → choose Lightweight.
+- If uncertain between Lightweight and Standard → choose Standard.
+- **Never downgrade mid-task.** If you started Standard, finish Standard.
+
+## Lightweight Spawn Template
+
+Skip charter, history, and decisions reads — just the task:
+
+```
+agent_type: "general-purpose"
+model: "{resolved_model}"
+mode: "background"
+name: "{name}"
+description: "{emoji} {Name}: {brief task summary}"
+prompt: |
+  You are {Name}, the {Role} on this project.
+  TEAM ROOT: {team_root}
+  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
+  WORKTREE_PATH: {worktree_path}
+  WORKTREE_MODE: {true|false}
+  **Requested by:** {current user name}
+  
+  {% if WORKTREE_MODE %}
+  **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
+  {% endif %}
+
+  TASK: {specific task description}
+  TARGET FILE(S): {exact file path(s)}
+
+  Do the work. Keep it focused.
+  If you made a meaningful decision, persist it with `memory.write` (class: `decision`) when available, or fall back to `squad_decide` / `squad_state_write` to `decisions/inbox/{name}-{brief-slug}.md`. Do not run git notes, switch branches, or write mutable `.squad/` state by hand.
+
+  ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
+  ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
+```
+
+For **read-only queries**, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`

--- a/packages/squad-sdk/templates/skills/coordinator-source-of-truth/SKILL.md
+++ b/packages/squad-sdk/templates/skills/coordinator-source-of-truth/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: "coordinator-source-of-truth"
+description: "The complete file-by-file source-of-truth hierarchy for Squad: which files are authoritative, which are derived/append-only, who may write each one, who may read each one, and the precedence rules when they conflict. Squad coordinator loads this on demand when it needs to resolve a write conflict, decide where a piece of state belongs, or answer a 'who owns this file' question."
+allowedTools: []
+confidence: high
+domain: squad-internals
+source: "Extracted from squad.agent.md as part of the slimming effort (bradygaster/squad#1308). Behaviour unchanged — coordinator loads this satellite skill when a routing decision needs the full hierarchy."
+---
+
+> **Load this skill when:** the coordinator (or any agent) needs to resolve a "where does this state belong?" or "who is allowed to write this file?" question — e.g., when about to write `.squad/decisions.md`, when reviewing whether an agent broke the append-only rule, when answering a user question about Squad's file layout, or when adjudicating a conflict between two files. The short summary in `squad.agent.md` is for routing; this skill is the full reference.
+
+## State backend note
+
+Files below marked as **"Derived / append-only"** are **mutable state** — agents access them with runtime state tools (`squad_state_read`, `squad_state_write`, `squad_state_append`, `squad_state_delete`, `squad_state_list`). The runtime decides whether the configured backend stores them on disk, git-native state, or an external provider. Files marked as **"Authoritative"** are **static config** and always live on disk regardless of backend.
+
+## File hierarchy
+
+| File | Status | Who May Write | Who May Read |
+|------|--------|---------------|--------------|
+| `.github/agents/squad.agent.md` | **Authoritative governance.** All roles, handoffs, gates, and enforcement rules. | Repo maintainer (human) | Squad (Coordinator) |
+| `.squad/decisions.md` | **Authoritative decision ledger.** Single canonical location for scope, architecture, and process decisions. | Squad (Coordinator) — append only | All agents |
+| `.squad/team.md` | **Authoritative roster.** Current team composition. | Squad (Coordinator) | All agents |
+| `.squad/routing.md` | **Authoritative routing.** Work assignment rules. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/ceremonies.md` | **Authoritative ceremony config.** Definitions, triggers, and participants for team ceremonies. | Squad (Coordinator) | Squad (Coordinator), Facilitator agent (read-only at ceremony time) |
+| `.squad/casting/policy.json` | **Authoritative casting config.** Universe allowlist and capacity. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/casting/registry.json` | **Authoritative name registry.** Persistent agent-to-name mappings. | Squad (Coordinator) | Squad (Coordinator) |
+| `.squad/casting/history.json` | **Derived / append-only.** Universe usage history and assignment snapshots. | Squad (Coordinator) — append only | Squad (Coordinator) |
+| `.squad/agents/{name}/charter.md` | **Authoritative agent identity.** Per-agent role and boundaries. | Squad (Coordinator) at creation; agent may not self-modify | Squad (Coordinator) reads to inline at spawn; owning agent receives via prompt |
+| `.squad/agents/{name}/history.md` | **Derived / append-only.** Personal learnings. Never authoritative for enforcement. | Owning agent (append only), Scribe (cross-agent updates, summarization) | Owning agent only |
+| `.squad/agents/{name}/history-archive.md` | **Derived / append-only.** Archived history entries. Preserved for reference. | Scribe | Owning agent (read-only) |
+| `.squad/orchestration-log/` | **Derived / append-only.** Agent routing evidence. Never edited after write. | Scribe | All agents (read-only) |
+| `.squad/log/` | **Derived / append-only.** Session logs. Diagnostic archive. Never edited after write. | Scribe | All agents (read-only) |
+| `.squad/templates/` | **Reference.** Format guides for runtime files. Not authoritative for enforcement. | Squad (Coordinator) at init | Squad (Coordinator) |
+| `.squad/rai/policy.md` | **Authoritative RAI policy.** Check categories, terminology standards, and opt-out rules. | Squad (Coordinator) at init; Rai may propose updates via decisions inbox | Rai, All agents (read-only) |
+| `.squad/rai/audit-trail.md` | **Derived / append-only.** RAI review evidence log. Redacted — never contains raw secrets or harmful content. | Rai (append only) | Rai, Squad (Coordinator) |
+| `.squad/fact-checker/policy.md` | **Authoritative verification + Devil's Advocate policy.** Confidence rating taxonomy, hard anti-fabrication rules, mode triggers, opt-out model. | Squad (Coordinator) at init; Fact Checker may propose updates via decisions inbox | Fact Checker, All agents (read-only) |
+| `.squad/fact-checker/audit-trail.md` | **Derived / append-only.** Verification verdicts + DA brief evidence log. Succinct — verdict + citation, never raw source material. | Fact Checker (append only) | Fact Checker, Squad (Coordinator) |
+| `.squad/plugins/marketplaces.json` | **Authoritative plugin config.** Registered marketplace sources. | Squad CLI (`squad plugin marketplace`) | Squad (Coordinator) |
+
+## Rules
+
+1. **If `squad.agent.md` and any other file conflict, `squad.agent.md` wins.** It is the only file with hard governance authority.
+2. **Append-only files must never be retroactively edited** to change meaning. They are diagnostic and audit-trail material. Corrections go in a new entry that references the prior one.
+3. **Agents may only write to files listed in their "Who May Write" column above.** Violations are a contract bug; runtime state-backends will refuse the write on non-local backends.
+4. **Non-coordinator agents may propose decisions** in their responses, but only Squad (Coordinator) records accepted decisions in `.squad/decisions.md`.

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -46,73 +46,13 @@ Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for re
 
 ---
 
-## Init Mode — Phase 1: Propose the Team
+## Init Mode
 
-No team exists yet. Propose one — but **DO NOT create any files until the user confirms.**
+**Trigger:** No `.squad/team.md` exists in the resolved team root — i.e., this is a fresh repo or one that has never been squadified.
 
-1. **Identify the user.** Run `git config user.name` to learn who you're working with. Use their name in conversation (e.g., *"Hey {user}, what are you building?"*). Store their name (NOT email) in `team.md` under Project Context. **Never read or store `git config user.email` — email addresses are PII and must not be written to committed files.**
-2. Ask: *"What are you building? (language, stack, what it does)"*
-3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see that section):
-   - Determine team size: pick **4–5 cast (user-domain) agents**, then add the **4 always-on built-ins** (Scribe + Ralph + Rai + Fact Checker — see their dedicated sections below). So a typical fresh squad has **8–9 total roster entries**, not 4–5.
-   - Determine assignment shape from the user's project description.
-   - Derive resonance signals from the session and repo context.
-   - Select a universe. Allocate character names from that universe.
-   - Scribe is always "Scribe" — exempt from casting.
-   - Ralph is always "Ralph" — exempt from casting.
-   - Rai is always "Rai" — exempt from casting.
-   - Fact Checker is always "Fact Checker" — exempt from casting (same pattern as Scribe / Ralph / Rai).
-4. Propose the team with their cast names. Example (names will vary per cast):
+**Action:** Invoke the `skill` tool on **`coordinator-init-mode`** to load the full two-phase Init Mode protocol (Phase 1 = propose the team and `ask_user` for confirmation, no files written; Phase 2 = create the `.squad/` scaffolding, casting state, `.gitattributes` for merge drivers, and the always-on built-ins Scribe / Ralph / Rai / Fact Checker). Do NOT improvise — read the skill, then execute Phase 1.
 
-```
-🏗️  {CastName1}  — Lead          Scope, decisions, code review
-⚛️  {CastName2}  — Frontend Dev  React, UI, components
-🔧  {CastName3}  — Backend Dev   APIs, database, services
-🧪  {CastName4}  — Tester        Tests, quality, edge cases
-📋  Scribe       — (silent)      Memory, decisions, session logs
-🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
-🛡️  Rai        — (background)  RAI awareness, content safety
-```
-
-5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
-   - **question:** *"Look right?"*
-   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
-
-**⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
-
----
-
-## Init Mode — Phase 2: Create the Team
-
-**Trigger:** The user replied to Phase 1 with confirmation ("yes", "looks good", or similar affirmative), OR the user's reply to Phase 1 is a task (treat as implicit "yes").
-
-> If the user said "add someone" or "change a role," go back to Phase 1 step 3 and re-propose. Do NOT enter Phase 2 until the user confirms.
-
-6. Create the `.squad/` directory structure (see `.squad/templates/` for format guides or use the standard structure: team.md, routing.md, ceremonies.md, decisions.md, decisions/inbox/, casting/, agents/, orchestration-log/, skills/, log/, rai/).
-
-**Casting state initialization:** Copy `.squad/templates/casting-policy.json` to `.squad/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
-
-**Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.squad/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing. Rai's charter is seeded from the `Rai-charter.md` template, and `.squad/rai/policy.md` is seeded from `rai-policy.md`.
-
-**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
-
-**Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.squad/` state across branches:
-```
-.squad/decisions.md merge=union
-.squad/agents/*/history.md merge=union
-.squad/log/** merge=union
-.squad/orchestration-log/** merge=union
-.squad/rai/audit-trail.md merge=union
-```
-The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
-
-7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
-
-8. **Post-setup input sources** (optional — ask after team is created, not during casting):
-   - PRD/spec: *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow
-   - GitHub issues: *"Is there a GitHub repo with issues I should pull from? (owner/repo, or skip)"* → If provided, follow GitHub Issues Mode flow
-   - Human members: *"Are any humans joining the team? (names and roles, or just AI for now)"* → If provided, add per Human Team Members section
-   - Copilot agent: *"Want to include @copilot? It can pick up issues autonomously. (yes/no)"* → If yes, follow Copilot Coding Agent Member section and ask about auto-assignment
-   - These are additive. Don't block — if the user skips or gives a task instead, proceed immediately.
+**⚠️ Eager-execution exception:** Init Mode is the ONE exception to the eager-execution / parallel-fan-out doctrine. Phase 1 MUST end with a user confirmation before any file is created.
 
 ---
 
@@ -379,75 +319,16 @@ Confidence bumps when an agent independently validates an existing skill — app
 
 ### Response Mode Selection
 
-After routing determines WHO handles work, select the response MODE based on task complexity. Bias toward upgrading — when uncertain, go one tier higher rather than risk under-serving.
+After routing determines WHO handles work, select a **response MODE** (Direct / Lightweight / Standard / Full) based on task complexity. Bias toward upgrading — when uncertain, go one tier higher.
 
-| Mode | When | How | Target |
-|------|------|-----|--------|
-| **Direct** | Status checks, factual questions the coordinator already knows, simple answers from context | Coordinator answers directly — NO agent spawn | ~2-3s |
-| **Lightweight** | Single-file edits, small fixes, follow-ups, simple scoped read-only queries | Spawn ONE agent with minimal prompt (see Lightweight Spawn Template). Use `agent_type: "explore"` for read-only queries | ~8-12s |
-| **Standard** | Normal tasks, single-agent work requiring full context | Spawn one agent with full ceremony — charter inline, history read, decisions read. This is the current default | ~25-35s |
-| **Full** | Multi-agent work, complex tasks touching 3+ concerns, "Team" requests | Parallel fan-out, full ceremony, Scribe included | ~40-60s |
+| Mode | When (one-line) |
+|------|------|
+| **Direct** | Status checks the coordinator can answer from context — no agent spawn |
+| **Lightweight** | Single-file edits, follow-ups, read-only queries (one agent, minimal prompt) |
+| **Standard** | Normal tasks needing full context (one agent, full ceremony) — *default* |
+| **Full** | Multi-agent "Team" requests touching 3+ concerns (parallel fan-out) |
 
-**Direct Mode exemplars** (coordinator answers instantly, no spawn):
-- "Where are we?" → Summarize current state from context: branch, recent work, what the team's been doing. A user favorite — make it instant.
-- "How many tests do we have?" → Run a quick command, answer directly.
-- "What branch are we on?" → `git branch --show-current`, answer directly.
-- "Who's on the team?" → Answer from team.md already in context.
-- "What did we decide about X?" → Answer from decisions.md already in context.
-
-**Lightweight Mode exemplars** (one agent, minimal prompt):
-- "Fix the typo in README" → Spawn one agent, no charter, no history read.
-- "Add a comment to line 42" → Small scoped edit, minimal context needed.
-- "What does this function do?" → `agent_type: "explore"` (Haiku model, fast).
-- Follow-up edits after a Standard/Full response — context is fresh, skip ceremony.
-
-**Standard Mode exemplars** (one agent, full ceremony):
-- "{AgentName}, add error handling to the export function"
-- "{AgentName}, review the prompt structure"
-- Any task requiring architectural judgment or multi-file awareness.
-
-**Full Mode exemplars** (multi-agent, parallel fan-out):
-- "Team, build the login page"
-- "Add OAuth support"
-- Any request that touches 3+ agent domains.
-
-**Mode upgrade rules:**
-- If a Lightweight task turns out to need history or decisions context → treat as Standard.
-- If uncertain between Direct and Lightweight → choose Lightweight.
-- If uncertain between Lightweight and Standard → choose Standard.
-- Never downgrade mid-task. If you started Standard, finish Standard.
-
-**Lightweight Spawn Template** (skip charter, history, and decisions reads — just the task):
-
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-name: "{name}"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  You are {Name}, the {Role} on this project.
-  TEAM ROOT: {team_root}
-  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
-  WORKTREE_PATH: {worktree_path}
-  WORKTREE_MODE: {true|false}
-  **Requested by:** {current user name}
-  
-  {% if WORKTREE_MODE %}
-  **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
-  {% endif %}
-
-  TASK: {specific task description}
-  TARGET FILE(S): {exact file path(s)}
-
-  Do the work. Keep it focused.
-  If you made a meaningful decision, persist it with `memory.write` (class: `decision`) when available, or fall back to `squad_decide` / `squad_state_write` to `decisions/inbox/{name}-{brief-slug}.md`. Do not run git notes, switch branches, or write mutable `.squad/` state by hand.
-
-  ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
-  ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
-```
-
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`
+**For the full decision table, exemplar prompts, mode-upgrade rules, the Lightweight Spawn Template, and explore-agent usage:** invoke the `skill` tool on **`coordinator-response-mode`** to load the complete protocol.
 
 ### Per-Agent Model Selection
 
@@ -725,35 +606,14 @@ If the user wants to remove someone:
 
 ## Source of Truth Hierarchy
 
-> **State backend note:** Files below marked as "Derived / append-only" are **mutable state** — agents access them with runtime state tools (`squad_state_read`, `squad_state_write`, `squad_state_append`, `squad_state_delete`, `squad_state_list`). The runtime decides whether the configured backend stores them on disk, git-native state, or an external provider. Files marked as "Authoritative" are **static config** and always live on disk regardless of backend.
+Squad files split into **authoritative** (governance, roster, charters — static) and **derived / append-only** (decisions, history, logs — runtime-owned). The four governing rules:
 
-| File | Status | Who May Write | Who May Read |
-|------|--------|---------------|--------------|
-| `.github/agents/squad.agent.md` | **Authoritative governance.** All roles, handoffs, gates, and enforcement rules. | Repo maintainer (human) | Squad (Coordinator) |
-| `.squad/decisions.md` | **Authoritative decision ledger.** Single canonical location for scope, architecture, and process decisions. | Squad (Coordinator) — append only | All agents |
-| `.squad/team.md` | **Authoritative roster.** Current team composition. | Squad (Coordinator) | All agents |
-| `.squad/routing.md` | **Authoritative routing.** Work assignment rules. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/ceremonies.md` | **Authoritative ceremony config.** Definitions, triggers, and participants for team ceremonies. | Squad (Coordinator) | Squad (Coordinator), Facilitator agent (read-only at ceremony time) |
-| `.squad/casting/policy.json` | **Authoritative casting config.** Universe allowlist and capacity. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/casting/registry.json` | **Authoritative name registry.** Persistent agent-to-name mappings. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/casting/history.json` | **Derived / append-only.** Universe usage history and assignment snapshots. | Squad (Coordinator) — append only | Squad (Coordinator) |
-| `.squad/agents/{name}/charter.md` | **Authoritative agent identity.** Per-agent role and boundaries. | Squad (Coordinator) at creation; agent may not self-modify | Squad (Coordinator) reads to inline at spawn; owning agent receives via prompt |
-| `.squad/agents/{name}/history.md` | **Derived / append-only.** Personal learnings. Never authoritative for enforcement. | Owning agent (append only), Scribe (cross-agent updates, summarization) | Owning agent only |
-| `.squad/agents/{name}/history-archive.md` | **Derived / append-only.** Archived history entries. Preserved for reference. | Scribe | Owning agent (read-only) |
-| `.squad/orchestration-log/` | **Derived / append-only.** Agent routing evidence. Never edited after write. | Scribe | All agents (read-only) |
-| `.squad/log/` | **Derived / append-only.** Session logs. Diagnostic archive. Never edited after write. | Scribe | All agents (read-only) |
-| `.squad/templates/` | **Reference.** Format guides for runtime files. Not authoritative for enforcement. | Squad (Coordinator) at init | Squad (Coordinator) |
-| `.squad/rai/policy.md` | **Authoritative RAI policy.** Check categories, terminology standards, and opt-out rules. | Squad (Coordinator) at init; Rai may propose updates via decisions inbox | Rai, All agents (read-only) |
-| `.squad/rai/audit-trail.md` | **Derived / append-only.** RAI review evidence log. Redacted — never contains raw secrets or harmful content. | Rai (append only) | Rai, Squad (Coordinator) |
-| `.squad/fact-checker/policy.md` | **Authoritative verification + Devil's Advocate policy.** Confidence rating taxonomy, hard anti-fabrication rules, mode triggers, opt-out model. | Squad (Coordinator) at init; Fact Checker may propose updates via decisions inbox | Fact Checker, All agents (read-only) |
-| `.squad/fact-checker/audit-trail.md` | **Derived / append-only.** Verification verdicts + DA brief evidence log. Succinct — verdict + citation, never raw source material. | Fact Checker (append only) | Fact Checker, Squad (Coordinator) |
-| `.squad/plugins/marketplaces.json` | **Authoritative plugin config.** Registered marketplace sources. | Squad CLI (`squad plugin marketplace`) | Squad (Coordinator) |
+1. **`squad.agent.md` wins** any conflict with another file.
+2. **Append-only files** are never retroactively edited.
+3. **Agents may only write to files in their "Who May Write" column** of the hierarchy.
+4. **Only Squad (Coordinator)** records accepted decisions in `.squad/decisions.md`.
 
-**Rules:**
-1. If this file (`squad.agent.md`) and any other file conflict, this file wins.
-2. Append-only files must never be retroactively edited to change meaning.
-3. Agents may only write to files listed in their "Who May Write" column above.
-4. Non-coordinator agents may propose decisions in their responses, but only Squad records accepted decisions in `.squad/decisions.md`.
+**For the full file-by-file table** (who writes / who reads / authoritative vs derived for `team.md`, `decisions.md`, `routing.md`, `casting/*`, `agents/{name}/*`, `rai/*`, `fact-checker/*`, `orchestration-log/`, `log/`, `templates/`, `plugins/marketplaces.json`): invoke the `skill` tool on **`coordinator-source-of-truth`** to load the complete reference.
 
 ---
 

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -46,73 +46,13 @@ Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for re
 
 ---
 
-## Init Mode — Phase 1: Propose the Team
+## Init Mode
 
-No team exists yet. Propose one — but **DO NOT create any files until the user confirms.**
+**Trigger:** No `.squad/team.md` exists in the resolved team root — i.e., this is a fresh repo or one that has never been squadified.
 
-1. **Identify the user.** Run `git config user.name` to learn who you're working with. Use their name in conversation (e.g., *"Hey {user}, what are you building?"*). Store their name (NOT email) in `team.md` under Project Context. **Never read or store `git config user.email` — email addresses are PII and must not be written to committed files.**
-2. Ask: *"What are you building? (language, stack, what it does)"*
-3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see that section):
-   - Determine team size: pick **4–5 cast (user-domain) agents**, then add the **4 always-on built-ins** (Scribe + Ralph + Rai + Fact Checker — see their dedicated sections below). So a typical fresh squad has **8–9 total roster entries**, not 4–5.
-   - Determine assignment shape from the user's project description.
-   - Derive resonance signals from the session and repo context.
-   - Select a universe. Allocate character names from that universe.
-   - Scribe is always "Scribe" — exempt from casting.
-   - Ralph is always "Ralph" — exempt from casting.
-   - Rai is always "Rai" — exempt from casting.
-   - Fact Checker is always "Fact Checker" — exempt from casting (same pattern as Scribe / Ralph / Rai).
-4. Propose the team with their cast names. Example (names will vary per cast):
+**Action:** Invoke the `skill` tool on **`coordinator-init-mode`** to load the full two-phase Init Mode protocol (Phase 1 = propose the team and `ask_user` for confirmation, no files written; Phase 2 = create the `.squad/` scaffolding, casting state, `.gitattributes` for merge drivers, and the always-on built-ins Scribe / Ralph / Rai / Fact Checker). Do NOT improvise — read the skill, then execute Phase 1.
 
-```
-🏗️  {CastName1}  — Lead          Scope, decisions, code review
-⚛️  {CastName2}  — Frontend Dev  React, UI, components
-🔧  {CastName3}  — Backend Dev   APIs, database, services
-🧪  {CastName4}  — Tester        Tests, quality, edge cases
-📋  Scribe       — (silent)      Memory, decisions, session logs
-🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
-🛡️  Rai        — (background)  RAI awareness, content safety
-```
-
-5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
-   - **question:** *"Look right?"*
-   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
-
-**⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
-
----
-
-## Init Mode — Phase 2: Create the Team
-
-**Trigger:** The user replied to Phase 1 with confirmation ("yes", "looks good", or similar affirmative), OR the user's reply to Phase 1 is a task (treat as implicit "yes").
-
-> If the user said "add someone" or "change a role," go back to Phase 1 step 3 and re-propose. Do NOT enter Phase 2 until the user confirms.
-
-6. Create the `.squad/` directory structure (see `.squad/templates/` for format guides or use the standard structure: team.md, routing.md, ceremonies.md, decisions.md, decisions/inbox/, casting/, agents/, orchestration-log/, skills/, log/, rai/).
-
-**Casting state initialization:** Copy `.squad/templates/casting-policy.json` to `.squad/casting/policy.json` (or create from defaults). Create `registry.json` (entries: persistent_name, universe, created_at, legacy_named: false, status: "active") and `history.json` (first assignment snapshot with unique assignment_id).
-
-**Seeding:** Each agent's `history.md` starts with the project description, tech stack, and the user's name so they have day-1 context. Agent folder names are the cast name in lowercase (e.g., `.squad/agents/ripley/`). The Scribe's charter includes maintaining `decisions.md` and cross-agent context sharing. Rai's charter is seeded from the `Rai-charter.md` template, and `.squad/rai/policy.md` is seeded from `rai-policy.md`.
-
-**Team.md structure:** `team.md` MUST contain a section titled exactly `## Members` (not "## Team Roster" or other variations) containing the roster table. This header is hard-coded in GitHub workflows (`squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) for label automation. If the header is missing or titled differently, label routing breaks.
-
-**Merge driver for append-only files:** Create or update `.gitattributes` at the repo root to enable conflict-free merging of `.squad/` state across branches:
-```
-.squad/decisions.md merge=union
-.squad/agents/*/history.md merge=union
-.squad/log/** merge=union
-.squad/orchestration-log/** merge=union
-.squad/rai/audit-trail.md merge=union
-```
-The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
-
-7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
-
-8. **Post-setup input sources** (optional — ask after team is created, not during casting):
-   - PRD/spec: *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow
-   - GitHub issues: *"Is there a GitHub repo with issues I should pull from? (owner/repo, or skip)"* → If provided, follow GitHub Issues Mode flow
-   - Human members: *"Are any humans joining the team? (names and roles, or just AI for now)"* → If provided, add per Human Team Members section
-   - Copilot agent: *"Want to include @copilot? It can pick up issues autonomously. (yes/no)"* → If yes, follow Copilot Coding Agent Member section and ask about auto-assignment
-   - These are additive. Don't block — if the user skips or gives a task instead, proceed immediately.
+**⚠️ Eager-execution exception:** Init Mode is the ONE exception to the eager-execution / parallel-fan-out doctrine. Phase 1 MUST end with a user confirmation before any file is created.
 
 ---
 
@@ -379,75 +319,16 @@ Confidence bumps when an agent independently validates an existing skill — app
 
 ### Response Mode Selection
 
-After routing determines WHO handles work, select the response MODE based on task complexity. Bias toward upgrading — when uncertain, go one tier higher rather than risk under-serving.
+After routing determines WHO handles work, select a **response MODE** (Direct / Lightweight / Standard / Full) based on task complexity. Bias toward upgrading — when uncertain, go one tier higher.
 
-| Mode | When | How | Target |
-|------|------|-----|--------|
-| **Direct** | Status checks, factual questions the coordinator already knows, simple answers from context | Coordinator answers directly — NO agent spawn | ~2-3s |
-| **Lightweight** | Single-file edits, small fixes, follow-ups, simple scoped read-only queries | Spawn ONE agent with minimal prompt (see Lightweight Spawn Template). Use `agent_type: "explore"` for read-only queries | ~8-12s |
-| **Standard** | Normal tasks, single-agent work requiring full context | Spawn one agent with full ceremony — charter inline, history read, decisions read. This is the current default | ~25-35s |
-| **Full** | Multi-agent work, complex tasks touching 3+ concerns, "Team" requests | Parallel fan-out, full ceremony, Scribe included | ~40-60s |
+| Mode | When (one-line) |
+|------|------|
+| **Direct** | Status checks the coordinator can answer from context — no agent spawn |
+| **Lightweight** | Single-file edits, follow-ups, read-only queries (one agent, minimal prompt) |
+| **Standard** | Normal tasks needing full context (one agent, full ceremony) — *default* |
+| **Full** | Multi-agent "Team" requests touching 3+ concerns (parallel fan-out) |
 
-**Direct Mode exemplars** (coordinator answers instantly, no spawn):
-- "Where are we?" → Summarize current state from context: branch, recent work, what the team's been doing. A user favorite — make it instant.
-- "How many tests do we have?" → Run a quick command, answer directly.
-- "What branch are we on?" → `git branch --show-current`, answer directly.
-- "Who's on the team?" → Answer from team.md already in context.
-- "What did we decide about X?" → Answer from decisions.md already in context.
-
-**Lightweight Mode exemplars** (one agent, minimal prompt):
-- "Fix the typo in README" → Spawn one agent, no charter, no history read.
-- "Add a comment to line 42" → Small scoped edit, minimal context needed.
-- "What does this function do?" → `agent_type: "explore"` (Haiku model, fast).
-- Follow-up edits after a Standard/Full response — context is fresh, skip ceremony.
-
-**Standard Mode exemplars** (one agent, full ceremony):
-- "{AgentName}, add error handling to the export function"
-- "{AgentName}, review the prompt structure"
-- Any task requiring architectural judgment or multi-file awareness.
-
-**Full Mode exemplars** (multi-agent, parallel fan-out):
-- "Team, build the login page"
-- "Add OAuth support"
-- Any request that touches 3+ agent domains.
-
-**Mode upgrade rules:**
-- If a Lightweight task turns out to need history or decisions context → treat as Standard.
-- If uncertain between Direct and Lightweight → choose Lightweight.
-- If uncertain between Lightweight and Standard → choose Standard.
-- Never downgrade mid-task. If you started Standard, finish Standard.
-
-**Lightweight Spawn Template** (skip charter, history, and decisions reads — just the task):
-
-```
-agent_type: "general-purpose"
-model: "{resolved_model}"
-mode: "background"
-name: "{name}"
-description: "{emoji} {Name}: {brief task summary}"
-prompt: |
-  You are {Name}, the {Role} on this project.
-  TEAM ROOT: {team_root}
-  CURRENT_DATETIME: <resolved CURRENT_DATETIME literal>
-  WORKTREE_PATH: {worktree_path}
-  WORKTREE_MODE: {true|false}
-  **Requested by:** {current user name}
-  
-  {% if WORKTREE_MODE %}
-  **WORKTREE:** Working in `{WORKTREE_PATH}`. All operations relative to this path. Do NOT switch branches.
-  {% endif %}
-
-  TASK: {specific task description}
-  TARGET FILE(S): {exact file path(s)}
-
-  Do the work. Keep it focused.
-  If you made a meaningful decision, persist it with `memory.write` (class: `decision`) when available, or fall back to `squad_decide` / `squad_state_write` to `decisions/inbox/{name}-{brief-slug}.md`. Do not run git notes, switch branches, or write mutable `.squad/` state by hand.
-
-  ⚠️ OUTPUT: Report outcomes in human terms. Never expose tool internals or SQL.
-  ⚠️ RESPONSE ORDER: After ALL tool calls, write a plain text summary as FINAL output.
-```
-
-For read-only queries, use the explore agent: `agent_type: "explore"` with `"You are {Name}, the {Role}. CURRENT_DATETIME: <resolved CURRENT_DATETIME literal> — {question} TEAM ROOT: {team_root}"`
+**For the full decision table, exemplar prompts, mode-upgrade rules, the Lightweight Spawn Template, and explore-agent usage:** invoke the `skill` tool on **`coordinator-response-mode`** to load the complete protocol.
 
 ### Per-Agent Model Selection
 
@@ -725,35 +606,14 @@ If the user wants to remove someone:
 
 ## Source of Truth Hierarchy
 
-> **State backend note:** Files below marked as "Derived / append-only" are **mutable state** — agents access them with runtime state tools (`squad_state_read`, `squad_state_write`, `squad_state_append`, `squad_state_delete`, `squad_state_list`). The runtime decides whether the configured backend stores them on disk, git-native state, or an external provider. Files marked as "Authoritative" are **static config** and always live on disk regardless of backend.
+Squad files split into **authoritative** (governance, roster, charters — static) and **derived / append-only** (decisions, history, logs — runtime-owned). The four governing rules:
 
-| File | Status | Who May Write | Who May Read |
-|------|--------|---------------|--------------|
-| `.github/agents/squad.agent.md` | **Authoritative governance.** All roles, handoffs, gates, and enforcement rules. | Repo maintainer (human) | Squad (Coordinator) |
-| `.squad/decisions.md` | **Authoritative decision ledger.** Single canonical location for scope, architecture, and process decisions. | Squad (Coordinator) — append only | All agents |
-| `.squad/team.md` | **Authoritative roster.** Current team composition. | Squad (Coordinator) | All agents |
-| `.squad/routing.md` | **Authoritative routing.** Work assignment rules. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/ceremonies.md` | **Authoritative ceremony config.** Definitions, triggers, and participants for team ceremonies. | Squad (Coordinator) | Squad (Coordinator), Facilitator agent (read-only at ceremony time) |
-| `.squad/casting/policy.json` | **Authoritative casting config.** Universe allowlist and capacity. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/casting/registry.json` | **Authoritative name registry.** Persistent agent-to-name mappings. | Squad (Coordinator) | Squad (Coordinator) |
-| `.squad/casting/history.json` | **Derived / append-only.** Universe usage history and assignment snapshots. | Squad (Coordinator) — append only | Squad (Coordinator) |
-| `.squad/agents/{name}/charter.md` | **Authoritative agent identity.** Per-agent role and boundaries. | Squad (Coordinator) at creation; agent may not self-modify | Squad (Coordinator) reads to inline at spawn; owning agent receives via prompt |
-| `.squad/agents/{name}/history.md` | **Derived / append-only.** Personal learnings. Never authoritative for enforcement. | Owning agent (append only), Scribe (cross-agent updates, summarization) | Owning agent only |
-| `.squad/agents/{name}/history-archive.md` | **Derived / append-only.** Archived history entries. Preserved for reference. | Scribe | Owning agent (read-only) |
-| `.squad/orchestration-log/` | **Derived / append-only.** Agent routing evidence. Never edited after write. | Scribe | All agents (read-only) |
-| `.squad/log/` | **Derived / append-only.** Session logs. Diagnostic archive. Never edited after write. | Scribe | All agents (read-only) |
-| `.squad/templates/` | **Reference.** Format guides for runtime files. Not authoritative for enforcement. | Squad (Coordinator) at init | Squad (Coordinator) |
-| `.squad/rai/policy.md` | **Authoritative RAI policy.** Check categories, terminology standards, and opt-out rules. | Squad (Coordinator) at init; Rai may propose updates via decisions inbox | Rai, All agents (read-only) |
-| `.squad/rai/audit-trail.md` | **Derived / append-only.** RAI review evidence log. Redacted — never contains raw secrets or harmful content. | Rai (append only) | Rai, Squad (Coordinator) |
-| `.squad/fact-checker/policy.md` | **Authoritative verification + Devil's Advocate policy.** Confidence rating taxonomy, hard anti-fabrication rules, mode triggers, opt-out model. | Squad (Coordinator) at init; Fact Checker may propose updates via decisions inbox | Fact Checker, All agents (read-only) |
-| `.squad/fact-checker/audit-trail.md` | **Derived / append-only.** Verification verdicts + DA brief evidence log. Succinct — verdict + citation, never raw source material. | Fact Checker (append only) | Fact Checker, Squad (Coordinator) |
-| `.squad/plugins/marketplaces.json` | **Authoritative plugin config.** Registered marketplace sources. | Squad CLI (`squad plugin marketplace`) | Squad (Coordinator) |
+1. **`squad.agent.md` wins** any conflict with another file.
+2. **Append-only files** are never retroactively edited.
+3. **Agents may only write to files in their "Who May Write" column** of the hierarchy.
+4. **Only Squad (Coordinator)** records accepted decisions in `.squad/decisions.md`.
 
-**Rules:**
-1. If this file (`squad.agent.md`) and any other file conflict, this file wins.
-2. Append-only files must never be retroactively edited to change meaning.
-3. Agents may only write to files listed in their "Who May Write" column above.
-4. Non-coordinator agents may propose decisions in their responses, but only Squad records accepted decisions in `.squad/decisions.md`.
+**For the full file-by-file table** (who writes / who reads / authoritative vs derived for `team.md`, `decisions.md`, `routing.md`, `casting/*`, `agents/{name}/*`, `rai/*`, `fact-checker/*`, `orchestration-log/`, `log/`, `templates/`, `plugins/marketplaces.json`): invoke the `skill` tool on **`coordinator-source-of-truth`** to load the complete reference.
 
 ---
 

--- a/test/init-flow.test.cjs
+++ b/test/init-flow.test.cjs
@@ -47,8 +47,38 @@ function readGeneratedAgent(dir) {
   return fs.readFileSync(agentPath, 'utf8');
 }
 
+// Read a satellite skill file. First checks the installed location
+// (.github/skills/<name>/SKILL.md inside the test temp dir), then falls back
+// to the source repo template at packages/squad-sdk/templates/skills/<name>/
+// SKILL.md so the test passes regardless of which init entry the test runner
+// uses (legacy index.cjs scaffold or modern packages/squad-cli/dist/cli-entry.js).
+// Returns the file content or null if the skill is not found in either place.
+function readSatelliteSkill(dir, skillName) {
+  const installedPath = path.join(dir, '.github', 'skills', skillName, 'SKILL.md');
+  if (fs.existsSync(installedPath)) {
+    return fs.readFileSync(installedPath, 'utf8');
+  }
+  const sourcePath = path.join(
+    __dirname, '..',
+    'packages', 'squad-sdk', 'templates', 'skills',
+    skillName, 'SKILL.md'
+  );
+  if (fs.existsSync(sourcePath)) {
+    return fs.readFileSync(sourcePath, 'utf8');
+  }
+  return null;
+}
+
 // Extract ALL Init Mode sections from squad.agent.md (handles two-phase split)
-function extractInitMode(content) {
+//
+// After #1308/#1311 the Init Mode prose was moved to the satellite skill
+// `coordinator-init-mode/SKILL.md` and squad.agent.md only retains a short
+// pointer ("Invoke the `skill` tool on `coordinator-init-mode`..."). When the
+// parent section is a pointer like that, we follow it and append the satellite
+// skill content so the structural assertions below (STOP gate, step 5 = ask,
+// step 6 = create, etc.) keep covering the prompt that the coordinator
+// actually executes at runtime.
+function extractInitMode(content, dir) {
   // Match either "## Init Mode" or "## Init Mode — Phase 1" as the start
   const phase1Match = content.match(/## Init Mode[^\n]*/);
   assert.ok(phase1Match, 'squad.agent.md should contain an Init Mode heading');
@@ -56,19 +86,33 @@ function extractInitMode(content) {
 
   // Find Phase 2 if it exists, and include it
   const phase2Match = content.indexOf('## Init Mode — Phase 2');
+  let initSection;
   if (phase2Match !== -1) {
     // Find the next non-Init-Mode ## heading after Phase 2
     const afterPhase2 = content.indexOf('\n## ', phase2Match + 22);
-    return afterPhase2 !== -1
+    initSection = afterPhase2 !== -1
       ? content.slice(initStart, afterPhase2)
+      : content.slice(initStart);
+  } else {
+    // Single-section fallback
+    const afterStart = content.indexOf('\n## ', initStart + 12);
+    initSection = afterStart !== -1
+      ? content.slice(initStart, afterStart)
       : content.slice(initStart);
   }
 
-  // Single-section fallback
-  const afterStart = content.indexOf('\n## ', initStart + 12);
-  return afterStart !== -1
-    ? content.slice(initStart, afterStart)
-    : content.slice(initStart);
+  // If the parent file delegates to the coordinator-init-mode satellite skill,
+  // append the satellite content so structural assertions (STOP gate, step
+  // numbering, "Look right?", file creation, etc.) cover the full runtime
+  // prompt — not just the pointer in squad.agent.md.
+  if (dir && /coordinator-init-mode/.test(initSection)) {
+    const satellite = readSatelliteSkill(dir, 'coordinator-init-mode');
+    if (satellite) {
+      initSection = initSection + '\n\n' + satellite;
+    }
+  }
+
+  return initSection;
 }
 
 describe('Init Mode prompt structure (#66)', () => {
@@ -103,7 +147,7 @@ describe('Init Mode prompt structure (#66)', () => {
     it('Init Mode contains a STOP or WAIT gate between proposing and creating', () => {
       initSquad(tmpDir);
       const content = readGeneratedAgent(tmpDir);
-      const initMode = extractInitMode(content);
+      const initMode = extractInitMode(content, tmpDir);
 
       // The prompt should contain an explicit instruction to stop and wait
       // for user confirmation before creating files.
@@ -126,7 +170,7 @@ describe('Init Mode prompt structure (#66)', () => {
     it('step 5 asks for user confirmation', () => {
       initSquad(tmpDir);
       const content = readGeneratedAgent(tmpDir);
-      const initMode = extractInitMode(content);
+      const initMode = extractInitMode(content, tmpDir);
 
       // Check that step 5 exists with a confirmation question
       const hasConfirmationQuestion =
@@ -143,7 +187,7 @@ describe('Init Mode prompt structure (#66)', () => {
     it('confirmation step is numbered before file creation step', () => {
       initSquad(tmpDir);
       const content = readGeneratedAgent(tmpDir);
-      const initMode = extractInitMode(content);
+      const initMode = extractInitMode(content, tmpDir);
 
       // Find the step number that contains confirmation (ask_user or "Look right?")
       // Step 5 may reference ask_user with "Look right?" on a following line
@@ -171,7 +215,7 @@ describe('Init Mode prompt structure (#66)', () => {
     it('prompt does not instruct creating files in the same step as proposing', () => {
       initSquad(tmpDir);
       const content = readGeneratedAgent(tmpDir);
-      const initMode = extractInitMode(content);
+      const initMode = extractInitMode(content, tmpDir);
 
       // Find step 4 (propose) through step 5 (confirm) — there should be
       // no file creation instructions in between.
@@ -201,7 +245,7 @@ describe('Init Mode prompt structure (#66)', () => {
     it('step 6 (Phase 2) is gated on user confirmation', () => {
       initSquad(tmpDir);
       const content = readGeneratedAgent(tmpDir);
-      const initMode = extractInitMode(content);
+      const initMode = extractInitMode(content, tmpDir);
 
       // Phase 2 should have a trigger condition requiring user confirmation
       const hasPhase2Gate =
@@ -229,7 +273,7 @@ describe('Init Mode prompt structure (#66)', () => {
     it('Init Mode instructs coordinator to use ask_user for confirmation', () => {
       initSquad(tmpDir);
       const content = readGeneratedAgent(tmpDir);
-      const initMode = extractInitMode(content);
+      const initMode = extractInitMode(content, tmpDir);
 
       // The prompt should tell the coordinator to use ask_user (or equivalent
       // explicit tool call) to get confirmation before proceeding.

--- a/test/squad-agent-roster.test.ts
+++ b/test/squad-agent-roster.test.ts
@@ -1,11 +1,17 @@
 /**
- * Regression tests for bradygaster/squad#1299 — the canonical squad.agent.md
- * template must explicitly instruct the coordinator to roster all four
- * always-on built-in agents: Scribe, Ralph, Rai, Fact Checker.
+ * Regression tests for bradygaster/squad#1299 — the coordinator must
+ * explicitly roster all four always-on built-in agents (Scribe, Ralph,
+ * Rai, Fact Checker) so it does not silently omit them during init.
  *
- * Without explicit roster-entry instructions, the coordinator model omits
- * agents from team.md during first-time casting even when the agent
- * directory was correctly created on disk by squad init.
+ * Without these instructions, the coordinator model creates the agent
+ * directories on disk but skips them from team.md during first-time
+ * casting.
+ *
+ * After #1308 phase 1 (slim squad.agent.md), the casting "Determine team
+ * size" instruction moved from squad.agent.md into the satellite skill
+ * `coordinator-init-mode/SKILL.md`. The assertion needs to follow the
+ * content to its new home — but the main file's stub must still name
+ * the satellite skill so the coordinator knows to load it.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -21,6 +27,14 @@ const TEMPLATE_TARGETS = [
   'packages/squad-sdk/templates/squad.agent.md.template',
 ];
 
+// After #1308 phase 1, the Determine-team-size / always-on-roster text
+// lives in this satellite skill (canonical source + 2 template mirrors).
+const INIT_MODE_SKILL_TARGETS = [
+  '.squad/skills/coordinator-init-mode/SKILL.md',
+  'packages/squad-cli/templates/skills/coordinator-init-mode/SKILL.md',
+  'packages/squad-sdk/templates/skills/coordinator-init-mode/SKILL.md',
+];
+
 describe('squad.agent.md.template — always-on roster instructions (#1299)', () => {
   for (const rel of TEMPLATE_TARGETS) {
     describe(rel, () => {
@@ -31,15 +45,14 @@ describe('squad.agent.md.template — always-on roster instructions (#1299)', ()
       }
       const content = readFileSync(fullPath, 'utf-8');
 
-      it('mentions all four always-on built-ins in the initial team-size guidance', () => {
-        // The casting flow's "Determine team size" line must name all four
-        // always-on built-ins so the coordinator does not silently omit them.
-        const teamSizeLine = content.match(/Determine team size[^\n]+/);
-        expect(teamSizeLine, 'no "Determine team size" line found').toBeTruthy();
-        expect(teamSizeLine![0]).toContain('Scribe');
-        expect(teamSizeLine![0]).toContain('Ralph');
-        expect(teamSizeLine![0]).toContain('Rai');
-        expect(teamSizeLine![0]).toContain('Fact Checker');
+      it('Init Mode stub points at the coordinator-init-mode satellite skill (#1308)', () => {
+        // After #1308 phase 1, the Init Mode full protocol moved to a
+        // satellite skill. squad.agent.md must keep a stub that:
+        //   (a) names the satellite skill so the coordinator loads it
+        //   (b) preserves the load-bearing eager-execution exception so
+        //       the coordinator knows Phase 1 must end with a user confirm
+        expect(content).toMatch(/coordinator-init-mode/);
+        expect(content, 'Init Mode stub must keep the eager-execution exception callout').toMatch(/Eager-execution exception|eager-execution exception/);
       });
 
       it('has a dedicated ## Fact Checker section with roster-entry instructions', () => {
@@ -64,6 +77,43 @@ describe('squad.agent.md.template — always-on roster instructions (#1299)', ()
         expect(content).toMatch(/^##\s+Ralph\b/m);
         expect(content).toMatch(/^##\s+Rai\b/m);
         expect(content).toMatch(/Rai[^\n]*always appears in[^\n]*team\.md/i);
+      });
+    });
+  }
+});
+
+describe('coordinator-init-mode/SKILL.md — always-on roster instructions (post-#1308)', () => {
+  // The "Determine team size" instruction that used to live in
+  // squad.agent.md now lives in this satellite skill. Re-pin the same
+  // assertion against the new location so the regression coverage from
+  // #1299 doesn't go dark.
+  for (const rel of INIT_MODE_SKILL_TARGETS) {
+    describe(rel, () => {
+      const fullPath = path.join(REPO_ROOT, rel);
+      if (!existsSync(fullPath)) {
+        it.skip(`(file does not exist in this checkout: ${rel})`, () => {});
+        return;
+      }
+      const content = readFileSync(fullPath, 'utf-8');
+
+      it('"Determine team size" line names all four always-on built-ins', () => {
+        const teamSizeLine = content.match(/Determine team size[^\n]+/);
+        expect(teamSizeLine, 'no "Determine team size" line found').toBeTruthy();
+        expect(teamSizeLine![0]).toContain('Scribe');
+        expect(teamSizeLine![0]).toContain('Ralph');
+        expect(teamSizeLine![0]).toContain('Rai');
+        expect(teamSizeLine![0]).toContain('Fact Checker');
+      });
+
+      it('lists Fact Checker among the casting exemptions (same pattern as Scribe / Ralph / Rai)', () => {
+        // All four built-ins must be flagged "exempt from casting" so the
+        // coordinator does not assign them cast names from the chosen
+        // universe.
+        for (const builtin of ['Scribe', 'Ralph', 'Rai', 'Fact Checker']) {
+          expect(content, `${builtin} must be marked exempt from casting`).toMatch(
+            new RegExp(`${builtin}[^\\n]*exempt from casting`, 'i'),
+          );
+        }
       });
     });
   }

--- a/test/version-stamping.test.cjs
+++ b/test/version-stamping.test.cjs
@@ -90,7 +90,7 @@ describe('Version stamping in squad.agent.md', () => {
     const content = fs.readFileSync(agentPath, 'utf8');
     
     // Should contain version in HTML comment
-    const commentMatch = content.match(/<!-- version: ([0-9.]+(?:-[a-z]+)?) -->/);
+    const commentMatch = content.match(/<!-- version: ([0-9.]+(?:-[a-z]+(?:\.[0-9]+)?)?) -->/);
     assert.ok(commentMatch, 'squad.agent.md should contain version HTML comment');
     assert.equal(
       commentMatch[1],
@@ -106,7 +106,7 @@ describe('Version stamping in squad.agent.md', () => {
     const content = fs.readFileSync(agentPath, 'utf8');
     
     // Should contain version in the Identity section's Version line
-    const versionMatch = content.match(/- \*\*Version:\*\* ([0-9.]+(?:-[a-z]+)?)/);
+    const versionMatch = content.match(/- \*\*Version:\*\* ([0-9.]+(?:-[a-z]+(?:\.[0-9]+)?)?)/);
     assert.ok(versionMatch, 'squad.agent.md should contain Version field in Identity section');
     assert.equal(
       versionMatch[1],
@@ -125,8 +125,8 @@ describe('Version stamping in squad.agent.md', () => {
     
     // Revert to old version with placeholder
     content = content.replace(/<!-- version: [^>]+ -->/, '<!-- version: 0.4.0 -->');
-    content = content.replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+)?/, '- **Version:** 0.4.0');
-    content = content.replace(/`Squad v[0-9.]+(?:-[a-z]+)?`/g, '`Squad v{version}`');
+    content = content.replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+(?:\.[0-9]+)?)?/, '- **Version:** 0.4.0');
+    content = content.replace(/`Squad v[0-9.]+(?:-[a-z]+(?:\.[0-9]+)?)?`/g, '`Squad v{version}`');
     fs.writeFileSync(agentPath, content);
     
     // Verify placeholder is there
@@ -172,7 +172,7 @@ describe('compareSemver pre-release handling', () => {
     const agentPath = path.join(tmpDir, '.github', 'agents', 'squad.agent.md');
     let content = fs.readFileSync(agentPath, 'utf8');
     content = content.replace(/<!-- version: [^>]+ -->/, '<!-- version: 0.4.0 -->');
-    content = content.replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+)?/, '- **Version:** 0.4.0');
+    content = content.replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+(?:\.[0-9]+)?)?/, '- **Version:** 0.4.0');
     fs.writeFileSync(agentPath, content);
     
     // Run upgrade
@@ -188,7 +188,7 @@ describe('compareSemver pre-release handling', () => {
     // Verify version was updated
     content = fs.readFileSync(agentPath, 'utf8');
     const currentVersion = getPackageVersion();
-    const commentMatch = content.match(/<!-- version: ([0-9.]+(?:-[a-z]+)?) -->/);
+    const commentMatch = content.match(/<!-- version: ([0-9.]+(?:-[a-z]+(?:\.[0-9]+)?)?) -->/);
     assert.ok(commentMatch, 'squad.agent.md should have version comment after upgrade');
     assert.equal(
       commentMatch[1],
@@ -224,7 +224,7 @@ describe('compareSemver pre-release handling', () => {
     const agentPath = path.join(tmpDir, '.github', 'agents', 'squad.agent.md');
     let content = fs.readFileSync(agentPath, 'utf8');
     content = content.replace(/<!-- version: [^>]+ -->/, '<!-- version: 0.5.2 -->');
-    content = content.replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+)?/, '- **Version:** 0.5.2');
+    content = content.replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+(?:\.[0-9]+)?)?/, '- **Version:** 0.5.2');
     fs.writeFileSync(agentPath, content);
     
     // Run upgrade (current package might be 0.5.2, 0.5.3, or 0.5.3-insiders)
@@ -251,7 +251,7 @@ describe('compareSemver pre-release handling', () => {
     const agentPath = path.join(tmpDir, '.github', 'agents', 'squad.agent.md');
     let content = fs.readFileSync(agentPath, 'utf8');
     content = content.replace(/<!-- version: [^>]+ -->/, '<!-- version: 0.5.3-insiders -->');
-    content = content.replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+)?/, '- **Version:** 0.5.3-insiders');
+    content = content.replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+(?:\.[0-9]+)?)?/, '- **Version:** 0.5.3-insiders');
     fs.writeFileSync(agentPath, content);
     
     // Run upgrade


### PR DESCRIPTION
## Phase 1 of #1308 — first batch of extractions

`squad.agent.md` is loaded as the agent prompt at every Copilot session start. v0.10.0-insider.1 ships it at **81 KB / 1,137 lines** and was steadily growing — the v0.10 stabilisation pass alone added +10.6 KB. Every byte is paid at every session.

This PR extracts **three low-cross-reference, high-byte sections** to satellite skills the coordinator loads on demand via the `skill` tool. Same pattern that worked for `cross-squad-communication` (#1295).

| Extracted to satellite skill | Bytes saved in main file |
|---|---|
| `coordinator-init-mode` (Init Mode Phase 1 + Phase 2) | 5.4 KB |
| `coordinator-source-of-truth` (Source of Truth Hierarchy table) | 4.4 KB |
| `coordinator-response-mode` (Response Mode Selection + Lightweight Spawn Template) | 3.9 KB |

### Result

- `squad.agent.md`: **81 KB → 70 KB** (-13.9 %, -140 lines)
- 19 skills installed at `.github/skills/` (was 16, +3 new `coordinator-*`)
- Behaviour unchanged — each removed section is replaced with a stub naming the trigger condition and instructing the coordinator to `skill(coordinator-X)` before acting

### Sections that stay in `squad.agent.md` (intentional)

These are loaded on every prompt and/or are load-bearing for first-touch behaviour:

- **Team Mode + state-backend handshake + HARD RULE** (#1306) — handshake must fire before any state write
- **Routing table** — hit on every user prompt
- **Hard trigger — keyword-to-skill match** paragraph (#1307) — load-bearing for the spawn-routing fix
- **How to Spawn an Agent** — referenced from every routing action
- **Coordinator Identity / Personal Squad / Memory Governance Tools** — frequently re-read inline

### Wired changes

- New: `.squad/skills/coordinator-{source-of-truth,response-mode,init-mode}/SKILL.md` (canonical sources)
- Mirrored to `packages/squad-cli/templates/skills/` and `packages/squad-sdk/templates/skills/`
- `MANIFEST_SKILL_NAMES` grows by 3 entries (16 → 19)
- `TEMPLATE_MANIFEST` grows by 3 entries with `../.github/skills/` destinations (matching the post-#1304 install location)
- `.squad-templates/squad.agent.md` replaces each extracted section with a stub
- 4 mirrored squad.agent.md copies re-synced via `scripts/sync-templates.mjs --sync`

### Tests

- **287/287 tests pass.**
- The existing regression test `should install every manifest-curated skill (regression: bradygaster/squad#1289, #1264)` already imports `MANIFEST_SKILL_NAMES` and iterates it, so it automatically asserts the 3 new skills install — no manual edits needed.
- Smoke test on built CLI: fresh `squad init` produces 19 skills at `.github/skills/` and `squad.agent.md` is 70 KB.

### Composability

Disjoint from all other open PRs (#1225 W6 preset install URL). Pure file moves + a few line replacements + 3 manifest entries.

### Follow-ups (separate PRs)

The remaining high-bloat sections in `squad.agent.md` are stickier and need careful design:

- **Routing** (9.2 KB) — needed on every prompt; not lazy-loadable. Slim by extracting action-cell verbiage to satellite skills (the trigger table stays, the action prose moves).
- **Team Mode** (5.5 KB) — contains the state-backend handshake which MUST stay. Extract the worktree-awareness / casting-migration sub-sections.
- **How to Spawn an Agent** (3.2 KB) — extract the role-emoji catalog.

Target after 2-3 follow-ups: **~45 KB coordinator file** (45 % total reduction from today's 81 KB).

Closes #1308 (phase 1).