### PR TITLE
docs: fix platform paths and explain global squad.agent.md

### DIFF
--- a/.changeset/docs-platform-path-fixes.md
+++ b/.changeset/docs-platform-path-fixes.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-sdk": patch
+"@bradygaster/squad-cli": patch
+---
+
+Fix platform-specific path examples in personal squad docs, JSDoc, and bundled skill templates.

--- a/.squad/skills/personal-squad/SKILL.md
+++ b/.squad/skills/personal-squad/SKILL.md
@@ -15,8 +15,9 @@ A personal squad is a user-level collection of AI agents that travel with you ac
 ## Directory Structure
 
 ```
-~/.config/squad/personal-squad/    # Linux/macOS
-%APPDATA%/squad/personal-squad/    # Windows
+~/Library/Application Support/squad/personal-squad/    # macOS
+~/.config/squad/personal-squad/                        # Linux
+%APPDATA%/squad/personal-squad/                        # Windows
 ├── agents/
 │   ├── {agent-name}/
 │   │   ├── charter.md

--- a/docs/src/content/docs/features/consult-mode.md
+++ b/docs/src/content/docs/features/consult-mode.md
@@ -9,7 +9,7 @@ Consult mode lets you bring your personal squad to projects you don't own — OS
 
 ## The Problem
 
-You have a personal squad at your global path (e.g., `~/.config/squad/.squad` on Linux) with agents, skills, and decisions refined over time. When you contribute to someone else's project, you face a dilemma:
+You have a personal squad at your global path (e.g., `~/Library/Application Support/squad/.squad` on macOS, `~/.config/squad/.squad` on Linux) with agents, skills, and decisions refined over time. When you contribute to someone else's project, you face a dilemma:
 
 - **Pollute the project?** Running `squad init` creates a `.squad/` folder they didn't ask for
 - **Pollute your squad?** Project-specific knowledge bleeds into your global squad

--- a/docs/src/content/docs/features/consult-mode.md
+++ b/docs/src/content/docs/features/consult-mode.md
@@ -9,7 +9,7 @@ Consult mode lets you bring your personal squad to projects you don't own — OS
 
 ## The Problem
 
-You have a personal squad at your global path (e.g., `~/Library/Application Support/squad/.squad` on macOS, `~/.config/squad/.squad` on Linux) with agents, skills, and decisions refined over time. When you contribute to someone else's project, you face a dilemma:
+You have a personal squad at your global path (e.g., `~/Library/Application Support/squad/personal-squad` on macOS, `~/.config/squad/personal-squad` on Linux) with agents, skills, and decisions refined over time. When you contribute to someone else's project, you face a dilemma:
 
 - **Pollute the project?** Running `squad init` creates a `.squad/` folder they didn't ask for
 - **Pollute your squad?** Project-specific knowledge bleeds into your global squad

--- a/docs/src/content/docs/guide/personal-squad.md
+++ b/docs/src/content/docs/guide/personal-squad.md
@@ -124,11 +124,11 @@ This is your **team identity**. It contains:
 
 This is the stuff that makes your agents *yours*. It persists across sessions. It grows as you work. It follows you from project to project.
 
-### The global `squad.agent.md` — a template, not a live file
+### The global `squad.agent.md` — a reference, not a live file
 
 You'll also see `.github/agents/squad.agent.md` inside your global config directory. This file is **not** discoverable by GitHub Copilot — Copilot only reads agent files inside a git repository's `.github/agents/` folder.
 
-So why is it there? It's a **template/reference**. When you run `squad init` inside a project, Squad uses this file as the source for the project's `.github/agents/squad.agent.md` — the copy that Copilot actually reads. Think of it as a master copy: edit it in your global directory, and every future `squad init` will use your customized version.
+So why is it there? It serves as a **local reference** of the Squad agent instructions that were applied to your projects. The actual source for `squad init` is the packaged template bundled with the CLI (`squad.agent.md.template`), so the global copy is not used as input for future inits. It exists so you can see what Squad generated without opening a project.
 
 If you want Copilot to use Squad's agent instructions in a project, run `squad init` in that project's root — that creates the "real" `.github/agents/squad.agent.md` inside the git repo where Copilot can discover it.
 

--- a/docs/src/content/docs/guide/personal-squad.md
+++ b/docs/src/content/docs/guide/personal-squad.md
@@ -124,6 +124,14 @@ This is your **team identity**. It contains:
 
 This is the stuff that makes your agents *yours*. It persists across sessions. It grows as you work. It follows you from project to project.
 
+### The global `squad.agent.md` — a template, not a live file
+
+You'll also see `.github/agents/squad.agent.md` inside your global config directory. This file is **not** discoverable by GitHub Copilot — Copilot only reads agent files inside a git repository's `.github/agents/` folder.
+
+So why is it there? It's a **template/reference**. When you run `squad init` inside a project, Squad uses this file as the source for the project's `.github/agents/squad.agent.md` — the copy that Copilot actually reads. Think of it as a master copy: edit it in your global directory, and every future `squad init` will use your customized version.
+
+If you want Copilot to use Squad's agent instructions in a project, run `squad init` in that project's root — that creates the "real" `.github/agents/squad.agent.md` inside the git repo where Copilot can discover it.
+
 ### The project pointer: `.squad/config.json`
 
 Inside each connected project, `.squad/config.json` looks like this:

--- a/packages/squad-cli/templates/skills/personal-squad/SKILL.md
+++ b/packages/squad-cli/templates/skills/personal-squad/SKILL.md
@@ -15,8 +15,9 @@ A personal squad is a user-level collection of AI agents that travel with you ac
 ## Directory Structure
 
 ```
-~/.config/squad/personal-squad/    # Linux/macOS
-%APPDATA%/squad/personal-squad/    # Windows
+~/Library/Application Support/squad/personal-squad/    # macOS
+~/.config/squad/personal-squad/                        # Linux
+%APPDATA%/squad/personal-squad/                        # Windows
 ├── agents/
 │   ├── {agent-name}/
 │   │   ├── charter.md

--- a/packages/squad-sdk/src/sharing/consult.ts
+++ b/packages/squad-sdk/src/sharing/consult.ts
@@ -897,7 +897,11 @@ export interface ExtractionResult {
  * Creates the consultations directory if it doesn't exist.
  * For new projects, creates a full header; for existing projects, appends session entry.
  *
- * @param personalSquadRoot - Path to personal squad root (e.g. ~/.config/squad/.squad)
+ * @param personalSquadRoot - Path to personal squad root. Defaults to the
+ *   platform-specific global config directory (can be overridden with SQUAD_HOME):
+ *   - macOS:   `~/Library/Application Support/squad/.squad`
+ *   - Linux:   `~/.config/squad/.squad`
+ *   - Windows: `%APPDATA%/squad/.squad`
  * @param result - Extraction result with learnings and metadata
  * @returns Path to the consultation log file
  */

--- a/packages/squad-sdk/src/sharing/consult.ts
+++ b/packages/squad-sdk/src/sharing/consult.ts
@@ -897,11 +897,11 @@ export interface ExtractionResult {
  * Creates the consultations directory if it doesn't exist.
  * For new projects, creates a full header; for existing projects, appends session entry.
  *
- * @param personalSquadRoot - Path to personal squad root. Defaults to the
- *   platform-specific global config directory (can be overridden with SQUAD_HOME):
- *   - macOS:   `~/Library/Application Support/squad/.squad`
- *   - Linux:   `~/.config/squad/.squad`
- *   - Windows: `%APPDATA%/squad/.squad`
+ * @param personalSquadRoot - Path to personal squad root (resolved via
+ *   `getPersonalSquadRoot()` if not provided). Platform defaults:
+ *   - macOS:   `~/Library/Application Support/squad/personal-squad`
+ *   - Linux:   `~/.config/squad/personal-squad`
+ *   - Windows: `%APPDATA%/squad/personal-squad`
  * @param result - Extraction result with learnings and metadata
  * @returns Path to the consultation log file
  */

--- a/packages/squad-sdk/templates/skills/personal-squad/SKILL.md
+++ b/packages/squad-sdk/templates/skills/personal-squad/SKILL.md
@@ -15,8 +15,9 @@ A personal squad is a user-level collection of AI agents that travel with you ac
 ## Directory Structure
 
 ```
-~/.config/squad/personal-squad/    # Linux/macOS
-%APPDATA%/squad/personal-squad/    # Windows
+~/Library/Application Support/squad/personal-squad/    # macOS
+~/.config/squad/personal-squad/                        # Linux
+%APPDATA%/squad/personal-squad/                        # Windows
 ├── agents/
 │   ├── {agent-name}/
 │   │   ├── charter.md


### PR DESCRIPTION
## Summary

Fixes four docs issues related to incorrect/incomplete platform paths:

- **#1284**: `consult.ts` JSDoc `@param personalSquadRoot` now shows macOS, Linux, and Windows paths plus the `SQUAD_HOME` override
- **#1283**: `consult-mode.md` "The Problem" section now shows macOS path alongside Linux
- **#1282**: `personal-squad.md` guide now explains that `squad.agent.md` in the global config dir is a template/reference — not a live Copilot instruction file
- **#1281**: All three `personal-squad/SKILL.md` templates correctly separate macOS and Linux paths (was incorrectly labeling `~/.config/` as "Linux/macOS")

## Changes

| File | Change |
|------|--------|
| `packages/squad-sdk/src/sharing/consult.ts` | JSDoc multi-platform paths |
| `docs/src/content/docs/features/consult-mode.md` | Added macOS path example |
| `docs/src/content/docs/guide/personal-squad.md` | New section explaining global `squad.agent.md` |
| `packages/squad-sdk/templates/skills/personal-squad/SKILL.md` | Split macOS/Linux paths |
| `packages/squad-cli/templates/skills/personal-squad/SKILL.md` | Split macOS/Linux paths |
| `.squad/skills/personal-squad/SKILL.md` | Split macOS/Linux paths |

Closes #1284, Closes #1283, Closes #1282, Closes #1281