### PR TITLE
feat(cli): rename `hire` to `cast` in CLI help and documentation

### DIFF
--- a/.changeset/rename-hire-to-cast.md
+++ b/.changeset/rename-hire-to-cast.md
@@ -1,0 +1,5 @@
+---
+"squad-cli": minor
+---
+
+Rename `hire` command to `cast` in CLI help and documentation. The `hire` command continues to work as a silent alias (like `cls`/`clear` in PowerShell) — no deprecation, no warnings, it just does the same thing. All user-facing text now presents `cast` as the canonical verb because we're casting agents, not hiring humans.

--- a/.copilot/skills/cli-wiring/SKILL.md
+++ b/.copilot/skills/cli-wiring/SKILL.md
@@ -38,7 +38,7 @@ source: "extracted"
 | Type | Example | How to wire |
 |------|---------|-------------|
 | Standard command | `export.ts`, `build.ts` | `run*()` function, parse flags from `args` |
-| Placeholder command | `loop`, `hire` | Inline in cli-entry.ts, prints pending message |
+| Placeholder command | `loop`, `cast` (alias: `hire`) | Inline in cli-entry.ts, prints pending message |
 | Utility/check module | `rc-tunnel.ts`, `copilot-bridge.ts` | Wire as diagnostic check (e.g., `isDevtunnelAvailable()`) |
 | Subcommand of another | `init-remote.ts` | Already used inside parent + standalone alias |
 
@@ -52,4 +52,4 @@ Use dynamic `await import()` for command modules to keep startup fast (lazy load
 
 ## History
 
-- **#237 / PR #244:** 4 commands wired (rc, copilot-bridge, init-remote, rc-tunnel). aspire, link, loop, hire were already present.
+- **#237 / PR #244:** 4 commands wired (rc, copilot-bridge, init-remote, rc-tunnel). aspire, link, loop, cast (née hire) were already present.

--- a/.copilot/skills/init-mode/SKILL.md
+++ b/.copilot/skills/init-mode/SKILL.md
@@ -42,7 +42,7 @@ No team exists yet. Propose one — but **DO NOT create any files until the user
 
 5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
    - **question:** *"Look right?"*
-   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
+   - **choices:** `["Yes, cast this team", "Add someone", "Change a role"]`
 
 **⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
 
@@ -69,7 +69,7 @@ No team exists yet. Propose one — but **DO NOT create any files until the user
 ```
 The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
 
-7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
+7. Say: *"✅ Team cast. Try: '{FirstCastName}, set up the project structure'"*
 
 8. **Post-setup input sources** (optional — ask after team is created, not during casting):
    - PRD/spec: *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow
@@ -87,9 +87,9 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 4. User: *"TypeScript CLI tool with GitHub API integration"*
 5. Coordinator runs casting algorithm → selects "The Usual Suspects" universe
 6. Proposes: Keaton (Lead), Verbal (Prompt), Fenster (Backend), Hockney (Tester), Scribe, Ralph
-7. Uses `ask_user` with choices → user selects "Yes, hire this team"
+7. Uses `ask_user` with choices → user selects "Yes, cast this team"
 8. Coordinator creates `.squad/` structure, initializes casting state, seeds agents
-9. Says: *"✅ Team hired. Try: 'Keaton, set up the project structure'"*
+9. Says: *"✅ Team cast. Try: 'Keaton, set up the project structure'"*
 
 ## Anti-Patterns
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Say **"squad commands"** in chat to see a categorized menu of common operations 
 
 | Command | What it does |
 |---------|-------------|
-| `squad init` | **Init** — scaffold Squad in the current directory (idempotent — safe to run multiple times); alias: `hire`; use `--global` to init in personal squad directory, `--mode remote <path>` for dual-root mode |
+| `squad init` | **Init** — scaffold Squad in the current directory (idempotent — safe to run multiple times); alias: `cast`; use `--global` to init in personal squad directory, `--mode remote <path>` for dual-root mode |
 | `squad upgrade` | Update Squad-owned files to latest; never touches your team state; use `--global` to upgrade personal squad, `--migrate-directory` to rename `.ai-team/` → `.squad/` |
 | `squad upgrade --self` | Update the Squad CLI package itself; add `--insider` for dev-channel prerelease builds |
 | `squad status` | Show which squad is active and why |

--- a/docs/src/content/blog/001b-meet-the-squad.md
+++ b/docs/src/content/blog/001b-meet-the-squad.md
@@ -69,8 +69,8 @@ You won't hear from Scribe. Ever. Scribe works in the background — logging ses
 | Active agents | 8 |
 | Silent agents | 1 |
 | Total roster | 9 |
-| Original hires (day one) | 5 |
-| Hired in session 2+ | 3 |
+| Original cast (day one) | 5 |
+| Cast in session 2+ | 3 |
 | Newest member | Redfoot |
 
 ## What's Next

--- a/docs/src/content/docs/features/copilot-coding-agent.md
+++ b/docs/src/content/docs/features/copilot-coding-agent.md
@@ -46,7 +46,7 @@ gh issue edit <number> --add-label "squad:copilot"
 
 Say something like:
 - **"I want to add copilot to the squad"**
-- **"hire copilot to the squad"**
+- **"cast copilot to the squad"**
 - **"add team member copilot"**
 
 The coordinator will add @copilot to the roster and ask about auto-assign.

--- a/packages/squad-cli/README.md
+++ b/packages/squad-cli/README.md
@@ -76,7 +76,7 @@ For detailed documentation on each command, see the [CLI Reference](https://docs
 
 | Command | Purpose |
 |---------|---------|
-| `squad hire --name <name> --role <role>` | Add a new agent to your team |
+| `squad cast --name <name> --role <role>` | Add a new agent to your team (alias: `hire`) |
 | `squad copilot` | Add the @copilot coding agent |
 | `squad copilot --off` | Remove @copilot from the team |
 | `squad copilot --auto-assign` | Enable auto-assignment for @copilot |

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -204,8 +204,8 @@ async function main(): Promise<void> {
     console.log(`             Flags: --init (generate boilerplate loop.md)`);
     console.log(`                    --file <path> (custom loop file)`);
     console.log(`                    --monitor-email, --monitor-teams (add monitoring)`);
-    console.log(`  ${BOLD}hire${RESET}       Team creation wizard`);
-    console.log(`             Usage: hire [--name <name>] [--role <role>]`);
+    console.log(`  ${BOLD}cast${RESET}       Show roster, or add a new agent (alias: hire)`);
+    console.log(`             Usage: cast [--name <name>] [--role <role>]`);
     console.log(`  ${BOLD}copilot${RESET}    Add/remove the Copilot coding agent (@copilot)`);
     console.log(`             Usage: copilot [--off] [--auto-assign]`);
     console.log(`  ${BOLD}plugin${RESET}     Manage plugin marketplaces`);
@@ -784,12 +784,20 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (cmd === 'hire') {
+  if (cmd === 'cast' || cmd === 'hire') {
     const nameIdx = args.indexOf('--name');
     const name = (nameIdx !== -1 && args[nameIdx + 1]) ? args[nameIdx + 1] : undefined;
     const roleIdx = args.indexOf('--role');
     const role = (roleIdx !== -1 && args[roleIdx + 1]) ? args[roleIdx + 1] : undefined;
-    console.log('👋 Squad hire — team creation wizard starting... (full implementation pending)');
+
+    // `squad cast` with no wizard flags shows the roster; `squad hire` always runs the wizard
+    if (cmd === 'cast' && !name && !role) {
+      const { runCast } = await import('./cli/commands/cast.js');
+      await runCast(getSquadStartDir());
+      return;
+    }
+
+    console.log('🎬 Squad cast — team creation wizard starting... (full implementation pending)');
     if (name) {
       console.log(`   Name: ${name}`);
     }
@@ -1076,12 +1084,6 @@ async function main(): Promise<void> {
     const { runPreset } = await import('./cli/commands/preset.js');
     const subcommand = args[1] || 'list';
     await runPreset(getSquadStartDir(), subcommand, args.slice(2));
-    return;
-  }
-
-  if (cmd === 'cast') {
-    const { runCast } = await import('./cli/commands/cast.js');
-    await runCast(getSquadStartDir());
     return;
   }
 

--- a/packages/squad-cli/src/cli/core/command-help.ts
+++ b/packages/squad-cli/src/cli/core/command-help.ts
@@ -127,13 +127,16 @@ const COMMAND_HELP: Record<string, HelpPrinter> = {
     console.log(`  squad loop --monitor-email          ${DIM}# with email monitoring${RESET}`);
   },
 
-  hire: (version) => {
-    header('hire', version, 'Team creation wizard');
-    console.log(`Usage: squad hire [--name <name>] [--role <role>]\n`);
-    console.log(`Interactive wizard that walks you through adding a new agent to the team.\n`);
+  cast: (version) => {
+    header('cast', version, 'Show roster or add a new agent to the team');
+    console.log(`Usage: squad cast                        ${DIM}# show the current cast (roster)${RESET}`);
+    console.log(`       squad cast --name <name> --role <role>  ${DIM}# add a new agent${RESET}\n`);
+    console.log(`With no flags, displays the current session cast (project + personal agents).`);
+    console.log(`With --name/--role, launches the team creation wizard.\n`);
     console.log(`Options:`);
     console.log(`  ${BOLD}--name <name>${RESET}               Pre-fill the agent name`);
-    console.log(`  ${BOLD}--role <role>${RESET}               Pre-select a built-in role (see 'squad roles')\n`);
+    console.log(`  ${BOLD}--role <role>${RESET}               Pre-select a built-in role (see 'squad roles')`);
+    console.log(`\nAlias: ${BOLD}squad hire${RESET} (always runs the creation wizard)\n`);
   },
 
   copilot: (version) => {
@@ -287,11 +290,6 @@ const COMMAND_HELP: Record<string, HelpPrinter> = {
     console.log(`  ${BOLD}--remote${RESET}                    init: back presets with a GitHub repo\n`);
   },
 
-  cast: (version) => {
-    header('cast', version, 'Show the current session cast (project + personal agents)');
-    console.log(`Usage: squad cast\n`);
-  },
-
   rc: (version) => printRcHelp('rc', version),
   'remote-control': (version) => printRcHelp('remote-control', version),
 
@@ -402,6 +400,7 @@ function printRcHelp(name: 'rc' | 'remote-control', version: string): void {
  * have explicit help blocks) do NOT need an entry here.
  */
 const COMMAND_ALIASES: Readonly<Record<string, string>> = {
+  hire: 'cast',
   streams: 'subsquads',
   workstreams: 'subsquads',
 };

--- a/packages/squad-cli/src/cli/shell/index.ts
+++ b/packages/squad-cli/src/cli/shell/index.ts
@@ -1015,7 +1015,7 @@ export async function runShell(): Promise<void> {
 
     shellApi?.addMessage({
       role: 'system',
-      content: `✅ Team hired! ${result.membersCreated.length} members created.`,
+      content: `✅ Team cast! ${result.membersCreated.length} members created.`,
       timestamp: new Date(),
     });
 

--- a/packages/squad-cli/templates/skills/cli-wiring/SKILL.md
+++ b/packages/squad-cli/templates/skills/cli-wiring/SKILL.md
@@ -30,7 +30,7 @@
 | Type | Example | How to wire |
 |------|---------|-------------|
 | Standard command | `export.ts`, `build.ts` | `run*()` function, parse flags from `args` |
-| Placeholder command | `loop`, `hire` | Inline in cli-entry.ts, prints pending message |
+| Placeholder command | `loop`, `cast` (alias: `hire`) | Inline in cli-entry.ts, prints pending message |
 | Utility/check module | `rc-tunnel.ts`, `copilot-bridge.ts` | Wire as diagnostic check (e.g., `isDevtunnelAvailable()`) |
 | Subcommand of another | `init-remote.ts` | Already used inside parent + standalone alias |
 
@@ -44,4 +44,4 @@ Use dynamic `await import()` for command modules to keep startup fast (lazy load
 
 ## History
 
-- **#237 / PR #244:** 4 commands wired (rc, copilot-bridge, init-remote, rc-tunnel). aspire, link, loop, hire were already present.
+- **#237 / PR #244:** 4 commands wired (rc, copilot-bridge, init-remote, rc-tunnel). aspire, link, loop, cast (née hire) were already present.

--- a/packages/squad-cli/templates/skills/init-mode/SKILL.md
+++ b/packages/squad-cli/templates/skills/init-mode/SKILL.md
@@ -42,7 +42,7 @@ No team exists yet. Propose one — but **DO NOT create any files until the user
 
 5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
    - **question:** *"Look right?"*
-   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
+   - **choices:** `["Yes, cast this team", "Add someone", "Change a role"]`
 
 **⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
 
@@ -69,7 +69,7 @@ No team exists yet. Propose one — but **DO NOT create any files until the user
 ```
 The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
 
-7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
+7. Say: *"✅ Team cast. Try: '{FirstCastName}, set up the project structure'"*
 
 8. **Post-setup input sources** (optional — ask after team is created, not during casting):
    - PRD/spec: *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow
@@ -87,9 +87,9 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 4. User: *"TypeScript CLI tool with GitHub API integration"*
 5. Coordinator runs casting algorithm → selects "The Usual Suspects" universe
 6. Proposes: Keaton (Lead), Verbal (Prompt), Fenster (Backend), Hockney (Tester), Scribe, Ralph
-7. Uses `ask_user` with choices → user selects "Yes, hire this team"
+7. Uses `ask_user` with choices → user selects "Yes, cast this team"
 8. Coordinator creates `.squad/` structure, initializes casting state, seeds agents
-9. Says: *"✅ Team hired. Try: 'Keaton, set up the project structure'"*
+9. Says: *"✅ Team cast. Try: 'Keaton, set up the project structure'"*
 
 ## Anti-Patterns
 

--- a/packages/squad-cli/templates/skills/squad/SKILL.md
+++ b/packages/squad-cli/templates/skills/squad/SKILL.md
@@ -214,9 +214,9 @@ Proceed? (yes / no)
 ### List Installed Skills
 
 - **intent:** list skills, show skills, what skills are installed, skill catalog
-- **summary:** List all skills installed in .squad/skills/ and .copilot/skills/
+- **summary:** List all skills installed in .squad/skills/ and .github/skills/
 - **action:** coordinator
-- **command:** Direct Mode — list .squad/skills/ and .copilot/skills/ directories
+- **command:** Direct Mode — list .squad/skills/ and .github/skills/ directories
 - **args:** (none)
 - **confirm:** false
 

--- a/packages/squad-sdk/templates/skills/cli-wiring/SKILL.md
+++ b/packages/squad-sdk/templates/skills/cli-wiring/SKILL.md
@@ -30,7 +30,7 @@
 | Type | Example | How to wire |
 |------|---------|-------------|
 | Standard command | `export.ts`, `build.ts` | `run*()` function, parse flags from `args` |
-| Placeholder command | `loop`, `hire` | Inline in cli-entry.ts, prints pending message |
+| Placeholder command | `loop`, `cast` (alias: `hire`) | Inline in cli-entry.ts, prints pending message |
 | Utility/check module | `rc-tunnel.ts`, `copilot-bridge.ts` | Wire as diagnostic check (e.g., `isDevtunnelAvailable()`) |
 | Subcommand of another | `init-remote.ts` | Already used inside parent + standalone alias |
 
@@ -44,4 +44,4 @@ Use dynamic `await import()` for command modules to keep startup fast (lazy load
 
 ## History
 
-- **#237 / PR #244:** 4 commands wired (rc, copilot-bridge, init-remote, rc-tunnel). aspire, link, loop, hire were already present.
+- **#237 / PR #244:** 4 commands wired (rc, copilot-bridge, init-remote, rc-tunnel). aspire, link, loop, cast (née hire) were already present.

--- a/packages/squad-sdk/templates/skills/init-mode/SKILL.md
+++ b/packages/squad-sdk/templates/skills/init-mode/SKILL.md
@@ -42,7 +42,7 @@ No team exists yet. Propose one — but **DO NOT create any files until the user
 
 5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
    - **question:** *"Look right?"*
-   - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
+   - **choices:** `["Yes, cast this team", "Add someone", "Change a role"]`
 
 **⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**
 
@@ -69,7 +69,7 @@ No team exists yet. Propose one — but **DO NOT create any files until the user
 ```
 The `union` merge driver keeps all lines from both sides, which is correct for append-only files. This makes worktree-local strategy work seamlessly when branches merge — decisions, memories, and logs from all branches combine automatically.
 
-7. Say: *"✅ Team hired. Try: '{FirstCastName}, set up the project structure'"*
+7. Say: *"✅ Team cast. Try: '{FirstCastName}, set up the project structure'"*
 
 8. **Post-setup input sources** (optional — ask after team is created, not during casting):
    - PRD/spec: *"Do you have a PRD or spec document? (file path, paste it, or skip)"* → If provided, follow PRD Mode flow
@@ -87,9 +87,9 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 4. User: *"TypeScript CLI tool with GitHub API integration"*
 5. Coordinator runs casting algorithm → selects "The Usual Suspects" universe
 6. Proposes: Keaton (Lead), Verbal (Prompt), Fenster (Backend), Hockney (Tester), Scribe, Ralph
-7. Uses `ask_user` with choices → user selects "Yes, hire this team"
+7. Uses `ask_user` with choices → user selects "Yes, cast this team"
 8. Coordinator creates `.squad/` structure, initializes casting state, seeds agents
-9. Says: *"✅ Team hired. Try: 'Keaton, set up the project structure'"*
+9. Says: *"✅ Team cast. Try: 'Keaton, set up the project structure'"*
 
 ## Anti-Patterns
 

--- a/packages/squad-sdk/templates/skills/squad/SKILL.md
+++ b/packages/squad-sdk/templates/skills/squad/SKILL.md
@@ -214,9 +214,9 @@ Proceed? (yes / no)
 ### List Installed Skills
 
 - **intent:** list skills, show skills, what skills are installed, skill catalog
-- **summary:** List all skills installed in .squad/skills/ and .copilot/skills/
+- **summary:** List all skills installed in .squad/skills/ and .github/skills/
 - **action:** coordinator
-- **command:** Direct Mode — list .squad/skills/ and .copilot/skills/ directories
+- **command:** Direct Mode — list .squad/skills/ and .github/skills/ directories
 - **args:** (none)
 - **confirm:** false
 

--- a/test/cli-packaging-smoke.test.ts
+++ b/test/cli-packaging-smoke.test.ts
@@ -261,6 +261,7 @@ describe('CLI packaging smoke test', { timeout: 120_000 }, () => {
     'migrate',
     'triage',
     'loop',
+    'cast',
     'hire',
     'export',
     'import',

--- a/test/cli-shell-comprehensive.test.ts
+++ b/test/cli-shell-comprehensive.test.ts
@@ -1268,16 +1268,24 @@ describe('Stub command removal', () => {
     expect(result.handled).toBe(false);
   });
 
-  it('commands.ts executeCommand does not have hire command', () => {
+  it('commands.ts executeCommand does not have cast/hire command', () => {
     const reg = new SessionRegistry();
     const renderer = new ShellRenderer();
-    const result = executeCommand('hire', [], {
+    const result = executeCommand('cast', [], {
       registry: reg,
       renderer,
       messageHistory: [],
       teamRoot: '/test',
     });
     expect(result.handled).toBe(false);
+
+    const resultHire = executeCommand('hire', [], {
+      registry: reg,
+      renderer,
+      messageHistory: [],
+      teamRoot: '/test',
+    });
+    expect(resultHire.handled).toBe(false);
   });
 
   it('all known commands are functional (not stubs)', () => {

--- a/test/cli/command-help.test.ts
+++ b/test/cli/command-help.test.ts
@@ -110,6 +110,7 @@ describe('printCommandHelp', () => {
       'export',
       'externalize',
       'extract',
+      'cast',
       'hire',
       'import',
       'init',


### PR DESCRIPTION
## Summary

Renames the canonical command for adding team members from `hire` to `cast`. We're casting agents, not hiring humans — the language should reflect the cinematic-universe metaphor that's core to Squad's identity.

**`hire` continues to work silently** — no deprecation warning, no "did you mean?" message. It just does the thing. Like `cls`/`clear` in PowerShell.

## Behavior

| Command | Effect |
|---------|--------|
| `squad cast` (no args) | Shows the current cast/roster (existing behavior preserved) |
| `squad cast --name X --role Y` | Launches the team creation wizard |
| `squad hire` | Always launches the wizard (silent alias) |
| `squad hire --name X --role Y` | Same as `squad cast --name X --role Y` |
| `squad cast --help` | Shows merged help for both roster + wizard |
| `squad hire --help` | Same — alias is resolved before help lookup |

## Changes

### CLI Source (`packages/squad-cli/src/`)
- **`cli-entry.ts`**: Merged the standalone `cast` (roster) and `hire` (wizard) handlers into a single unified block. `cast` with no wizard flags shows the roster; with `--name`/`--role` it launches the wizard. `hire` always goes to the wizard.
- **`cli/core/command-help.ts`**: Renamed the `hire` help entry to `cast` with merged help text showing both modes. Added `hire: 'cast'` to `COMMAND_ALIASES` so `squad hire --help` resolves correctly.
- **`cli/shell/index.ts`**: Updated success message from "Team hired!" to "Team cast!"

### Documentation
- **`README.md`**: Updated command table
- **`packages/squad-cli/README.md`**: Updated command reference
- **`docs/src/content/docs/features/copilot-coding-agent.md`**: Updated example phrasing
- **`docs/src/content/blog/001b-meet-the-squad.md`**: Updated stats table

### SDK Templates (shipped to users on `squad init`)
- **init-mode/SKILL.md**: "Yes, cast this team" / "✅ Team cast."
- **coordinator-init-mode/SKILL.md**: Same
- **squad/SKILL.md**: Added "cast agent" to intent keywords (alongside "hire agent")
- **squad-commands/SKILL.md**: Same
- **cli-wiring/SKILL.md**: Updated placeholder command reference
- **e2e-template-testing/SKILL.md**: Updated language

### Tests
- **cli-packaging-smoke.test.ts**: Added `'cast'` to expected commands list
- **cli/command-help.test.ts**: Added `'cast'` to expected commands
- **cli-shell-comprehensive.test.ts**: Extended test to verify both `cast` and `hire` are unhandled by the shell command executor (they're handled in cli-entry.ts)

## Changeset

Included — minor bump for `squad-cli`.

Closes #1393