### PR TITLE
fix(test): anchor docs fence-parity regex to line start

### DIFF
--- a/test/docs-build.test.ts
+++ b/test/docs-build.test.ts
@@ -152,7 +152,9 @@ describe('Docs Structure Validation', () => {
     it('all code blocks are properly fenced (even count of ```)', () => {
       for (const file of getAllMarkdownFiles()) {
         const content = readFile(file);
-        const fenceCount = (content.match(/```/g) || []).length;
+        // Anchor to line-start so inline/table backticks (e.g. documenting fence syntax)
+        // are not counted as real fence delimiters.
+        const fenceCount = (content.match(/^```/gm) || []).length;
         expect(fenceCount % 2, `${basename(file)} has mismatched fences`).toBe(0);
       }
     });
@@ -167,7 +169,9 @@ describe('Docs Structure Validation', () => {
   describe('Code Example Validation', () => {
     it('code blocks contain language specification or valid content', () => {
       for (const file of getAllMarkdownFiles()) {
-        const codeBlocks = readFile(file).match(/```[\s\S]*?```/g) || [];
+        // Anchor both opening and closing fences to line-start so inline
+        // backtick usage inside table cells or prose does not form phantom blocks.
+        const codeBlocks = readFile(file).match(/^```[\s\S]*?^```/gm) || [];
         for (const block of codeBlocks) {
           expect(block.split('\n').length).toBeGreaterThan(1);
         }


### PR DESCRIPTION
## Summary

The fence-parity check in 	est/docs-build.test.ts used /\\\/g which matched triple-backticks **anywhere** in file content — including inside table cells and inline code spans that document fence syntax itself. This caused false positives on legitimate documentation.

## Root cause

docs/src/content/docs/features/skill-security-scanner.md line 69 contains a Markdown table cell that shows the fence-syntax escape using four-backtick quoting:

`
| Inside a fenced code block (`` ` ``) | Suppressed ... |
`

The old regex matched 3 triple-backtick occurrences from that single table cell (the two four-backtick spans each contain a triple-backtick match, plus the standalone ` ` ` in the middle), plus 2 from the real fenced bash block at L82/L91 = **5 total (odd) → failing parity check**.

The second assertion (lock.split('\n').length).toBeGreaterThan(1)) also failed as a cascade — the over-matching regex formed phantom single-line "code blocks" that failed the line-count check.

## Fix

Anchor both regexes to **line start** with /^`/gm so only real fence delimiters (at column 0) are counted or matched:

- Fence parity: ` /`/g ` → ` /^`/gm `
- Block extraction: ` /`[\s\S]*?`/g ` → ` /^`[\s\S]*?^`/gm `

## Validation

Both failing tests now pass locally (
px vitest run test/docs-build.test.ts):

`
✓ Docs Structure Validation > Markdown Files > all code blocks are properly fenced (even count of `)
✓ Docs Structure Validation > Code Example Validation > code blocks contain language specification or valid content
`

## Impact

This unblocks PRs #1316, #1317, #1234 which are all blocked on the red CI on dev. The most recent failing CI run on dev: https://github.com/bradygaster/squad/actions/runs/27525511648
