### PR TITLE
Stage 0.11.0 release: CHANGELOG + version bump

### DIFF
--- a/.changeset/release-0.11.0.md
+++ b/.changeset/release-0.11.0.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": minor
+"@bradygaster/squad-sdk": minor
+---
+
+Stage the 0.11.0 release by cleaning the committed package versions and publishing the 0.11.0 changelog notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-29
+
+### Added
+- (cli) Add `squad preset install <source>` for installing shared presets from GitHub URLs or local paths (#1224).
+- (cli) Add `squad registry add/list/remove` for discovery-only peer squads, plus the bundled cross-squad communication skill.
+- (cli) Add `cast` terminology across help and docs while keeping `hire` as a silent compatibility alias (#1394).
+- (sdk+cli) Add Copilot App sub-session spawning for cast members and thread reasoning-effort settings through agent dispatch (#1385).
+- (sdk+cli) Expose memory tools through the `squad_state` MCP server and improve Fact Checker auto-scaffolding/plumbing.
+
+### Changed
+- (sdk+cli) Slim the bundled `squad.agent.md` by extracting long guidance into satellite skills (#1311).
+- (cli) Move bundled skills from `.copilot/skills/` to `.github/skills/` so they are visible to all Copilot surfaces.
+- (cli) Rename user-facing ".NET Aspire" references to "Aspire" in CLI help and command output (#1239).
+- (sdk+cli) Refresh the toolchain and integrations, including `@github/copilot-sdk` 1.0.4, TypeScript 6, Vitest 4, Ink 7, OpenTelemetry 2.x, and Node type updates.
+
+### Fixed
+- (cli) Pin CLI-to-SDK workspace resolution so local builds and runtime use the workspace SDK instead of a stale published package (#1406).
+- (sdk+cli) Restore the green test suite by reconciling personal squad paths, stabilizing observer category handling, guarding storage case-insensitivity, and skipping environment-dependent tests when prerequisites are missing (#1416).
+- (sdk+cli) Guard symlink-sensitive tests on Windows or restricted CI filesystems (#1418).
+- (sdk+cli) Harden observer change resolution for directory events, symlinks, and filesystem scan errors.
+- (sdk+cli) Fix state-backend handshake, SQUAD_HOME/SQUAD_PERSONAL_DIR resolution, preset apply wiring, routing example quote stripping, YAML escaping, and MCP config pollution regressions.
+- (cli) Fix Windows command escaping, top-level help coverage for `externalize`/`internalize`, slash-command discovery, and upgrade/self-repair flows.
+- (sdk) Export gitignore-state helpers, update OTel resource APIs for 2.x, and align the adapter client with `@github/copilot-sdk` 1.0.4.
+
 ## [0.10.0] — 2026-06-07
 
 First stable release since v0.9.4 (April 25). Consumes 97 changesets (sdk: 50, cli: 71).
@@ -397,6 +421,5 @@ First stable release since v0.9.4 (April 25). Consumes 97 changesets (sdk: 50, c
 - New entry point: `src/cli-entry.ts` (CLI bootstrap separated from library exports)
 - Migrated to npm workspace publishing (`@bradygaster/squad-sdk`, `@bradygaster/squad-cli`)
 - Changesets infrastructure for independent package versioning
-
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.10.0-build.2",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bradygaster/squad",
-      "version": "0.10.0-build.2",
+      "version": "0.11.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7566,7 +7566,7 @@
     },
     "packages/squad-cli": {
       "name": "@bradygaster/squad-cli",
-      "version": "0.10.0-build.2",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -7606,7 +7606,7 @@
     },
     "packages/squad-sdk": {
       "name": "@bradygaster/squad-sdk",
-      "version": "0.10.0-build.2",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.10.0-build.2",
+  "version": "0.11.0",
   "private": true,
   "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.10.0-build.2",
+  "version": "0.11.0",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.10.0-build.2",
+  "version": "0.11.0",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump root, squad-sdk, and squad-cli package versions from 0.10.0-build.2 to clean 0.11.0.
- Add the 0.11.0 CHANGELOG section with release highlights for preset install, cast terminology, Copilot App sub-sessions, workspace linkage, and green-suite hardening.
- Add a release changeset for the 0.11.0 minor staging.

## Validation
- SKIP_BUILD_BUMP=1 npm run build
- npm test: 251 passed | 1 skipped files; 6974 passed | 21 skipped | 47 todo tests
- Dependency leak scan clean for packages/*/package.json

Does not publish — promotion to preview→main is Brady's trigger.