### PR TITLE
fix(templates): resolve GitHub API host from env in ralph-triage.js

### DIFF
--- a/.changeset/fix-1142-ralph-triage-ghe-api-host.md
+++ b/.changeset/fix-1142-ralph-triage-ghe-api-host.md
@@ -1,0 +1,10 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+Fix #1142: `ralph-triage.js` hardcoded `hostname: 'api.github.com'` in its `https.request()` call, so `Squad Heartbeat (Ralph)` failed with a 401 on GitHub Enterprise (the `GITHUB_TOKEN` there is only valid against the enterprise API host, not github.com).
+
+Added a `resolveGithubApiBase()` helper that picks the API base in order — `GITHUB_API_URL` (set by Actions on both github.com and GHE runners), then `GITHUB_SERVER_URL` + `/api/v3`, then `https://api.github.com` as a last-resort fallback — and builds the request from a `URL` object instead of a hardcoded hostname/path pair. No behavior change on github.com-hosted repos, since `GITHUB_API_URL` there already resolves to `https://api.github.com`.
+
+Fixed in the canonical `.squad-templates/ralph-triage.js` and synced to all 3 mirror targets (`templates/`, `packages/squad-cli/templates/`, `packages/squad-sdk/templates/`).

--- a/.squad-templates/ralph-triage.js
+++ b/.squad-templates/ralph-triage.js
@@ -414,13 +414,31 @@ function getOwnerRepoFromGit() {
   return parseOwnerRepoFromRemote(remoteUrl);
 }
 
+/**
+ * Resolve the GitHub REST API base URL from the environment, so triage
+ * works on GitHub Enterprise as well as github.com.
+ *
+ * Order: GITHUB_API_URL (set by Actions on both github.com and GHE runners)
+ * > GITHUB_SERVER_URL + /api/v3 (GHE without an explicit API URL)
+ * > https://api.github.com (fallback for local/non-Actions runs).
+ */
+function resolveGithubApiBase() {
+  const apiUrl = process.env.GITHUB_API_URL;
+  if (apiUrl) return apiUrl.replace(/\/+$/, '');
+
+  const serverUrl = process.env.GITHUB_SERVER_URL;
+  if (serverUrl) return `${serverUrl.replace(/\/+$/, '')}/api/v3`;
+
+  return 'https://api.github.com';
+}
+
 function githubRequestJson(pathname, token) {
   return new Promise((resolve, reject) => {
+    const requestUrl = new URL(`${resolveGithubApiBase()}${pathname}`);
     const req = https.request(
+      requestUrl,
       {
-        hostname: 'api.github.com',
         method: 'GET',
-        path: pathname,
         headers: {
           Accept: 'application/vnd.github+json',
           Authorization: `Bearer ${token}`,
@@ -539,7 +557,11 @@ async function main() {
   fs.writeFileSync(outputPath, `${JSON.stringify(results, null, 2)}\n`, 'utf8');
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { resolveGithubApiBase };

--- a/docs/src/content/docs/scenarios/ci-cd-integration.md
+++ b/docs/src/content/docs/scenarios/ci-cd-integration.md
@@ -45,6 +45,8 @@ jobs:
 
 > ⚡ **Cron is permanently disabled.** Scheduled cron jobs are no longer supported in GitHub Actions to reduce costs. The heartbeat workflow runs on event-based triggers: when issues are closed, PRs are merged, or you manually trigger via `workflow_dispatch`. For periodic polling without events, use `squad watch` in a separate terminal (local, no GitHub Actions cost).
 
+> 🏢 **GitHub Enterprise supported.** Ralph's triage script (`ralph-triage.js`) resolves the GitHub REST API host from `GITHUB_API_URL`, falling back to `GITHUB_SERVER_URL` + `/api/v3`, then `https://api.github.com`. On Actions runners (github.com or GHE) this is set automatically — no configuration needed. Running `squad heartbeat` outside Actions against a GHE instance? Set `GITHUB_API_URL` yourself first: `GITHUB_API_URL=https://ghe.mycompany.com/api/v3 squad heartbeat`.
+
 Ralph reads `.squad/routing.md`, looks at open issues, and applies labels:
 
 ```

--- a/packages/squad-cli/templates/ralph-triage.js
+++ b/packages/squad-cli/templates/ralph-triage.js
@@ -414,13 +414,31 @@ function getOwnerRepoFromGit() {
   return parseOwnerRepoFromRemote(remoteUrl);
 }
 
+/**
+ * Resolve the GitHub REST API base URL from the environment, so triage
+ * works on GitHub Enterprise as well as github.com.
+ *
+ * Order: GITHUB_API_URL (set by Actions on both github.com and GHE runners)
+ * > GITHUB_SERVER_URL + /api/v3 (GHE without an explicit API URL)
+ * > https://api.github.com (fallback for local/non-Actions runs).
+ */
+function resolveGithubApiBase() {
+  const apiUrl = process.env.GITHUB_API_URL;
+  if (apiUrl) return apiUrl.replace(/\/+$/, '');
+
+  const serverUrl = process.env.GITHUB_SERVER_URL;
+  if (serverUrl) return `${serverUrl.replace(/\/+$/, '')}/api/v3`;
+
+  return 'https://api.github.com';
+}
+
 function githubRequestJson(pathname, token) {
   return new Promise((resolve, reject) => {
+    const requestUrl = new URL(`${resolveGithubApiBase()}${pathname}`);
     const req = https.request(
+      requestUrl,
       {
-        hostname: 'api.github.com',
         method: 'GET',
-        path: pathname,
         headers: {
           Accept: 'application/vnd.github+json',
           Authorization: `Bearer ${token}`,
@@ -539,7 +557,11 @@ async function main() {
   fs.writeFileSync(outputPath, `${JSON.stringify(results, null, 2)}\n`, 'utf8');
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { resolveGithubApiBase };

--- a/packages/squad-sdk/templates/ralph-triage.js
+++ b/packages/squad-sdk/templates/ralph-triage.js
@@ -414,13 +414,31 @@ function getOwnerRepoFromGit() {
   return parseOwnerRepoFromRemote(remoteUrl);
 }
 
+/**
+ * Resolve the GitHub REST API base URL from the environment, so triage
+ * works on GitHub Enterprise as well as github.com.
+ *
+ * Order: GITHUB_API_URL (set by Actions on both github.com and GHE runners)
+ * > GITHUB_SERVER_URL + /api/v3 (GHE without an explicit API URL)
+ * > https://api.github.com (fallback for local/non-Actions runs).
+ */
+function resolveGithubApiBase() {
+  const apiUrl = process.env.GITHUB_API_URL;
+  if (apiUrl) return apiUrl.replace(/\/+$/, '');
+
+  const serverUrl = process.env.GITHUB_SERVER_URL;
+  if (serverUrl) return `${serverUrl.replace(/\/+$/, '')}/api/v3`;
+
+  return 'https://api.github.com';
+}
+
 function githubRequestJson(pathname, token) {
   return new Promise((resolve, reject) => {
+    const requestUrl = new URL(`${resolveGithubApiBase()}${pathname}`);
     const req = https.request(
+      requestUrl,
       {
-        hostname: 'api.github.com',
         method: 'GET',
-        path: pathname,
         headers: {
           Accept: 'application/vnd.github+json',
           Authorization: `Bearer ${token}`,
@@ -539,7 +557,11 @@ async function main() {
   fs.writeFileSync(outputPath, `${JSON.stringify(results, null, 2)}\n`, 'utf8');
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { resolveGithubApiBase };

--- a/templates/ralph-triage.js
+++ b/templates/ralph-triage.js
@@ -414,13 +414,31 @@ function getOwnerRepoFromGit() {
   return parseOwnerRepoFromRemote(remoteUrl);
 }
 
+/**
+ * Resolve the GitHub REST API base URL from the environment, so triage
+ * works on GitHub Enterprise as well as github.com.
+ *
+ * Order: GITHUB_API_URL (set by Actions on both github.com and GHE runners)
+ * > GITHUB_SERVER_URL + /api/v3 (GHE without an explicit API URL)
+ * > https://api.github.com (fallback for local/non-Actions runs).
+ */
+function resolveGithubApiBase() {
+  const apiUrl = process.env.GITHUB_API_URL;
+  if (apiUrl) return apiUrl.replace(/\/+$/, '');
+
+  const serverUrl = process.env.GITHUB_SERVER_URL;
+  if (serverUrl) return `${serverUrl.replace(/\/+$/, '')}/api/v3`;
+
+  return 'https://api.github.com';
+}
+
 function githubRequestJson(pathname, token) {
   return new Promise((resolve, reject) => {
+    const requestUrl = new URL(`${resolveGithubApiBase()}${pathname}`);
     const req = https.request(
+      requestUrl,
       {
-        hostname: 'api.github.com',
         method: 'GET',
-        path: pathname,
         headers: {
           Accept: 'application/vnd.github+json',
           Authorization: `Bearer ${token}`,
@@ -539,7 +557,11 @@ async function main() {
   fs.writeFileSync(outputPath, `${JSON.stringify(results, null, 2)}\n`, 'utf8');
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { resolveGithubApiBase };

--- a/test/ralph-triage.test.ts
+++ b/test/ralph-triage.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, it, expect, expectTypeOf } from 'vitest';
+import { createRequire } from 'node:module';
+import { describe, it, expect, expectTypeOf, afterEach } from 'vitest';
 import {
   parseRoster,
   parseRoutingRules,
@@ -375,6 +376,44 @@ describe('triage parity', () => {
     const ruleIssue = { number: 2, title: 'Fix event loop issue', body: '', labels: [] };
     const result2 = triageIssue(ruleIssue, rules, modules, roster);
     expect(result2?.source).toBe('routing-rule');
+  });
+});
+
+describe('resolveGithubApiBase() — GitHub Enterprise support', () => {
+  const require = createRequire(import.meta.url);
+  const { resolveGithubApiBase } = require('../templates/ralph-triage.js');
+
+  const originalApiUrl = process.env.GITHUB_API_URL;
+  const originalServerUrl = process.env.GITHUB_SERVER_URL;
+
+  afterEach(() => {
+    if (originalApiUrl === undefined) delete process.env.GITHUB_API_URL;
+    else process.env.GITHUB_API_URL = originalApiUrl;
+    if (originalServerUrl === undefined) delete process.env.GITHUB_SERVER_URL;
+    else process.env.GITHUB_SERVER_URL = originalServerUrl;
+  });
+
+  it('uses GITHUB_API_URL when set (GHE runners set this to <host>/api/v3)', () => {
+    process.env.GITHUB_API_URL = 'https://ghe.example.com/api/v3';
+    delete process.env.GITHUB_SERVER_URL;
+    expect(resolveGithubApiBase()).toBe('https://ghe.example.com/api/v3');
+  });
+
+  it('strips a trailing slash from GITHUB_API_URL', () => {
+    process.env.GITHUB_API_URL = 'https://api.github.com/';
+    expect(resolveGithubApiBase()).toBe('https://api.github.com');
+  });
+
+  it('falls back to GITHUB_SERVER_URL + /api/v3 when GITHUB_API_URL is unset', () => {
+    delete process.env.GITHUB_API_URL;
+    process.env.GITHUB_SERVER_URL = 'https://ghe.example.com';
+    expect(resolveGithubApiBase()).toBe('https://ghe.example.com/api/v3');
+  });
+
+  it('falls back to https://api.github.com when neither env var is set', () => {
+    delete process.env.GITHUB_API_URL;
+    delete process.env.GITHUB_SERVER_URL;
+    expect(resolveGithubApiBase()).toBe('https://api.github.com');
   });
 });
 


### PR DESCRIPTION
### What
`ralph-triage.js` now resolves the GitHub REST API host from the environment instead of hardcoding `api.github.com`.

### Why
`Squad Heartbeat (Ralph)` fails with a 401 on GitHub Enterprise. `githubRequestJson()` in `.squad-templates/ralph-triage.js` sent every request to `hostname: 'api.github.com'`, but on GHE the `GITHUB_TOKEN` is only valid against the enterprise API host (`https://<ghe-host>/api/v3`), so calls to github.com are rejected with `Bad credentials`.

Closes #1142

### How
Added a `resolveGithubApiBase()` helper that picks the API base in order:
1. `GITHUB_API_URL` — set automatically by Actions on both github.com and GHE runners.
2. `GITHUB_SERVER_URL` + `/api/v3` — fallback for GHE if `GITHUB_API_URL` isn't set.
3. `https://api.github.com` — fallback for local/non-Actions runs.

`githubRequestJson()` now builds the request from a `URL` object (`${resolveGithubApiBase()}${pathname}`) instead of a hardcoded `hostname`/`path` pair, so `https.request()` picks up the correct protocol, host, and base path automatically. No behavior change on github.com-hosted repos, since `GITHUB_API_URL` there already resolves to `https://api.github.com`.

Fixed in the canonical `.squad-templates/ralph-triage.js` and propagated via `node scripts/sync-templates.mjs --sync` to the 3 mirror targets (`templates/`, `packages/squad-cli/templates/`, `packages/squad-sdk/templates/`), matching the parity checks in `test/template-sync.test.ts`.

Also added a `require.main === module` guard around the script's `main()` call and exported `resolveGithubApiBase` via `module.exports`, purely so the new unit tests can import and exercise the helper without invoking `main()` (which needs `GITHUB_TOKEN` and network access). No change to the script's behavior when run directly via `node ralph-triage.js`.

### Testing
- Added 4 new unit tests in `test/ralph-triage.test.ts` covering all three resolution branches plus trailing-slash normalization. Verified they fail with `resolveGithubApiBase is not a function` against the pre-fix code and pass against the fix.
- `npx vitest run test/ralph-triage.test.ts test/template-sync.test.ts` — 284 passed.
- `npm run build` — passes.
- `npm run lint` (`tsc --noEmit`) — passes.
- `npm run lint:eslint` — 0 errors (pre-existing warnings only, unrelated to this change).
- `npm test` (full suite) — no regressions from this change. A number of unrelated tests fail on this Windows dev machine (EBUSY temp-dir races, timing-sensitive timeouts, a locale-dependent number-formatting assertion) — confirmed identical failures on a clean `upstream/dev` checkout before my changes, so they're pre-existing local-environment flakiness, not something this PR introduces.

---

### ⚠️ Quick Check
- [x] Changeset added via `npx changeset add`-equivalent manual file: `.changeset/fix-1142-ralph-triage-ghe-api-host.md` (patch bump for `@bradygaster/squad-cli` and `@bradygaster/squad-sdk`, since this touches governed template paths under both packages' `templates/`)

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev`
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes (`git diff --cached --stat`)
- [x] PR is **not** in draft mode — will mark ready once CI is green
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] `npm run build` passes
- [x] `npm test` passes (all tests relevant to this change; see testing notes above for pre-existing unrelated local failures)
- [x] `npm run lint` passes (type check clean)
- [x] `npm run lint:eslint` passes (0 errors)

#### Changeset
- [x] Changeset added (patch, both packages)

#### Docs
- [x] N/A — internal script fix, no user-facing CLI/SDK API change

#### Exports
- [x] N/A — no new modules

---

### Breaking Changes
None.

### Waivers
None.