### PR TITLE
Add tools: ["*"] to Squad coordinator agent template (fixes empty toolset on Copilot CLI 1.0.66+)

### DIFF
--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -1,6 +1,7 @@
 ---
 name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
+tools: ["*"]
 ---
 
 <!-- version: 0.0.0-source -->

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -1,6 +1,7 @@
 ---
 name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
+tools: ["*"]
 ---
 
 <!-- version: 0.0.0-source -->

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -1,6 +1,7 @@
 ---
 name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
+tools: ["*"]
 ---
 
 <!-- version: 0.0.0-source -->

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -1,6 +1,7 @@
 ---
 name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
+tools: ["*"]
 ---
 
 <!-- version: 0.0.0-source -->


### PR DESCRIPTION
Closes #1425

### What
Adds `tools: ["*"]` to the Squad coordinator agent template in the canonical location and its three mirrored copies:

- `.squad-templates/squad.agent.md` (canonical, source of truth for `scripts/sync-templates.mjs`)
- `templates/squad.agent.md.template` (root mirror)
- `packages/squad-cli/templates/squad.agent.md.template` (mirror, bundled into `@bradygaster/squad-cli` npm package)
- `packages/squad-sdk/templates/squad.agent.md.template` (mirror, bundled into `@bradygaster/squad-sdk` npm package)

`.github/agents/squad.agent.md` (this repo's own coordinator) is intentionally left out of this PR.

### Why
On Copilot CLI **1.0.66+**, an agent file whose frontmatter omits the `tools:` key is interpreted as `tools: []`. The current coordinator template ships without `tools:`, so after `squad init` the coordinator loads with **no built-in tools** — `shell`, `view`, `edit`, `grep`, `glob` are not exposed to the model. Only MCP-provided tools (e.g. `skill`, `sql`) remain, which makes the coordinator unable to list or edit files. Tracked in #1425.

Because `packages/squad-cli/templates/` is bundled into the published npm package (per `files: ["dist","templates",...]` in `packages/squad-cli/package.json`), the mirror copies must be patched for the next release to ship the fix to end users.

### How
Single-line frontmatter addition in each file:

```diff
 ---
 name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
+tools: ["*"]
 ---
```

Applied to the canonical `.squad-templates/squad.agent.md` and propagated to the three mirror copies (equivalent to running `node scripts/sync-templates.mjs --sync`). Each file: `+1 / -0`, no other changes.

Verified locally with Copilot CLI 1.0.66-2 — after this change, the built-in tools are exposed to the coordinator again.

---

### ⚠️ Quick Check
- [x] No SDK/CLI source files changed — `skip-changelog` label required (template-only fix, no user-facing public API change). Cannot self-apply; please add on review.

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev` (not `main`)
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes (4 files, `+1 / -0` each)
- [ ] PR is **not** in draft mode (mark ready when checks pass)
- [x] Commit history is clean (single squashed commit)

#### Build & Test
- [x] `npm run build` passes (verified locally on a fresh clone of this branch)
- [x] `npm test` passes (verified locally — 6972/6973 pass; the 1 failure is environmental, triggered when the test suite runs from inside a git worktree of squad, unrelated to the template-only changes in this PR)
- [x] `npm run lint` passes (verified locally — `tsc --noEmit` clean across squad-sdk and squad-cli)
- [x] `npm run lint:eslint` passes — N/A (no JS/TS source files changed)

#### Changeset
- [x] `skip-changelog` label requested — template-only change, no public SDK/CLI API change. External contributors cannot apply labels; please apply on review.

#### Docs
- [x] N/A — no user-facing feature added; this is a regression fix to existing scaffolding

#### Exports
- [x] N/A — no SDK exports changed

---

### Breaking Changes
None.

### Waivers
None.

