### PR TITLE
ci: pin GitHub Actions references to full-length commit SHAs

### DIFF
--- a/.changeset/fix-1441-pin-actions-sha.md
+++ b/.changeset/fix-1441-pin-actions-sha.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+Pin GitHub Actions references to full-length commit SHAs across the 10 shipped workflow templates (`squad-ci.yml`, `squad-docs.yml`, `squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-label-enforce.yml`, `squad-preview.yml`, `squad-promote.yml`, `squad-release.yml`, `squad-triage.yml`, `sync-squad-labels.yml`), matching the same hardening already applied to this repo's own `.github/workflows/`. Orgs that require SHA-pinned actions as a supply-chain policy can now use `squad init`/`squad upgrade` without hand-patching every installed workflow. Closes #1441.

--- a/.github/actions/setup-squad-node/action.yml
+++ b/.github/actions/setup-squad-node/action.yml
@@ -50,7 +50,7 @@ runs:
           exit 1
         fi
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}

--- a/.github/workflows/squad-agents-ai-ci.yml
+++ b/.github/workflows/squad-agents-ai-ci.yml
@@ -44,10 +44,10 @@ jobs:
       DOTNET_NOLOGO: '1'
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 #v5
         with:
           dotnet-version: '10.0.x'
 
@@ -77,14 +77,14 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
         with:
           name: squad-agents-ai-testresults-${{ matrix.os }}
           path: TestResults
           if-no-files-found: ignore
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
         with:
           name: squad-agents-ai-nupkgs-${{ matrix.os }}
           path: nupkgs

--- a/.github/workflows/squad-agents-ai-release.yml
+++ b/.github/workflows/squad-agents-ai-release.yml
@@ -62,12 +62,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 #v5
         with:
           dotnet-version: '10.0.x'
 
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload NuGet package artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
         with:
           name: squad-agents-ai-nupkgs-${{ steps.version.outputs.PACKAGE_VERSION }}
           path: nupkgs/*
@@ -170,7 +170,7 @@ jobs:
 
       - name: NuGet login (OIDC → temp API key)
         id: nuget-login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 #v1
         with:
           user: ${{ vars.NUGET_USER }}
 

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -26,7 +26,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
       - name: Detect changed paths
@@ -62,8 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
           cache: 'npm'
@@ -91,8 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
           cache: 'npm'
@@ -189,10 +189,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
       - name: Fetch PR labels
@@ -386,10 +386,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
       - name: Check skip conditions
@@ -519,10 +519,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/squad-docs-links.yml
+++ b/.github/workflows/squad-docs-links.yml
@@ -9,11 +9,11 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
       
       - name: Check external links
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 #v2
         with:
           args: >-
             --verbose
@@ -27,7 +27,7 @@ jobs:
           
       - name: Create issue on broken links
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v6
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 #v6
         with:
           title: '🔗 Broken external links detected'
           content-filepath: ./lychee/out.md

--- a/.github/workflows/squad-docs.yml
+++ b/.github/workflows/squad-docs.yml
@@ -21,9 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: '22'
           cache: npm
@@ -41,7 +41,7 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 #v5
         with:
           path: docs/dist
 
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 #v5

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -39,13 +39,13 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       # CI Hardening: GitHub API rate limit monitoring (item 9)
       # Ralph makes multiple API calls (list issues, add labels, create comments).
       # Check rate limit early to avoid silent failures mid-workflow.
       - name: "📊 Check GitHub API rate limit"
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const { data: rateLimit } = await github.rest.rateLimit.get();
@@ -63,7 +63,7 @@ jobs:
             }
 
       - name: Ralph — Repair orphaned squad labels
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             // Find issues with squad:{member} labels but missing parent "squad" label
@@ -115,7 +115,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const fs = require('fs');
@@ -167,7 +167,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/squad-impact.yml
+++ b/.github/workflows/squad-impact.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout scripts (base branch only)
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           sparse-checkout: |
             scripts/analyze-impact.mjs
@@ -34,7 +34,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
 
@@ -45,7 +45,7 @@ jobs:
         run: node scripts/analyze-impact.mjs ${{ github.event.pull_request.number }}
 
       - name: Post impact report
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/squad-insider-publish.yml
+++ b/.github/workflows/squad-insider-publish.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node-version: [22]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           ref: dev
 
@@ -81,7 +81,7 @@ jobs:
       matrix:
         node-version: [22]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           ref: dev
 

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -19,12 +19,12 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       # CI Hardening: GitHub API rate limit monitoring (item 9)
       # Issue assignment makes multiple API calls (read team file, add labels, comment, assign).
       - name: "📊 Check GitHub API rate limit"
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const { data: rateLimit } = await github.rest.rateLimit.get();
@@ -42,7 +42,7 @@ jobs:
             }
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const fs = require('fs');
@@ -153,7 +153,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/.github/workflows/squad-label-enforce.yml
+++ b/.github/workflows/squad-label-enforce.yml
@@ -17,10 +17,10 @@ jobs:
   enforce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/squad-npm-publish.yml
+++ b/.github/workflows/squad-npm-publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
       - name: "Scan for file: references in package.json files"
@@ -119,10 +119,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
           cache: 'npm'
@@ -191,10 +191,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
@@ -265,10 +265,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/squad-pr-nudge.yml
+++ b/.github/workflows/squad-pr-nudge.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Nudge Stale PRs"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const STALE_DAYS = 7;

--- a/.github/workflows/squad-pr-readiness.yml
+++ b/.github/workflows/squad-pr-readiness.yml
@@ -33,7 +33,7 @@ jobs:
           || github.event.workflow_run.pull_requests[0] != null)
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           sparse-checkout: scripts/pr-readiness.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/squad-preview.yml
+++ b/.github/workflows/squad-preview.yml
@@ -15,9 +15,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
 

--- a/.github/workflows/squad-promote.yml
+++ b/.github/workflows/squad-promote.yml
@@ -22,7 +22,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -15,11 +15,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: 22
 

--- a/.github/workflows/squad-repo-health.yml
+++ b/.github/workflows/squad-repo-health.yml
@@ -25,14 +25,14 @@ jobs:
     timeout-minutes: 3
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           sparse-checkout: |
             scripts/check-bootstrap-deps.mjs
           sparse-checkout-cone-mode: false
       - name: Fetch PR head (data only — not executed)
         run: git fetch origin ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: '22'
       - name: Check bootstrap dependencies
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 2
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
       - name: Fetch PR head (data only — not executed)
@@ -82,12 +82,12 @@ jobs:
     timeout-minutes: 3
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
       - name: Fetch PR head (data only — not executed)
         run: git fetch origin ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: '22'
       - name: Detect .squad/ leakage
@@ -101,7 +101,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Comment on leakage
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const { run } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/repo-health-comment.mjs`);
@@ -119,12 +119,12 @@ jobs:
     timeout-minutes: 5
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
       - name: Fetch PR head (data only — not executed)
         run: git fetch origin ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: '22'
       - name: Run architectural review
@@ -138,7 +138,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Comment on findings
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const { run } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/repo-health-comment.mjs`);
@@ -156,12 +156,12 @@ jobs:
     timeout-minutes: 5
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
       - name: Fetch PR head (data only — not executed)
         run: git fetch origin ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
         with:
           node-version: '22'
       - name: Run security review
@@ -175,7 +175,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Comment on findings
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const { run } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/repo-health-comment.mjs`);

--- a/.github/workflows/squad-scope-check.yml
+++ b/.github/workflows/squad-scope-check.yml
@@ -15,7 +15,7 @@ jobs:
       startsWith(github.head_ref, 'repo-health/') ||
       contains(github.event.pull_request.labels.*.name, 'repo-health')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
       - name: Check for product code in repo-health PR

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -18,12 +18,12 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       # CI Hardening: GitHub API rate limit monitoring (item 9)
       # Triage makes multiple API calls (list issues, add labels, create comments).
       - name: "📊 Check GitHub API rate limit"
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const { data: rateLimit } = await github.rest.rateLimit.get();
@@ -41,7 +41,7 @@ jobs:
             }
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -19,10 +19,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9
         with:
           script: |
             const fs = require('fs');

--- a/.squad-templates/workflows/squad-ci.yml
+++ b/.squad-templates/workflows/squad-ci.yml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/.squad-templates/workflows/squad-docs.yml
+++ b/.squad-templates/workflows/squad-docs.yml
@@ -21,9 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: '22'
           cache: npm
@@ -38,7 +38,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3
         with:
           path: docs/dist
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4

--- a/.squad-templates/workflows/squad-heartbeat.yml
+++ b/.squad-templates/workflows/squad-heartbeat.yml
@@ -25,7 +25,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Check triage script
         id: check-script
@@ -48,7 +48,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');
@@ -100,7 +100,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.squad-templates/workflows/squad-issue-assign.yml
+++ b/.squad-templates/workflows/squad-issue-assign.yml
@@ -14,10 +14,10 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');
@@ -112,7 +112,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/.squad-templates/workflows/squad-label-enforce.yml
+++ b/.squad-templates/workflows/squad-label-enforce.yml
@@ -12,10 +12,10 @@ jobs:
   enforce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const issue = context.payload.issue;

--- a/.squad-templates/workflows/squad-preview.yml
+++ b/.squad-templates/workflows/squad-preview.yml
@@ -11,9 +11,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/.squad-templates/workflows/squad-promote.yml
+++ b/.squad-templates/workflows/squad-promote.yml
@@ -18,7 +18,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.squad-templates/workflows/squad-release.yml
+++ b/.squad-templates/workflows/squad-release.yml
@@ -11,11 +11,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/.squad-templates/workflows/squad-triage.yml
+++ b/.squad-templates/workflows/squad-triage.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');

--- a/.squad-templates/workflows/sync-squad-labels.yml
+++ b/.squad-templates/workflows/sync-squad-labels.yml
@@ -14,10 +14,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');

--- a/packages/squad-cli/templates/workflows/squad-ci.yml
+++ b/packages/squad-cli/templates/workflows/squad-ci.yml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/packages/squad-cli/templates/workflows/squad-docs.yml
+++ b/packages/squad-cli/templates/workflows/squad-docs.yml
@@ -21,9 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: '22'
           cache: npm
@@ -38,7 +38,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3
         with:
           path: docs/dist
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4

--- a/packages/squad-cli/templates/workflows/squad-heartbeat.yml
+++ b/packages/squad-cli/templates/workflows/squad-heartbeat.yml
@@ -25,7 +25,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Check triage script
         id: check-script
@@ -48,7 +48,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');
@@ -100,7 +100,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/packages/squad-cli/templates/workflows/squad-issue-assign.yml
+++ b/packages/squad-cli/templates/workflows/squad-issue-assign.yml
@@ -14,10 +14,10 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');
@@ -112,7 +112,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/packages/squad-cli/templates/workflows/squad-label-enforce.yml
+++ b/packages/squad-cli/templates/workflows/squad-label-enforce.yml
@@ -12,10 +12,10 @@ jobs:
   enforce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const issue = context.payload.issue;

--- a/packages/squad-cli/templates/workflows/squad-preview.yml
+++ b/packages/squad-cli/templates/workflows/squad-preview.yml
@@ -11,9 +11,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/packages/squad-cli/templates/workflows/squad-promote.yml
+++ b/packages/squad-cli/templates/workflows/squad-promote.yml
@@ -18,7 +18,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/squad-cli/templates/workflows/squad-release.yml
+++ b/packages/squad-cli/templates/workflows/squad-release.yml
@@ -11,11 +11,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/packages/squad-cli/templates/workflows/squad-triage.yml
+++ b/packages/squad-cli/templates/workflows/squad-triage.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');

--- a/packages/squad-cli/templates/workflows/sync-squad-labels.yml
+++ b/packages/squad-cli/templates/workflows/sync-squad-labels.yml
@@ -14,10 +14,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');

--- a/packages/squad-sdk/templates/workflows/squad-ci.yml
+++ b/packages/squad-sdk/templates/workflows/squad-ci.yml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/packages/squad-sdk/templates/workflows/squad-docs.yml
+++ b/packages/squad-sdk/templates/workflows/squad-docs.yml
@@ -21,9 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: '22'
           cache: npm
@@ -38,7 +38,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3
         with:
           path: docs/dist
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4

--- a/packages/squad-sdk/templates/workflows/squad-heartbeat.yml
+++ b/packages/squad-sdk/templates/workflows/squad-heartbeat.yml
@@ -25,7 +25,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Check triage script
         id: check-script
@@ -48,7 +48,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');
@@ -100,7 +100,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/packages/squad-sdk/templates/workflows/squad-issue-assign.yml
+++ b/packages/squad-sdk/templates/workflows/squad-issue-assign.yml
@@ -14,10 +14,10 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');
@@ -112,7 +112,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/packages/squad-sdk/templates/workflows/squad-label-enforce.yml
+++ b/packages/squad-sdk/templates/workflows/squad-label-enforce.yml
@@ -12,10 +12,10 @@ jobs:
   enforce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const issue = context.payload.issue;

--- a/packages/squad-sdk/templates/workflows/squad-preview.yml
+++ b/packages/squad-sdk/templates/workflows/squad-preview.yml
@@ -11,9 +11,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/packages/squad-sdk/templates/workflows/squad-promote.yml
+++ b/packages/squad-sdk/templates/workflows/squad-promote.yml
@@ -18,7 +18,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/squad-sdk/templates/workflows/squad-release.yml
+++ b/packages/squad-sdk/templates/workflows/squad-release.yml
@@ -11,11 +11,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/packages/squad-sdk/templates/workflows/squad-triage.yml
+++ b/packages/squad-sdk/templates/workflows/squad-triage.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');

--- a/packages/squad-sdk/templates/workflows/sync-squad-labels.yml
+++ b/packages/squad-sdk/templates/workflows/sync-squad-labels.yml
@@ -14,10 +14,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');

--- a/templates/workflows/squad-ci.yml
+++ b/templates/workflows/squad-ci.yml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/templates/workflows/squad-docs.yml
+++ b/templates/workflows/squad-docs.yml
@@ -21,9 +21,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: '22'
           cache: npm
@@ -38,7 +38,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3
         with:
           path: docs/dist
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4

--- a/templates/workflows/squad-heartbeat.yml
+++ b/templates/workflows/squad-heartbeat.yml
@@ -25,7 +25,7 @@ jobs:
   heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Check triage script
         id: check-script
@@ -48,7 +48,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');
@@ -100,7 +100,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/templates/workflows/squad-issue-assign.yml
+++ b/templates/workflows/squad-issue-assign.yml
@@ -14,10 +14,10 @@ jobs:
     if: startsWith(github.event.label.name, 'squad:')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');
@@ -112,7 +112,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |

--- a/templates/workflows/squad-label-enforce.yml
+++ b/templates/workflows/squad-label-enforce.yml
@@ -12,10 +12,10 @@ jobs:
   enforce:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Enforce mutual exclusivity
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const issue = context.payload.issue;

--- a/templates/workflows/squad-preview.yml
+++ b/templates/workflows/squad-preview.yml
@@ -11,9 +11,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/templates/workflows/squad-promote.yml
+++ b/templates/workflows/squad-promote.yml
@@ -18,7 +18,7 @@ jobs:
     name: Promote dev → preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     needs: dev-to-preview
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/workflows/squad-release.yml
+++ b/templates/workflows/squad-release.yml
@@ -11,11 +11,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: 22
 

--- a/templates/workflows/squad-triage.yml
+++ b/templates/workflows/squad-triage.yml
@@ -13,10 +13,10 @@ jobs:
     if: github.event.label.name == 'squad'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');

--- a/templates/workflows/sync-squad-labels.yml
+++ b/templates/workflows/sync-squad-labels.yml
@@ -14,10 +14,10 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
### What
Every `uses:` reference across `.github/workflows/*.yml` (and the local `setup-squad-node` composite action) is rewritten from a floating version tag (`@v7`, `@v6`, etc.) to a pinned, full-length commit SHA, with the original version kept as a trailing comment for readability. **Update:** the same pinning is now also applied to the 10 shipped workflow templates in `.squad-templates/workflows/` and its 3 synced mirrors (`templates/`, `packages/squad-cli/templates/`, `packages/squad-sdk/templates/`), so `squad init`/`squad upgrade` installs pinned workflows too — not just this repo's own dogfooded copies.

### Why
Closes #1441

Many GitHub Enterprises/orgs require every action reference in a workflow to be pinned to a full commit SHA as a supply-chain security policy. Squad's shipped workflows currently use floating tags, so any org with that policy can't adopt them as-is — they have to hand-patch every workflow file after `squad init`/`squad upgrade`, and re-patch again on the next upgrade.

### How
Resolved each of the 10 unique `action@tag` pairs actually in use in `.github/workflows/` (`actions/checkout@v7`, `actions/setup-node@v6`, `actions/github-script@v9`, `actions/setup-dotnet@v5`, `actions/upload-artifact@v7`, `actions/upload-pages-artifact@v5`, `actions/deploy-pages@v5`, `lycheeverse/lychee-action@v2`, `NuGet/login@v1`, `peter-evans/create-issue-from-file@v6`) to its current commit SHA via the GitHub REST API (`repos/{owner}/{repo}/commits/{tag}`), then rewrote every `uses:` line to:

```yaml
uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
```

matching the format from the issue's own acceptance criteria. Also pinned `actions/setup-node@v4` inside `.github/actions/setup-squad-node/action.yml` — it's outside `.github/workflows/` strictly, but it's a composite action invoked by several of these workflows and carries the same unpinned-reference problem, so leaving it out would defeat the point.

The two `uses: ./.github/actions/setup-squad-node` references are untouched — they're local path references with no tag to resolve, already "pinned" by living in-repo.

**Template sync:** the Architectural Review bot correctly flagged that `.github/workflows/` changed without the matching template locations. Checked `scripts/sync-templates.mjs` — `.squad-templates/` is the canonical source, mirrored byte-for-byte into `templates/`, `packages/squad-cli/templates/`, `packages/squad-sdk/templates/`. The 10 workflow templates that share a filename with a `.github/workflows/` file (`squad-ci.yml`, `squad-docs.yml`, `squad-heartbeat.yml`, `squad-issue-assign.yml`, `squad-label-enforce.yml`, `squad-preview.yml`, `squad-promote.yml`, `squad-release.yml`, `squad-triage.yml`, `sync-squad-labels.yml`) got the same treatment — but note these templates already carry older tags than `.github/workflows` (`checkout@v4` not `v7`, `github-script@v7` not `v9`, `setup-node@v4` not `v6`, `upload-pages-artifact@v3` not `v5`, `deploy-pages@v4` not `v5`), because `.github/workflows/` has accumulated repo-specific CI hardening (rate-limit checks, concurrency groups, etc.) that was never backported to the shipped templates. Rather than silently bumping every template to match `.github/workflows`'s newer versions — a separate, unrelated concern — each template's own existing tag was pinned to its own SHA, keeping this PR strictly about pinning, not upgrading.

`squad-insider-release.yml` (template-only, no `.github/workflows` counterpart) was **not** touched — see PR comment for why.

No other content in any touched file was changed — every diff line is a `uses:` swap only.

### Testing
- Verified all changed YAML files still parse with `js-yaml` (no `actionlint` binary installable in this environment).
- `npm run lint` — passes.
- Diffed every added line against the pattern `uses: owner/repo@<40-hex-sha> #vX` — matches everywhere, zero exceptions.
- `git diff --check` — clean, no whitespace/CRLF noise.
- Confirmed the 3 mirror directories stayed byte-identical to `.squad-templates/` after the edit (diff -q, no output).

---

### ⚠️ Quick Check
- [x] Changeset added (`.changeset/fix-1441-pin-actions-sha.md`, patch bump for both packages) — this PR now touches governed template paths (`.squad-templates/`, `templates/`, `packages/*/templates/`)

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev`
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes (`git diff --cached --stat`)
- [x] PR is not in draft mode
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] `npm run build` — N/A, no code changed, but passes regardless
- [x] `npm test` — N/A, no code changed (no test suite covers workflow YAML content)
- [x] `npm run lint` passes
- [x] `npm run lint:eslint` — N/A, no `.ts`/`.js` files changed

#### Changeset
- [x] Changeset added — governed template paths touched

#### Docs
- [x] N/A — internal CI hardening, no user-facing API change

#### Exports
- [x] N/A — no SDK changes

---

### Breaking Changes
None. Pinning to a SHA that resolves to the exact same commit as the tag it replaces is behavior-neutral.

### Waivers
None.
