### PR TITLE
fix: remove duplicate cast entry in squad -h output

### DIFF
--- a/.changeset/fix-duplicate-cast-help.md
+++ b/.changeset/fix-duplicate-cast-help.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+Remove duplicate `cast` entry in `squad -h` output

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -204,8 +204,8 @@ async function main(): Promise<void> {
     console.log(`             Flags: --init (generate boilerplate loop.md)`);
     console.log(`                    --file <path> (custom loop file)`);
     console.log(`                    --monitor-email, --monitor-teams (add monitoring)`);
-    console.log(`  ${BOLD}cast${RESET}       Show roster, or add a new agent (alias: hire)`);
-    console.log(`             Usage: cast [--name <name>] [--role <role>]`);
+    console.log(`  ${BOLD}cast${RESET}       Show current session cast (project + personal agents)`);
+      console.log(`             Usage: cast [--name <name>] [--role <role>] (alias: hire)`);
     console.log(`  ${BOLD}copilot${RESET}    Add/remove the Copilot coding agent (@copilot)`);
     console.log(`             Usage: copilot [--off] [--auto-assign]`);
     console.log(`  ${BOLD}plugin${RESET}     Manage plugin marketplaces`);
@@ -255,7 +255,6 @@ async function main(): Promise<void> {
     console.log(`             Usage: preset list | show <name>`);
     console.log(`                    apply <name> [--force] | save <name>`);
     console.log(`                    init [--remote]`);
-    console.log(`  ${BOLD}cast${RESET}       Show current session cast (project + personal agents)`);
     console.log(`  ${BOLD}rc${RESET}         Start Remote Control bridge (phone/browser → Copilot)`);
     console.log(`             Usage: rc [--tunnel] [--port <n>] [--path <dir>]`);
     console.log(`  ${BOLD}copilot-bridge${RESET}  Check Copilot ACP stdio compatibility`);

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -205,7 +205,7 @@ async function main(): Promise<void> {
     console.log(`                    --file <path> (custom loop file)`);
     console.log(`                    --monitor-email, --monitor-teams (add monitoring)`);
     console.log(`  ${BOLD}cast${RESET}       Show current session cast (project + personal agents)`);
-      console.log(`             Usage: cast [--name <name>] [--role <role>] (alias: hire)`);
+    console.log(`             Usage: cast [--name <name>] [--role <role>] (alias: hire)`);
     console.log(`  ${BOLD}copilot${RESET}    Add/remove the Copilot coding agent (@copilot)`);
     console.log(`             Usage: copilot [--off] [--auto-assign]`);
     console.log(`  ${BOLD}plugin${RESET}     Manage plugin marketplaces`);


### PR DESCRIPTION
## Summary

The `cast` command appeared twice in `squad -h` output (v0.11.0):
- Line ~207: `cast       Show roster, or add a new agent (alias: hire)`
- Line ~258: `cast       Show current session cast (project + personal agents)`

## Fix

Consolidated into a single entry with a unified description that accurately reflects the command's behavior — showing the current session cast (project + personal agents) with the `--name`/`--role` flags for adding agents noted in the usage line.

Closes #1423