### PR TITLE
fix(cli): resolve externalized state in squad export

### DIFF
--- a/.changeset/fix-1396-export-external-state.md
+++ b/.changeset/fix-1396-export-external-state.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+Fix #1396: `squad export` now resolves externalized state. After `squad externalize`, export read the local `.squad/` directory directly, so it either failed with a misleading "No squad found — run init first" or silently exported stale/scaffolded local files instead of the real team state in the external directory. Export now routes through the same `effectiveSquadDir()` resolution used by `build`, `loop`, `plugin`, `watch`, and `doctor`, reading `team.md`, `decisions.md`, `routing.md`, `casting/`, `agents/`, and `.squad`-local skills from the effective state directory.

--- a/packages/squad-cli/src/cli/commands/export.ts
+++ b/packages/squad-cli/src/cli/commands/export.ts
@@ -6,7 +6,7 @@
 import path from 'node:path';
 import { FSStorageProvider, exportToRepo, parseRepoString } from '@bradygaster/squad-sdk';
 import type { RepoSpec } from '@bradygaster/squad-sdk';
-import { detectSquadDir } from '../core/detect-squad-dir.js';
+import { effectiveSquadDir } from '../core/effective-squad-dir.js';
 import { success, warn, info } from '../core/output.js';
 import { fatal } from '../core/errors.js';
 import { getPackageVersion } from '../core/version.js';
@@ -32,7 +32,8 @@ export interface ExportRepoOptions {
 }
 
 /**
- * Build the export manifest from a local squad directory.
+ * Build the export manifest from the effective squad state directory
+ * (the external state dir when state is externalized, otherwise local .squad/).
  */
 function buildManifest(dest: string, storage: FSStorageProvider, squadInfo: { path: string }): ExportManifest {
   const manifest: ExportManifest = {
@@ -129,14 +130,14 @@ function buildManifest(dest: string, storage: FSStorageProvider, squadInfo: { pa
  */
 export async function runExport(dest: string, outPath?: string, repoOptions?: ExportRepoOptions): Promise<void> {
   const storage = new FSStorageProvider();
-  const squadInfo = detectSquadDir(dest);
-  const teamMd = path.join(squadInfo.path, 'team.md');
+  const { stateDir } = effectiveSquadDir(dest);
+  const teamMd = path.join(stateDir, 'team.md');
   
   if (!storage.existsSync(teamMd)) {
     fatal('No squad found — run init first');
   }
 
-  const manifest = buildManifest(dest, storage, squadInfo);
+  const manifest = buildManifest(dest, storage, { path: stateDir });
   const bundleJson = JSON.stringify(manifest, null, 2) + '\n';
 
   // Export to GitHub repo if --repo is specified

--- a/test/cli/export-import.test.ts
+++ b/test/cli/export-import.test.ts
@@ -13,6 +13,10 @@ import { runInit } from '@bradygaster/squad-cli/core/init';
 import { runExport } from '@bradygaster/squad-cli/commands/export';
 import { runImport } from '@bradygaster/squad-cli/commands/import';
 
+const EXT_ROOT = join(tmpdir(), `.test-cli-export-ext-${randomBytes(4).toString('hex')}`);
+const EXT_GLOBAL = join(tmpdir(), `.test-cli-export-ext-global-${randomBytes(4).toString('hex')}`);
+const EXT_PROJECT_KEY = `test-export-ext-${randomBytes(4).toString('hex')}`;
+
 const TEST_ROOT = join(tmpdir(), `.test-cli-export-import-${randomBytes(4).toString('hex')}`);
 const IMPORT_ROOT = join(tmpdir(), `.test-cli-import-target-${randomBytes(4).toString('hex')}`);
 
@@ -345,5 +349,76 @@ describe('CLI: export/import commands', () => {
     expect(importedDecisions).toBe('');
     // routing.md should not be created if not in bundle
     expect(existsSync(join(IMPORT_ROOT, '.squad', 'routing.md'))).toBe(false);
+  });
+});
+
+describe('CLI: export with externalized state (#1396)', () => {
+  const origAppData = process.env['APPDATA'];
+  const origXdgConfig = process.env['XDG_CONFIG_HOME'];
+  const externalStateDir = join(EXT_GLOBAL, 'squad', 'projects', EXT_PROJECT_KEY);
+
+  beforeEach(async () => {
+    if (existsSync(EXT_ROOT)) {
+      await rm(EXT_ROOT, { recursive: true, force: true });
+    }
+    if (existsSync(EXT_GLOBAL)) {
+      await rm(EXT_GLOBAL, { recursive: true, force: true });
+    }
+
+    // Point resolveGlobalSquadPath() inside EXT_GLOBAL (not the real user dir)
+    if (process.platform === 'win32') {
+      process.env['APPDATA'] = EXT_GLOBAL;
+    } else {
+      process.env['XDG_CONFIG_HOME'] = EXT_GLOBAL;
+    }
+
+    // Local repo: thin .squad/ holding only the marker `squad externalize` leaves behind
+    await mkdir(join(EXT_ROOT, '.squad'), { recursive: true });
+    await writeFile(
+      join(EXT_ROOT, '.squad', 'config.json'),
+      JSON.stringify({ version: 1, teamRoot: '.', projectKey: EXT_PROJECT_KEY, stateLocation: 'external' }, null, 2)
+    );
+
+    // External state dir: the real team state
+    await mkdir(join(externalStateDir, 'agents', 'alice'), { recursive: true });
+    await writeFile(join(externalStateDir, 'team.md'), '# External Team\n');
+    await writeFile(join(externalStateDir, 'decisions.md'), '# External Decisions\n');
+    await writeFile(join(externalStateDir, 'agents', 'alice', 'charter.md'), '# Alice Charter\n');
+  });
+
+  afterEach(async () => {
+    if (origAppData === undefined) delete process.env['APPDATA'];
+    else process.env['APPDATA'] = origAppData;
+    if (origXdgConfig === undefined) delete process.env['XDG_CONFIG_HOME'];
+    else process.env['XDG_CONFIG_HOME'] = origXdgConfig;
+
+    if (existsSync(EXT_ROOT)) {
+      await rm(EXT_ROOT, { recursive: true, force: true });
+    }
+    if (existsSync(EXT_GLOBAL)) {
+      await rm(EXT_GLOBAL, { recursive: true, force: true });
+    }
+  });
+
+  it('exports team state from the external state dir', async () => {
+    await runExport(EXT_ROOT);
+
+    const exportPath = join(EXT_ROOT, 'squad-export.json');
+    expect(existsSync(exportPath)).toBe(true);
+
+    const manifest = JSON.parse(await readFile(exportPath, 'utf-8'));
+    expect(manifest.team_md).toBe('# External Team\n');
+    expect(manifest.decisions_md).toBe('# External Decisions\n');
+    expect(manifest.agents['alice']?.charter).toBe('# Alice Charter\n');
+  });
+
+  it('prefers external state over stale local files when the marker is set', async () => {
+    // Simulate local scaffolding re-created after externalize (e.g. a re-run init)
+    await writeFile(join(EXT_ROOT, '.squad', 'team.md'), '# Stale Local Scaffold\n');
+
+    await runExport(EXT_ROOT);
+
+    const manifest = JSON.parse(await readFile(join(EXT_ROOT, 'squad-export.json'), 'utf-8'));
+    expect(manifest.team_md).toBe('# External Team\n');
   });
 });


### PR DESCRIPTION
### What
`squad export` now resolves the effective state directory (external when `stateLocation: "external"` is set, local otherwise) instead of reading the local `.squad/` path unconditionally.

### Why
Closes #1396

**Severity: silent data-loss class.** `squad export` is the documented backup/share/migration path. After `squad externalize` (a first-class feature that *moves* `team.md`, `decisions.md`, `routing.md`, `casting/`, `agents/` out of the working tree, leaving only a thin `config.json` marker), export broke in one of two ways:

1. **Misleading hard failure** — the marker-only `.squad/` has no `team.md`, so export dies with `No squad found — run init first`. Following that advice re-scaffolds local state, which sets up:
2. **Silent corruption** — with any local `team.md` present (re-run `init`, partial internalize, manual edits), export reads the local files, reports ✅ success, and ships default scaffolding / stale content instead of the team's real accumulated knowledge. A user who relies on that export as a backup has lost their state without any error.

Anyone using `squad externalize` + `squad export` together is affected, on all platforms.

### Root cause
`export.ts` called `detectSquadDir()` directly and read every state file from `squadInfo.path`. The external-state-aware helper `effectiveSquadDir()` (`packages/squad-cli/src/cli/core/effective-squad-dir.ts`) already exists and is used by `build`, `loop`, `plugin`, `watch`, `doctor`, and shell lifecycle — export was simply never wired through it. (Same class of gap as the sibling issues #1397/#1398/#1399, which are tracked separately under #1402; this PR fixes export only, per one-issue-one-PR.)

### How
- `runExport()` resolves `{ stateDir } = effectiveSquadDir(dest)` and uses `stateDir` for the `team.md` existence check and manifest build.
- `buildManifest()` reads `team.md`, `decisions.md`, `routing.md`, `casting/`, `agents/`, and the `.squad`-local `skills/` source from the effective state dir. Working-tree skill sources (`.copilot/skills`, `.ai-team/skills`) still resolve from `dest` — those live in the repo and are not externalized.
- Non-externalized and legacy `.ai-team` projects are unaffected: without the `stateLocation` marker, `resolveStateDir()` returns the local path unchanged, so behavior is byte-identical to before.

### Repro
```bash
squad init
squad externalize
squad export        # before: "No squad found — run init first" (misleading fatal)
squad init          # follow the bad advice…
squad export        # before: ✅ success — but the export contains default scaffolding, not your team
```

### Regression tests
Two new tests in `test/cli/export-import.test.ts` (`CLI: export with externalized state (#1396)`), using the same `APPDATA`/`XDG_CONFIG_HOME` isolation pattern as `test/effective-squad-dir.test.ts`:
1. **Exports team state from the external state dir** — marker-only local `.squad/` + real state in the external dir → manifest carries the external `team.md`/`decisions.md`/agent charter. Fails without the fix (fatal `No squad found`).
2. **Prefers external state over stale local files when the marker is set** — a stale local `team.md` alongside the marker → manifest carries the external content, not the stale copy. Fails without the fix (exports the stale copy — the silent-corruption case).

### Testing
- `npx vitest run test/cli/export-import.test.ts test/effective-squad-dir.test.ts test/external-state.test.ts` — 41/41 pass.
- Both new tests verified to fail against unfixed code before applying the fix.
- Full `npm test`: no failures in export/external-state/effective-dir areas; remaining failures are the known pre-existing Windows-local flakes (EBUSY temp-dir races, timing-sensitive timeouts), identical on a clean `upstream/dev` checkout.
- `npm run lint` (tsc) — passes. `npx eslint` on changed files — 0 errors (pre-existing `n/no-sync` warnings only).
- `git diff --check` — clean, zero CRLF/whitespace noise.

---

### ⚠️ Quick Check
- [x] Changeset added: `.changeset/fix-1396-export-external-state.md` (patch, `@bradygaster/squad-cli`)

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev`
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes (`git diff --cached --stat`: 3 files, +86 −5)
- [x] Draft now; will mark ready once CI is green
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] `npm run build` passes
- [x] `npm test` — see testing notes above
- [x] `npm run lint` passes
- [x] `npm run lint:eslint` — 0 errors

#### Changeset
- [x] Changeset added (patch, squad-cli)

#### Docs
- [x] N/A — bug fix, no new user-facing capability; existing export/externalize docs describe the now-correct behavior

#### Exports
- [x] N/A — no new modules

---

### Breaking Changes
None. Non-externalized projects resolve to the identical local path as before.

### Waivers
None.