### PR TITLE
chore: bump @types/node to 25.9.3 (cli + sdk)

### DIFF
--- a/.changeset/types-node-25.md
+++ b/.changeset/types-node-25.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-sdk": patch
+"@bradygaster/squad-cli": patch
+---
+
+Bump @types/node from ^22.0.0 to ^25.9.3 in cli and sdk packages. Removes a no-longer-needed @ts-expect-error directive in cli-entry.ts now that process.emit is properly typed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2694,11 +2694,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/react": {
@@ -7492,7 +7494,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -8039,7 +8043,7 @@
         "squad-test": "dist/cli-entry.js"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^25.9.3",
         "@types/react": "^19.2.17",
         "ink-testing-library": "^4.0.0",
         "typescript": "^5.7.0"
@@ -8058,11 +8062,10 @@
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^0.3.0",
-        "vscode-jsonrpc": "^8.2.1",
-        "ws": "8.21.0"
+        "vscode-jsonrpc": "^8.2.1"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^25.9.3",
         "@types/sql.js": "^1.4.10",
         "@types/ws": "^8.5.13",
         "typedoc": "~0.28.19",

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -194,7 +194,7 @@
     "vscode-jsonrpc": "^8.2.1"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
     "typescript": "^5.7.0",
     "ink-testing-library": "^4.0.0"

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -14,7 +14,6 @@ process.env.NODE_NO_WARNINGS = '1';
 // process.env.NODE_NO_WARNINGS only works when set BEFORE process starts;
 // this runtime hook catches warnings emitted during dynamic imports below.
 const _origEmit = process.emit;
-// @ts-expect-error — narrowing emit signature for warning suppression
 process.emit = function (evt: string, ...args: unknown[]) {
   if (evt === 'warning' && (args[0] as { name?: string })?.name === 'ExperimentalWarning') {
     return false;

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -254,7 +254,7 @@
     "ws": "^8.21.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.9.3",
     "@types/sql.js": "^1.4.10",
     "@types/ws": "^8.5.13",
     "typedoc": "~0.28.19",


### PR DESCRIPTION
## Summary

Combines Dependabot PRs #1321 and #1326 into a single, tested bump.

- Bumps `@types/node` from `^22.0.0` to `^25.9.3` in both `packages/squad-cli` and `packages/squad-sdk`
- Removes the now-unnecessary `@ts-expect-error` directive at `packages/squad-cli/src/cli-entry.ts:17` — `@types/node 25` ships proper typings for the `process.emit` override pattern, so the suppression directive became invalid (TS2578)
- Regenerates `package-lock.json` to resolve the lockfile drift that caused #1326 CI to fail

## Motivation

`@types/node 22 → 25` is a dev-dependency-only change (runtime stays on Node 22 LTS, unchanged). The bump gives TypeScript accurate type information for Node 25 APIs without affecting any runtime behaviour.

## Closes

Closes #1321
Closes #1326

## Validation

- `npm run build` — ✅ both `squad-sdk` and `squad-cli` compile cleanly
- `npm run lint` (`tsc --noEmit`) — ✅ no type errors
- `npx vitest run test/sdk-failure-scenarios.test.ts` — ✅ 21/21 pass
- `npx vitest run test/cli/` — ✅ 503/505 pass (2 known Windows-only flakes: `state-mcp.test.ts`, `team-root-resolution.test.ts`)
