### PR TITLE
feat: add project-navigation commands (open, pick, list, add)

### DIFF
--- a/.changeset/log-projects-at-init.md
+++ b/.changeset/log-projects-at-init.md
@@ -1,0 +1,15 @@
+---
+"@bradygaster/squad-cli": minor
+"@bradygaster/squad-sdk": minor
+---
+
+Log each project at `squad init` and add `squad projects` to list them
+
+`squad init` now records the project (name, absolute path, and creation timestamp) in a global registry, `projects.json`, stored under the existing global Squad home (`resolveGlobalSquadPath()`). A new `squad projects` command reads that registry and prints every Squad project on the machine, newest first.
+
+This closes a small but common gap: after working across several repositories, a user had no built-in way to remember where all of their Squad projects live. The feature is purely additive:
+
+- **`squad-sdk`** gains `registerProject()` and `readProjectsRegistry()` (plus the `ProjectRegistryEntry` type). The registry write is idempotent on the project path (re-running `squad init` updates the entry in place, never duplicating) and fail-safe (a registry error never blocks init).
+- **`squad-cli`** calls `registerProject()` during repo `squad init` (global `--global` init is intentionally not registered, since it is the personal home, not a project) and adds the `squad projects` reader command.
+
+No existing init output, project `.squad/` state, or other command behavior changes.

--- a/.changeset/squad-add-command.md
+++ b/.changeset/squad-add-command.md
@@ -1,0 +1,7 @@
+---
+"@bradygaster/squad-cli": minor
+---
+
+Add `squad add` to register an existing directory as a Squad project.
+
+`squad add <path>` registers a pre-existing directory in the global project registry so it appears in `squad projects`, `squad list`, and `squad pick`, without re-running `squad init`. The command handles paths containing spaces even when passed without quotes, reconstructing the full path from remaining CLI arguments.

--- a/.changeset/squad-list-alias.md
+++ b/.changeset/squad-list-alias.md
@@ -1,0 +1,7 @@
+---
+"@bradygaster/squad-cli": minor
+---
+
+Add `squad list` as an alias for `squad projects`.
+
+`squad list` is a convenience alias: it accepts the same flags as `squad projects` (including `--open`) and behaves identically. Existing `squad projects` usage is unchanged.

--- a/.changeset/squad-open-command.md
+++ b/.changeset/squad-open-command.md
@@ -4,3 +4,5 @@
 ---
 
 Add `squad open` to launch a registered project in Copilot.
+
+- `squad projects` now accepts `--open [name]` (alias `-o`) to launch a project from the list, delegating to `squad open`. Listing remains the default behavior.

--- a/.changeset/squad-open-command.md
+++ b/.changeset/squad-open-command.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": minor
+"@bradygaster/squad-sdk": minor
+---
+
+Add `squad open` to launch a registered project in Copilot.

--- a/.changeset/squad-pick-command.md
+++ b/.changeset/squad-pick-command.md
@@ -1,0 +1,7 @@
+---
+"@bradygaster/squad-cli": minor
+---
+
+Add `squad pick` as an interactive project picker.
+
+`squad pick` presents a numbered menu of all registered Squad projects, prompts the user to choose one, then opens it in Copilot. It is equivalent to running `squad open` after manually locating a project name in `squad projects`.

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -179,6 +179,7 @@ async function main(): Promise<void> {
     console.log(`             Alias: list`);
     console.log(`  ${BOLD}open [name]${RESET} Open a registered project in Copilot`);
     console.log(`  ${BOLD}pick${RESET}       Show an interactive picker and open the chosen project`);
+    console.log(`  ${BOLD}add [path]${RESET}  Register an existing directory as a Squad project`);
     console.log(`  ${BOLD}roles${RESET}      List built-in Squad roles`);
     console.log(`             Usage: roles [--category <name>] [--search <query>]`);
     console.log(`  ${BOLD}cost${RESET}       Report token usage from orchestration logs`);
@@ -898,6 +899,12 @@ async function main(): Promise<void> {
   if (cmd === 'pick') {
     const { runPick } = await import('./cli/commands/pick.js');
     await runPick(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'add') {
+    const { runAdd } = await import('./cli/commands/add.js');
+    await runAdd(args.slice(1));
     return;
   }
 

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -175,6 +175,7 @@ async function main(): Promise<void> {
     console.log(`             Flags: --push, --pull, --remote <name>, --quiet`);
     console.log(`             No-op for local/worktree backends. Invoked by git hooks.`);
     console.log(`  ${BOLD}status${RESET}     Show which squad is active and why`);
+    console.log(`  ${BOLD}projects${RESET}   List all Squad projects on this machine`);
     console.log(`  ${BOLD}roles${RESET}      List built-in Squad roles`);
     console.log(`             Usage: roles [--category <name>] [--search <query>]`);
     console.log(`  ${BOLD}cost${RESET}       Report token usage from orchestration logs`);
@@ -876,6 +877,12 @@ async function main(): Promise<void> {
     console.log(`  ${DIM}Global squad:      ${globalExists ? globalSquadDir : 'not initialized'}${RESET}`);
     console.log();
 
+    return;
+  }
+
+  if (cmd === 'projects') {
+    const { runProjects } = await import('./cli/commands/projects.js');
+    await runProjects(args.slice(1));
     return;
   }
 

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -177,6 +177,7 @@ async function main(): Promise<void> {
     console.log(`  ${BOLD}status${RESET}     Show which squad is active and why`);
     console.log(`  ${BOLD}projects${RESET}   List all Squad projects on this machine`);
     console.log(`  ${BOLD}open [name]${RESET} Open a registered project in Copilot`);
+    console.log(`  ${BOLD}pick${RESET}       Show an interactive picker and open the chosen project`);
     console.log(`  ${BOLD}roles${RESET}      List built-in Squad roles`);
     console.log(`             Usage: roles [--category <name>] [--search <query>]`);
     console.log(`  ${BOLD}cost${RESET}       Report token usage from orchestration logs`);
@@ -890,6 +891,12 @@ async function main(): Promise<void> {
   if (cmd === 'open') {
     const { runOpen } = await import('./cli/commands/open.js');
     await runOpen(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'pick') {
+    const { runPick } = await import('./cli/commands/pick.js');
+    await runPick(args.slice(1));
     return;
   }
 

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -176,6 +176,7 @@ async function main(): Promise<void> {
     console.log(`             No-op for local/worktree backends. Invoked by git hooks.`);
     console.log(`  ${BOLD}status${RESET}     Show which squad is active and why`);
     console.log(`  ${BOLD}projects${RESET}   List all Squad projects on this machine`);
+    console.log(`             Alias: list`);
     console.log(`  ${BOLD}open [name]${RESET} Open a registered project in Copilot`);
     console.log(`  ${BOLD}pick${RESET}       Show an interactive picker and open the chosen project`);
     console.log(`  ${BOLD}roles${RESET}      List built-in Squad roles`);
@@ -882,7 +883,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (cmd === 'projects') {
+  if (cmd === 'projects' || cmd === 'list') {
     const { runProjects } = await import('./cli/commands/projects.js');
     await runProjects(args.slice(1));
     return;

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -176,6 +176,7 @@ async function main(): Promise<void> {
     console.log(`             No-op for local/worktree backends. Invoked by git hooks.`);
     console.log(`  ${BOLD}status${RESET}     Show which squad is active and why`);
     console.log(`  ${BOLD}projects${RESET}   List all Squad projects on this machine`);
+    console.log(`  ${BOLD}open [name]${RESET} Open a registered project in Copilot`);
     console.log(`  ${BOLD}roles${RESET}      List built-in Squad roles`);
     console.log(`             Usage: roles [--category <name>] [--search <query>]`);
     console.log(`  ${BOLD}cost${RESET}       Report token usage from orchestration logs`);
@@ -883,6 +884,12 @@ async function main(): Promise<void> {
   if (cmd === 'projects') {
     const { runProjects } = await import('./cli/commands/projects.js');
     await runProjects(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'open') {
+    const { runOpen } = await import('./cli/commands/open.js');
+    await runOpen(args.slice(1));
     return;
   }
 

--- a/packages/squad-cli/src/cli/commands/add.ts
+++ b/packages/squad-cli/src/cli/commands/add.ts
@@ -28,7 +28,7 @@ export async function runAdd(args: string[]): Promise<void> {
     remaining = args.filter((_, i) => i !== nameIdx && i !== nameIdx + 1);
   }
 
-  const rawPath = remaining[0] ?? '.';
+  const rawPath = remaining.length > 0 ? remaining.join(' ') : '.';
   const absPath = path.resolve(rawPath);
 
   // Validate the path exists and is a directory.
@@ -37,6 +37,9 @@ export async function runAdd(args: string[]): Promise<void> {
     stat = fs.statSync(absPath);
   } catch {
     console.log(`Path does not exist: ${absPath}`);
+    if (remaining.length > 1) {
+      console.log(`If the path contains spaces, wrap it in quotes: squad add "<path>"`);
+    }
     return;
   }
 

--- a/packages/squad-cli/src/cli/commands/add.ts
+++ b/packages/squad-cli/src/cli/commands/add.ts
@@ -1,0 +1,61 @@
+/**
+ * `squad add` command.
+ *
+ * Registers an existing directory into the global projects registry so it
+ * appears in `squad projects`/`squad list` and can be opened with
+ * `squad open`/`squad pick`. Unlike `squad init`, this command does NOT
+ * scaffold a `.squad/` directory; it only records the project path. Use
+ * `squad init` when you want to initialize Squad in a new project.
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import { readProjectsRegistry, registerProject } from '@bradygaster/squad-sdk';
+
+const CASE_INSENSITIVE = process.platform === 'win32' || process.platform === 'darwin';
+
+function samePath(a: string, b: string): boolean {
+  return CASE_INSENSITIVE ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
+export async function runAdd(args: string[]): Promise<void> {
+  // Parse --name <value>
+  const nameIdx = args.indexOf('--name');
+  let name: string | undefined;
+  let remaining = args;
+  if (nameIdx !== -1) {
+    name = args[nameIdx + 1];
+    remaining = args.filter((_, i) => i !== nameIdx && i !== nameIdx + 1);
+  }
+
+  const rawPath = remaining[0] ?? '.';
+  const absPath = path.resolve(rawPath);
+
+  // Validate the path exists and is a directory.
+  let stat: fs.Stats | undefined;
+  try {
+    stat = fs.statSync(absPath);
+  } catch {
+    console.log(`Path does not exist: ${absPath}`);
+    return;
+  }
+
+  if (!stat.isDirectory()) {
+    console.log(`Not a directory: ${absPath}`);
+    return;
+  }
+
+  const displayName = name ?? path.basename(absPath);
+
+  // Detect whether already registered (case-insensitive on win32/darwin).
+  const entries = readProjectsRegistry();
+  const alreadyRegistered = entries.some(e => samePath(path.resolve(e.path), absPath));
+
+  registerProject(displayName, absPath);
+
+  if (alreadyRegistered) {
+    console.log(`Updated "${displayName}" in your Squad projects (${absPath}).`);
+  } else {
+    console.log(`Added "${displayName}" to your Squad projects (${absPath}).`);
+  }
+}

--- a/packages/squad-cli/src/cli/commands/open.ts
+++ b/packages/squad-cli/src/cli/commands/open.ts
@@ -1,0 +1,160 @@
+/**
+ * `squad open` command.
+ *
+ * Opens a registered Squad project in Copilot. Accepts an optional project
+ * name or query; when omitted and stdout is a TTY, presents an interactive
+ * numbered picker. Pass `--print-path` (or `-p`) to print the resolved path
+ * and return without launching Copilot (useful for shell integrations such as
+ * `cd (squad open foo --print-path)`).
+ */
+
+import fs from 'node:fs';
+import { spawn } from 'node:child_process';
+import readline from 'node:readline';
+import { readProjectsRegistry, resolveProject } from '@bradygaster/squad-sdk';
+import type { ProjectRegistryEntry } from '@bradygaster/squad-sdk';
+
+function relativeAge(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const days = Math.floor((Date.now() - then) / 86_400_000);
+  if (days <= 0) return 'today';
+  if (days === 1) return '1 day ago';
+  if (days < 30) return `${days} days ago`;
+  const months = Math.floor(days / 30);
+  if (months === 1) return '1 month ago';
+  return `${months} months ago`;
+}
+
+function sortedNewestFirst(entries: ProjectRegistryEntry[]): ProjectRegistryEntry[] {
+  return [...entries].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+}
+
+async function pickInteractive(sorted: ProjectRegistryEntry[]): Promise<ProjectRegistryEntry | null> {
+  const nameWidth = Math.max(...sorted.map(e => e.name.length), 4);
+  const pathWidth = Math.max(...sorted.map(e => e.path.length), 4);
+
+  console.log();
+  console.log(`Squad projects on this machine (${sorted.length}):`);
+  console.log();
+  console.log(`  ${'#'.padEnd(3)}${'NAME'.padEnd(nameWidth)}  ${'PATH'.padEnd(pathWidth)}  CREATED`);
+  sorted.forEach((e, i) => {
+    console.log(
+      `  ${String(i + 1).padEnd(3)}${e.name.padEnd(nameWidth)}  ${e.path.padEnd(pathWidth)}  ${relativeAge(e.created_at)}`,
+    );
+  });
+  console.log();
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>(resolve => {
+    rl.question(`Select a project (1-${sorted.length}), or blank to cancel: `, resolve);
+  });
+  rl.close();
+
+  const trimmed = answer.trim();
+  if (!trimmed) return null;
+
+  const index = parseInt(trimmed, 10);
+  if (Number.isNaN(index) || index < 1 || index > sorted.length) return null;
+  return sorted[index - 1] ?? null;
+}
+
+async function launchCopilot(entry: ProjectRegistryEntry): Promise<void> {
+  console.log(`Opening ${entry.name} in Copilot (${entry.path})...`);
+
+  await new Promise<void>((resolve, reject) => {
+    const child =
+      process.platform === 'win32'
+        ? spawn('copilot', [], { cwd: entry.path, stdio: 'inherit', shell: true })
+        : spawn('copilot', [], { cwd: entry.path, stdio: 'inherit' });
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ENOENT') {
+        console.log(
+          `Could not launch \`copilot\`. Open it manually in: ${entry.path}`,
+        );
+        resolve();
+      } else {
+        reject(err);
+      }
+    });
+
+    child.on('close', () => resolve());
+  });
+}
+
+export async function runOpen(args: string[]): Promise<void> {
+  const printPath = args.includes('--print-path') || args.includes('-p');
+  const query = args
+    .filter(a => a !== '--print-path' && a !== '-p')
+    .join(' ')
+    .trim();
+
+  const entries = readProjectsRegistry();
+  if (entries.length === 0) {
+    console.log('No Squad projects registered yet.');
+    console.log('Run `squad init` in a project to add it to the list.');
+    return;
+  }
+
+  let entry: ProjectRegistryEntry;
+
+  if (query) {
+    const result = resolveProject(query);
+    if ('notFound' in result) {
+      console.log(`No project matching "${query}".`);
+      console.log('Run `squad projects` to see the list.');
+      return;
+    }
+    if ('ambiguous' in result) {
+      console.log(`Multiple projects match "${query}":`);
+      for (const candidate of result.ambiguous) {
+        console.log(`  ${candidate.name}`);
+      }
+      console.log('Be more specific.');
+      return;
+    }
+    entry = result.match;
+  } else {
+    const isTTY = process.stdout.isTTY === true;
+    if (!isTTY) {
+      const sorted = sortedNewestFirst(entries);
+      const nameWidth = Math.max(...sorted.map(e => e.name.length), 4);
+      const pathWidth = Math.max(...sorted.map(e => e.path.length), 4);
+      console.log();
+      console.log(`Squad projects on this machine (${sorted.length}):`);
+      console.log();
+      console.log(`  ${'NAME'.padEnd(nameWidth)}  ${'PATH'.padEnd(pathWidth)}  CREATED`);
+      for (const e of sorted) {
+        console.log(
+          `  ${e.name.padEnd(nameWidth)}  ${e.path.padEnd(pathWidth)}  ${relativeAge(e.created_at)}`,
+        );
+      }
+      console.log();
+      console.log('Pass a project name: squad open <name>');
+      return;
+    }
+
+    const sorted = sortedNewestFirst(entries);
+    const picked = await pickInteractive(sorted);
+    if (!picked) {
+      console.log('Cancelled.');
+      return;
+    }
+    entry = picked;
+  }
+
+  if (!fs.existsSync(entry.path)) {
+    console.log(`Project path no longer exists: ${entry.path}`);
+    return;
+  }
+
+  if (printPath) {
+    console.log(entry.path);
+    return;
+  }
+
+  await launchCopilot(entry);
+}

--- a/packages/squad-cli/src/cli/commands/pick.ts
+++ b/packages/squad-cli/src/cli/commands/pick.ts
@@ -1,0 +1,23 @@
+/**
+ * `squad pick` command.
+ *
+ * Shows an interactive numbered picker of registered Squad projects and opens
+ * the chosen one in Copilot. Accepts flags forwarded to `squad open`
+ * (currently `--print-path` / `-p`); any positional arguments are stripped so
+ * the picker is always entered interactively.
+ *
+ * This command completes the projects/pick/open trio:
+ *   squad projects   -- read-only list
+ *   squad pick       -- always-interactive opener  (this file)
+ *   squad open       -- direct-by-name or interactive opener
+ *
+ * Implementation: delegates entirely to `runOpen` with positional args removed.
+ * All picker rendering, TTY detection, empty-registry messaging, path printing,
+ * and Copilot launch logic live in open.ts and are reused without duplication.
+ */
+
+import { runOpen } from './open.js';
+
+export async function runPick(args: string[]): Promise<void> {
+  return runOpen(args.filter(a => a.startsWith('-')));
+}

--- a/packages/squad-cli/src/cli/commands/projects.ts
+++ b/packages/squad-cli/src/cli/commands/projects.ts
@@ -4,9 +4,15 @@
  * Lists every Squad project registered on this machine (populated by
  * `squad init`), newest first. Read-only: it only reports what the registry
  * already contains.
+ *
+ * Pass `--open [name]` (alias `-o`) to open a project in Copilot instead of
+ * listing. Delegates fully to `squad open`, so the interactive picker, name
+ * resolver, `--print-path` flag, and missing-path guard all work exactly as
+ * they do on that command.
  */
 
 import { readProjectsRegistry } from '@bradygaster/squad-sdk';
+import { runOpen } from './open.js';
 
 function relativeAge(iso: string): string {
   const then = new Date(iso).getTime();
@@ -20,7 +26,12 @@ function relativeAge(iso: string): string {
   return `${months} months ago`;
 }
 
-export async function runProjects(_args: string[]): Promise<void> {
+export async function runProjects(args: string[]): Promise<void> {
+  if (args.includes('--open') || args.includes('-o')) {
+    const rest = args.filter(a => a !== '--open' && a !== '-o');
+    return runOpen(rest);
+  }
+
   const entries = readProjectsRegistry();
 
   if (entries.length === 0) {

--- a/packages/squad-cli/src/cli/commands/projects.ts
+++ b/packages/squad-cli/src/cli/commands/projects.ts
@@ -1,0 +1,49 @@
+/**
+ * `squad projects` command.
+ *
+ * Lists every Squad project registered on this machine (populated by
+ * `squad init`), newest first. Read-only: it only reports what the registry
+ * already contains.
+ */
+
+import { readProjectsRegistry } from '@bradygaster/squad-sdk';
+
+function relativeAge(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const days = Math.floor((Date.now() - then) / 86_400_000);
+  if (days <= 0) return 'today';
+  if (days === 1) return '1 day ago';
+  if (days < 30) return `${days} days ago`;
+  const months = Math.floor(days / 30);
+  if (months === 1) return '1 month ago';
+  return `${months} months ago`;
+}
+
+export async function runProjects(_args: string[]): Promise<void> {
+  const entries = readProjectsRegistry();
+
+  if (entries.length === 0) {
+    console.log('No Squad projects registered yet.');
+    console.log('Run `squad init` in a project to add it to the list.');
+    return;
+  }
+
+  const sorted = [...entries].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+
+  const nameWidth = Math.max(...sorted.map(e => e.name.length), 4);
+  const pathWidth = Math.max(...sorted.map(e => e.path.length), 4);
+
+  console.log();
+  console.log(`Squad projects on this machine (${sorted.length}):`);
+  console.log();
+  console.log(`  ${'NAME'.padEnd(nameWidth)}  ${'PATH'.padEnd(pathWidth)}  CREATED`);
+  for (const e of sorted) {
+    console.log(
+      `  ${e.name.padEnd(nameWidth)}  ${e.path.padEnd(pathWidth)}  ${relativeAge(e.created_at)}`,
+    );
+  }
+  console.log();
+}

--- a/packages/squad-cli/src/cli/core/command-help.ts
+++ b/packages/squad-cli/src/cli/core/command-help.ts
@@ -86,6 +86,7 @@ const COMMAND_HELP: Record<string, HelpPrinter> = {
     console.log(`                      and a TTY, shows a numbered picker; with a name, opens`);
     console.log(`                      the matching project directly.`);
     console.log(`  ${BOLD}--print-path${RESET}        With --open, print the resolved path instead of launching.\n`);
+    console.log(`Aliases: ${BOLD}list${RESET}\n`);
   },
 
   open: (version) => {
@@ -440,6 +441,7 @@ function printRcHelp(name: 'rc' | 'remote-control', version: string): void {
  * have explicit help blocks) do NOT need an entry here.
  */
 const COMMAND_ALIASES: Readonly<Record<string, string>> = {
+  list: 'projects',
   streams: 'subsquads',
   workstreams: 'subsquads',
 };

--- a/packages/squad-cli/src/cli/core/command-help.ts
+++ b/packages/squad-cli/src/cli/core/command-help.ts
@@ -76,6 +76,13 @@ const COMMAND_HELP: Record<string, HelpPrinter> = {
     console.log(`global), and the state of the personal squad path.\n`);
   },
 
+  projects: (version) => {
+    header('projects', version, 'List all Squad projects on this machine');
+    console.log(`Usage: squad projects\n`);
+    console.log(`Lists every project where 'squad init' has run, newest first,`);
+    console.log(`showing its name, path, and when it was first registered.\n`);
+  },
+
   roles: (version) => {
     header('roles', version, 'List built-in Squad roles');
     console.log(`Usage: squad roles [--category <name>] [--search <query>]\n`);

--- a/packages/squad-cli/src/cli/core/command-help.ts
+++ b/packages/squad-cli/src/cli/core/command-help.ts
@@ -78,9 +78,14 @@ const COMMAND_HELP: Record<string, HelpPrinter> = {
 
   projects: (version) => {
     header('projects', version, 'List all Squad projects on this machine');
-    console.log(`Usage: squad projects\n`);
+    console.log(`Usage: squad projects [--open [name]] [--print-path]\n`);
     console.log(`Lists every project where 'squad init' has run, newest first,`);
     console.log(`showing its name, path, and when it was first registered.\n`);
+    console.log(`Options:`);
+    console.log(`  ${BOLD}--open${RESET}, ${BOLD}-o${RESET} [name]   Open a project from the list in Copilot. With no name`);
+    console.log(`                      and a TTY, shows a numbered picker; with a name, opens`);
+    console.log(`                      the matching project directly.`);
+    console.log(`  ${BOLD}--print-path${RESET}        With --open, print the resolved path instead of launching.\n`);
   },
 
   open: (version) => {

--- a/packages/squad-cli/src/cli/core/command-help.ts
+++ b/packages/squad-cli/src/cli/core/command-help.ts
@@ -83,6 +83,21 @@ const COMMAND_HELP: Record<string, HelpPrinter> = {
     console.log(`showing its name, path, and when it was first registered.\n`);
   },
 
+  open: (version) => {
+    header('open', version, 'Open a registered project in Copilot');
+    console.log(`Usage: squad open [name] [--print-path]\n`);
+    console.log(`Looks up a registered project by name (or partial name) and launches`);
+    console.log(`Copilot in that directory. When no name is given and stdout is a TTY,`);
+    console.log(`a numbered picker is shown. Pass --print-path to print the resolved`);
+    console.log(`path instead of launching Copilot (useful for shell cd integrations).\n`);
+    console.log(`Options:`);
+    console.log(`  ${BOLD}--print-path${RESET}, ${BOLD}-p${RESET}            Print the project path and exit`);
+    console.log(`\nExamples:`);
+    console.log(`  squad open my-repo`);
+    console.log(`  squad open my-repo --print-path`);
+    console.log(`  squad open\n`);
+  },
+
   roles: (version) => {
     header('roles', version, 'List built-in Squad roles');
     console.log(`Usage: squad roles [--category <name>] [--search <query>]\n`);

--- a/packages/squad-cli/src/cli/core/command-help.ts
+++ b/packages/squad-cli/src/cli/core/command-help.ts
@@ -30,6 +30,20 @@ function header(cmd: string, version: string, tagline: string): void {
  * one place that needs updating when a new subcommand is added to the CLI.
  */
 const COMMAND_HELP: Record<string, HelpPrinter> = {
+  add: (version) => {
+    header('add', version, 'Register an existing directory as a Squad project');
+    console.log(`Usage: squad add [path] [--name <name>]\n`);
+    console.log(`Registers an existing directory into the projects registry so it appears in`);
+    console.log(`\`squad projects\`/\`squad list\` and can be opened with \`squad open\`/\`squad pick\`.`);
+    console.log(`Does not scaffold .squad/ (use \`squad init\` for that).\n`);
+    console.log(`Options:`);
+    console.log(`  ${BOLD}--name <name>${RESET}               Display name (defaults to the folder name).\n`);
+    console.log(`Examples:`);
+    console.log(`  squad add`);
+    console.log(`  squad add /path/to/my-project`);
+    console.log(`  squad add /path/to/my-project --name my-project\n`);
+  },
+
   init: (version) => {
     header('init', version, 'Initialize Squad in the current project');
     console.log(`Usage: squad init [options]`);

--- a/packages/squad-cli/src/cli/core/command-help.ts
+++ b/packages/squad-cli/src/cli/core/command-help.ts
@@ -303,6 +303,20 @@ const COMMAND_HELP: Record<string, HelpPrinter> = {
     console.log(`  ${BOLD}--role <role>${RESET}               Built-in role to attach (see 'squad roles')\n`);
   },
 
+  pick: (version) => {
+    header('pick', version, 'Show an interactive picker and open the chosen project');
+    console.log(`Usage: squad pick [--print-path]\n`);
+    console.log(`Shows a numbered list of registered projects and prompts for a selection,`);
+    console.log(`then opens the chosen project in Copilot. Unlike 'squad open', which accepts`);
+    console.log(`an optional name argument, 'squad pick' always enters the interactive picker`);
+    console.log(`(completing the projects/pick/open trio).\n`);
+    console.log(`Options:`);
+    console.log(`  ${BOLD}--print-path${RESET}, ${BOLD}-p${RESET}            Print the project path instead of launching Copilot.\n`);
+    console.log(`Examples:`);
+    console.log(`  squad pick`);
+    console.log(`  squad pick --print-path\n`);
+  },
+
   preset: (version) => {
     header('preset', version, 'Manage squad presets (curated agent collections)');
     console.log(`Usage: squad preset <list|show <name>|apply <name>|save <name>|init> [options]\n`);

--- a/packages/squad-cli/src/cli/core/init.ts
+++ b/packages/squad-cli/src/cli/core/init.ts
@@ -11,7 +11,7 @@ import { success, BOLD, RESET, YELLOW, GREEN, DIM } from './output.js';
 import { fatal } from './errors.js';
 import { detectProjectType } from './project-type.js';
 import { getPackageVersion, stampVersion } from './version.js';
-import { initSquad as sdkInitSquad, cleanupOrphanInitPrompt, ensurePersonalSquadDir, resolvePersonalSquadDir, clearResolveSquadCache, type InitOptions } from '@bradygaster/squad-sdk';
+import { initSquad as sdkInitSquad, cleanupOrphanInitPrompt, ensurePersonalSquadDir, resolvePersonalSquadDir, clearResolveSquadCache, registerProject, type InitOptions } from '@bradygaster/squad-sdk';
 import { installGitHooks } from '../commands/install-hooks.js';
 import { liftInitMutableStateOntoOrphan } from '../commands/migrate-backend.js';
 import { resolveSquadStateMcpSpec } from './mcp-spec.js';
@@ -445,6 +445,15 @@ export async function runInit(dest: string, options: RunInitOptions = {}): Promi
     console.log(`${DIM}  Add agents with: squad personal add <name> --role <role>${RESET}`);
     console.log();
   } else {
+    // Log this project in the global registry so `squad projects` can list
+    // every Squad project on this machine. Best-effort: a failure here must
+    // never block init.
+    try {
+      registerProject(path.basename(path.resolve(dest)), dest);
+    } catch {
+      // Registry write failed; ignore so init still succeeds.
+    }
+
     // Repo init: inform user if personal squad is available
     const personalDir = resolvePersonalSquadDir();
     if (personalDir) {

--- a/packages/squad-sdk/src/index.ts
+++ b/packages/squad-sdk/src/index.ts
@@ -12,6 +12,8 @@ export const VERSION: string = pkg.version;
 // Export public API
 export { resolveSquad, resolveGlobalSquadPath, resolvePersonalSquadDir, ensurePersonalSquadDir, ensureSquadPath, ensureSquadPathTriple, loadDirConfig, isConsultMode, scratchDir, scratchFile, deriveProjectKey, resolveExternalStateDir, resolveSquadHome, ensureSquadHome, resolvePresetsDir, resolveSquadState, clearResolveSquadCache } from './resolution.js';
 export type { ResolvedSquadPaths, SquadDirConfig, SquadStateContext } from './resolution.js';
+export { registerProject, readProjectsRegistry } from './projects-registry.js';
+export type { ProjectRegistryEntry } from './projects-registry.js';
 export * from './config/index.js';
 export * from './agents/onboarding.js';
 export { resolvePersonalAgents, mergeSessionCast } from './agents/personal.js';

--- a/packages/squad-sdk/src/index.ts
+++ b/packages/squad-sdk/src/index.ts
@@ -12,7 +12,7 @@ export const VERSION: string = pkg.version;
 // Export public API
 export { resolveSquad, resolveGlobalSquadPath, resolvePersonalSquadDir, ensurePersonalSquadDir, ensureSquadPath, ensureSquadPathTriple, loadDirConfig, isConsultMode, scratchDir, scratchFile, deriveProjectKey, resolveExternalStateDir, resolveSquadHome, ensureSquadHome, resolvePresetsDir, resolveSquadState, clearResolveSquadCache } from './resolution.js';
 export type { ResolvedSquadPaths, SquadDirConfig, SquadStateContext } from './resolution.js';
-export { registerProject, readProjectsRegistry } from './projects-registry.js';
+export { registerProject, readProjectsRegistry, resolveProject } from './projects-registry.js';
 export type { ProjectRegistryEntry } from './projects-registry.js';
 export * from './config/index.js';
 export * from './agents/onboarding.js';

--- a/packages/squad-sdk/src/projects-registry.ts
+++ b/packages/squad-sdk/src/projects-registry.ts
@@ -1,0 +1,95 @@
+/**
+ * Global project registry.
+ *
+ * Records every repository where `squad init` runs so a user can later list all
+ * of their Squad projects and where each one lives on disk. This is purely
+ * additive metadata: it never changes how a project is initialized or how its
+ * own `.squad/` state behaves.
+ *
+ * The registry is a single JSON file, `projects.json`, stored under
+ * {@link resolveGlobalSquadPath} (a sibling of the existing personal-squad and
+ * externalized-state directories).
+ *
+ * @module projects-registry
+ */
+
+import path from 'node:path';
+import fs from 'node:fs';
+import { resolveGlobalSquadPath } from './resolution.js';
+
+/** A single entry in the global project registry. */
+export interface ProjectRegistryEntry {
+  /** Display name of the project (directory basename at init time). */
+  name: string;
+  /** Absolute path to the project root. */
+  path: string;
+  /** ISO 8601 timestamp of when the project was first registered. */
+  created_at: string;
+}
+
+function registryFilePath(): string {
+  return path.join(resolveGlobalSquadPath(), 'projects.json');
+}
+
+/**
+ * Windows and macOS use case-insensitive filesystems, so the same project can
+ * be reached via paths that differ only in case (e.g. a lowercased drive
+ * letter). Compare paths accordingly so re-registering never duplicates an
+ * entry. Mirrors the convention used by FSStorageProvider.
+ */
+const CASE_INSENSITIVE = process.platform === 'win32' || process.platform === 'darwin';
+
+function samePath(a: string, b: string): boolean {
+  return CASE_INSENSITIVE ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
+/**
+ * Reads the global project registry.
+ *
+ * Returns an empty array if the registry does not exist yet or cannot be
+ * parsed, so callers never have to guard against a missing or corrupt file.
+ */
+export function readProjectsRegistry(): ProjectRegistryEntry[] {
+  const file = registryFilePath();
+  try {
+    if (!fs.existsSync(file)) return [];
+    const parsed: unknown = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is ProjectRegistryEntry =>
+        !!e &&
+        typeof (e as ProjectRegistryEntry).name === 'string' &&
+        typeof (e as ProjectRegistryEntry).path === 'string' &&
+        typeof (e as ProjectRegistryEntry).created_at === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Registers a project in the global registry.
+ *
+ * Idempotent: re-running for an already-registered path updates that entry in
+ * place (refreshing the name) rather than adding a duplicate. The original
+ * `created_at` is preserved. This is a best-effort write; callers that run it
+ * during initialization should wrap it so a failure here cannot block init.
+ *
+ * @param name - Display name for the project.
+ * @param projectPath - Path to the project root (resolved to absolute).
+ */
+export function registerProject(name: string, projectPath: string): void {
+  const file = registryFilePath();
+  const absPath = path.resolve(projectPath);
+  const entries = readProjectsRegistry();
+
+  const existing = entries.find(e => samePath(path.resolve(e.path), absPath));
+  if (existing) {
+    existing.name = name;
+    existing.path = absPath;
+  } else {
+    entries.push({ name, path: absPath, created_at: new Date().toISOString() });
+  }
+
+  fs.writeFileSync(file, `${JSON.stringify(entries, null, 2)}\n`, 'utf8');
+}

--- a/packages/squad-sdk/src/projects-registry.ts
+++ b/packages/squad-sdk/src/projects-registry.ts
@@ -93,3 +93,51 @@ export function registerProject(name: string, projectPath: string): void {
 
   fs.writeFileSync(file, `${JSON.stringify(entries, null, 2)}\n`, 'utf8');
 }
+
+/**
+ * Resolves a user-supplied query to a registry entry.
+ *
+ * Resolution order (all comparisons are case-insensitive on platforms where
+ * CASE_INSENSITIVE is true):
+ *
+ *   a. Exact name match. Returns { match } for a unique hit; { ambiguous }
+ *      when multiple entries share the same name.
+ *   b. Exact path match via samePath on the resolved absolute paths.
+ *      Returns { match } when exactly one entry matches.
+ *   c. Unique case-insensitive substring match on name. Returns { match }
+ *      for one hit, { ambiguous } for several.
+ *   d. Falls back to { notFound: true }.
+ *
+ * An empty query (after trimming) always returns { notFound: true }.
+ *
+ * @param query - A project name, partial name, or path to search for.
+ */
+export function resolveProject(
+  query: string,
+): { match: ProjectRegistryEntry } | { ambiguous: ProjectRegistryEntry[] } | { notFound: true } {
+  const trimmed = query.trim();
+  if (!trimmed) return { notFound: true };
+
+  const entries = readProjectsRegistry();
+
+  const nameEq = (a: string, b: string): boolean =>
+    CASE_INSENSITIVE ? a.toLowerCase() === b.toLowerCase() : a === b;
+
+  // a. Exact name match
+  const exactName = entries.filter(e => nameEq(e.name, trimmed));
+  if (exactName.length === 1) return { match: exactName[0]! };
+  if (exactName.length > 1) return { ambiguous: exactName };
+
+  // b. Exact path match
+  const resolvedQuery = path.resolve(trimmed);
+  const exactPath = entries.filter(e => samePath(path.resolve(e.path), resolvedQuery));
+  if (exactPath.length === 1) return { match: exactPath[0]! };
+
+  // c. Substring match on name
+  const lowerQuery = trimmed.toLowerCase();
+  const substringMatches = entries.filter(e => e.name.toLowerCase().includes(lowerQuery));
+  if (substringMatches.length === 1) return { match: substringMatches[0]! };
+  if (substringMatches.length > 1) return { ambiguous: substringMatches };
+
+  return { notFound: true };
+}

--- a/test/cli/add.test.ts
+++ b/test/cli/add.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 const execFileAsync = promisify(execFile);
 
@@ -47,6 +48,39 @@ describe.skipIf(!cliBuilt)('squad add end-to-end', () => {
     const out = stdout + stderr;
 
     expect(out).toContain(`Path does not exist: ${missingPath}`);
+    expect(out).not.toMatch(/Error:|runAdd \(/);
+  });
+
+  it('reconstructs a spaced path from split argv tokens and registers the full path', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'squad-add-spaced-'));
+    const spacedDir = join(tempRoot, 'my project dir');
+    mkdirSync(spacedDir, { recursive: true });
+
+    const splitPathTokens = spacedDir.split(' ');
+    const { stdout: addStdout, stderr: addStderr } = await runSquad(
+      ['add', ...splitPathTokens],
+      process.cwd(),
+    );
+    const addOut = addStdout + addStderr;
+    expect(addOut).toMatch(/(Added|Updated) "/);
+    expect(addOut).toContain(spacedDir);
+
+    const { stdout: listStdout, stderr: listStderr } = await runSquad(['list'], process.cwd());
+    const listOut = listStdout + listStderr;
+    expect(listOut).toContain(spacedDir);
+    expect(listOut).toContain('my project dir');
+  });
+
+  it('prints quoting hint for nonexistent multi-token path without crashing', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'squad-add-missing-'));
+    const firstToken = join(tempRoot, 'nope');
+    const expectedMissingPath = resolve(`${firstToken} x y`);
+
+    const { stdout, stderr } = await runSquad(['add', firstToken, 'x', 'y'], process.cwd());
+    const out = stdout + stderr;
+
+    expect(out).toContain(`Path does not exist: ${expectedMissingPath}`);
+    expect(out).toContain('If the path contains spaces, wrap it in quotes: squad add "<path>"');
     expect(out).not.toMatch(/Error:|runAdd \(/);
   });
 });

--- a/test/cli/add.test.ts
+++ b/test/cli/add.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+const cliEntry = resolve(
+  process.cwd(),
+  'packages/squad-cli/dist/cli-entry.js',
+);
+
+const cliBuilt = existsSync(cliEntry);
+
+const runSquad = async (args: string[], cwd: string) => {
+  return execFileAsync('node', [cliEntry, ...args], {
+    cwd,
+    env: { ...process.env, NODE_NO_WARNINGS: '1' },
+    timeout: 20_000,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+};
+
+describe.skipIf(!cliBuilt)('squad add end-to-end', () => {
+  it('registers an existing directory and makes it visible in squad list', async () => {
+    const existingDir = resolve(process.cwd());
+    const name = `add-e2e-${Date.now()}`;
+
+    const { stdout: addStdout, stderr: addStderr } = await runSquad(
+      ['add', existingDir, '--name', name],
+      process.cwd(),
+    );
+    const addOut = addStdout + addStderr;
+    expect(addOut).toMatch(new RegExp(`(Added|Updated) "${name}"`));
+    expect(addOut).toContain(existingDir);
+
+    const { stdout: listStdout, stderr: listStderr } = await runSquad(['list'], process.cwd());
+    const listOut = listStdout + listStderr;
+    expect(listOut).toContain(name);
+    expect(listOut).toContain(existingDir);
+  });
+
+  it('prints a clear error for a nonexistent path and exits cleanly', async () => {
+    const missingPath = resolve(process.cwd(), `missing-add-path-${Date.now()}`);
+    const { stdout, stderr } = await runSquad(['add', missingPath], process.cwd());
+    const out = stdout + stderr;
+
+    expect(out).toContain(`Path does not exist: ${missingPath}`);
+    expect(out).not.toMatch(/Error:|runAdd \(/);
+  });
+});

--- a/test/cli/command-help.test.ts
+++ b/test/cli/command-help.test.ts
@@ -120,6 +120,7 @@ describe('printCommandHelp', () => {
       'memory',
       'migrate',
       'nap',
+      'open',
       'personal',
       'plugin',
       'preset',

--- a/test/cli/command-help.test.ts
+++ b/test/cli/command-help.test.ts
@@ -83,6 +83,7 @@ describe('printCommandHelp', () => {
   });
 
   it('normalizeCommandAlias maps known aliases and leaves others untouched', () => {
+    expect(normalizeCommandAlias('list')).toBe('projects');
     expect(normalizeCommandAlias('streams')).toBe('subsquads');
     expect(normalizeCommandAlias('workstreams')).toBe('subsquads');
     expect(normalizeCommandAlias('subsquads')).toBe('subsquads');

--- a/test/cli/command-help.test.ts
+++ b/test/cli/command-help.test.ts
@@ -123,6 +123,7 @@ describe('printCommandHelp', () => {
       'personal',
       'plugin',
       'preset',
+      'projects',
       'rc',
       'rc-tunnel',
       'remote-control',

--- a/test/cli/command-help.test.ts
+++ b/test/cli/command-help.test.ts
@@ -122,6 +122,7 @@ describe('printCommandHelp', () => {
       'nap',
       'open',
       'personal',
+      'pick',
       'plugin',
       'preset',
       'projects',

--- a/test/cli/command-help.test.ts
+++ b/test/cli/command-help.test.ts
@@ -96,6 +96,7 @@ describe('printCommandHelp', () => {
     // router, this list must grow too — otherwise `<new-cmd> --help` will
     // fall through to the generic fallback instead of helpful text.
     const expected = [
+      'add',
       'aspire',
       'build',
       'cast',

--- a/test/global-squad-isolation.test.ts
+++ b/test/global-squad-isolation.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Assertion proof: global squad path is isolated during tests.
+ *
+ * This test verifies that the setup file (test/setup/isolate-global-squad.ts)
+ * successfully redirects resolveGlobalSquadPath() away from the real user
+ * global registry (%APPDATA%\squad on Windows) to an OS temp directory.
+ *
+ * If this test passes, every other test in the suite runs under the same
+ * setup file and is therefore also isolated from the real global registry.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveGlobalSquadPath } from '@bradygaster/squad-sdk/resolution';
+
+describe('global squad path isolation (setup file proof)', () => {
+  it('resolveGlobalSquadPath() returns a path under the OS temp dir', () => {
+    const globalPath = resolveGlobalSquadPath();
+    const tmp = tmpdir();
+
+    // The isolated dir created by the setup file starts with tmpdir() + sep + 'squad-test-global-'
+    expect(globalPath.startsWith(tmp), `Expected "${globalPath}" to start with tmpdir "${tmp}"`).toBe(true);
+  });
+
+  it('resolveGlobalSquadPath() path contains the isolation marker', () => {
+    const globalPath = resolveGlobalSquadPath();
+    expect(globalPath).toContain('squad-test-global-');
+  });
+
+  it('resolveGlobalSquadPath() is NOT the real %APPDATA%\\squad', () => {
+    const globalPath = resolveGlobalSquadPath();
+
+    if (process.platform === 'win32') {
+      // Before our setup file runs, the real registry is under the original APPDATA.
+      // After it runs, APPDATA is overwritten with the temp dir, so we just confirm
+      // the path contains the isolation marker (already done above) and does NOT
+      // end with a path that looks like a real roaming profile.
+      expect(globalPath).not.toMatch(/AppData[/\\]Roaming[/\\]squad$/i);
+    } else {
+      // On non-Windows, should not be under ~/.config/squad or ~/Library/...
+      const realHome = join(process.env['USERPROFILE'] ?? '/nonexistent', 'Library', 'Application Support', 'squad');
+      expect(globalPath).not.toBe(realHome);
+    }
+  });
+});

--- a/test/setup/isolate-global-squad.ts
+++ b/test/setup/isolate-global-squad.ts
@@ -1,0 +1,42 @@
+/**
+ * Global test setup: redirect the squad global directory to an isolated temp dir.
+ *
+ * Why this is necessary:
+ *   PR1 made `squad init` call registerProject(), which writes to the global
+ *   projects.json at resolveGlobalSquadPath(). On Windows that is
+ *   %APPDATA%\squad\projects.json. Without this redirect, running `npm test`
+ *   (or any vitest run) pollutes the developer's real global registry with
+ *   junk entries for every temp directory created by the test suite.
+ *
+ * How the redirect works:
+ *   resolveGlobalSquadPath() (packages/squad-sdk/src/resolution.ts ~L408) reads
+ *   process.env live on every call -- no import-time cache. Setting the relevant
+ *   env vars here, before any test file loads, causes ALL calls (including those
+ *   inside CLI child processes that inherit process.env) to resolve to our temp
+ *   dir instead of the real user data directory.
+ *
+ * The isolated directory is created once per vitest worker process and is never
+ * cleaned up explicitly -- the OS temp cleaner handles it. Tests that need a
+ * clean global state should use beforeEach/afterEach as normal.
+ */
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const isolated = mkdtempSync(join(tmpdir(), 'squad-test-global-'));
+
+// Windows: resolveGlobalSquadPath reads APPDATA, then LOCALAPPDATA as fallback.
+process.env['APPDATA'] = isolated;
+process.env['LOCALAPPDATA'] = isolated;
+
+// Linux: resolveGlobalSquadPath reads XDG_CONFIG_HOME, then ~/.config as fallback.
+process.env['XDG_CONFIG_HOME'] = isolated;
+
+// macOS: resolveGlobalSquadPath uses os.homedir() + 'Library/Application Support'.
+// On POSIX, Node.js os.homedir() honors the HOME env var, so redirect HOME there.
+// We skip this on Windows because USERPROFILE/HOMEDRIVE govern homedir there, and
+// Windows tests rely on APPDATA (already set above), not homedir.
+if (process.platform !== 'win32') {
+  process.env['HOME'] = isolated;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     dedupe: ['@bradygaster/squad-sdk'],
   },
   test: {
+    setupFiles: ['./test/setup/isolate-global-squad.ts'],
     include: ['test/**/*.test.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
> Depends on #1391. Until that PR merges, this PR's diff also includes its single commit (b186993). Both target `dev`; no retarget needed after PR1 merges.

### What

PR1 added a global registry of every project where `squad init` runs, plus a
read-only `squad projects` list. This PR makes that registry actionable. It adds
four navigation commands so you can jump to, choose, alias-list, and register
your Squad projects without leaving the terminal.

**`squad open [name]`**

Resolves a registered project and launches Copilot in that project's directory.

- `squad open <name>`: looks up the project by name, partial name, or path, then
  starts `copilot` in that directory.
- `squad open` with no name, on a TTY, shows a numbered picker.
- `squad open` with no name, when stdout is not a TTY, prints the project list
  and a hint to pass a name, rather than blocking on a prompt.
- `squad open <name> --print-path` (`-p`) prints the resolved path instead of
  launching, for shell integrations like `cd (squad open foo -p)`.

**`squad pick`**

An always-interactive opener. It presents the numbered picker of all registered
projects, prompts for a choice, then opens the chosen project in Copilot. It is
equivalent to running `squad open` after manually finding a name in the list.
Positional arguments are stripped so it always enters the picker; flags such as
`--print-path` are forwarded.

**`squad list`**

A convenience alias for `squad projects`. It accepts the same flags, including
`--open`, and behaves identically. Existing `squad projects` usage is unchanged.

**`squad add [path]`**

Registers a pre-existing directory in the global registry so it shows up in
`squad projects`, `squad list`, and `squad pick`, without re-running
`squad init` and without scaffolding a `.squad/` directory.

- `squad add <path>`: registers the directory at that path. With no path, it
  registers the current directory.
- `squad add <path> --name <name>`: sets a custom display name. Without it, the
  directory basename is used.
- Paths with spaces are handled even when passed unquoted: the remaining
  argument tokens are rejoined into the full path. If the reconstructed path does
  not exist and there were multiple tokens, it prints a hint to quote the path.

### Why

A list of projects is only useful if you can act on it. These commands close the
loop: from "what have I initialized?" to "take me there," to "let me choose from
a menu," to "remember this directory too." `squad open` is the core verb,
`squad pick` is the discoverable interactive form, `squad list` is muscle-memory
ergonomics, and `squad add` lets you backfill projects that predate the registry
or that you set up by hand.

### How

**SDK resolver: `resolveProject(query)`** in `projects-registry.ts`. Resolution
order, first match wins:

1. Exact name match (case-insensitive on win32 and darwin). One hit returns
   `{ match }`; several with the same name return `{ ambiguous }`.
2. Exact path match via `samePath` on the resolved absolute paths.
3. Unique case-insensitive substring match on name. One hit returns `{ match }`,
   several return `{ ambiguous }`.

It returns a discriminated union: `{ match }`, `{ ambiguous: [...] }`, or
`{ notFound: true }`. An empty query (after trimming) always returns
`{ notFound: true }`.

**SDK registration: `registerProject(name, path)`** (introduced in PR1, reused
here by `squad add`). It is idempotent: re-registering a path that already exists
updates that entry in place and preserves the original `created_at`, rather than
adding a duplicate. `squad add` first checks whether the path is already present
so it can report "Added" versus "Updated" accurately.

**Command implementations:**

- `open.ts` owns all shared opener logic: the resolver call, the empty-registry
  and not-found and ambiguous messages, the numbered picker, the non-TTY list
  fallback, the missing-on-disk guard, `--print-path`, and the Copilot launch.
  Launch is platform-aware (`shell: true` on win32) and inherits stdio. If
  `copilot` is not on PATH (ENOENT), it prints the path with a hint instead of
  crashing.
- `pick.ts` delegates to `runOpen` with positional args removed, so all picker
  and launch behavior is reused with no duplication.
- `projects.ts` gains an `--open`/`-o` branch that delegates to `runOpen`;
  listing remains the default.
- `add.ts` parses `--name`, rejoins remaining tokens into a path, resolves it to
  absolute, validates it exists and is a directory, then calls `registerProject`.

`cli-entry.ts` wires `open`, `pick`, and `add` to their handlers and routes both
`projects` and `list` to `runProjects`. `command-help.ts` adds dedicated help
blocks for `open`, `pick`, and `add`, updates the `projects` help to document
`--open`, and registers `list` as an alias of `projects`.

### Scope and safety

- `squad open`, `squad pick`, and `squad list` are read-only against the
  registry. They never write.
- `squad add` DOES write to the registry: it calls `registerProject`, which adds
  or updates a single entry in `projects.json`. It does not scaffold `.squad/`,
  does not touch project contents, and does not change how `squad init` behaves.
  Re-adding an existing path updates in place and preserves `created_at`.
- No change to PR1's behavior or to any project's `.squad/` state.
- Every command degrades gracefully on edge cases: empty registry, no match,
  ambiguous match, non-TTY invocation, missing-on-disk path, `copilot` not
  installed, nonexistent or non-directory `add` target, and spaced unquoted
  paths.

### Tests / build

- `npm run build` clean (tsc, both packages).
- Lint clean (`tsc --noEmit` on both package tsconfigs).
- Targeted suites green, 21 tests passing:
  - `test/cli/add.test.ts` (4): registers and shows up in `squad list`, clear
    error for a nonexistent path, spaced-path reconstruction from split argv
    tokens, and the quoting hint for a nonexistent multi-token path. All assert
    no stack trace leaks.
  - `test/cli/command-help.test.ts` (14): the command-help end-to-end suite,
    covering the help blocks and the command list now including the new verbs.
  - `test/global-squad-isolation.test.ts` (3): proves the new test harness
    redirects the global Squad path to an OS temp dir.
- New test-isolation infrastructure: `test/setup/isolate-global-squad.ts`
  redirects `resolveGlobalSquadPath()` to a per-worker temp dir (via `APPDATA`,
  `LOCALAPPDATA`, `XDG_CONFIG_HOME`, and `HOME`), wired through `vitest.config.ts`
  as a setup file. Because PR1 made `squad init` write to the global
  `projects.json`, this prevents the test suite from polluting a developer's real
  registry.

### Files (17 changed, +590/-4)

```
.changeset/squad-add-command.md
.changeset/squad-list-alias.md
.changeset/squad-open-command.md
.changeset/squad-pick-command.md
packages/squad-cli/src/cli-entry.ts
packages/squad-cli/src/cli/commands/add.ts
packages/squad-cli/src/cli/commands/open.ts
packages/squad-cli/src/cli/commands/pick.ts
packages/squad-cli/src/cli/commands/projects.ts
packages/squad-cli/src/cli/core/command-help.ts
packages/squad-sdk/src/index.ts
packages/squad-sdk/src/projects-registry.ts
test/cli/add.test.ts
test/cli/command-help.test.ts
test/global-squad-isolation.test.ts
test/setup/isolate-global-squad.ts
vitest.config.ts
```

### Changeset

Four changeset files, all minor:

- `squad-open-command.md`: `@bradygaster/squad-cli` minor, `@bradygaster/squad-sdk` minor.
- `squad-pick-command.md`: `@bradygaster/squad-cli` minor.
- `squad-list-alias.md`: `@bradygaster/squad-cli` minor.
- `squad-add-command.md`: `@bradygaster/squad-cli` minor.

The SDK bump rides on the open/resolver changeset since `resolveProject` is a new
public SDK export; the other three are CLI-only.