### PR TITLE
Guard symlink test for Windows/restricted environments

### DIFF
--- a/test/squad-observer.test.ts
+++ b/test/squad-observer.test.ts
@@ -61,9 +61,29 @@ function cleanupTmpDir() {
 }
 
 function isUnsupportedSymlinkError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException).code;
+  const code = typeof error === 'object' && error !== null && 'code' in error
+    ? (error as NodeJS.ErrnoException).code
+    : undefined;
   return code === 'EPERM' || code === 'EACCES' || code === 'ENOSYS';
 }
+
+function canCreateSymlink(): boolean {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'squad-observer-symlink-probe-'));
+  try {
+    const targetDir = path.join(probeDir, 'target');
+    const symlinkPath = path.join(probeDir, 'link');
+    fs.mkdirSync(targetDir);
+    fs.symlinkSync(targetDir, symlinkPath, 'dir');
+    return true;
+  } catch (error) {
+    if (isUnsupportedSymlinkError(error)) return false;
+    throw error;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+}
+
+const symlinkSupported = canCreateSymlink();
 
 // ---------------------------------------------------------------------------
 // classifyFile tests
@@ -211,17 +231,12 @@ describe('SquadObserver', () => {
     expect(spans.some(s => s.name === 'squad.observer.file_change')).toBe(false);
   });
 
-  it('skips symlinked directories when resolving root directory events', async () => {
+  (symlinkSupported ? it : it.skip)('skips symlinked directories when resolving root directory events', async () => {
     const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'squad-observer-outside-'));
     try {
       fs.writeFileSync(path.join(outsideDir, 'newest.md'), 'outside');
       const symlinkPath = path.join(squadDir, 'linked-outside');
-      try {
-        fs.symlinkSync(outsideDir, symlinkPath, 'dir');
-      } catch (error) {
-        if (isUnsupportedSymlinkError(error)) return;
-        throw error;
-      }
+      fs.symlinkSync(outsideDir, symlinkPath, 'dir');
 
       const olderFile = path.join(squadDir, 'team.md');
       fs.writeFileSync(olderFile, 'inside');

--- a/test/squad-observer.test.ts
+++ b/test/squad-observer.test.ts
@@ -60,6 +60,11 @@ function cleanupTmpDir() {
   }
 }
 
+function isUnsupportedSymlinkError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'EPERM' || code === 'EACCES' || code === 'ENOSYS';
+}
+
 // ---------------------------------------------------------------------------
 // classifyFile tests
 // ---------------------------------------------------------------------------
@@ -210,7 +215,13 @@ describe('SquadObserver', () => {
     const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'squad-observer-outside-'));
     try {
       fs.writeFileSync(path.join(outsideDir, 'newest.md'), 'outside');
-      fs.symlinkSync(outsideDir, path.join(squadDir, 'linked-outside'), 'dir');
+      const symlinkPath = path.join(squadDir, 'linked-outside');
+      try {
+        fs.symlinkSync(outsideDir, symlinkPath, 'dir');
+      } catch (error) {
+        if (isUnsupportedSymlinkError(error)) return;
+        throw error;
+      }
 
       const olderFile = path.join(squadDir, 'team.md');
       fs.writeFileSync(olderFile, 'inside');


### PR DESCRIPTION
## Summary
- guard the observer symlink test when symlink creation is unsupported
- return early for EPERM/EACCES/ENOSYS so restricted environments do not fail the suite

## Validation
- SKIP_BUILD_BUMP=1 npm run build
- npx vitest run test/squad-observer.test.ts
- npx vitest run test/squad-observer.test.ts test/storage-provider.test.ts --fileParallelism=false

Follow-up to #1416.