### PR TITLE
fix: add tools: ['*'] to agent front-matter for agency compatibility

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -1,6 +1,7 @@
 ---
 name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
+tools: ['*']
 ---
 
 <!-- version: 0.0.0-source -->


### PR DESCRIPTION
## Problem

When running Squad through Microsoft's `agency` wrapper (`agency cp`), agents receive only 3 built-in tools (skill, sql, task_complete) instead of the full 200+ toolset.

**Root cause:** `agency` serializes a missing `tools:` key in YAML front-matter as `tools: []`, which Copilot CLI interprets as "no tools allowed."

## Fix

Add `tools: ['*']` to the agent's YAML front-matter. The asterisk wildcard means "all tools" and is understood by both agency and raw Copilot CLI.

## Verification

| Config | Via copilot CLI (direct) | Via agency cp |
|--------|--------------------------|---------------|
| No tools: key | 314 tools | 3 tools (the bug) |
| tools: ['*'] | 263 tools | 340 tools |

All critical tools confirmed present with wildcard (powershell, view, edit, create, grep, glob, task, sql).

## Safe across surfaces

Tested that `tools: ['*']` works correctly on:
- Copilot CLI (direct) - 263 tools
- Agency cp - 340 tools
- Does not affect VS Code or GitHub App (wildcard is engine-level)

## References

- Bug reported in Copilot CLI Teams channel
- Agency team confirmed and suggested the wildcard workaround
- Agency support: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-jacezcz/startrightgitops/agency/support/support