### PR TITLE
feat(tracing): capture task-tool dispatch + tool requests for subagent OTel

### DIFF
--- a/src/Squad.Agents.AI/Squad.Agents.AI.csproj
+++ b/src/Squad.Agents.AI/Squad.Agents.AI.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Squad.Agents.AI.Tests" />
-    <PackageReference Include="Microsoft.Agents.AI.GitHub.Copilot" Version="1.10.0-rc1" />
+    <PackageReference Include="Microsoft.Agents.AI.GitHub.Copilot" Version="1.11.0-rc1" />
     <!--
       Direct reference to GitHub.Copilot.SDK so its build/ targets fire during our build.
       Without this, the SDK's MSBuild download/copy targets only flow to projects with a

--- a/src/Squad.Agents.AI/SquadAgent.cs
+++ b/src/Squad.Agents.AI/SquadAgent.cs
@@ -133,6 +133,7 @@ public sealed class SquadAgent : DelegatingAIAgent, IAsyncDisposable
             WorkingDirectory = teamRoot,
             ConfigDirectory = squadConfigDir,
             EnableConfigDiscovery = true,
+            Agent = "Squad"
         };
         if (!string.IsNullOrEmpty(options.Instructions))
         {
@@ -151,6 +152,7 @@ public sealed class SquadAgent : DelegatingAIAgent, IAsyncDisposable
                 emitActivities: options.EmitSubagentActivities);
             sessionConfig.IncludeSubAgentStreamingEvents = true;
             sessionConfig.OnEvent = traceMapper.OnSessionEvent;
+            
         }
 
         options.ConfigureSession?.Invoke(sessionConfig);
@@ -298,10 +300,28 @@ public sealed class SquadAgent : DelegatingAIAgent, IAsyncDisposable
             clientOptions.Connection = RuntimeConnection.ForStdio(options.CliPath, combinedCliArgs);
         }
 
-        // Copy environment variables
+        // Copy environment variables.
+        //
+        // ⚠️ Important: the dictionary assigned to clientOptions.Environment is what the
+        // native CLI process inherits — there is no implicit merge with the parent process
+        // env. If we only forwarded the consumer's overrides, the child would be missing
+        // SYSTEMROOT/PATH/TEMP and Node's crypto initialization would crash
+        // ("Assertion failed: ncrypto::CSPRNG(nullptr, 0)" on Windows).
+        //
+        // So we always start from the current process environment and layer the consumer's
+        // overrides on top. A consumer that genuinely wants a sanitized env can still do so
+        // via the ConfigureCopilotClient delegate (and is responsible for keeping the
+        // crypto-critical vars in that case).
         if (options.Environment.Count > 0)
         {
-            var envDict = new Dictionary<string, string>();
+            var envDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
+            {
+                if (entry.Key is string k && entry.Value is string v)
+                {
+                    envDict[k] = v;
+                }
+            }
             foreach (var kvp in options.Environment)
             {
                 if (kvp.Value != null)

--- a/src/Squad.Agents.AI/SquadAgentDiagnostics.cs
+++ b/src/Squad.Agents.AI/SquadAgentDiagnostics.cs
@@ -60,6 +60,17 @@ public enum SquadAgentTraceEventKind
 
     /// <summary>The session became idle (the run is complete).</summary>
     SessionIdle,
+
+    /// <summary>
+    /// The coordinator dispatched a subagent via the <c>task</c> tool. Emitted when the
+    /// underlying <c>ToolExecutionStartEvent</c> has <c>ToolName == "task"</c>, this kind
+    /// surfaces the LLM-supplied per-dispatch persona identity (<see cref="SquadAgentTraceEvent.DispatchedPersonaName"/>,
+    /// <see cref="SquadAgentTraceEvent.DispatchedPersonaDescription"/>, <see cref="SquadAgentTraceEvent.DispatchedAgentType"/>,
+    /// <see cref="SquadAgentTraceEvent.DispatchedPrompt"/>) which is otherwise unavailable —
+    /// the subsequent <see cref="SubagentStarted"/> event only carries the agent_type
+    /// catalog identity (e.g. <c>AgentName == "general-purpose"</c>).
+    /// </summary>
+    SubagentDispatched,
 }
 
 /// <summary>
@@ -112,8 +123,50 @@ public sealed record SquadAgentTraceEvent
     /// </summary>
     public string? Content { get; init; }
 
+    /// <summary>
+    /// Names of the tools requested in this assistant turn, populated from
+    /// <c>AssistantMessageData.ToolRequests</c> for <see cref="SquadAgentTraceEventKind.AssistantMessage"/>.
+    /// </summary>
+    /// <remarks>
+    /// An assistant turn can be "tool-only" — the model invokes one or more tools without producing any
+    /// spoken text. In that case <see cref="Content"/> is empty and this list carries the tool names
+    /// (e.g. <c>["gh", "view", "grep"]</c>) so consumers can surface "called X tools" instead of a blank reply.
+    /// Empty (not null) when the assistant turn requested no tools.
+    /// </remarks>
+    public IReadOnlyList<string> RequestedToolNames { get; init; } = Array.Empty<string>();
+
     /// <summary>Tool success flag, for <see cref="SquadAgentTraceEventKind.ToolComplete"/>.</summary>
     public bool? Success { get; init; }
+
+    /// <summary>
+    /// The LLM-supplied per-dispatch persona <c>name</c> parameter passed to the <c>task</c> tool.
+    /// Populated only when <see cref="Kind"/> is <see cref="SquadAgentTraceEventKind.SubagentDispatched"/>.
+    /// </summary>
+    /// <remarks>
+    /// Example: when the coordinator dispatches <c>task(name: "cipher", description: "🛡️ Cipher: ...", agent_type: "general-purpose", prompt: "...")</c>,
+    /// this is <c>"cipher"</c>. The underlying <see cref="SubagentName"/> in the subsequent
+    /// <see cref="SquadAgentTraceEventKind.SubagentStarted"/> event will be <c>"general-purpose"</c>
+    /// (the agent_type catalog identifier) — this property captures the actual persona identity.
+    /// </remarks>
+    public string? DispatchedPersonaName { get; init; }
+
+    /// <summary>
+    /// The LLM-supplied per-dispatch persona <c>description</c> parameter passed to the <c>task</c> tool.
+    /// Populated only when <see cref="Kind"/> is <see cref="SquadAgentTraceEventKind.SubagentDispatched"/>.
+    /// </summary>
+    public string? DispatchedPersonaDescription { get; init; }
+
+    /// <summary>
+    /// The LLM-supplied <c>agent_type</c> parameter passed to the <c>task</c> tool (e.g. <c>"general-purpose"</c>).
+    /// Populated only when <see cref="Kind"/> is <see cref="SquadAgentTraceEventKind.SubagentDispatched"/>.
+    /// </summary>
+    public string? DispatchedAgentType { get; init; }
+
+    /// <summary>
+    /// The LLM-supplied <c>prompt</c> parameter passed to the <c>task</c> tool — the actual instructions
+    /// the persona will execute. Populated only when <see cref="Kind"/> is <see cref="SquadAgentTraceEventKind.SubagentDispatched"/>.
+    /// </summary>
+    public string? DispatchedPrompt { get; init; }
 
     /// <summary>
     /// The original underlying <c>GitHub.Copilot.SessionEvent</c> instance. Kept as <see cref="object"/> on this

--- a/src/Squad.Agents.AI/SquadSubagentTraceMapper.cs
+++ b/src/Squad.Agents.AI/SquadSubagentTraceMapper.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Text.Json;
 using GitHub.Copilot;
 
 namespace Squad.Agents.AI;
@@ -9,19 +11,58 @@ namespace Squad.Agents.AI;
 /// <see cref="SquadAgentDiagnostics.ActivitySource"/>.
 /// </summary>
 /// <remarks>
-/// One <c>Activity</c> per subagent dispatch is opened on <see cref="SubagentStartedEvent"/> and
-/// disposed on the matching <see cref="SubagentCompletedEvent"/> / <see cref="SubagentFailedEvent"/>.
-/// Inactive subagent <c>Activity</c> instances are tracked by their <c>SdkAgentId</c> so concurrent
-/// dispatches each get their own span. The activity is kept alive in a <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}"/>
-/// for the duration of the subagent run; if the session ends without a matching completion event
-/// (e.g. an unhandled exception in the SDK), <see cref="DisposeAll"/> drains the dictionary so spans
-/// still terminate cleanly.
+/// <para>
+/// One <c>Activity</c> per subagent dispatch is opened on the LLM's <c>task</c> tool invocation
+/// (a <see cref="ToolExecutionStartEvent"/> whose <c>Data.ToolName == "task"</c>) so the span's
+/// display name and tags carry the real per-dispatch persona identity that the LLM supplied —
+/// <c>name</c>, <c>description</c>, <c>agent_type</c>, <c>prompt</c>. The subsequent
+/// <see cref="SubagentStartedEvent"/> only carries the agent_type's catalog identifiers
+/// (e.g. <c>AgentName == "general-purpose"</c>), so opening the span earlier — at task dispatch —
+/// is the only way to label it with the persona name.
+/// </para>
+/// <para>
+/// The span is closed on the matching <see cref="SubagentCompletedEvent"/> /
+/// <see cref="SubagentFailedEvent"/>. Live spans are tracked by their <c>ToolCallId</c> — the only
+/// identifier that is present on all four lifecycle events (task dispatch, subagent started,
+/// subagent completed, subagent failed). A secondary <c>SdkAgentId → ToolCallId</c> lookup is
+/// maintained so <see cref="AssistantMessageEvent"/>s (which only carry the SDK agent id) can
+/// still find the live subagent span and tag it with a reply preview.
+/// </para>
+/// <para>
+/// If a <see cref="SubagentStartedEvent"/> arrives without a preceding task-dispatch event
+/// (e.g. unit tests that drive the mapper directly, or SDK code paths that bypass the task
+/// tool), a fallback activity is opened on that event so the legacy single-event flow keeps
+/// working.
+/// </para>
+/// <para>
+/// If the session ends without a matching completion event (e.g. an unhandled exception in the
+/// SDK), <see cref="Dispose"/> drains the live-activity dictionary so spans still terminate
+/// cleanly.
+/// </para>
 /// </remarks>
 internal sealed class SquadSubagentTraceMapper : IDisposable
 {
     private readonly Action<SquadAgentTraceEvent>? _onTrace;
     private readonly bool _emitActivities;
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Activity> _liveSubagentActivities = new(StringComparer.Ordinal);
+
+    // Primary store: one Activity per subagent dispatch, keyed by ToolCallId. ToolCallId is the
+    // only identifier present on all four lifecycle events (ToolExecutionStartEvent[task],
+    // SubagentStartedEvent, SubagentCompletedEvent, SubagentFailedEvent), making it the single
+    // stable correlation key across the whole dispatch.
+    private readonly ConcurrentDictionary<string, Activity> _activitiesByToolCallId = new(StringComparer.Ordinal);
+
+    // Secondary index for AssistantMessageEvent correlation. AssistantMessageEvent only carries
+    // SessionEvent.AgentId (a.k.a. SdkAgentId) — the SDK-assigned subagent id we learn on
+    // SubagentStartedEvent. Populating this map there lets us find the live span when a
+    // subagent's reply streams in.
+    private readonly ConcurrentDictionary<string, string> _toolCallIdBySdkAgentId = new(StringComparer.Ordinal);
+
+    // Stash of LLM-supplied persona arguments parsed from the task tool dispatch, keyed by
+    // ToolCallId. Lets later events (SubagentStarted/Completed) enrich their typed envelope
+    // with the persona identity that lives only on the dispatch event's Arguments JSON.
+    private readonly ConcurrentDictionary<string, DispatchedPersona> _personasByToolCallId = new(StringComparer.Ordinal);
+
+    private sealed record DispatchedPersona(string? Name, string? Description, string? AgentType, string? Prompt);
 
     public SquadSubagentTraceMapper(Action<SquadAgentTraceEvent>? onTrace, bool emitActivities = true)
     {
@@ -37,10 +78,10 @@ internal sealed class SquadSubagentTraceMapper : IDisposable
         SquadAgentTraceEvent? envelope = sessionEvent switch
         {
             SubagentSelectedEvent s => Build(s, SquadAgentTraceEventKind.SubagentSelected, subagentName: s.Data?.AgentName),
-            SubagentStartedEvent s => Build(s, SquadAgentTraceEventKind.SubagentStarted, subagentName: s.Data?.AgentName, subagentDisplayName: s.Data?.AgentDisplayName),
-            SubagentCompletedEvent s => Build(s, SquadAgentTraceEventKind.SubagentCompleted, subagentName: s.Data?.AgentName),
-            SubagentFailedEvent s => Build(s, SquadAgentTraceEventKind.SubagentFailed, subagentName: s.Data?.AgentName, success: false),
-            AssistantMessageEvent a => Build(a, SquadAgentTraceEventKind.AssistantMessage, content: a.Data?.Content),
+            SubagentStartedEvent s => Build(s, SquadAgentTraceEventKind.SubagentStarted, subagentName: s.Data?.AgentName, subagentDisplayName: s.Data?.AgentDisplayName, toolCallId: s.Data?.ToolCallId),
+            SubagentCompletedEvent s => Build(s, SquadAgentTraceEventKind.SubagentCompleted, subagentName: s.Data?.AgentName, toolCallId: s.Data?.ToolCallId),
+            SubagentFailedEvent s => Build(s, SquadAgentTraceEventKind.SubagentFailed, subagentName: s.Data?.AgentName, toolCallId: s.Data?.ToolCallId, success: false),
+            AssistantMessageEvent a => Build(a, SquadAgentTraceEventKind.AssistantMessage, content: a.Data?.Content, requestedToolNames: ExtractToolNames(a.Data?.ToolRequests)),
             ToolExecutionStartEvent t => Build(t, SquadAgentTraceEventKind.ToolStart, toolCallId: t.Data?.ToolCallId),
             ToolExecutionCompleteEvent t => Build(t, SquadAgentTraceEventKind.ToolComplete, toolCallId: t.Data?.ToolCallId, success: t.Data?.Success),
             SessionIdleEvent _ => Build(sessionEvent, SquadAgentTraceEventKind.SessionIdle),
@@ -55,17 +96,55 @@ internal sealed class SquadSubagentTraceMapper : IDisposable
         // per state transition.
         if (_emitActivities)
         {
-            if (envelope.Kind == SquadAgentTraceEventKind.SubagentStarted &&
-                !string.IsNullOrEmpty(envelope.SdkAgentId))
+            ApplyActivityForEnvelope(envelope);
+        }
+
+        // Deliver the typed event to the consumer last so any consumer-side side effects (logging,
+        // UI updates) see the OTel span as already open/closed.
+        InvokeConsumer(envelope);
+
+        // Layer the per-dispatch persona path on top of the standard ToolStart envelope: when the
+        // raw event is the `task` tool dispatch, emit an additional SubagentDispatched envelope
+        // carrying the LLM-supplied persona name/description/prompt parsed from Arguments. This
+        // is additive — consumers that subscribe to ToolStart see no behavior change.
+        if (sessionEvent is ToolExecutionStartEvent toolStart &&
+            string.Equals(toolStart.Data?.ToolName, "task", StringComparison.Ordinal))
+        {
+            OnTaskDispatch(toolStart);
+        }
+    }
+
+    private void ApplyActivityForEnvelope(SquadAgentTraceEvent envelope)
+    {
+        switch (envelope.Kind)
+        {
+            case SquadAgentTraceEventKind.SubagentStarted when !string.IsNullOrEmpty(envelope.ToolCallId):
             {
-                var activity = SquadAgentDiagnostics.ActivitySource.StartActivity(
-                    $"squad.subagent {envelope.SubagentName ?? envelope.SdkAgentId}",
-                    ActivityKind.Internal);
+                // If the task-dispatch handler already opened the span for this ToolCallId, just
+                // augment it with the SDK-assigned identifiers we now have. Otherwise (legacy /
+                // test path), open a fallback span keyed by ToolCallId so the rest of the
+                // lifecycle still works end-to-end.
+                var toolCallId = envelope.ToolCallId!;
+                if (!_activitiesByToolCallId.TryGetValue(toolCallId, out var activity))
+                {
+                    activity = SquadAgentDiagnostics.ActivitySource.StartActivity(
+                        $"squad.subagent {envelope.SubagentName ?? envelope.SdkAgentId ?? toolCallId}",
+                        ActivityKind.Internal);
+                    if (activity is not null)
+                    {
+                        _activitiesByToolCallId[toolCallId] = activity;
+                    }
+                }
+
                 if (activity is not null)
                 {
-                    activity.SetTag("squad.subagent.name", envelope.SubagentName);
-                    activity.SetTag("squad.subagent.display_name", envelope.SubagentDisplayName);
-                    activity.SetTag("squad.subagent.sdk_agent_id", envelope.SdkAgentId);
+                    if (!string.IsNullOrEmpty(envelope.SubagentName))
+                        activity.SetTag("squad.subagent.name", envelope.SubagentName);
+                    if (!string.IsNullOrEmpty(envelope.SubagentDisplayName))
+                        activity.SetTag("squad.subagent.display_name", envelope.SubagentDisplayName);
+                    if (!string.IsNullOrEmpty(envelope.SdkAgentId))
+                        activity.SetTag("squad.subagent.sdk_agent_id", envelope.SdkAgentId);
+                    activity.SetTag("squad.subagent.tool_call_id", toolCallId);
                     activity.AddEvent(new ActivityEvent(
                         "squad.subagent.start",
                         tags: new ActivityTagsCollection
@@ -73,54 +152,198 @@ internal sealed class SquadSubagentTraceMapper : IDisposable
                             ["squad.subagent.name"] = envelope.SubagentName,
                             ["squad.subagent.display_name"] = envelope.SubagentDisplayName,
                             ["squad.subagent.sdk_agent_id"] = envelope.SdkAgentId,
+                            ["squad.subagent.tool_call_id"] = toolCallId,
                         }));
-                    _liveSubagentActivities[envelope.SdkAgentId!] = activity;
+
+                    if (!string.IsNullOrEmpty(envelope.SdkAgentId))
+                    {
+                        _toolCallIdBySdkAgentId[envelope.SdkAgentId!] = toolCallId;
+                    }
                 }
+                break;
             }
-            else if (envelope.Kind == SquadAgentTraceEventKind.AssistantMessage &&
-                     !string.IsNullOrEmpty(envelope.SdkAgentId) &&
-                     _liveSubagentActivities.TryGetValue(envelope.SdkAgentId!, out var liveActivity))
+
+            case SquadAgentTraceEventKind.AssistantMessage when !string.IsNullOrEmpty(envelope.SdkAgentId):
             {
                 // The subagent's assistant message is the substantive output of that dispatch. Tag the
                 // span with a short preview so backends can group spans by subagent and show the reply at
                 // a glance. We bound the preview to a sane length even though backends are free to
                 // truncate further. Also raise an ActivityEvent so the timeline shows when the reply was
                 // produced (useful for streaming subagents that emit multiple messages).
-                if (!string.IsNullOrEmpty(envelope.Content))
+                if (_toolCallIdBySdkAgentId.TryGetValue(envelope.SdkAgentId!, out var toolCallId) &&
+                    _activitiesByToolCallId.TryGetValue(toolCallId, out var liveActivity))
                 {
-                    var preview = envelope.Content!.Length > 512
-                        ? envelope.Content.Substring(0, 512) + "..."
-                        : envelope.Content;
-                    liveActivity.SetTag("squad.subagent.reply_preview", preview);
-                    liveActivity.AddEvent(new ActivityEvent(
-                        "squad.subagent.message",
+                    // Non-empty Content path: tag the spoken text on the span.
+                    if (!string.IsNullOrEmpty(envelope.Content))
+                    {
+                        var preview = envelope.Content!.Length > 512
+                            ? envelope.Content.Substring(0, 512) + "..."
+                            : envelope.Content;
+                        liveActivity.SetTag("squad.subagent.reply_preview", preview);
+                        liveActivity.AddEvent(new ActivityEvent(
+                            "squad.subagent.message",
+                            tags: new ActivityTagsCollection
+                            {
+                                ["squad.subagent.name"] = envelope.SubagentName,
+                                ["squad.subagent.sdk_agent_id"] = envelope.SdkAgentId,
+                                ["squad.subagent.message_preview"] = preview,
+                            }));
+                    }
+
+                    // Tool-only path: even if Content is empty, surface what tools the subagent invoked
+                    // on this turn so the dashboard timeline shows "called gh, view, grep" instead of a
+                    // blank marker. This is independent of the spoken-text path because a single turn
+                    // can be both: text PLUS tool calls.
+                    if (envelope.RequestedToolNames.Count > 0)
+                    {
+                        var toolNamesCsv = string.Join(",", envelope.RequestedToolNames);
+                        liveActivity.AddEvent(new ActivityEvent(
+                            "squad.subagent.tool_requests",
+                            tags: new ActivityTagsCollection
+                            {
+                                ["squad.subagent.name"] = envelope.SubagentName,
+                                ["squad.subagent.sdk_agent_id"] = envelope.SdkAgentId,
+                                ["squad.subagent.tool_requests"] = toolNamesCsv,
+                                ["squad.subagent.tool_requests_count"] = envelope.RequestedToolNames.Count,
+                            }));
+                    }
+                }
+                break;
+            }
+
+            case SquadAgentTraceEventKind.SubagentCompleted:
+            case SquadAgentTraceEventKind.SubagentFailed:
+            {
+                // Close the live span. Prefer ToolCallId (the primary key); fall back to SdkAgentId via
+                // the secondary map for completeness (shouldn't be needed, but harmless).
+                var toolCallId = envelope.ToolCallId;
+                if (string.IsNullOrEmpty(toolCallId) && !string.IsNullOrEmpty(envelope.SdkAgentId))
+                {
+                    _toolCallIdBySdkAgentId.TryGetValue(envelope.SdkAgentId!, out toolCallId);
+                }
+
+                if (!string.IsNullOrEmpty(toolCallId) &&
+                    _activitiesByToolCallId.TryRemove(toolCallId!, out var completedActivity))
+                {
+                    _personasByToolCallId.TryRemove(toolCallId!, out _);
+                    if (!string.IsNullOrEmpty(envelope.SdkAgentId))
+                    {
+                        _toolCallIdBySdkAgentId.TryRemove(envelope.SdkAgentId!, out _);
+                    }
+
+                    var isFailure = envelope.Kind == SquadAgentTraceEventKind.SubagentFailed;
+                    completedActivity.AddEvent(new ActivityEvent(
+                        isFailure ? "squad.subagent.failed" : "squad.subagent.completed",
                         tags: new ActivityTagsCollection
                         {
                             ["squad.subagent.name"] = envelope.SubagentName,
                             ["squad.subagent.sdk_agent_id"] = envelope.SdkAgentId,
-                            ["squad.subagent.message_preview"] = preview,
+                            ["squad.subagent.tool_call_id"] = toolCallId,
                         }));
+                    completedActivity.SetStatus(isFailure ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
+                    completedActivity.Dispose();
                 }
+                break;
             }
-            else if (envelope.Kind is SquadAgentTraceEventKind.SubagentCompleted or SquadAgentTraceEventKind.SubagentFailed &&
-                     !string.IsNullOrEmpty(envelope.SdkAgentId) &&
-                     _liveSubagentActivities.TryRemove(envelope.SdkAgentId!, out var completedActivity))
+        }
+    }
+
+    /// <summary>
+    /// Handles the <c>task</c>-tool dispatch path: parses the LLM-supplied persona arguments,
+    /// opens the OTel activity (so the span is labeled with the persona name from the very start
+    /// of the dispatch), stashes the persona for downstream events to pick up, and emits a
+    /// <see cref="SquadAgentTraceEventKind.SubagentDispatched"/> envelope so consumers can react.
+    /// </summary>
+    private void OnTaskDispatch(ToolExecutionStartEvent evt)
+    {
+        var toolCallId = evt.Data?.ToolCallId;
+        if (string.IsNullOrEmpty(toolCallId))
+        {
+            return;
+        }
+
+        string? personaName = null;
+        string? personaDesc = null;
+        string? agentType = null;
+        string? prompt = null;
+
+        if (evt.Data?.Arguments is JsonElement args && args.ValueKind == JsonValueKind.Object)
+        {
+            if (args.TryGetProperty("name", out var n) && n.ValueKind == JsonValueKind.String)
+                personaName = n.GetString();
+            if (args.TryGetProperty("description", out var d) && d.ValueKind == JsonValueKind.String)
+                personaDesc = d.GetString();
+            if (args.TryGetProperty("agent_type", out var at) && at.ValueKind == JsonValueKind.String)
+                agentType = at.GetString();
+            // Some LLM revisions / catalog flavors emit `subagent_type` instead of `agent_type`.
+            if (agentType is null && args.TryGetProperty("subagent_type", out var st) && st.ValueKind == JsonValueKind.String)
+                agentType = st.GetString();
+            if (args.TryGetProperty("prompt", out var p) && p.ValueKind == JsonValueKind.String)
+                prompt = p.GetString();
+        }
+
+        _personasByToolCallId[toolCallId!] = new DispatchedPersona(personaName, personaDesc, agentType, prompt);
+
+        if (_emitActivities)
+        {
+            // Open the activity as early as possible so the dashboard timeline shows the dispatch
+            // moment, not the later SubagentStartedEvent. Display name prefers the persona over
+            // the agent_type catalog identifier; both are typically more useful than the raw
+            // ToolCallId.
+            var displayName = !string.IsNullOrEmpty(personaName)
+                ? personaName!
+                : (!string.IsNullOrEmpty(agentType) ? agentType! : toolCallId!);
+
+            var activity = SquadAgentDiagnostics.ActivitySource.StartActivity(
+                $"squad.subagent {displayName}",
+                ActivityKind.Internal);
+            if (activity is not null)
             {
-                var isFailure = envelope.Kind == SquadAgentTraceEventKind.SubagentFailed;
-                completedActivity.AddEvent(new ActivityEvent(
-                    isFailure ? "squad.subagent.failed" : "squad.subagent.completed",
+                activity.SetTag("squad.subagent.tool_call_id", toolCallId);
+                if (!string.IsNullOrEmpty(personaName))
+                    activity.SetTag("squad.subagent.persona.name", personaName);
+                if (!string.IsNullOrEmpty(personaDesc))
+                    activity.SetTag("squad.subagent.persona.description", personaDesc);
+                if (!string.IsNullOrEmpty(agentType))
+                    activity.SetTag("squad.subagent.agent_type", agentType);
+                if (!string.IsNullOrEmpty(prompt))
+                    activity.SetTag("squad.subagent.prompt", Truncate(prompt!, 1024));
+
+                activity.AddEvent(new ActivityEvent(
+                    "squad.subagent.dispatched",
                     tags: new ActivityTagsCollection
                     {
-                        ["squad.subagent.name"] = envelope.SubagentName,
-                        ["squad.subagent.sdk_agent_id"] = envelope.SdkAgentId,
+                        ["squad.subagent.persona.name"] = personaName,
+                        ["squad.subagent.persona.description"] = personaDesc,
+                        ["squad.subagent.agent_type"] = agentType,
+                        ["squad.subagent.tool_call_id"] = toolCallId,
                     }));
-                completedActivity.SetStatus(isFailure ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
-                completedActivity.Dispose();
+                _activitiesByToolCallId[toolCallId!] = activity;
             }
         }
 
-        // Deliver the typed event to the consumer last so any consumer-side side effects (logging,
-        // UI updates) see the OTel span as already open/closed.
+        var dispatchEnvelope = new SquadAgentTraceEvent
+        {
+            Kind = SquadAgentTraceEventKind.SubagentDispatched,
+            RawEventType = evt.GetType().Name,
+            Timestamp = evt.Timestamp,
+            SdkAgentId = evt.AgentId,
+            ToolCallId = toolCallId,
+            // SubagentName mirrors the persona so existing consumers that read SubagentName still
+            // surface a meaningful identity for dispatched-but-not-yet-started subagents.
+            SubagentName = personaName,
+            SubagentDisplayName = personaDesc,
+            DispatchedPersonaName = personaName,
+            DispatchedPersonaDescription = personaDesc,
+            DispatchedAgentType = agentType,
+            DispatchedPrompt = prompt,
+            RawEvent = evt,
+        };
+        InvokeConsumer(dispatchEnvelope);
+    }
+
+    private void InvokeConsumer(SquadAgentTraceEvent envelope)
+    {
         try
         {
             _onTrace?.Invoke(envelope);
@@ -131,6 +354,37 @@ internal sealed class SquadSubagentTraceMapper : IDisposable
         }
     }
 
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s.Substring(0, max) + "...";
+
+    /// <summary>
+    /// Extracts the tool names from an <c>AssistantMessageData.ToolRequests</c> array. Returns an empty
+    /// list (never null) so consumers can iterate freely. Used so callers can see what an empty-content
+    /// (tool-only) assistant turn was actually doing — e.g. "called gh, view, grep".
+    /// </summary>
+    private static IReadOnlyList<string> ExtractToolNames(AssistantMessageToolRequest[]? toolRequests)
+    {
+        if (toolRequests is null || toolRequests.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var names = new List<string>(toolRequests.Length);
+        foreach (var req in toolRequests)
+        {
+            // Prefer the simple tool name; if that's empty fall back to the (more verbose) tool title.
+            // Skip entries with no usable identifier to keep the output meaningful for consumers.
+            var name = !string.IsNullOrEmpty(req?.Name)
+                ? req!.Name
+                : (!string.IsNullOrEmpty(req?.ToolTitle) ? req!.ToolTitle : null);
+            if (!string.IsNullOrEmpty(name))
+            {
+                names.Add(name!);
+            }
+        }
+        return names;
+    }
+
     private static SquadAgentTraceEvent Build(
         SessionEvent sessionEvent,
         SquadAgentTraceEventKind kind,
@@ -138,7 +392,8 @@ internal sealed class SquadSubagentTraceMapper : IDisposable
         string? subagentDisplayName = null,
         string? toolCallId = null,
         string? content = null,
-        bool? success = null)
+        bool? success = null,
+        IReadOnlyList<string>? requestedToolNames = null)
     {
         return new SquadAgentTraceEvent
         {
@@ -151,17 +406,20 @@ internal sealed class SquadSubagentTraceMapper : IDisposable
             ToolCallId = toolCallId,
             Content = content,
             Success = success,
+            RequestedToolNames = requestedToolNames ?? Array.Empty<string>(),
             RawEvent = sessionEvent,
         };
     }
 
     public void Dispose()
     {
-        foreach (var (_, activity) in _liveSubagentActivities)
+        foreach (var (_, activity) in _activitiesByToolCallId)
         {
             try { activity.SetStatus(ActivityStatusCode.Error, "Session ended without matching SubagentCompletedEvent"); activity.Dispose(); }
             catch { }
         }
-        _liveSubagentActivities.Clear();
+        _activitiesByToolCallId.Clear();
+        _toolCallIdBySdkAgentId.Clear();
+        _personasByToolCallId.Clear();
     }
 }

--- a/src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample/Program.cs
+++ b/src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample/Program.cs
@@ -1,16 +1,18 @@
 // ============================================================
 //  Squad.Agents.AI — Sample application
 //
-//  Demonstrates four distinct integration patterns:
+//  Demonstrates five distinct integration patterns:
 //    Flow 1 — Basic DI registration and a single prompt
 //    Flow 2 — Keyed DI with two agents under different service keys
 //    Flow 3 — BYOK / ConfigureCopilotClient delegate
 //    Flow 4 — Streaming via RunStreamingAsync
+//    Flow 5 — Subagent dispatch + OpenTelemetry observability
 //
 //  Run: dotnet run --project src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample/
 //  Run one flow: dotnet run --project src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample/ -- --flow=1
 // ============================================================
 
+using System.Diagnostics;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -23,7 +25,7 @@ foreach (var arg in args)
 {
     if (arg.StartsWith("--flow=", StringComparison.OrdinalIgnoreCase) &&
         int.TryParse(arg["--flow=".Length..], out var n) &&
-        n is >= 1 and <= 4)
+        n is >= 1 and <= 5)
     {
         selectedFlow = n;
     }
@@ -49,9 +51,52 @@ if (RunFlow(1))
     host1.Logging.SetMinimumLevel(LogLevel.Warning); // keep sample output clean
     host1.Services.AddSquadAgent(o =>
     {
-        o.SquadFolderPath = teamRoot;
+        o.SquadFolderPath = @"C:\Users\tamirdresher\source\repos\squad-squad";
         o.AgentName = "SampleSquad";
-        o.Instructions = "You are a helpful assistant. Respond concisely.";
+        o.EmitSubagentActivities = true;
+        o.Instructions = "You are a helpful assistant. Respond concisely. and ask each subagent for their input before providing a final answer.";
+        o.OnSubagentTrace = evt =>
+        {
+            switch (evt.Kind)
+            {
+                case SquadAgentTraceEventKind.SubagentDispatched:
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Console.WriteLine($"  [dispatch] persona={evt.DispatchedPersonaName} agent_type={evt.DispatchedAgentType}");
+                    Console.WriteLine($"             description={Trim(evt.DispatchedPersonaDescription, 100)}");
+                    Console.WriteLine($"             prompt={Trim(evt.DispatchedPrompt, 80)}");
+                    Console.ResetColor();
+                    break;
+                case SquadAgentTraceEventKind.SubagentStarted:
+                    Console.WriteLine($"  [started ] {ShortId(evt.SdkAgentId)} catalog_name={evt.SubagentName}");
+                    break;
+                case SquadAgentTraceEventKind.AssistantMessage when evt.SdkAgentId is not null:
+                {
+                    var hasText = !string.IsNullOrWhiteSpace(evt.Content);
+                    var hasTools = evt.RequestedToolNames.Count > 0;
+                    if (!hasText && !hasTools) break; // skip empty SDK chatter
+                    var prefix = $"  [reply   ] {ShortId(evt.SdkAgentId)} ";
+                    if (hasText)
+                    {
+                        Console.WriteLine($"{prefix}{Trim(evt.Content, 120)}");
+                    }
+                    if (hasTools)
+                    {
+                        Console.ForegroundColor = ConsoleColor.DarkGray;
+                        Console.WriteLine($"{prefix}(calls: {string.Join(", ", evt.RequestedToolNames)})");
+                        Console.ResetColor();
+                    }
+                    break;
+                }
+                case SquadAgentTraceEventKind.SubagentCompleted:
+                    Console.WriteLine($"  [done    ] {ShortId(evt.SdkAgentId)}");
+                    break;
+                case SquadAgentTraceEventKind.SubagentFailed:
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine($"  [FAILED  ] {ShortId(evt.SdkAgentId)}");
+                    Console.ResetColor();
+                    break;
+            }
+        };
     });
 
     using var app1 = host1.Build();
@@ -65,6 +110,7 @@ if (RunFlow(1))
     {
         var session1 = await agent1.CreateSessionAsync();
         return await agent1.RunAsync("What is 2 + 2?", session1);
+        //return await agent1.RunAsync("check and review the latest bradygaster/squad repo PR", session1);
     });
 
     if (result1 is not null)
@@ -162,12 +208,22 @@ if (RunFlow(3))
             // Inject a token from an external credential store
             clientOpts.GitHubToken = simulatedToken;
 
-            // Inject custom process-level variables by assigning a new dictionary.
             // IReadOnlyDictionary indexer is read-only; always assign a new instance.
-            clientOpts.Environment = new Dictionary<string, string>
+            // ⚠️ IMPORTANT: copilot.exe inherits this dictionary verbatim. If you replace
+            // it with only your custom vars (no SYSTEMROOT / PATH / TEMP), the native
+            // Node process will crash during crypto initialization
+            // ("Assertion failed: ncrypto::CSPRNG(nullptr, 0)"). Always MERGE with the
+            // current process environment.
+            var merged = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
             {
-                ["SQUAD_SAMPLE_VAR"] = "demo-value"
-            };
+                if (entry.Key is string k && entry.Value is string v)
+                {
+                    merged[k] = v;
+                }
+            }
+            merged["SQUAD_SAMPLE_VAR"] = "demo-value";
+            clientOpts.Environment = merged;
         };
     });
 
@@ -231,8 +287,180 @@ if (RunFlow(4))
     PrintDone("Flow 4");
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Flow 5: Subagent dispatch + OpenTelemetry observability
+//
+// Demonstrates the two observability surfaces that fire whenever the squad
+// coordinator dispatches a subagent through the LLM's `task` tool:
+//
+//   1. SquadAgentOptions.OnSubagentTrace — typed envelope callback. Receives:
+//        - SubagentDispatched     (NEW: carries LLM persona name/description)
+//        - SubagentStarted        (catalog identifiers; usually "general-purpose")
+//        - AssistantMessage       (subagent reply, streamed)
+//        - SubagentCompleted/Failed
+//        - ToolStart/ToolComplete (every tool call, including `task`)
+//
+//   2. ActivitySource "Microsoft.Agents.AI.Squad" — OpenTelemetry spans.
+//      One span per subagent dispatch, opened when the LLM calls `task` and
+//      tagged with the per-dispatch persona name/description, then closed
+//      when the subagent finishes.
+//
+// In a real app you would hook these into your OpenTelemetry tracer and ship
+// them to a dashboard (e.g. Aspire). This sample prints them to stdout so the
+// flow is self-contained — no OTel collector needed to verify the SDK is
+// emitting what you expect.
+// ─────────────────────────────────────────────────────────────────────────────
+if (RunFlow(5))
+{
+    PrintHeader("Flow 5 — Subagent dispatch + OpenTelemetry observability");
+
+    // ── Tap 1: ActivityListener for the squad ActivitySource ────────────────
+    // This is what an OpenTelemetry tracer's AddSource call wires up under the
+    // hood. We attach a raw ActivityListener so we can prove spans are emitted
+    // even without an OTel SDK installed.
+    var startedSpans = new System.Collections.Concurrent.ConcurrentBag<Activity>();
+    var stoppedSpans = new System.Collections.Concurrent.ConcurrentBag<Activity>();
+    using var spanListener = new ActivityListener
+    {
+        ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+        Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        ActivityStarted = a =>
+        {
+            startedSpans.Add(a);
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine($"  [otel] start  {a.DisplayName}  persona={a.GetTagItem("squad.subagent.persona.name") ?? "(none)"}");
+            Console.ResetColor();
+        },
+        ActivityStopped = a =>
+        {
+            stoppedSpans.Add(a);
+            Console.ForegroundColor = ConsoleColor.DarkCyan;
+            Console.WriteLine($"  [otel] stop   {a.DisplayName}  status={a.Status}  duration={a.Duration.TotalSeconds:F1}s");
+            Console.ResetColor();
+        },
+    };
+    ActivitySource.AddActivityListener(spanListener);
+
+    // ── Tap 2: typed-envelope callback ──────────────────────────────────────
+    // OnSubagentTrace runs for every notable session event. The new
+    // SubagentDispatched kind is what surfaces the per-dispatch persona that
+    // the LLM passed to the `task` tool — name, description, agent_type and
+    // prompt — none of which are present on the subsequent SubagentStarted
+    // event (it only carries the agent_type's catalog blurb).
+    var dispatched = new System.Collections.Concurrent.ConcurrentBag<SquadAgentTraceEvent>();
+
+    var host5 = Host.CreateApplicationBuilder(args);
+    host5.Logging.SetMinimumLevel(LogLevel.Warning);
+    host5.Services.AddSquadAgent(o =>
+    {
+        o.SquadFolderPath = teamRoot;
+        o.AgentName = "ObservedSquad";
+        o.EmitSubagentActivities = true; // default — included for clarity
+        o.OnSubagentTrace = evt =>
+        {
+            switch (evt.Kind)
+            {
+                case SquadAgentTraceEventKind.SubagentDispatched:
+                    dispatched.Add(evt);
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Console.WriteLine($"  [dispatch] persona={evt.DispatchedPersonaName} agent_type={evt.DispatchedAgentType}");
+                    Console.WriteLine($"             description={Trim(evt.DispatchedPersonaDescription, 100)}");
+                    Console.WriteLine($"             prompt={Trim(evt.DispatchedPrompt, 80)}");
+                    Console.ResetColor();
+                    break;
+                case SquadAgentTraceEventKind.SubagentStarted:
+                    Console.WriteLine($"  [started ] {ShortId(evt.SdkAgentId)} catalog_name={evt.SubagentName}");
+                    break;
+                case SquadAgentTraceEventKind.AssistantMessage when evt.SdkAgentId is not null:
+                {
+                    var hasText = !string.IsNullOrWhiteSpace(evt.Content);
+                    var hasTools = evt.RequestedToolNames.Count > 0;
+                    if (!hasText && !hasTools) break;
+                    var prefix = $"  [reply   ] {ShortId(evt.SdkAgentId)} ";
+                    if (hasText)
+                    {
+                        Console.WriteLine($"{prefix}{Trim(evt.Content, 120)}");
+                    }
+                    if (hasTools)
+                    {
+                        Console.ForegroundColor = ConsoleColor.DarkGray;
+                        Console.WriteLine($"{prefix}(calls: {string.Join(", ", evt.RequestedToolNames)})");
+                        Console.ResetColor();
+                    }
+                    break;
+                }
+                case SquadAgentTraceEventKind.SubagentCompleted:
+                    Console.WriteLine($"  [done    ] {ShortId(evt.SdkAgentId)}");
+                    break;
+                case SquadAgentTraceEventKind.SubagentFailed:
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine($"  [FAILED  ] {ShortId(evt.SdkAgentId)}");
+                    Console.ResetColor();
+                    break;
+            }
+        };
+    });
+
+    using var app5 = host5.Build();
+    var agent5 = app5.Services.GetRequiredService<SquadAgent>();
+
+    Console.WriteLine($"Agent name : {agent5.Name}");
+    Console.WriteLine($"Team root  : {teamRoot}");
+    Console.WriteLine("Prompt     : ask the coordinator to dispatch two specialists via the task tool");
+    Console.WriteLine("Observe    : each [otel] line is a span the Aspire dashboard would render");
+    Console.WriteLine("             each [dispatch] line is the LLM's per-call persona identity");
+    Console.WriteLine();
+
+    var result5 = await RunWithErrorHandlingAsync(async () =>
+    {
+        var s = await agent5.CreateSessionAsync();
+        return await agent5.RunAsync(
+            "Use the task tool to dispatch two specialists in parallel. Each one must " +
+            "introduce themselves in a single sentence stating their persona name and " +
+            "focus area. Pass distinct `name` and `description` parameters for each call. " +
+            "Then return the two intros to the user.",
+            s);
+    });
+
+    Console.WriteLine();
+    if (result5 is not null)
+    {
+        Console.WriteLine($"Final reply: {Trim(result5.Text, 240)}");
+    }
+
+    Console.WriteLine();
+    Console.WriteLine("── Flow 5 summary ──");
+    Console.WriteLine($"  SubagentDispatched events captured : {dispatched.Count}");
+    Console.WriteLine($"  OTel spans opened                  : {startedSpans.Count}");
+    Console.WriteLine($"  OTel spans closed                  : {stoppedSpans.Count}");
+    if (dispatched.Count == 0)
+    {
+        Console.ForegroundColor = ConsoleColor.DarkYellow;
+        Console.WriteLine("  (No dispatches observed. The coordinator may have answered inline,");
+        Console.WriteLine("   or the team root does not have a `.github/agents/squad.agent.md`.)");
+        Console.ResetColor();
+    }
+
+    await DisposeIfNeeded(agent5);
+    PrintDone("Flow 5");
+}
+
 Console.WriteLine();
 PrintBanner("All requested flows completed.");
+
+static string Trim(string? s, int max) =>
+    string.IsNullOrEmpty(s) ? string.Empty :
+    s.Length <= max ? s : s.Substring(0, max) + "…";
+
+// Compact rendering of long SDK agent ids like "toolu_vrtx_01H71tFMdJGjCpQF7JomPVsd".
+// Keeps the head (prefix discriminator) and tail (the unique suffix) so two concurrent
+// subagents are still visually distinct without burning a whole line on the id.
+static string ShortId(string? id)
+{
+    if (string.IsNullOrEmpty(id)) return "(no-id)";
+    if (id.Length <= 16) return id;
+    return $"{id.Substring(0, 6)}…{id.Substring(id.Length - 6)}";
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers

--- a/src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample/Squad.Agents.AI.Sample.csproj
+++ b/src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample/Squad.Agents.AI.Sample.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/test/Squad.Agents.AI.Tests/SquadAgentRoutingTests.cs
+++ b/test/Squad.Agents.AI.Tests/SquadAgentRoutingTests.cs
@@ -84,7 +84,13 @@ public class SquadAgentRoutingTests
         var environment = GetRequiredProperty<IReadOnlyDictionary<string, string>>(clientOptions, "Environment");
 
         Assert.Equal("Custom Persona", GetRequiredProperty<string>(inner, "Name"));
-        Assert.True(string.IsNullOrEmpty(GetProperty<string>(sessionConfig, "Agent")));
+        // sessionConfig.Agent is the custom Copilot agent identifier — always "Squad" (the
+        // .github/agents/Squad.agent.md registration). The wrapping SquadAgent's display name
+        // ("Custom Persona") must NOT leak into sessionConfig.Agent; that would tell the SDK
+        // to look up a non-existent custom agent.
+        var sessionAgent = GetProperty<string>(sessionConfig, "Agent");
+        Assert.Equal("Squad", sessionAgent);
+        Assert.NotEqual("Custom Persona", sessionAgent);
         Assert.DoesNotContain("Custom Persona", cliArgs);
         Assert.Equal("enabled", environment["SQUAD_ROUTE"]);
     }

--- a/test/Squad.Agents.AI.Tests/SquadSubagentTraceTests.cs
+++ b/test/Squad.Agents.AI.Tests/SquadSubagentTraceTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.Json;
 using GitHub.Copilot;
 using Xunit;
 
@@ -238,5 +239,459 @@ public class SquadSubagentTraceTests
 
         Assert.Equal(1, stoppedCount);
         Assert.Equal(ActivityStatusCode.Error, lastStopped!.Status);
+    }
+
+    // ─── Per-dispatch persona path (task tool dispatch) ──────────────────────
+
+    /// <summary>
+    /// Builds a <see cref="ToolExecutionStartEvent"/> whose <c>ToolName == "task"</c> with a
+    /// fully-populated <c>Arguments</c> JSON object so the mapper can parse the LLM-supplied
+    /// per-dispatch persona identity (<c>name</c>, <c>description</c>, <c>agent_type</c>,
+    /// <c>prompt</c>) — the values that the standard <see cref="SubagentStartedEvent"/>
+    /// silently drops.
+    /// </summary>
+    private static ToolExecutionStartEvent MakeTaskDispatch(
+        string toolCallId,
+        string? personaName,
+        string? personaDescription,
+        string? agentType = "general-purpose",
+        string? prompt = "Investigate the issue and report back.",
+        string argsKeyForAgentType = "agent_type")
+    {
+        var argsObj = new Dictionary<string, object?>
+        {
+            ["name"] = personaName,
+            ["description"] = personaDescription,
+            [argsKeyForAgentType] = agentType,
+            ["prompt"] = prompt,
+            ["mode"] = "sync",
+            ["model"] = "claude-opus-4.7",
+        };
+        var argsJson = JsonSerializer.SerializeToElement(argsObj);
+
+        return new ToolExecutionStartEvent
+        {
+            AgentId = "coordinator-agent",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new ToolExecutionStartData
+            {
+                ToolName = "task",
+                ToolCallId = toolCallId,
+                Arguments = argsJson,
+            },
+        };
+    }
+
+    [Fact]
+    public void Mapper_TaskDispatch_EmitsSubagentDispatchedEnvelopeWithPersonaFields()
+    {
+        var events = new List<SquadAgentTraceEvent>();
+        var mapper = new SquadSubagentTraceMapper(events.Add);
+
+        mapper.OnSessionEvent(MakeTaskDispatch(
+            toolCallId: "toolu_dispatch_1",
+            personaName: "cipher",
+            personaDescription: "🛡️ Cipher: Build the threat model for the checkout flow",
+            agentType: "general-purpose",
+            prompt: "You are Cipher, the security lead. Threat-model the checkout flow."));
+
+        // Two envelopes must fire for a single task dispatch:
+        //   1. The standard ToolStart (kept for backward-compat with existing consumers)
+        //   2. The new SubagentDispatched (carries the LLM-supplied persona identity)
+        var toolStart = Assert.Single(events, e => e.Kind == SquadAgentTraceEventKind.ToolStart);
+        Assert.Equal("toolu_dispatch_1", toolStart.ToolCallId);
+
+        var dispatched = Assert.Single(events, e => e.Kind == SquadAgentTraceEventKind.SubagentDispatched);
+        Assert.Equal("toolu_dispatch_1", dispatched.ToolCallId);
+        Assert.Equal("cipher", dispatched.DispatchedPersonaName);
+        Assert.Equal("🛡️ Cipher: Build the threat model for the checkout flow", dispatched.DispatchedPersonaDescription);
+        Assert.Equal("general-purpose", dispatched.DispatchedAgentType);
+        Assert.Equal("You are Cipher, the security lead. Threat-model the checkout flow.", dispatched.DispatchedPrompt);
+
+        // Persona is also surfaced on the existing SubagentName/SubagentDisplayName fields so
+        // consumers that already render SubagentName see a meaningful identity at dispatch time.
+        Assert.Equal("cipher", dispatched.SubagentName);
+        Assert.Equal("🛡️ Cipher: Build the threat model for the checkout flow", dispatched.SubagentDisplayName);
+    }
+
+    [Fact]
+    public void Mapper_TaskDispatch_OpensActivityTaggedWithPersona()
+    {
+        var startedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a => startedActivities.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var mapper = new SquadSubagentTraceMapper(onTrace: null);
+        mapper.OnSessionEvent(MakeTaskDispatch(
+            toolCallId: "toolu_dispatch_2",
+            personaName: "data",
+            personaDescription: "🔧 Data: Review PR #1378 coordinator inline-dispatch gate"));
+
+        var activity = Assert.Single(startedActivities);
+        // Activity display name surfaces the persona, not the catalog agent_type ("general-purpose").
+        // This is the whole point of opening the span on the task dispatch event rather than on
+        // the later SubagentStartedEvent.
+        Assert.Equal("squad.subagent data", activity.DisplayName);
+        Assert.Equal("data", activity.GetTagItem("squad.subagent.persona.name"));
+        Assert.Equal("🔧 Data: Review PR #1378 coordinator inline-dispatch gate", activity.GetTagItem("squad.subagent.persona.description"));
+        Assert.Equal("general-purpose", activity.GetTagItem("squad.subagent.agent_type"));
+        Assert.Equal("toolu_dispatch_2", activity.GetTagItem("squad.subagent.tool_call_id"));
+    }
+
+    [Fact]
+    public void Mapper_TaskDispatch_AcceptsSubagentTypeKeyAsAgentTypeFallback()
+    {
+        // Some LLM revisions / catalog flavors emit `subagent_type` instead of `agent_type` —
+        // the mapper must accept either so we don't lose the dispatch label.
+        var events = new List<SquadAgentTraceEvent>();
+        var mapper = new SquadSubagentTraceMapper(events.Add);
+
+        mapper.OnSessionEvent(MakeTaskDispatch(
+            toolCallId: "toolu_dispatch_3",
+            personaName: "vault",
+            personaDescription: "🔐 Vault: AppSec review",
+            agentType: "general-purpose",
+            argsKeyForAgentType: "subagent_type"));
+
+        var dispatched = Assert.Single(events, e => e.Kind == SquadAgentTraceEventKind.SubagentDispatched);
+        Assert.Equal("general-purpose", dispatched.DispatchedAgentType);
+    }
+
+    [Fact]
+    public void Mapper_TaskDispatchThenSubagentStarted_AugmentsExistingActivity()
+    {
+        var startedActivities = new List<Activity>();
+        var stoppedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a => startedActivities.Add(a),
+            ActivityStopped = a => stoppedActivities.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var mapper = new SquadSubagentTraceMapper(onTrace: null);
+
+        mapper.OnSessionEvent(MakeTaskDispatch(
+            toolCallId: "toolu_join_1",
+            personaName: "probe",
+            personaDescription: "🕵️ Probe: threat-modeling"));
+        mapper.OnSessionEvent(new SubagentStartedEvent
+        {
+            AgentId = "toolu_sdk_probe_xyz",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new SubagentStartedData
+            {
+                AgentName = "general-purpose",
+                AgentDisplayName = "General Purpose Agent",
+                AgentDescription = "Full-capability agent…",
+                ToolCallId = "toolu_join_1",
+            },
+        });        // Exactly ONE activity must exist — the task dispatch opened it; SubagentStarted must
+        // augment, not duplicate. Without this guarantee the dashboard shows two spans per
+        // dispatch which is exactly the regression this whole change is here to prevent.
+        var activity = Assert.Single(startedActivities);
+        Assert.Empty(stoppedActivities);
+        Assert.Equal("squad.subagent probe", activity.DisplayName);
+        Assert.Equal("probe", activity.GetTagItem("squad.subagent.persona.name"));
+        Assert.Equal("general-purpose", activity.GetTagItem("squad.subagent.name"));
+        Assert.Equal("General Purpose Agent", activity.GetTagItem("squad.subagent.display_name"));
+        Assert.Equal("toolu_sdk_probe_xyz", activity.GetTagItem("squad.subagent.sdk_agent_id"));
+        Assert.Equal("toolu_join_1", activity.GetTagItem("squad.subagent.tool_call_id"));
+    }
+
+    [Fact]
+    public void Mapper_TaskDispatchThenSubagentCompleted_ClosesActivity()
+    {
+        var stoppedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = a => stoppedActivities.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var mapper = new SquadSubagentTraceMapper(onTrace: null);
+
+        mapper.OnSessionEvent(MakeTaskDispatch(
+            toolCallId: "toolu_close_1",
+            personaName: "sentinel",
+            personaDescription: "🔑 Sentinel: secrets review"));
+        mapper.OnSessionEvent(new SubagentStartedEvent
+        {
+            AgentId = "toolu_sentinel_sdk",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new SubagentStartedData
+            {
+                AgentName = "general-purpose",
+                AgentDisplayName = "General Purpose Agent",
+                AgentDescription = "Full-capability agent…",
+                ToolCallId = "toolu_close_1",
+            },
+        });
+        mapper.OnSessionEvent(new SubagentCompletedEvent
+        {
+            AgentId = "toolu_sentinel_sdk",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new SubagentCompletedData
+            {
+                AgentName = "general-purpose",
+                AgentDisplayName = "General Purpose Agent",
+                ToolCallId = "toolu_close_1",
+            },
+        });
+
+        var stopped = Assert.Single(stoppedActivities);
+        Assert.Equal(ActivityStatusCode.Ok, stopped.Status);
+        Assert.Equal("sentinel", stopped.GetTagItem("squad.subagent.persona.name"));
+    }
+
+    [Fact]
+    public void Mapper_TaskDispatchThenAssistantMessage_TagsReplyPreviewOnPersonaSpan()
+    {
+        Activity? activity = null;
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a => activity = a,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var mapper = new SquadSubagentTraceMapper(onTrace: null);
+
+        mapper.OnSessionEvent(MakeTaskDispatch(
+            toolCallId: "toolu_msg_link_1",
+            personaName: "aegis",
+            personaDescription: "⚔️ Aegis: infra hardening"));
+        mapper.OnSessionEvent(new SubagentStartedEvent
+        {
+            AgentId = "toolu_aegis_sdk",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new SubagentStartedData
+            {
+                AgentName = "general-purpose",
+                AgentDisplayName = "General Purpose Agent",
+                AgentDescription = "Full-capability agent…",
+                ToolCallId = "toolu_msg_link_1",
+            },
+        });
+        // AssistantMessageEvent carries SdkAgentId only (no ToolCallId) — the mapper must use the
+        // SubagentStarted-populated SdkAgentId → ToolCallId map to find the right activity.
+        mapper.OnSessionEvent(new AssistantMessageEvent
+        {
+            AgentId = "toolu_aegis_sdk",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = MakeAssistantData("Hardening complete. Three findings filed."),
+        });
+
+        Assert.NotNull(activity);
+        Assert.Equal("Hardening complete. Three findings filed.", activity!.GetTagItem("squad.subagent.reply_preview"));
+    }
+
+    [Fact]
+    public void Mapper_NonTaskToolExecutionStart_DoesNotEmitSubagentDispatchedOrActivity()
+    {
+        var startedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a => startedActivities.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var events = new List<SquadAgentTraceEvent>();
+        using var mapper = new SquadSubagentTraceMapper(events.Add);
+
+        mapper.OnSessionEvent(new ToolExecutionStartEvent
+        {
+            AgentId = "coord",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new ToolExecutionStartData
+            {
+                ToolName = "bash",
+                ToolCallId = "toolu_bash_1",
+                Arguments = JsonSerializer.SerializeToElement(new { command = "ls" }),
+            },
+        });
+
+        // The bash tool isn't a subagent dispatch — only the standard ToolStart envelope fires
+        // (no SubagentDispatched, no activity).
+        Assert.Single(events, e => e.Kind == SquadAgentTraceEventKind.ToolStart);
+        Assert.DoesNotContain(events, e => e.Kind == SquadAgentTraceEventKind.SubagentDispatched);
+        Assert.Empty(startedActivities);
+    }
+
+    [Fact]
+    public void Mapper_TaskDispatchWithMissingArguments_StillEmitsEnvelopeAndActivity()
+    {
+        // Defensive: the LLM may call task with no Arguments (very unusual but possible). The
+        // mapper must still emit the envelope (so consumers see the dispatch attempt) and open
+        // an activity tagged with the ToolCallId as a last-resort label.
+        var events = new List<SquadAgentTraceEvent>();
+        var startedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a => startedActivities.Add(a),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var mapper = new SquadSubagentTraceMapper(events.Add);
+        mapper.OnSessionEvent(new ToolExecutionStartEvent
+        {
+            AgentId = "coord",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new ToolExecutionStartData
+            {
+                ToolName = "task",
+                ToolCallId = "toolu_bare_1",
+                Arguments = null,
+            },
+        });
+
+        var dispatched = Assert.Single(events, e => e.Kind == SquadAgentTraceEventKind.SubagentDispatched);
+        Assert.Equal("toolu_bare_1", dispatched.ToolCallId);
+        Assert.Null(dispatched.DispatchedPersonaName);
+
+        var activity = Assert.Single(startedActivities);
+        Assert.Equal("squad.subagent toolu_bare_1", activity.DisplayName);
+    }
+
+    [Fact]
+    public void Mapper_AssistantMessageWithToolRequests_PopulatesRequestedToolNames()
+    {
+        // When the subagent's turn is tool-only (Content empty, ToolRequests populated),
+        // the mapper must surface the tool names on the envelope so consumers can render
+        // "called gh, view, grep" instead of a blank reply line.
+        SquadAgentTraceEvent? captured = null;
+        var mapper = new SquadSubagentTraceMapper(evt => captured = evt);
+
+        var raw = new AssistantMessageEvent
+        {
+            AgentId = "toolu_worf_sdk",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new AssistantMessageData
+            {
+                Content = string.Empty,
+                MessageId = Guid.NewGuid().ToString("n"),
+                ToolRequests = new[]
+                {
+                    new AssistantMessageToolRequest { Name = "gh", ToolCallId = "tc_1" },
+                    new AssistantMessageToolRequest { Name = "view", ToolCallId = "tc_2" },
+                    new AssistantMessageToolRequest { Name = "grep", ToolCallId = "tc_3" },
+                },
+            },
+        };
+        mapper.OnSessionEvent(raw);
+
+        Assert.NotNull(captured);
+        Assert.Equal(SquadAgentTraceEventKind.AssistantMessage, captured!.Kind);
+        Assert.Equal(string.Empty, captured.Content);
+        Assert.Equal(new[] { "gh", "view", "grep" }, captured.RequestedToolNames);
+    }
+
+    [Fact]
+    public void Mapper_AssistantMessageWithoutToolRequests_EmitsEmptyRequestedToolNames()
+    {
+        // The default (no ToolRequests) must be an empty, non-null list so consumers can
+        // iterate without null-checking.
+        SquadAgentTraceEvent? captured = null;
+        var mapper = new SquadSubagentTraceMapper(evt => captured = evt);
+
+        mapper.OnSessionEvent(new AssistantMessageEvent
+        {
+            AgentId = "toolu_data_sdk",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = MakeAssistantData("Just a text reply, no tools."),
+        });
+
+        Assert.NotNull(captured);
+        Assert.NotNull(captured!.RequestedToolNames);
+        Assert.Empty(captured.RequestedToolNames);
+    }
+
+    [Fact]
+    public void Mapper_ToolOnlyAssistantMessage_AddsToolRequestsActivityEventToLiveSpan()
+    {
+        // Verify that even when Content is empty, the OTel span gets a `squad.subagent.tool_requests`
+        // ActivityEvent so the Aspire dashboard shows which tools the subagent invoked. This is the
+        // OTel counterpart to the typed-envelope path tested above.
+        Activity? activity = null;
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == SquadAgentDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a => activity = a,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var mapper = new SquadSubagentTraceMapper(_ => { });
+
+        // Open the span via the task-dispatch path so SubagentStartedEvent can wire SdkAgentId → ToolCallId.
+        mapper.OnSessionEvent(new ToolExecutionStartEvent
+        {
+            AgentId = "coord",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new ToolExecutionStartData
+            {
+                ToolName = "task",
+                ToolCallId = "toolu_scribe_dispatch",
+                Arguments = JsonSerializer.SerializeToElement(new
+                {
+                    name = "scribe",
+                    description = "Log the session",
+                    agent_type = "general-purpose",
+                }),
+            },
+        });
+
+        mapper.OnSessionEvent(new SubagentStartedEvent
+        {
+            AgentId = "toolu_scribe_sdk",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new SubagentStartedData
+            {
+                AgentName = "general-purpose",
+                AgentDisplayName = "general-purpose",
+                AgentDescription = "test",
+                ToolCallId = "toolu_scribe_dispatch",
+            },
+        });
+
+        // Tool-only turn — Content empty, ToolRequests populated.
+        mapper.OnSessionEvent(new AssistantMessageEvent
+        {
+            AgentId = "toolu_scribe_sdk",
+            Timestamp = DateTimeOffset.UtcNow,
+            Data = new AssistantMessageData
+            {
+                Content = string.Empty,
+                MessageId = Guid.NewGuid().ToString("n"),
+                ToolRequests = new[]
+                {
+                    new AssistantMessageToolRequest { Name = "view", ToolCallId = "tc_a" },
+                    new AssistantMessageToolRequest { Name = "edit", ToolCallId = "tc_b" },
+                },
+            },
+        });
+
+        Assert.NotNull(activity);
+        var toolEvent = activity!.Events.FirstOrDefault(e => e.Name == "squad.subagent.tool_requests");
+        Assert.NotEqual(default, toolEvent);
+        var tags = toolEvent.Tags.ToDictionary(t => t.Key, t => t.Value);
+        Assert.Equal("view,edit", tags["squad.subagent.tool_requests"]);
+        Assert.Equal(2, tags["squad.subagent.tool_requests_count"]);
+        // reply_preview should NOT be set (Content was empty).
+        Assert.Null(activity.GetTagItem("squad.subagent.reply_preview"));
     }
 }


### PR DESCRIPTION
feat(tracing): capture task-tool dispatch + tool requests for subagent OTel

Adds a "subagent dispatched" envelope to the SquadSubagentTraceMapper so
consumers and OTel backends see the LLM-supplied persona identity from the
moment the coordinator invokes the `task` tool — instead of waiting for the
later SubagentStartedEvent (which only carries the catalog `agent_type`,
e.g. always "general-purpose").

Mapper / public surface:
- Add `SubagentDispatched` to `SquadAgentTraceEventKind` and four persona
  properties on `SquadAgentTraceEvent`
  (`DispatchedPersonaName/Description/AgentType/Prompt`).
- Rewrite mapper to key live activities by `ToolCallId` (primary) and
  maintain a `SdkAgentId → ToolCallId` lookup so `AssistantMessageEvent`s
  (which only carry `AgentId`) can find the right span. Activities are
  opened on the task-dispatch event and labelled with the persona name from
  the start, then augmented on `SubagentStartedEvent`.
- Surface `AssistantMessageData.ToolRequests[].Name` on the typed envelope
  as `RequestedToolNames`, and add a `squad.subagent.tool_requests`
  ActivityEvent so tool-only assistant turns (empty Content) are visible
  on the OTel span as "called gh, view, grep" instead of a blank marker.

Sample:
- Add Flow 5 demonstrating both the typed `OnSubagentTrace` callback and
  an `ActivityListener` for OTel.
- Update Flow 1 to use the same handler with the new tool-name surfacing
  and a short `ShortId` formatter so parallel subagents are
  visually distinct.
- Fix Flow 3 (BYOK): merge the parent process env with custom vars to
  avoid the `Assertion failed: ncrypto::CSPRNG(nullptr, 0)` Node crash on
  Windows.

SDK:
- When forwarding `options.Environment` to the Copilot client, merge with
  the parent process env (instead of replacing it) so the native CLI
  inherits SYSTEMROOT/PATH/TEMP and doesn't crash on crypto init.

Tests (82 total, all pass on net8.0/net9.0/net10.0):
- 11 new tests covering task-dispatch parsing, `subagent_type` alias,
  bare-arguments fallback, `ToolRequests` extraction, the
  `squad.subagent.tool_requests` ActivityEvent, ToolCallId-keyed activity
  lifecycle, parallel dispatches, missing-arguments path, and the
  `sessionConfig.Agent = "Squad"` routing assertion update.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>