### PR TITLE
feat(platform): add setAssignee() to PlatformAdapter (GitHub + ADO)

### DIFF
--- a/.changeset/forge-set-assignee.md
+++ b/.changeset/forge-set-assignee.md
@@ -1,0 +1,8 @@
+---
+"@bradygaster/squad-sdk": minor
+"@bradygaster/squad-cli": patch
+---
+
+feat(platform): add `setAssignee()` to PlatformAdapter so assignee changes route through the platform abstraction (GitHub + ADO) instead of inline `gh`/`az` calls
+
+`GitHubAdapter.setAssignee` uses `gh issue edit --add/--remove-assignee`; `AzureDevOpsAdapter.setAssignee` sets `System.AssignedTo`. The watch command's `editWorkItem` now delegates assignee operations to the adapter, removing the hardcoded GitHub-vs-ADO branch.

--- a/packages/squad-cli/src/cli/commands/loop.ts
+++ b/packages/squad-cli/src/cli/commands/loop.ts
@@ -236,6 +236,7 @@ function createNoopAdapter(): ReturnType<typeof createPlatformAdapter> {
     addTag: async () => {},
     removeTag: async () => {},
     addComment: async () => {},
+    setAssignee: async () => {},
     listPullRequests: async () => [],
     createPullRequest: async () => { throw new Error(msg); },
     mergePullRequest: async () => {},

--- a/packages/squad-cli/src/cli/commands/watch/index.ts
+++ b/packages/squad-cli/src/cli/commands/watch/index.ts
@@ -136,28 +136,20 @@ async function listWatchPullRequests(
 async function editWorkItem(
   adapter: PlatformAdapter,
   id: number,
-  options: { addLabel?: string; removeLabel?: string; addAssignee?: string; removeAssignee?: string },
+  options: { addLabel?: string; removeLabel?: string; addAssignee?: string; removeAssignee?: boolean },
 ): Promise<void> {
   if (options.addLabel) await adapter.addTag(id, options.addLabel);
   if (options.removeLabel) await adapter.removeTag(id, options.removeLabel);
   if (options.addAssignee) {
-    if (adapter.type === 'github') {
-      try {
-        await execFileAsync('gh', ['issue', 'edit', String(id), '--add-assignee', options.addAssignee]);
-      } catch { /* best-effort */ }
-    } else if (adapter.type === 'azure-devops') {
-      const assignee = options.addAssignee === '@me' ? '' : options.addAssignee;
-      if (assignee) {
-        try {
-          execFileSync(azCmd, [
-            'boards', 'work-item', 'update',
-            '--id', String(id),
-            '--fields', `System.AssignedTo=${assignee}`,
-            '--output', 'json',
-          ], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], ...azExecOpts });
-        } catch { /* best-effort */ }
-      }
-    }
+    try {
+      await adapter.setAssignee(id, options.addAssignee);
+    } catch { /* best-effort */ }
+  }
+  if (options.removeAssignee) {
+    try {
+      // setAssignee(undefined) unassigns the current assignee on both platforms.
+      await adapter.setAssignee(id, undefined);
+    } catch { /* best-effort */ }
   }
 }
 

--- a/packages/squad-sdk/src/platform/azure-devops.ts
+++ b/packages/squad-sdk/src/platform/azure-devops.ts
@@ -341,6 +341,17 @@ export class AzureDevOpsAdapter implements PlatformAdapter {
     ]);
   }
 
+  async setAssignee(workItemId: number, assignee: string | undefined): Promise<void> {
+    // ADO has no '@me' token; the az CLI can't resolve current user, so skip it
+    // (matches prior behavior). undefined/empty unassigns; a name assigns.
+    if (assignee === '@me') return;
+    const value = assignee ?? '';
+    this.az([
+      'boards', 'work-item', 'update', '--id', String(workItemId),
+      '--fields', `System.AssignedTo=${value}`, ...this.workItemArgs, '--output', 'json',
+    ]);
+  }
+
   async listPullRequests(options: { status?: string; limit?: number }): Promise<PullRequest[]> {
     const args = [
       'repos', 'pr', 'list',

--- a/packages/squad-sdk/src/platform/github.ts
+++ b/packages/squad-sdk/src/platform/github.ts
@@ -147,6 +147,19 @@ export class GitHubAdapter implements PlatformAdapter {
     this.gh(['issue', 'comment', String(workItemId), '--repo', this.repoFlag, '--body', comment]);
   }
 
+  async setAssignee(workItemId: number, assignee: string | undefined): Promise<void> {
+    const args = ['issue', 'edit', String(workItemId), '--repo', this.repoFlag];
+    if (assignee) {
+      args.push('--add-assignee', assignee);
+    } else {
+      // Unassign: remove the current assignee (if any).
+      const wi = await this.getWorkItem(workItemId);
+      if (!wi.assignedTo) return;
+      args.push('--remove-assignee', wi.assignedTo);
+    }
+    this.gh(args);
+  }
+
   async listPullRequests(options: { status?: string; limit?: number }): Promise<PullRequest[]> {
     const args = ['pr', 'list', '--repo', this.repoFlag, '--json', 'number,title,headRefName,baseRefName,state,isDraft,reviewDecision,author,url'];
     if (options.status) args.push('--state', mapStatusToGhState(options.status));

--- a/packages/squad-sdk/src/platform/types.ts
+++ b/packages/squad-sdk/src/platform/types.ts
@@ -49,6 +49,11 @@ export interface PlatformAdapter {
   addTag(workItemId: number, tag: string): Promise<void>;
   removeTag(workItemId: number, tag: string): Promise<void>;
   addComment(workItemId: number, comment: string): Promise<void>;
+  /**
+   * Assign a work item to a user. Pass undefined/empty to unassign the current assignee.
+   * '@me' assigns the current user on GitHub; the ADO adapter cannot resolve '@me' and skips it (no-op).
+   */
+  setAssignee(workItemId: number, assignee: string | undefined): Promise<void>;
 
   /** Ensure a tag/label exists (creates it if missing). No-op on platforms with auto-created tags. */
   ensureTag?(tag: string, options?: { color?: string; description?: string }): Promise<void>;

--- a/test/platform-adapter.test.ts
+++ b/test/platform-adapter.test.ts
@@ -251,6 +251,7 @@ describe('PlatformAdapter createWorkItem interface', () => {
       addTag: async () => {},
       removeTag: async () => {},
       addComment: async () => {},
+      setAssignee: async () => {},
       listPullRequests: async () => [],
       createPullRequest: async () => ({ id: 1, title: '', sourceBranch: '', targetBranch: '', status: 'active' as const, author: '', url: '' }),
       mergePullRequest: async () => {},
@@ -275,6 +276,7 @@ describe('PlatformAdapter createWorkItem interface', () => {
       addTag: async () => {},
       removeTag: async () => {},
       addComment: async () => {},
+      setAssignee: async () => {},
       listPullRequests: async () => [],
       createPullRequest: async () => ({ id: 1, title: '', sourceBranch: '', targetBranch: '', status: 'active' as const, author: '', url: '' }),
       mergePullRequest: async () => {},
@@ -307,6 +309,7 @@ describe('PlatformAdapter createWorkItem interface', () => {
       addTag: async () => {},
       removeTag: async () => {},
       addComment: async () => {},
+      setAssignee: async () => {},
       listPullRequests: async () => [],
       createPullRequest: async () => ({ id: 1, title: '', sourceBranch: '', targetBranch: '', status: 'active' as const, author: '', url: '' }),
       mergePullRequest: async () => {},
@@ -317,6 +320,31 @@ describe('PlatformAdapter createWorkItem interface', () => {
     expect(wi.id).toBe(10);
     expect(wi.title).toBe('Quick fix');
     expect(wi.tags).toEqual([]);
+  });
+});
+
+// ─── setAssignee ──────────────────────────────────────────────────────
+
+describe('setAssignee', () => {
+  it('is part of the PlatformAdapter interface and accepts a user or undefined', async () => {
+    const calls: Array<string | undefined> = [];
+    const mockAdapter: PlatformAdapter = {
+      type: 'github' as PlatformType,
+      listWorkItems: async () => [],
+      getWorkItem: async (id: number) => ({ id, title: '', state: '', tags: [], url: '' }),
+      createWorkItem: async (o) => ({ id: 1, title: o.title, state: 'new', tags: [], url: '' }),
+      addTag: async () => {},
+      removeTag: async () => {},
+      addComment: async () => {},
+      setAssignee: async (_id, user) => { calls.push(user); },
+      listPullRequests: async () => [],
+      createPullRequest: async () => ({ id: 1, title: '', sourceBranch: '', targetBranch: '', status: 'active' as const, author: '', url: '' }),
+      mergePullRequest: async () => {},
+      createBranch: async () => {},
+    };
+    await mockAdapter.setAssignee(1, 'copilot-swe-agent');
+    await mockAdapter.setAssignee(1, undefined);
+    expect(calls).toEqual(['copilot-swe-agent', undefined]);
   });
 });
 


### PR DESCRIPTION
Closes part of the ADO-first squad routing gap. Adds setAssignee() to PlatformAdapter so assignee changes route through the platform abstraction instead of inline gh/az branches.

- GitHubAdapter: gh issue edit --add/--remove-assignee
- AzureDevOpsAdapter: System.AssignedTo
- watch editWorkItem delegates to adapter (removes hardcoded gh-vs-ado branch)
- tests + changeset (sdk minor, cli patch)

Validation: SKIP_BUILD_BUMP=1 npm run build; vitest platform (135 pass).