### PR TITLE
docs(Squad.Agents.AI): update README header to 0.5.1 and multi-target net8/9/10

### DIFF
--- a/src/Squad.Agents.AI/README.md
+++ b/src/Squad.Agents.AI/README.md
@@ -1,6 +1,6 @@
 # Squad.Agents.AI
 
-> **Preview package.** `Squad.Agents.AI` is a `0.1.0-preview` NuGet package for early adopters. It targets `net10.0` and depends on preview Microsoft Agent Framework / GitHub Copilot SDK packages, so APIs may change before a stable release.
+> **Preview package.** `Squad.Agents.AI` is a `0.5.1` preview NuGet package for early adopters. It multi-targets `net8.0`, `net9.0`, and `net10.0`, and depends on preview Microsoft Agent Framework / GitHub Copilot SDK packages, so APIs may change before a stable release.
 
 ## What it does
 


### PR DESCRIPTION
The README header currently says the package is `0.1.0-preview` and targets `net10.0`. Actual values in `src/Squad.Agents.AI/Squad.Agents.AI.csproj`:

- `<Version>0.5.1</Version>`
- `<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>`

The multi-target work landed back in 0.2.0; the header just never got refreshed. Brings the one stale sentence in line with the published package.

No other content changes.
