### PR TITLE
fix(sdk): export gitignore-state helpers to unblock release (refs #1386)

### DIFF
--- a/.changeset/fix-sdk-export-gitignore-state.md
+++ b/.changeset/fix-sdk-export-gitignore-state.md
@@ -1,0 +1,11 @@
+---
+"@bradygaster/squad-sdk": patch
+---
+
+fix(sdk): export `addSquadStateGitignoreBlock` / `removeSquadStateGitignoreBlock` from the package root
+
+`packages/squad-cli/src/cli/commands/migrate-backend.ts` imports these helpers from
+`@bradygaster/squad-sdk`, but they were never re-exported from `src/index.ts`. This broke
+the CLI TypeScript build (`TS2305: has no exported member`). Re-export the two functions
+(plus their marker constants) so the CLI compiles and the state-backend migration command
+resolves them. Unblocks cutting a stable release that carries the #1378 inline-dispatch-gate fix.

--- a/packages/squad-sdk/src/index.ts
+++ b/packages/squad-sdk/src/index.ts
@@ -114,6 +114,7 @@ export * from './memory/index.js';
 export type { StateBackend, StateBackendType, StateBackendConfig } from './state-backend.js';
 export { WorktreeBackend, GitNotesBackend, OrphanBranchBackend, TwoLayerBackend, CircuitBreaker, GitExecError, resolveStateBackend, validateStateKey, StateBackendStorageAdapter, verifyStateBackend } from './state-backend.js';
 export type { PromoteNotesResult } from './state-backend.js';
+export { addSquadStateGitignoreBlock, removeSquadStateGitignoreBlock, SQUAD_STATE_GITIGNORE_OPEN_MARKER, SQUAD_STATE_GITIGNORE_CLOSE_MARKER } from './config/gitignore-state.js';
 
 // State facade (Phase 2) — namespaced to avoid conflicts with existing config/sharing exports
 export {

--- a/src/Squad.Agents.AI/Squad.Agents.AI.csproj
+++ b/src/Squad.Agents.AI/Squad.Agents.AI.csproj
@@ -17,7 +17,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.5.1</Version>
+    <Version>0.5.5</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="samples/**/*.cs" />


### PR DESCRIPTION
## Why

`dev` does not currently build: `packages/squad-cli/src/cli/commands/migrate-backend.ts` imports `addSquadStateGitignoreBlock` / `removeSquadStateGitignoreBlock` from `@bradygaster/squad-sdk`, but `packages/squad-sdk/src/index.ts` never re-exported them. The CLI fails to compile with:

```
src/cli/commands/migrate-backend.ts(23,10): error TS2305: Module '"@bradygaster/squad-sdk"' has no exported member 'addSquadStateGitignoreBlock'.
src/cli/commands/migrate-backend.ts(23,39): error TS2305: Module '"@bradygaster/squad-sdk"' has no exported member 'removeSquadStateGitignoreBlock'.
```

This blocks cutting a stable release that carries the **#1378 inline-dispatch-gate fix** — the subject of #1386 (Tamir's report that the fix is stranded on `dev`).

## What

- **`packages/squad-sdk/src/index.ts`** — re-export `addSquadStateGitignoreBlock`, `removeSquadStateGitignoreBlock`, and their two marker constants from `./config/gitignore-state.js` (the functions already existed; they were simply never surfaced from the package root).
- **`src/Squad.Agents.AI/Squad.Agents.AI.csproj`** — bump stale `<Version>` `0.5.1` → `0.5.5` so a NuGet republish pins to the fixed CLI (the package is a thin wrapper that shells out to the npm CLI; the fix is a CLI-dependency bump, not package code).
- Added a `patch` changeset.

## Validation

- `npm run lint` (tsc `--noEmit` for both projects) → ✅ passes
- `npm run build` (sdk + cli) → ✅ both compile
- `node --test test/*.test.cjs` (release-gating suite) → ✅ passes

## Notes

This is intentionally a tight, build-fixing PR. The npm version bump + CHANGELOG entry for the actual stable cut are handled in the release step.

Refs #1386

⚠️ Touches `packages/squad-sdk/src/` — changeset included per the changelog-gate.