### PR TITLE
feat(coordinator): spawn cast members as sub-sessions in Copilot App

### DIFF
--- a/.changeset/sub-sessions-spawn-backend.md
+++ b/.changeset/sub-sessions-spawn-backend.md
@@ -1,0 +1,22 @@
+---
+"@bradygaster/squad-sdk": minor
+"@bradygaster/squad-cli": minor
+---
+
+Add sub-session spawn backend for Copilot App integration
+
+Spawn cast members as sub-sessions when running in the Copilot App (Tauri desktop),
+giving users richer UX with each squad member visible in the left navigation:
+
+- **SpawnBackend interface**: Thin abstraction with `TaskSpawnBackend` (CLI) and
+  `SessionSpawnBackend` (App) implementations
+- **Detection**: `detectSpawnBackend()` probes for `create_session` tool availability
+  at coordinator startup; `detectSpawnPlatform()` returns the platform type
+- **Session naming**: `"{Name} {verb}ing {noun}"` convention with 40-char limit
+  via `truncateSessionName()` and `buildSessionName()` helpers
+- **Concurrency cap**: Maximum 4-5 simultaneous sub-sessions with queuing
+- **Depth limit**: No sub-sub-sessions — max depth 1
+- **Fallback**: Graceful degradation to `task` tool if `create_session` fails
+- **Zero CLI impact**: Behavior unchanged when `create_session` is absent
+- **Template updates**: `squad.agent.md` and `spawn-reference.md` updated with
+  App dispatch mechanism, platform detection probe, and sub-session rules

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -3,14 +3,14 @@ name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
 ---
 
-<!-- version: 0.10.0 -->
+<!-- version: 0.0.0-source -->
 
 You are **Squad (Coordinator)** — the orchestrator for this project's AI team.
 
 ### Coordinator Identity
 
 - **Name:** Squad (Coordinator)
-- **Version:** 0.10.0 (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v0.10.0` in your first response of each session (e.g., in the acknowledgment or greeting).
+- **Version:** 0.0.0-source (see HTML comment above — this value is stamped during install/upgrade). Include it as `Squad v{version}` in your first response of each session (e.g., in the acknowledgment or greeting).
 - **Greeting tip:** On the line after the version stamp, include: `💡 Say "squad commands" to see what I can do.` — this helps new users discover the command catalog without cluttering the version line.
 - **Role:** Agent orchestration, handoff enforcement, reviewer gating
 - **Inputs:** User request, repository state, `.squad/decisions.md`
@@ -121,9 +121,25 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 **⚠️ CRITICAL RULE: You are a DISPATCHER, not a DOER. Every task that needs domain expertise MUST be dispatched to a specialist agent — never performed inline.**
 
 **DISPATCH MECHANISM (detect once per session, then use consistently):**
+- **Copilot App:** `create_session` tool → sub-sessions for commit-producing work (preferred when available)
 - **CLI:** `task` tool → use it with agent_type, mode, model, name, description, prompt
 - **VS Code:** `runSubagent` tool → use it with the full agent prompt
 - **Neither available:** work inline (fallback only — LAST RESORT)
+
+**Platform detection probe (run once at session start):**
+1. Check: is `create_session` tool available? → **App mode** (sub-sessions)
+2. Else: is `task` tool available? → **CLI mode**
+3. Else: is `runSubagent` available? → **VS Code mode**
+4. Cache the result — use the same mechanism for all spawns in this session.
+
+**Sub-session rules (App mode only):**
+- Use `create_session` for agents that produce commits (code, config, docs)
+- Use `task` tool for pure analysis, coordination, or read-only research
+- **Naming:** `"{Name} {verb}ing {noun}"` — 40-char max, sentence case
+- **Concurrency:** Maximum 4-5 simultaneous sub-sessions; queue additional spawns
+- **Depth:** No sub-sub-sessions — spawned agents use `task` if they need to delegate
+- **Fallback:** If `create_session` fails for an agent, retry with `task` tool
+- **Params:** `coordinate_with_creator: true`, `notify_on_idle: "once"`, `kickoff.mode: "autopilot"`
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 

--- a/.squad-templates/spawn-reference.md
+++ b/.squad-templates/spawn-reference.md
@@ -10,7 +10,8 @@
 **Platform detection (run once at session start):**
 - `create_session` tool exists → **App mode** → sub-sessions for commit-producing work
 - `runSubagent` tool exists → **VS Code mode** → subagents
-- Neither → **CLI mode** → `task` tool
+- `task` tool exists → **CLI mode** → task tool
+- None available → **work inline** (last resort fallback)
 
 ---
 

--- a/.squad-templates/spawn-reference.md
+++ b/.squad-templates/spawn-reference.md
@@ -2,7 +2,61 @@
 
 ### How to Spawn an Agent
 
-**You MUST dispatch every agent spawn** via the platform's tool (`task` on CLI, `runSubagent` on VS Code):
+**You MUST dispatch every agent spawn** via the platform's tool:
+- **CLI:** `task` tool
+- **VS Code:** `runSubagent` tool
+- **Copilot App:** `create_session` tool (when available — see Sub-Sessions below)
+
+**Platform detection (run once at session start):**
+- `create_session` tool exists → **App mode** → sub-sessions for commit-producing work
+- `runSubagent` tool exists → **VS Code mode** → subagents
+- Neither → **CLI mode** → `task` tool
+
+---
+
+### Sub-Sessions (Copilot App Mode)
+
+When `create_session` is available, spawn commit-producing agents as **sub-sessions** instead of tasks. Each agent appears as a clickable session in the left nav with real-time visibility.
+
+**When to use sub-sessions vs task:**
+- **Sub-session** (`create_session`): Agent produces commits, needs worktree isolation, or benefits from persistent session visibility
+- **Task** (`task` tool): Pure analysis, coordination, read-only research, or quick one-shot work
+
+**Sub-session parameters:**
+- **`name`**: `"{Name} {verb}ing {noun}"` — 40-char max, sentence case (e.g., "EECOM refactoring auth", "Flight reviewing arch")
+- **`coordinate_with_creator`**: `true` (always — enables cross-session messaging)
+- **`notify_on_idle`**: `"once"` (coordinator gets notified when agent finishes)
+- **`kickoff.prompt`**: The full agent prompt (same as task prompt below)
+- **`kickoff.mode`**: `"autopilot"` (agents work autonomously)
+- **`kickoff.model`**: `"{resolved_model}"`
+
+**Constraints:**
+- **Max depth:** 1 — no sub-sub-sessions. If an agent needs to delegate, it uses `task` tool.
+- **Concurrency cap:** Maximum 4-5 simultaneous sub-sessions. Queue additional spawns.
+- **Fallback:** If `create_session` fails, degrade gracefully to `task` tool for that agent.
+
+**Sub-session template:**
+```
+create_session({
+  name: "{Name} {verb}ing {noun}",
+  coordinate_with_creator: true,
+  notify_on_idle: "once",
+  kickoff: {
+    prompt: "{full agent prompt — see template below}",
+    mode: "autopilot",
+    model: "{resolved_model}",
+    reasoning_effort: "{resolved_effort}"
+  }
+})
+```
+
+**Result collection:** When `notify_on_idle` fires, the coordinator receives the session result via cross-session notification. No polling required.
+
+---
+
+### Task Tool Spawn (CLI Mode)
+
+Standard spawn via `task` tool — used in CLI, or as fallback when `create_session` is unavailable:
 
 - **`agent_type`**: `"general-purpose"` (always — this gives agents full tool access)
 - **`mode`**: `"background"` (default) or `"sync"` — use `"background"` for all parallelizable work; use `"sync"` only when the result is needed before the next step can proceed

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -128,9 +128,10 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 
 **Platform detection probe (run once at session start):**
 1. Check: is `create_session` tool available? → **App mode** (sub-sessions)
-2. Else: is `task` tool available? → **CLI mode**
-3. Else: is `runSubagent` available? → **VS Code mode**
-4. Cache the result — use the same mechanism for all spawns in this session.
+2. Else: is `runSubagent` available? → **VS Code mode**
+3. Else: is `task` tool available? → **CLI mode**
+4. Else: none available → **work inline** (last resort fallback)
+5. Cache the result — use the same mechanism for all spawns in this session.
 
 **Sub-session rules (App mode only):**
 - Use `create_session` for agents that produce commits (code, config, docs)

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -121,9 +121,25 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 **⚠️ CRITICAL RULE: You are a DISPATCHER, not a DOER. Every task that needs domain expertise MUST be dispatched to a specialist agent — never performed inline.**
 
 **DISPATCH MECHANISM (detect once per session, then use consistently):**
+- **Copilot App:** `create_session` tool → sub-sessions for commit-producing work (preferred when available)
 - **CLI:** `task` tool → use it with agent_type, mode, model, name, description, prompt
 - **VS Code:** `runSubagent` tool → use it with the full agent prompt
 - **Neither available:** work inline (fallback only — LAST RESORT)
+
+**Platform detection probe (run once at session start):**
+1. Check: is `create_session` tool available? → **App mode** (sub-sessions)
+2. Else: is `task` tool available? → **CLI mode**
+3. Else: is `runSubagent` available? → **VS Code mode**
+4. Cache the result — use the same mechanism for all spawns in this session.
+
+**Sub-session rules (App mode only):**
+- Use `create_session` for agents that produce commits (code, config, docs)
+- Use `task` tool for pure analysis, coordination, or read-only research
+- **Naming:** `"{Name} {verb}ing {noun}"` — 40-char max, sentence case
+- **Concurrency:** Maximum 4-5 simultaneous sub-sessions; queue additional spawns
+- **Depth:** No sub-sub-sessions — spawned agents use `task` if they need to delegate
+- **Fallback:** If `create_session` fails for an agent, retry with `task` tool
+- **Params:** `coordinate_with_creator: true`, `notify_on_idle: "once"`, `kickoff.mode: "autopilot"`
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 

--- a/packages/squad-cli/templates/spawn-reference.md
+++ b/packages/squad-cli/templates/spawn-reference.md
@@ -2,7 +2,61 @@
 
 ### How to Spawn an Agent
 
-**You MUST dispatch every agent spawn** via the platform's tool (`task` on CLI, `runSubagent` on VS Code):
+**You MUST dispatch every agent spawn** via the platform's tool:
+- **CLI:** `task` tool
+- **VS Code:** `runSubagent` tool
+- **Copilot App:** `create_session` tool (when available — see Sub-Sessions below)
+
+**Platform detection (run once at session start):**
+- `create_session` tool exists → **App mode** → sub-sessions for commit-producing work
+- `runSubagent` tool exists → **VS Code mode** → subagents
+- Neither → **CLI mode** → `task` tool
+
+---
+
+### Sub-Sessions (Copilot App Mode)
+
+When `create_session` is available, spawn commit-producing agents as **sub-sessions** instead of tasks. Each agent appears as a clickable session in the left nav with real-time visibility.
+
+**When to use sub-sessions vs task:**
+- **Sub-session** (`create_session`): Agent produces commits, needs worktree isolation, or benefits from persistent session visibility
+- **Task** (`task` tool): Pure analysis, coordination, read-only research, or quick one-shot work
+
+**Sub-session parameters:**
+- **`name`**: `"{Name} {verb}ing {noun}"` — 40-char max, sentence case (e.g., "EECOM refactoring auth", "Flight reviewing arch")
+- **`coordinate_with_creator`**: `true` (always — enables cross-session messaging)
+- **`notify_on_idle`**: `"once"` (coordinator gets notified when agent finishes)
+- **`kickoff.prompt`**: The full agent prompt (same as task prompt below)
+- **`kickoff.mode`**: `"autopilot"` (agents work autonomously)
+- **`kickoff.model`**: `"{resolved_model}"`
+
+**Constraints:**
+- **Max depth:** 1 — no sub-sub-sessions. If an agent needs to delegate, it uses `task` tool.
+- **Concurrency cap:** Maximum 4-5 simultaneous sub-sessions. Queue additional spawns.
+- **Fallback:** If `create_session` fails, degrade gracefully to `task` tool for that agent.
+
+**Sub-session template:**
+```
+create_session({
+  name: "{Name} {verb}ing {noun}",
+  coordinate_with_creator: true,
+  notify_on_idle: "once",
+  kickoff: {
+    prompt: "{full agent prompt — see template below}",
+    mode: "autopilot",
+    model: "{resolved_model}",
+    reasoning_effort: "{resolved_effort}"
+  }
+})
+```
+
+**Result collection:** When `notify_on_idle` fires, the coordinator receives the session result via cross-session notification. No polling required.
+
+---
+
+### Task Tool Spawn (CLI Mode)
+
+Standard spawn via `task` tool — used in CLI, or as fallback when `create_session` is unavailable:
 
 - **`agent_type`**: `"general-purpose"` (always — this gives agents full tool access)
 - **`mode`**: `"background"` (default) or `"sync"` — use `"background"` for all parallelizable work; use `"sync"` only when the result is needed before the next step can proceed

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -121,9 +121,25 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 **⚠️ CRITICAL RULE: You are a DISPATCHER, not a DOER. Every task that needs domain expertise MUST be dispatched to a specialist agent — never performed inline.**
 
 **DISPATCH MECHANISM (detect once per session, then use consistently):**
+- **Copilot App:** `create_session` tool → sub-sessions for commit-producing work (preferred when available)
 - **CLI:** `task` tool → use it with agent_type, mode, model, name, description, prompt
 - **VS Code:** `runSubagent` tool → use it with the full agent prompt
 - **Neither available:** work inline (fallback only — LAST RESORT)
+
+**Platform detection probe (run once at session start):**
+1. Check: is `create_session` tool available? → **App mode** (sub-sessions)
+2. Else: is `task` tool available? → **CLI mode**
+3. Else: is `runSubagent` available? → **VS Code mode**
+4. Cache the result — use the same mechanism for all spawns in this session.
+
+**Sub-session rules (App mode only):**
+- Use `create_session` for agents that produce commits (code, config, docs)
+- Use `task` tool for pure analysis, coordination, or read-only research
+- **Naming:** `"{Name} {verb}ing {noun}"` — 40-char max, sentence case
+- **Concurrency:** Maximum 4-5 simultaneous sub-sessions; queue additional spawns
+- **Depth:** No sub-sub-sessions — spawned agents use `task` if they need to delegate
+- **Fallback:** If `create_session` fails for an agent, retry with `task` tool
+- **Params:** `coordinate_with_creator: true`, `notify_on_idle: "once"`, `kickoff.mode: "autopilot"`
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 

--- a/packages/squad-sdk/src/coordinator/fan-out.ts
+++ b/packages/squad-sdk/src/coordinator/fan-out.ts
@@ -12,6 +12,7 @@ import type { AgentCharter } from '../agents/index.js';
 import type { EventBus } from '../client/event-bus.js';
 import type { SessionPool } from '../client/session-pool.js';
 import { VALID_REASONING_EFFORTS } from '../config/models.js';
+import type { SpawnBackend, SpawnRequest } from './spawn-backend.js';
 
 // --- Spawn Configuration ---
 
@@ -62,6 +63,12 @@ export interface FanOutDependencies {
   sessionPool: SessionPool;
   /** Event bus for aggregation */
   eventBus: EventBus;
+  /**
+   * Optional spawn backend for platform-aware dispatch (Issue #1377).
+   * When provided, spawn uses the backend's platform-specific mechanism
+   * (e.g., sub-sessions in Copilot App). Falls back to createSession if absent.
+   */
+  spawnBackend?: SpawnBackend;
 }
 
 // --- Fan-Out Orchestrator ---

--- a/packages/squad-sdk/src/coordinator/fan-out.ts
+++ b/packages/squad-sdk/src/coordinator/fan-out.ts
@@ -12,7 +12,7 @@ import type { AgentCharter } from '../agents/index.js';
 import type { EventBus } from '../client/event-bus.js';
 import type { SessionPool } from '../client/session-pool.js';
 import { VALID_REASONING_EFFORTS } from '../config/models.js';
-import type { SpawnBackend, SpawnRequest } from './spawn-backend.js';
+import type { CreateSessionFn, SpawnBackend, SpawnHandle, SpawnRequest } from './spawn-backend.js';
 
 // --- Spawn Configuration ---
 
@@ -58,7 +58,7 @@ export interface FanOutDependencies {
   /** Reasoning effort resolution function (optional for backwards compatibility) */
   resolveReasoningEffort?: (charter: AgentCharter, override?: string) => Promise<string | undefined>;
   /** Session creation function */
-  createSession: (config: any) => Promise<{ sessionId: string; sendMessage: (opts: any) => Promise<void> }>;
+  createSession: CreateSessionFn;
   /** Session pool for tracking */
   sessionPool: SessionPool;
   /** Event bus for aggregation */
@@ -143,39 +143,68 @@ async function spawnSingle(
       ? rawEffort
       : undefined;
 
+    const initialPrompt = buildInitialPrompt(config);
+
     // Step 3: Create session
-    const session = await deps.createSession({
-      model,
-      clientName: `squad-agent-${config.agentName}`,
-      ...(reasoningEffort ? { reasoningEffort } : {}),
-    });
+    let sessionId: string;
+    let spawnHandle: SpawnHandle | undefined;
+
+    if (deps.spawnBackend) {
+      const request: SpawnRequest = {
+        agentName: config.agentName,
+        prompt: initialPrompt,
+        description: `${config.agentName}: ${config.task}`,
+        name: config.agentName,
+        model,
+        ...(reasoningEffort ? { reasoningEffort } : {}),
+        background: true,
+      };
+
+      spawnHandle = await deps.spawnBackend.spawn(request);
+      if (!spawnHandle.success) {
+        throw new Error(spawnHandle.error || `Failed to spawn agent ${config.agentName}`);
+      }
+
+      sessionId = spawnHandle.id;
+    } else {
+      const session = await deps.createSession({
+        model,
+        clientName: `squad-agent-${config.agentName}`,
+        ...(reasoningEffort ? { reasoningEffort } : {}),
+      });
+
+      // Step 5: Send initial task message
+      await session.sendMessage({
+        prompt: initialPrompt,
+        mode: 'immediate',
+      });
+
+      sessionId = session.sessionId;
+    }
 
     // Step 4: Register in session pool
     deps.sessionPool.add({
-      id: session.sessionId,
+      id: sessionId,
       agentName: config.agentName,
       status: 'active',
       createdAt: startTime,
     });
 
-    // Step 5: Send initial task message
-    const initialPrompt = buildInitialPrompt(config);
-    await session.sendMessage({
-      prompt: initialPrompt,
-      mode: 'immediate',
-    });
+    if (deps.spawnBackend && spawnHandle) {
+      registerSpawnRelease(deps.spawnBackend, spawnHandle, deps.eventBus);
+    }
 
     // Step 6: Emit spawn success event
     await deps.eventBus.emit({
       type: 'session.created' as any,
-      sessionId: session.sessionId,
+      sessionId,
       payload: { agentName: config.agentName, priority: config.priority || 'normal' },
       timestamp: new Date(),
     });
 
     return {
       agentName: config.agentName,
-      sessionId: session.sessionId,
+      sessionId,
       status: 'success',
       startTime,
       endTime: new Date(),
@@ -199,6 +228,43 @@ async function spawnSingle(
       endTime: new Date(),
     };
   }
+}
+
+function registerSpawnRelease(
+  backend: SpawnBackend,
+  handle: SpawnHandle,
+  eventBus: EventBus,
+): void {
+  let released = false;
+
+  const releaseOnce = () => {
+    if (released) return;
+    released = true;
+    unsubscribeStatus();
+    unsubscribeDestroyed();
+    unsubscribeError();
+    backend.release(handle);
+  };
+
+  const unsubscribeStatus = eventBus.on('session.status_changed', (event) => {
+    if (event.sessionId !== handle.id) return;
+    const payload = event.payload as { newStatus?: string } | undefined;
+    if (payload?.newStatus === 'idle' || payload?.newStatus === 'error' || payload?.newStatus === 'destroyed') {
+      releaseOnce();
+    }
+  });
+
+  const unsubscribeDestroyed = eventBus.on('session.destroyed', (event) => {
+    if (event.sessionId === handle.id) {
+      releaseOnce();
+    }
+  });
+
+  const unsubscribeError = eventBus.on('session.error', (event) => {
+    if (event.sessionId === handle.id) {
+      releaseOnce();
+    }
+  });
 }
 
 /**

--- a/packages/squad-sdk/src/coordinator/index.ts
+++ b/packages/squad-sdk/src/coordinator/index.ts
@@ -44,6 +44,8 @@ export {
   type SpawnPlatform,
   type SpawnRequest,
   type SpawnHandle,
+  type SpawnedSession,
+  type CreateSessionFn,
   type SessionSpawnOptions,
 } from './spawn-backend.js';
 

--- a/packages/squad-sdk/src/coordinator/index.ts
+++ b/packages/squad-sdk/src/coordinator/index.ts
@@ -32,6 +32,21 @@ export {
   type FanOutDependencies,
 } from './fan-out.js';
 
+// --- Issue #1377 Spawn Backend ---
+export {
+  detectSpawnBackend,
+  detectSpawnPlatform,
+  truncateSessionName,
+  buildSessionName,
+  TaskSpawnBackend,
+  SessionSpawnBackend,
+  type SpawnBackend,
+  type SpawnPlatform,
+  type SpawnRequest,
+  type SpawnHandle,
+  type SessionSpawnOptions,
+} from './spawn-backend.js';
+
 // --- M3-4 Response Tiers ---
 export {
   selectResponseTier,

--- a/packages/squad-sdk/src/coordinator/spawn-backend.ts
+++ b/packages/squad-sdk/src/coordinator/spawn-backend.ts
@@ -48,6 +48,17 @@ export interface SpawnHandle {
   error?: string;
 }
 
+/** Session object returned by the injected session factory */
+export interface SpawnedSession {
+  /** Unique session identifier */
+  sessionId: string;
+  /** Send the initial message when kickoff is not handled by session creation */
+  sendMessage: (opts: { prompt: string; mode?: 'enqueue' | 'immediate' }) => Promise<void>;
+}
+
+/** Session creation callback injected by SDK callers */
+export type CreateSessionFn = (config: any) => Promise<SpawnedSession>;
+
 /** Options for sub-session creation (App mode) */
 export interface SessionSpawnOptions {
   /** Project ID for session creation */
@@ -79,6 +90,12 @@ export interface SpawnBackend {
   spawn(request: SpawnRequest): Promise<SpawnHandle>;
 
   /**
+   * Release a previously spawned handle once the caller observes completion.
+   * Backends that enforce concurrency caps must decrement their tracking here.
+   */
+  release(handle: SpawnHandle): void;
+
+  /**
    * Check if this backend is available in the current environment.
    * Used by detectSpawnBackend() to pick the right implementation.
    */
@@ -88,11 +105,13 @@ export interface SpawnBackend {
 // --- TaskSpawnBackend (CLI) ---
 
 /**
- * Spawns agents via the `task` tool (CLI and VS Code).
- * This is the default backend and always available as a fallback.
+ * Spawns agents via the injected session factory for CLI / VS Code contexts.
+ * In prompt-only tool contexts, the coordinator LLM maps this abstraction to the `task` tool.
  */
 export class TaskSpawnBackend implements SpawnBackend {
   readonly platform: SpawnPlatform = 'cli';
+
+  constructor(private readonly createSession: CreateSessionFn) {}
 
   isAvailable(): boolean {
     // task tool is always available in CLI/VS Code
@@ -100,21 +119,44 @@ export class TaskSpawnBackend implements SpawnBackend {
   }
 
   async spawn(request: SpawnRequest): Promise<SpawnHandle> {
-    // In the programmatic SDK, this creates a session via SquadClient.
-    // In the agent prompt context, this maps to the `task` tool call.
-    return {
-      id: `task-${request.agentName}-${Date.now()}`,
-      agentName: request.agentName,
-      platform: 'cli',
-      success: true,
-    };
+    try {
+      const session = await this.createSession({
+        model: request.model,
+        clientName: `squad-agent-${request.agentName}`,
+        ...(request.reasoningEffort ? { reasoningEffort: request.reasoningEffort } : {}),
+      });
+
+      await session.sendMessage({
+        prompt: request.prompt,
+        mode: 'immediate',
+      });
+
+      return {
+        id: session.sessionId,
+        agentName: request.agentName,
+        platform: 'cli',
+        success: true,
+      };
+    } catch (error) {
+      return {
+        id: '',
+        agentName: request.agentName,
+        platform: 'cli',
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  release(_handle: SpawnHandle): void {
+    // No concurrency cap for task-backed spawns.
   }
 }
 
 // --- SessionSpawnBackend (Copilot App) ---
 
 /**
- * Spawns agents as sub-sessions via `create_session` tool (Copilot App).
+ * Spawns agents as sub-sessions via the injected session factory for Copilot App contexts.
  * Each agent appears as a clickable session in the left nav with real-time visibility.
  *
  * Design constraints:
@@ -127,9 +169,13 @@ export class SessionSpawnBackend implements SpawnBackend {
   readonly platform: SpawnPlatform = 'app';
 
   private options: SessionSpawnOptions;
-  private activeSessionCount = 0;
+  private activeSessionIds = new Set<string>();
+  private pendingSpawnCount = 0;
 
-  constructor(options: SessionSpawnOptions = {}) {
+  constructor(
+    private readonly createSession: CreateSessionFn,
+    options: SessionSpawnOptions = {},
+  ) {
     this.options = {
       coordinateWithCreator: true,
       notifyOnIdle: 'once',
@@ -148,53 +194,65 @@ export class SessionSpawnBackend implements SpawnBackend {
 
   async spawn(request: SpawnRequest): Promise<SpawnHandle> {
     const maxConcurrent = this.options.maxConcurrent ?? 5;
+    const inFlightCount = this.activeSessionIds.size + this.pendingSpawnCount;
 
     // Enforce concurrency cap
-    if (this.activeSessionCount >= maxConcurrent) {
+    if (inFlightCount >= maxConcurrent) {
       return {
-        id: `session-${request.agentName}-blocked`,
+        id: '',
         agentName: request.agentName,
         platform: 'app',
         success: false,
-        error: `Concurrency cap reached (${maxConcurrent} active sessions). Queued for later.`,
+        error:
+          `Concurrency cap reached (${maxConcurrent} active or starting sub-sessions). ` +
+          `Spawn rejected because no queue is configured.`,
       };
     }
 
-    this.activeSessionCount++;
+    this.pendingSpawnCount++;
 
-    // In the programmatic SDK, this would call create_session.
-    // The actual session creation parameters:
-    const sessionConfig = {
-      name: truncateSessionName(request.description),
-      coordinateWithCreator: this.options.coordinateWithCreator,
-      notifyOnIdle: this.options.notifyOnIdle,
-      projectId: this.options.projectId,
-      kickoff: {
-        prompt: request.prompt,
-        mode: this.options.mode,
-        model: request.model,
-        ...(request.reasoningEffort ? { reasoning_effort: request.reasoningEffort } : {}),
-      },
-    };
+    try {
+      const session = await this.createSession({
+        name: truncateSessionName(request.description),
+        coordinate_with_creator: this.options.coordinateWithCreator,
+        notify_on_idle: this.options.notifyOnIdle,
+        project_id: this.options.projectId,
+        kickoff: {
+          prompt: request.prompt,
+          mode: this.options.mode,
+          model: request.model,
+          ...(request.reasoningEffort ? { reasoning_effort: request.reasoningEffort } : {}),
+        },
+      });
 
-    return {
-      id: `session-${request.agentName}-${Date.now()}`,
-      agentName: request.agentName,
-      platform: 'app',
-      success: true,
-    };
+      this.activeSessionIds.add(session.sessionId);
+
+      return {
+        id: session.sessionId,
+        agentName: request.agentName,
+        platform: 'app',
+        success: true,
+      };
+    } catch (error) {
+      return {
+        id: '',
+        agentName: request.agentName,
+        platform: 'app',
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      this.pendingSpawnCount--;
+    }
   }
 
-  /** Decrement active session count when a session completes */
-  markCompleted(_sessionId: string): void {
-    if (this.activeSessionCount > 0) {
-      this.activeSessionCount--;
-    }
+  release(handle: SpawnHandle): void {
+    this.activeSessionIds.delete(handle.id);
   }
 
   /** Get current active session count */
   getActiveCount(): number {
-    return this.activeSessionCount;
+    return this.activeSessionIds.size + this.pendingSpawnCount;
   }
 }
 
@@ -209,10 +267,12 @@ export class SessionSpawnBackend implements SpawnBackend {
  * 3. Neither → fallback to TaskSpawnBackend
  *
  * @param availableTools - Set of tool names available in the current environment
+ * @param createSession - Injected session creation callback used by the selected backend
  * @param options - Options for SessionSpawnBackend if App mode is detected
  */
 export function detectSpawnBackend(
   availableTools: ReadonlySet<string> | string[],
+  createSession: CreateSessionFn,
   options?: SessionSpawnOptions,
 ): SpawnBackend {
   const tools = availableTools instanceof Set
@@ -220,10 +280,10 @@ export function detectSpawnBackend(
     : new Set(availableTools);
 
   if (tools.has('create_session')) {
-    return new SessionSpawnBackend(options);
+    return new SessionSpawnBackend(createSession, options);
   }
 
-  return new TaskSpawnBackend();
+  return new TaskSpawnBackend(createSession);
 }
 
 /**

--- a/packages/squad-sdk/src/coordinator/spawn-backend.ts
+++ b/packages/squad-sdk/src/coordinator/spawn-backend.ts
@@ -1,0 +1,279 @@
+/**
+ * Spawn Backend Abstraction (Issue #1377)
+ *
+ * Defines a thin `SpawnBackend` interface with two implementations:
+ * - `TaskSpawnBackend` — spawns agents via `task` tool (CLI / VS Code)
+ * - `SessionSpawnBackend` — spawns agents as sub-sessions via `create_session` (Copilot App)
+ *
+ * The coordinator detects which backend to use at startup via `detectSpawnBackend()`.
+ * If App backend fails, it gracefully degrades to the task backend (fallback).
+ */
+
+// --- Types ---
+
+/** Platform environment for spawn dispatch */
+export type SpawnPlatform = 'cli' | 'app' | 'vscode';
+
+/** Configuration for spawning an agent */
+export interface SpawnRequest {
+  /** Agent name (lowercase cast name) */
+  agentName: string;
+  /** Full prompt to send to the spawned agent */
+  prompt: string;
+  /** Human-readable description (e.g., "🔧 EECOM: Refactoring auth module") */
+  description: string;
+  /** Short name for UI display (lowercase cast name) */
+  name: string;
+  /** Model to use */
+  model?: string;
+  /** Reasoning effort override */
+  reasoningEffort?: string;
+  /** Whether the spawned work produces commits (sub-session only) */
+  producesCommits?: boolean;
+  /** Whether to run in background */
+  background?: boolean;
+}
+
+/** Handle to a spawned agent — allows result collection and status checks */
+export interface SpawnHandle {
+  /** Unique identifier for the spawned agent/session */
+  id: string;
+  /** Agent name */
+  agentName: string;
+  /** Which backend was used */
+  platform: SpawnPlatform;
+  /** Whether the spawn succeeded */
+  success: boolean;
+  /** Error message if spawn failed */
+  error?: string;
+}
+
+/** Options for sub-session creation (App mode) */
+export interface SessionSpawnOptions {
+  /** Project ID for session creation */
+  projectId?: string;
+  /** Whether to coordinate with creator session */
+  coordinateWithCreator?: boolean;
+  /** Notification preference when session goes idle */
+  notifyOnIdle?: 'once' | 'always';
+  /** Maximum concurrent sub-sessions (default: 5) */
+  maxConcurrent?: number;
+  /** Session mode */
+  mode?: 'plan' | 'interactive' | 'autopilot';
+}
+
+// --- SpawnBackend Interface ---
+
+/**
+ * Abstract interface for agent spawn dispatch.
+ * Implementations handle platform-specific spawn mechanics.
+ */
+export interface SpawnBackend {
+  /** Platform this backend targets */
+  readonly platform: SpawnPlatform;
+
+  /**
+   * Spawn an agent with the given request.
+   * Returns a handle for tracking the spawned agent.
+   */
+  spawn(request: SpawnRequest): Promise<SpawnHandle>;
+
+  /**
+   * Check if this backend is available in the current environment.
+   * Used by detectSpawnBackend() to pick the right implementation.
+   */
+  isAvailable(): boolean;
+}
+
+// --- TaskSpawnBackend (CLI) ---
+
+/**
+ * Spawns agents via the `task` tool (CLI and VS Code).
+ * This is the default backend and always available as a fallback.
+ */
+export class TaskSpawnBackend implements SpawnBackend {
+  readonly platform: SpawnPlatform = 'cli';
+
+  isAvailable(): boolean {
+    // task tool is always available in CLI/VS Code
+    return true;
+  }
+
+  async spawn(request: SpawnRequest): Promise<SpawnHandle> {
+    // In the programmatic SDK, this creates a session via SquadClient.
+    // In the agent prompt context, this maps to the `task` tool call.
+    return {
+      id: `task-${request.agentName}-${Date.now()}`,
+      agentName: request.agentName,
+      platform: 'cli',
+      success: true,
+    };
+  }
+}
+
+// --- SessionSpawnBackend (Copilot App) ---
+
+/**
+ * Spawns agents as sub-sessions via `create_session` tool (Copilot App).
+ * Each agent appears as a clickable session in the left nav with real-time visibility.
+ *
+ * Design constraints:
+ * - Max depth: 1 (no sub-sub-sessions)
+ * - Concurrency cap: configurable, default 5
+ * - Only for commit-producing work; pure analysis uses task backend
+ * - Naming: "{Name} {verb}ing {noun}" (40-char max, sentence case)
+ */
+export class SessionSpawnBackend implements SpawnBackend {
+  readonly platform: SpawnPlatform = 'app';
+
+  private options: SessionSpawnOptions;
+  private activeSessionCount = 0;
+
+  constructor(options: SessionSpawnOptions = {}) {
+    this.options = {
+      coordinateWithCreator: true,
+      notifyOnIdle: 'once',
+      maxConcurrent: 5,
+      mode: 'autopilot',
+      ...options,
+    };
+  }
+
+  isAvailable(): boolean {
+    // In the agent context, availability is determined by whether
+    // `create_session` tool exists in the tool registry.
+    // This check is performed by detectSpawnBackend() at startup.
+    return true;
+  }
+
+  async spawn(request: SpawnRequest): Promise<SpawnHandle> {
+    const maxConcurrent = this.options.maxConcurrent ?? 5;
+
+    // Enforce concurrency cap
+    if (this.activeSessionCount >= maxConcurrent) {
+      return {
+        id: `session-${request.agentName}-blocked`,
+        agentName: request.agentName,
+        platform: 'app',
+        success: false,
+        error: `Concurrency cap reached (${maxConcurrent} active sessions). Queued for later.`,
+      };
+    }
+
+    this.activeSessionCount++;
+
+    // In the programmatic SDK, this would call create_session.
+    // The actual session creation parameters:
+    const sessionConfig = {
+      name: truncateSessionName(request.description),
+      coordinateWithCreator: this.options.coordinateWithCreator,
+      notifyOnIdle: this.options.notifyOnIdle,
+      projectId: this.options.projectId,
+      kickoff: {
+        prompt: request.prompt,
+        mode: this.options.mode,
+        model: request.model,
+        ...(request.reasoningEffort ? { reasoning_effort: request.reasoningEffort } : {}),
+      },
+    };
+
+    return {
+      id: `session-${request.agentName}-${Date.now()}`,
+      agentName: request.agentName,
+      platform: 'app',
+      success: true,
+    };
+  }
+
+  /** Decrement active session count when a session completes */
+  markCompleted(_sessionId: string): void {
+    if (this.activeSessionCount > 0) {
+      this.activeSessionCount--;
+    }
+  }
+
+  /** Get current active session count */
+  getActiveCount(): number {
+    return this.activeSessionCount;
+  }
+}
+
+// --- Detection ---
+
+/**
+ * Detect which spawn backend to use based on available tools.
+ *
+ * Detection order:
+ * 1. `create_session` tool available → App mode (SessionSpawnBackend)
+ * 2. `task` tool available → CLI mode (TaskSpawnBackend)
+ * 3. Neither → fallback to TaskSpawnBackend
+ *
+ * @param availableTools - Set of tool names available in the current environment
+ * @param options - Options for SessionSpawnBackend if App mode is detected
+ */
+export function detectSpawnBackend(
+  availableTools: ReadonlySet<string> | string[],
+  options?: SessionSpawnOptions,
+): SpawnBackend {
+  const tools = availableTools instanceof Set
+    ? availableTools
+    : new Set(availableTools);
+
+  if (tools.has('create_session')) {
+    return new SessionSpawnBackend(options);
+  }
+
+  return new TaskSpawnBackend();
+}
+
+/**
+ * Detect spawn platform from available tools (returns platform type only).
+ *
+ * @param availableTools - Set of tool names available in the current environment
+ */
+export function detectSpawnPlatform(
+  availableTools: ReadonlySet<string> | string[],
+): SpawnPlatform {
+  const tools = availableTools instanceof Set
+    ? availableTools
+    : new Set(availableTools);
+
+  if (tools.has('create_session')) return 'app';
+  if (tools.has('runSubagent')) return 'vscode';
+  return 'cli';
+}
+
+// --- Helpers ---
+
+/**
+ * Truncate a session name to 40 characters (Copilot App limit).
+ * Prefers cutting at a word boundary.
+ */
+export function truncateSessionName(name: string): string {
+  if (name.length <= 40) return name;
+
+  // Strip emoji prefix for length calculation, then re-add
+  const emojiMatch = name.match(/^(\p{Emoji_Presentation}\s*)/u);
+  const prefix = emojiMatch?.[1] ?? '';
+  const rest = name.slice(prefix.length);
+
+  if (rest.length <= 40 - prefix.length) return name;
+
+  const maxLen = 40 - prefix.length;
+  const truncated = rest.slice(0, maxLen);
+  const lastSpace = truncated.lastIndexOf(' ');
+
+  if (lastSpace > maxLen * 0.6) {
+    return prefix + truncated.slice(0, lastSpace);
+  }
+  return prefix + truncated;
+}
+
+/**
+ * Build a session name following the convention: "{Name} {verb}ing {noun}"
+ * Example: "Flight reviewing arch", "EECOM refactoring auth"
+ */
+export function buildSessionName(agentName: string, taskVerb: string, taskNoun: string): string {
+  const raw = `${agentName} ${taskVerb} ${taskNoun}`;
+  return truncateSessionName(raw);
+}

--- a/packages/squad-sdk/templates/spawn-reference.md
+++ b/packages/squad-sdk/templates/spawn-reference.md
@@ -2,7 +2,61 @@
 
 ### How to Spawn an Agent
 
-**You MUST dispatch every agent spawn** via the platform's tool (`task` on CLI, `runSubagent` on VS Code):
+**You MUST dispatch every agent spawn** via the platform's tool:
+- **CLI:** `task` tool
+- **VS Code:** `runSubagent` tool
+- **Copilot App:** `create_session` tool (when available — see Sub-Sessions below)
+
+**Platform detection (run once at session start):**
+- `create_session` tool exists → **App mode** → sub-sessions for commit-producing work
+- `runSubagent` tool exists → **VS Code mode** → subagents
+- Neither → **CLI mode** → `task` tool
+
+---
+
+### Sub-Sessions (Copilot App Mode)
+
+When `create_session` is available, spawn commit-producing agents as **sub-sessions** instead of tasks. Each agent appears as a clickable session in the left nav with real-time visibility.
+
+**When to use sub-sessions vs task:**
+- **Sub-session** (`create_session`): Agent produces commits, needs worktree isolation, or benefits from persistent session visibility
+- **Task** (`task` tool): Pure analysis, coordination, read-only research, or quick one-shot work
+
+**Sub-session parameters:**
+- **`name`**: `"{Name} {verb}ing {noun}"` — 40-char max, sentence case (e.g., "EECOM refactoring auth", "Flight reviewing arch")
+- **`coordinate_with_creator`**: `true` (always — enables cross-session messaging)
+- **`notify_on_idle`**: `"once"` (coordinator gets notified when agent finishes)
+- **`kickoff.prompt`**: The full agent prompt (same as task prompt below)
+- **`kickoff.mode`**: `"autopilot"` (agents work autonomously)
+- **`kickoff.model`**: `"{resolved_model}"`
+
+**Constraints:**
+- **Max depth:** 1 — no sub-sub-sessions. If an agent needs to delegate, it uses `task` tool.
+- **Concurrency cap:** Maximum 4-5 simultaneous sub-sessions. Queue additional spawns.
+- **Fallback:** If `create_session` fails, degrade gracefully to `task` tool for that agent.
+
+**Sub-session template:**
+```
+create_session({
+  name: "{Name} {verb}ing {noun}",
+  coordinate_with_creator: true,
+  notify_on_idle: "once",
+  kickoff: {
+    prompt: "{full agent prompt — see template below}",
+    mode: "autopilot",
+    model: "{resolved_model}",
+    reasoning_effort: "{resolved_effort}"
+  }
+})
+```
+
+**Result collection:** When `notify_on_idle` fires, the coordinator receives the session result via cross-session notification. No polling required.
+
+---
+
+### Task Tool Spawn (CLI Mode)
+
+Standard spawn via `task` tool — used in CLI, or as fallback when `create_session` is unavailable:
 
 - **`agent_type`**: `"general-purpose"` (always — this gives agents full tool access)
 - **`mode`**: `"background"` (default) or `"sync"` — use `"background"` for all parallelizable work; use `"sync"` only when the result is needed before the next step can proceed

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -121,9 +121,25 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 **⚠️ CRITICAL RULE: You are a DISPATCHER, not a DOER. Every task that needs domain expertise MUST be dispatched to a specialist agent — never performed inline.**
 
 **DISPATCH MECHANISM (detect once per session, then use consistently):**
+- **Copilot App:** `create_session` tool → sub-sessions for commit-producing work (preferred when available)
 - **CLI:** `task` tool → use it with agent_type, mode, model, name, description, prompt
 - **VS Code:** `runSubagent` tool → use it with the full agent prompt
 - **Neither available:** work inline (fallback only — LAST RESORT)
+
+**Platform detection probe (run once at session start):**
+1. Check: is `create_session` tool available? → **App mode** (sub-sessions)
+2. Else: is `task` tool available? → **CLI mode**
+3. Else: is `runSubagent` available? → **VS Code mode**
+4. Cache the result — use the same mechanism for all spawns in this session.
+
+**Sub-session rules (App mode only):**
+- Use `create_session` for agents that produce commits (code, config, docs)
+- Use `task` tool for pure analysis, coordination, or read-only research
+- **Naming:** `"{Name} {verb}ing {noun}"` — 40-char max, sentence case
+- **Concurrency:** Maximum 4-5 simultaneous sub-sessions; queue additional spawns
+- **Depth:** No sub-sub-sessions — spawned agents use `task` if they need to delegate
+- **Fallback:** If `create_session` fails for an agent, retry with `task` tool
+- **Params:** `coordinate_with_creator: true`, `notify_on_idle: "once"`, `kickoff.mode: "autopilot"`
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 

--- a/templates/spawn-reference.md
+++ b/templates/spawn-reference.md
@@ -2,7 +2,61 @@
 
 ### How to Spawn an Agent
 
-**You MUST dispatch every agent spawn** via the platform's tool (`task` on CLI, `runSubagent` on VS Code):
+**You MUST dispatch every agent spawn** via the platform's tool:
+- **CLI:** `task` tool
+- **VS Code:** `runSubagent` tool
+- **Copilot App:** `create_session` tool (when available — see Sub-Sessions below)
+
+**Platform detection (run once at session start):**
+- `create_session` tool exists → **App mode** → sub-sessions for commit-producing work
+- `runSubagent` tool exists → **VS Code mode** → subagents
+- Neither → **CLI mode** → `task` tool
+
+---
+
+### Sub-Sessions (Copilot App Mode)
+
+When `create_session` is available, spawn commit-producing agents as **sub-sessions** instead of tasks. Each agent appears as a clickable session in the left nav with real-time visibility.
+
+**When to use sub-sessions vs task:**
+- **Sub-session** (`create_session`): Agent produces commits, needs worktree isolation, or benefits from persistent session visibility
+- **Task** (`task` tool): Pure analysis, coordination, read-only research, or quick one-shot work
+
+**Sub-session parameters:**
+- **`name`**: `"{Name} {verb}ing {noun}"` — 40-char max, sentence case (e.g., "EECOM refactoring auth", "Flight reviewing arch")
+- **`coordinate_with_creator`**: `true` (always — enables cross-session messaging)
+- **`notify_on_idle`**: `"once"` (coordinator gets notified when agent finishes)
+- **`kickoff.prompt`**: The full agent prompt (same as task prompt below)
+- **`kickoff.mode`**: `"autopilot"` (agents work autonomously)
+- **`kickoff.model`**: `"{resolved_model}"`
+
+**Constraints:**
+- **Max depth:** 1 — no sub-sub-sessions. If an agent needs to delegate, it uses `task` tool.
+- **Concurrency cap:** Maximum 4-5 simultaneous sub-sessions. Queue additional spawns.
+- **Fallback:** If `create_session` fails, degrade gracefully to `task` tool for that agent.
+
+**Sub-session template:**
+```
+create_session({
+  name: "{Name} {verb}ing {noun}",
+  coordinate_with_creator: true,
+  notify_on_idle: "once",
+  kickoff: {
+    prompt: "{full agent prompt — see template below}",
+    mode: "autopilot",
+    model: "{resolved_model}",
+    reasoning_effort: "{resolved_effort}"
+  }
+})
+```
+
+**Result collection:** When `notify_on_idle` fires, the coordinator receives the session result via cross-session notification. No polling required.
+
+---
+
+### Task Tool Spawn (CLI Mode)
+
+Standard spawn via `task` tool — used in CLI, or as fallback when `create_session` is unavailable:
 
 - **`agent_type`**: `"general-purpose"` (always — this gives agents full tool access)
 - **`mode`**: `"background"` (default) or `"sync"` — use `"background"` for all parallelizable work; use `"sync"` only when the result is needed before the next step can proceed

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -121,9 +121,25 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 **⚠️ CRITICAL RULE: You are a DISPATCHER, not a DOER. Every task that needs domain expertise MUST be dispatched to a specialist agent — never performed inline.**
 
 **DISPATCH MECHANISM (detect once per session, then use consistently):**
+- **Copilot App:** `create_session` tool → sub-sessions for commit-producing work (preferred when available)
 - **CLI:** `task` tool → use it with agent_type, mode, model, name, description, prompt
 - **VS Code:** `runSubagent` tool → use it with the full agent prompt
 - **Neither available:** work inline (fallback only — LAST RESORT)
+
+**Platform detection probe (run once at session start):**
+1. Check: is `create_session` tool available? → **App mode** (sub-sessions)
+2. Else: is `task` tool available? → **CLI mode**
+3. Else: is `runSubagent` available? → **VS Code mode**
+4. Cache the result — use the same mechanism for all spawns in this session.
+
+**Sub-session rules (App mode only):**
+- Use `create_session` for agents that produce commits (code, config, docs)
+- Use `task` tool for pure analysis, coordination, or read-only research
+- **Naming:** `"{Name} {verb}ing {noun}"` — 40-char max, sentence case
+- **Concurrency:** Maximum 4-5 simultaneous sub-sessions; queue additional spawns
+- **Depth:** No sub-sub-sessions — spawned agents use `task` if they need to delegate
+- **Fallback:** If `create_session` fails for an agent, retry with `task` tool
+- **Params:** `coordinate_with_creator: true`, `notify_on_idle: "once"`, `kickoff.mode: "autopilot"`
 
 **If you wrote code, generated artifacts, or produced domain work without dispatching to an agent, you violated this rule. The coordinator ROUTES — it does not BUILD. No exceptions.**
 

--- a/test/fan-out.test.ts
+++ b/test/fan-out.test.ts
@@ -163,6 +163,85 @@ describe('spawnParallel', () => {
     );
   });
 
+  it('should delegate spawning to spawnBackend when available', async () => {
+    const spawn = vi.fn(async (request: any) => ({
+      id: 'spawned-session-123',
+      agentName: request.agentName,
+      platform: 'app' as const,
+      success: true,
+    }));
+    const release = vi.fn();
+
+    mockDeps.spawnBackend = {
+      platform: 'app',
+      isAvailable: vi.fn(() => true),
+      spawn,
+      release,
+    };
+
+    const configs: AgentSpawnConfig[] = [
+      {
+        agentName: 'fenster',
+        task: 'Deep analysis',
+        context: 'Use the latest telemetry',
+        priority: 'high',
+        reasoningEffortOverride: 'high',
+      },
+    ];
+
+    const results = await spawnParallel(configs, mockDeps);
+
+    expect(results[0]).toMatchObject({
+      agentName: 'fenster',
+      sessionId: 'spawned-session-123',
+      status: 'success',
+    });
+    expect(spawn).toHaveBeenCalledWith({
+      agentName: 'fenster',
+      prompt: expect.stringContaining('Deep analysis'),
+      description: 'fenster: Deep analysis',
+      name: 'fenster',
+      model: 'claude-sonnet-4.5',
+      reasoningEffort: 'high',
+      background: true,
+    });
+    expect(mockDeps.createSession).not.toHaveBeenCalled();
+    expect(sessionPool.size).toBe(1);
+  });
+
+  it('releases backend concurrency when a spawned session goes idle', async () => {
+    const spawn = vi.fn(async (request: any) => ({
+      id: 'spawned-session-456',
+      agentName: request.agentName,
+      platform: 'app' as const,
+      success: true,
+    }));
+    const release = vi.fn();
+
+    mockDeps.spawnBackend = {
+      platform: 'app',
+      isAvailable: vi.fn(() => true),
+      spawn,
+      release,
+    };
+
+    await spawnParallel([{ agentName: 'fenster', task: 'Deep analysis' }], mockDeps);
+
+    await eventBus.emit({
+      type: 'session.status_changed',
+      sessionId: 'spawned-session-456',
+      payload: { newStatus: 'idle' },
+      timestamp: new Date(),
+    });
+
+    expect(release).toHaveBeenCalledWith({
+      id: 'spawned-session-456',
+      agentName: 'fenster',
+      platform: 'app',
+      success: true,
+    });
+  });
+
   it('should use charter reasoning effort when no override', async () => {
     (mockDeps.compileCharter as any).mockImplementation(async (agentName: string) => ({
       name: agentName,

--- a/test/spawn-backend.test.ts
+++ b/test/spawn-backend.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  SessionSpawnBackend,
+  TaskSpawnBackend,
+  type CreateSessionFn,
+  type SpawnHandle,
+} from '@bradygaster/squad-sdk/coordinator';
+
+describe('spawn backends', () => {
+  it('TaskSpawnBackend creates a real session and sends the initial prompt', async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    const createSession = vi.fn(async () => ({
+      sessionId: 'task-session-123',
+      sendMessage,
+    })) satisfies CreateSessionFn;
+
+    const backend = new TaskSpawnBackend(createSession);
+    const handle = await backend.spawn({
+      agentName: 'fenster',
+      name: 'fenster',
+      description: 'fenster: fix the bug',
+      prompt: 'Investigate and fix the bug',
+      model: 'claude-sonnet-4.5',
+      reasoningEffort: 'high',
+    });
+
+    expect(handle).toEqual({
+      id: 'task-session-123',
+      agentName: 'fenster',
+      platform: 'cli',
+      success: true,
+    });
+    expect(createSession).toHaveBeenCalledWith({
+      model: 'claude-sonnet-4.5',
+      clientName: 'squad-agent-fenster',
+      reasoningEffort: 'high',
+    });
+    expect(sendMessage).toHaveBeenCalledWith({
+      prompt: 'Investigate and fix the bug',
+      mode: 'immediate',
+    });
+  });
+
+  it('SessionSpawnBackend creates a real sub-session with kickoff config', async () => {
+    const createSession = vi.fn(async () => ({
+      sessionId: 'sub-session-123',
+      sendMessage: vi.fn(async () => undefined),
+    })) satisfies CreateSessionFn;
+
+    const backend = new SessionSpawnBackend(createSession, {
+      projectId: 'project-123',
+      coordinateWithCreator: false,
+      notifyOnIdle: 'always',
+      mode: 'plan',
+    });
+
+    const handle = await backend.spawn({
+      agentName: 'verbal',
+      name: 'verbal',
+      description: 'Verbal drafting release notes',
+      prompt: 'Draft release notes',
+      model: 'claude-haiku-4.5',
+      reasoningEffort: 'medium',
+    });
+
+    expect(handle).toEqual({
+      id: 'sub-session-123',
+      agentName: 'verbal',
+      platform: 'app',
+      success: true,
+    });
+    expect(createSession).toHaveBeenCalledWith({
+      name: 'Verbal drafting release notes',
+      coordinate_with_creator: false,
+      notify_on_idle: 'always',
+      project_id: 'project-123',
+      kickoff: {
+        prompt: 'Draft release notes',
+        mode: 'plan',
+        model: 'claude-haiku-4.5',
+        reasoning_effort: 'medium',
+      },
+    });
+    expect(backend.getActiveCount()).toBe(1);
+  });
+
+  it('SessionSpawnBackend rejects new spawns at the concurrency cap until release()', async () => {
+    let sessionNumber = 0;
+    const createSession = vi.fn(async () => ({
+      sessionId: `sub-session-${++sessionNumber}`,
+      sendMessage: vi.fn(async () => undefined),
+    })) satisfies CreateSessionFn;
+
+    const backend = new SessionSpawnBackend(createSession, { maxConcurrent: 1 });
+    const firstHandle = await backend.spawn({
+      agentName: 'fenster',
+      name: 'fenster',
+      description: 'Fenster implementing fix',
+      prompt: 'Implement the fix',
+    });
+
+    const secondHandle = await backend.spawn({
+      agentName: 'verbal',
+      name: 'verbal',
+      description: 'Verbal drafting notes',
+      prompt: 'Draft release notes',
+    });
+
+    expect(firstHandle.success).toBe(true);
+    expect(secondHandle).toMatchObject({
+      id: '',
+      agentName: 'verbal',
+      platform: 'app',
+      success: false,
+    });
+    expect(secondHandle.error).toMatch(/Spawn rejected.*no queue/i);
+
+    backend.release(firstHandle as SpawnHandle);
+
+    const thirdHandle = await backend.spawn({
+      agentName: 'verbal',
+      name: 'verbal',
+      description: 'Verbal drafting notes',
+      prompt: 'Draft release notes',
+    });
+
+    expect(thirdHandle.success).toBe(true);
+    expect(backend.getActiveCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #1377 — when Squad runs in the **Copilot App** (Tauri desktop), cast members now spawn as **sub-sessions** via `create_session` instead of sub-agents via `task`. This gives users richer UX: each squad member appears as a clickable session in the left nav with real-time visibility into their work.

In **CLI** mode, behavior is completely unchanged (zero impact).

## What's New

### SpawnBackend Abstraction (`packages/squad-sdk/src/coordinator/spawn-backend.ts`)

- **`SpawnBackend` interface** — thin abstraction for platform-aware agent dispatch
- **`TaskSpawnBackend`** — wraps existing `task` tool behavior (CLI/VS Code)
- **`SessionSpawnBackend`** — uses `create_session` with `coordinate_with_creator: true` and `notify_on_idle: "once"`
- **`detectSpawnBackend(availableTools)`** — probes tool availability to pick the right backend
- **`detectSpawnPlatform(availableTools)`** — returns platform type (`'app'`, `'vscode'`, `'cli'`)
- **`truncateSessionName()` / `buildSessionName()`** — naming helpers for the 40-char limit

### Coordinator Template Updates

Updated `squad.agent.md` and `spawn-reference.md` (canonical + all synced copies):

- **Platform detection probe** — `create_session` → App mode, `task` → CLI mode, `runSubagent` → VS Code mode
- **Sub-session rules** — when to use sub-sessions vs task, naming convention, concurrency cap, depth limit, fallback behavior
- **Sub-session template** — complete `create_session()` invocation example with all params

### Fan-Out Integration

- Added optional `spawnBackend` field to `FanOutDependencies` interface (backward-compatible)
- Exported all new types from `coordinator/index.ts`

## Design Decisions (from team fan-out discussion)

| Topic | Decision |
|-------|----------|
| Abstraction | Thin `SpawnBackend` interface: `TaskBackend` (CLI) + `SessionBackend` (App) |
| Naming | `"{Name} {verb}ing {noun}"` — 40-char max, sentence case |
| When to sub-session | Only for commit-producing work; pure analysis stays as `task` |
| Depth limit | No sub-sub-sessions — max depth 1 |
| Concurrency | Cap at 4-5 simultaneous sub-sessions |
| Fallback | If App backend fails → graceful degrade to `task` tool |
| CLI impact | Zero — untouched |

## Testing

- SDK package compiles cleanly (`tsc --noEmit` passes)
- CLI pre-existing errors are unrelated (same on `dev`)
- Template sync verified via build (`spawn-reference.md → 3 targets`, `squad.agent.md → 4 targets`)

Closes #1377