### PR TITLE
ci(release): stop publishing on test-only dep bumps

### DIFF
--- a/.github/workflows/squad-agents-ai-release.yml
+++ b/.github/workflows/squad-agents-ai-release.yml
@@ -40,7 +40,6 @@ on:
       - main
     paths:
       - 'src/Squad.Agents.AI/**'
-      - 'test/Squad.Agents.AI.Tests/**'
       - 'Directory.*.props'
       - 'global.json'
 


### PR DESCRIPTION
## Summary

Removes `test/Squad.Agents.AI.Tests/**` from the push paths trigger in `squad-agents-ai-release.yml` so that test-dependency updates (e.g. xunit bumps via Dependabot) no longer trigger a NuGet publish.

The tests still build and run as part of the workflow — they just no longer act as a publish trigger.

## Problem

As Tamir flagged in #1338, the path filter included the test project directory, causing test-only dep bumps to produce noise `0.5.1-preview.N` packages on NuGet even though no shipped code changed.

## Change

One line removed from the `paths:` filter.

Closes #1338