### PR TITLE
fix(docs): rephrase backtick-in-table cell that breaks docs-build CI on dev

### DIFF
--- a/docs/src/content/docs/features/skill-security-scanner.md
+++ b/docs/src/content/docs/features/skill-security-scanner.md
@@ -66,8 +66,8 @@ The scanner is markdown-aware, which means it understands when a "dangerous" pat
 
 | Where pattern appears | Action |
 |----------------------|--------|
-| Inside a fenced code block (```` ``` ````) | **Suppressed** — treated as documentation, not advice |
-| Inside an inline code span (`` ` ``) | **Suppressed** — treated as a reference |
+| Inside a fenced code block (three backticks) | **Suppressed** — treated as documentation, not advice |
+| Inside an inline code span (single backtick) | **Suppressed** — treated as a reference |
 | In prose with a placeholder token (`<your-token>`, `<api-key>`, `xxx`, `***`) | **Suppressed** — clearly an example |
 | In prose without any of the above | **Flagged** as a finding |
 


### PR DESCRIPTION
Fixes the `Squad CI / test` job that's red on `dev` right now (run [27488323855](https://github.com/bradygaster/squad/actions/runs/27488323855), commit `567f4475`).

## Root cause

The `skill-security-scanner.md` doc landed via #1276 with a 4-backtick table cell intended to display a literal triple-backtick:

```markdown
| Inside a fenced code block (```` ``` ````) | Suppressed |
```

That made `test/docs-build.test.ts`'s regex `/```/g` see 5 occurrences across the file (the real `bash` example contributes 2; the 4-backtick cell's inner `` ``` `` contributes 1; the surrounding `` ```` `` contributes 2 split across opening + closing) — odd total, even-fence check fails. The same construct also tripped the "code blocks contain language specification or valid content" check.

## Fix

Two-line rephrase in `skill-security-scanner.md`: say *"three backticks"* / *"single backtick"* in prose instead of trying to render literal delimiters in a markdown table cell. Reads cleaner anyway.

## Verified locally

- `npx vitest run test/docs-build.test.ts` → 22/22 pass
- `npm run build` in `docs/` → 171 files emitted; pagefind indexes 168 pages / 6911 words