### PR TITLE
fix(routing): strip surrounding quotes from routing.md examples

### DIFF
--- a/.changeset/fix-routing-strip-example-quotes.md
+++ b/.changeset/fix-routing-strip-example-quotes.md
@@ -1,0 +1,9 @@
+---
+"@bradygaster/squad-sdk": patch
+---
+
+Fix: strip surrounding quotes from routing.md example phrases in `parseRoutingMarkdown`
+
+`parseRoutingMarkdown` split the Examples cell on commas but never stripped the surrounding quotes, so a quoted example like `"unit tests"` was stored verbatim (quotes included). When `compileRoutingRules` / `matchRoute` later tokenized it, the quote characters glued onto the boundary words (`"unit`, `tests"`), producing regex patterns that could never match — so routing tables that used quoted examples silently routed every message to the fallback agent.
+
+Leading/trailing quotes (`"`, `'`, `` ` ``) are now stripped from each example, so quoted and unquoted examples behave identically. Adds regression tests covering both the parse step and end-to-end `matchRoute`.

--- a/packages/squad-sdk/src/config/routing.ts
+++ b/packages/squad-sdk/src/config/routing.ts
@@ -162,7 +162,16 @@ export function parseRoutingMarkdown(content: string): RoutingConfig {
       if (cells.length >= 2) {
         const workType = cells[0];
         const routeTo = cells[1]!;
-        const examples = cells.length >= 3 ? cells[2]!.split(',').map(ex => ex.trim()) : undefined;
+        // Strip surrounding quotes (", ', `) so quoted and unquoted examples
+        // tokenize identically. Without this, a quoted example like "unit tests"
+        // keeps its quotes and compiles to patterns that never match, which made
+        // quoted routing examples silently route everything to fallback.
+        const examples = cells.length >= 3
+          ? cells[2]!
+              .split(',')
+              .map(ex => ex.trim().replace(/^["'`]+|["'`]+$/g, '').trim())
+              .filter(ex => ex.length > 0)
+          : undefined;
         
         // Parse agent names (may be comma-separated or single)
         const agents = routeTo.split(',').map(a => a.trim()).filter(a => a.length > 0);

--- a/test/routing.test.ts
+++ b/test/routing.test.ts
@@ -36,6 +36,20 @@ describe('parseRoutingMarkdown', () => {
     expect(config.rules[1].agents).toEqual(['Developer']);
   });
 
+  it('strips surrounding quotes from examples', () => {
+    const markdown = `
+## Routing Table
+
+| Work Type | Route To | Examples |
+|-----------|----------|----------|
+| testing | Tester | "unit tests", "jest coverage" |
+`;
+
+    const config = parseRoutingMarkdown(markdown);
+
+    expect(config.rules[0].examples).toEqual(['unit tests', 'jest coverage']);
+  });
+
   it('handles multiple agents per rule', () => {
     const markdown = `
 ## Routing Table
@@ -198,6 +212,20 @@ describe('matchRoute', () => {
     
     expect(match.agents).toContain('Developer');
     expect(match.rule?.workType).toBe('bug-fix');
+  });
+
+  it('matches quoted examples after quote-stripping (regression)', () => {
+    const md = `
+## Routing Table
+
+| Work Type | Route To | Examples |
+|-----------|----------|----------|
+| testing | Tester | "unit tests", "jest coverage" |
+`;
+    const quotedRouter = compileRoutingRules(parseRoutingMarkdown(md));
+    const match = matchRoute('please write unit tests now', quotedRouter);
+
+    expect(match.agents).toEqual(['Tester']);
   });
 
   it('returns fallback for no match', () => {


### PR DESCRIPTION
## Problem

`parseRoutingMarkdown` splits the **Examples** cell on commas and trims whitespace, but it never strips the surrounding quotes. A quoted example like `"unit tests"` is therefore stored verbatim — quotes included.

When `compileRoutingRules` → `generatePatterns` tokenizes that example (`split(/[-_\s,]+/)`), the quote characters stay glued to the boundary words (`"unit`, `tests"`). The resulting regex (`\b"unit\b|\btests"\b`) can never match real input, because `\b` doesn't sit next to a quote character.

Net effect: **any routing table that quotes its examples silently routes every message to the fallback agent.** Only unquoted examples — or the accidental clean *interior* words of longer quoted phrases (often stopwords like "the"/"new") — matched, which made keyword routing look erratic.

## Fix

Strip leading/trailing quotes (`"`, `'`, `` ` ``) from each example after the comma split, and drop any now-empty entries. Quoted and unquoted examples now tokenize identically.

```diff
-const examples = cells.length >= 3 ? cells[2]!.split(',').map(ex => ex.trim()) : undefined;
+const examples = cells.length >= 3
+  ? cells[2]!
+      .split(',')
+      .map(ex => ex.trim().replace(/^["'`]+|["'`]+$/g, '').trim())
+      .filter(ex => ex.length > 0)
+  : undefined;
```

## Tests

Adds two regression tests to `test/routing.test.ts`:

- `parseRoutingMarkdown` strips surrounding quotes from examples.
- `matchRoute` routes a quoted-example table correctly (this case hit the fallback agent before the fix).

All 18 routing tests pass; `npm run build -w packages/squad-sdk` is clean.

## Changeset

Included — `@bradygaster/squad-sdk`: patch.

## How it was found

Building a small harness that drives the coordinator's routing on a real `routing.md`, I noticed quoted examples produced 100% fallback while unquoted keywords worked — traced it to the missing quote-strip in `parseRoutingMarkdown`.
