### PR TITLE
ci(dependabot): add npm ecosystem coverage for JS workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,85 @@ updates:
         update-types:
           - "version-update:semver-major"
 
+  # npm — root workspace (vitest, typescript, shared tooling)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "squad:belanna"]
+    commit-message:
+      prefix: "deps"
+    groups:
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # npm — Squad CLI package
+  - package-ecosystem: "npm"
+    directory: "/packages/squad-cli"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "squad:belanna"]
+    commit-message:
+      prefix: "deps"
+    groups:
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # npm — Squad SDK package
+  - package-ecosystem: "npm"
+    directory: "/packages/squad-sdk"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "squad:belanna"]
+    commit-message:
+      prefix: "deps"
+    groups:
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # npm — Docs site (Astro/Starlight)
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "squad:belanna"]
+    commit-message:
+      prefix: "deps"
+    groups:
+      astro-minor-patch:
+        patterns:
+          - "@astrojs/*"
+          - "astro"
+        update-types:
+          - "minor"
+          - "patch"
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

This repo is a JS-first monorepo — Squad CLI, Squad SDK, and the Astro docs site all ship npm packages — but .github/dependabot.yml had zero npm monitoring (NuGet and GitHub Actions only). This PR closes that gap.

## Directories added

| Directory | Contents |
|-----------|----------|
| / | Root workspace — vitest, typescript, shared tooling |
| /packages/squad-cli | Squad CLI package |
| /packages/squad-sdk | Squad SDK package |
| /docs | Astro/Starlight documentation site |

samples/ and 	est-fixtures/ were intentionally excluded — they are scaffolding templates and test fixtures, not published packages requiring security monitoring.

## Configuration

Each entry mirrors the existing NuGet convention:
- Schedule: weekly, Monday, 08:00 UTC
- open-pull-requests-limit: 5
- Labels: [dependencies, squad:belanna]
- commit-message.prefix: "deps"
- Minor/patch updates grouped to reduce noise
- The docs entry adds an stro-minor-patch group for @astrojs/* and stro packages

## Rationale

A JS-first monorepo with no npm Dependabot monitoring means vulnerabilities in itest, @astrojs/*, the CLI/SDK runtimes, and docs tooling would go undetected. This adds full coverage with a config style consistent with the existing NuGet entries.
