### PR TITLE
fix(init): include proposed roster in confirmation prompt

### DIFF
--- a/.changeset/1454-init-confirmation-roster.md
+++ b/.changeset/1454-init-confirmation-roster.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+Ensure first-time Squad casting includes the complete proposed roster and universe inside the blocking confirmation prompt, so users can review the team even when preceding assistant output is not displayed.

--- a/.squad/skills/coordinator-init-mode/SKILL.md
+++ b/.squad/skills/coordinator-init-mode/SKILL.md
@@ -39,8 +39,24 @@ No team exists yet. **Propose one — but DO NOT create any files until the user
 🔍  Fact Checker — (verifier)    Verification + Devil's Advocate
 ```
 
-5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
-   - **question:** *"Look right?"*
+5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu.
+
+   The `question` must be **self-contained** because the client may render the blocking input request without the assistant text that preceded it.
+
+   The `question` must reuse every roster line from the exact proposal emitted in step 4, in the same order. Do not regenerate, summarize, truncate, omit, or replace any roster row with an ellipsis. Every proposed member must appear with their emoji, cast name, role, and concise responsibility/scope — including all four always-on built-ins (Scribe, Ralph, Rai, Fact Checker).
+
+   Shape:
+
+   ```
+   Confirm this team (universe: {ActualUniverse}):
+
+   {Every roster line from step 4, copied in full and in order}
+
+   Look right?
+   ```
+
+   Never use a bare "Look right?" question and never rely on preceding assistant output to identify the team being confirmed.
+
    - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
 
 **⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**

--- a/packages/squad-cli/templates/skills/coordinator-init-mode/SKILL.md
+++ b/packages/squad-cli/templates/skills/coordinator-init-mode/SKILL.md
@@ -39,8 +39,24 @@ No team exists yet. **Propose one — but DO NOT create any files until the user
 🔍  Fact Checker — (verifier)    Verification + Devil's Advocate
 ```
 
-5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
-   - **question:** *"Look right?"*
+5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu.
+
+   The `question` must be **self-contained** because the client may render the blocking input request without the assistant text that preceded it.
+
+   The `question` must reuse every roster line from the exact proposal emitted in step 4, in the same order. Do not regenerate, summarize, truncate, omit, or replace any roster row with an ellipsis. Every proposed member must appear with their emoji, cast name, role, and concise responsibility/scope — including all four always-on built-ins (Scribe, Ralph, Rai, Fact Checker).
+
+   Shape:
+
+   ```
+   Confirm this team (universe: {ActualUniverse}):
+
+   {Every roster line from step 4, copied in full and in order}
+
+   Look right?
+   ```
+
+   Never use a bare "Look right?" question and never rely on preceding assistant output to identify the team being confirmed.
+
    - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
 
 **⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**

--- a/packages/squad-sdk/templates/skills/coordinator-init-mode/SKILL.md
+++ b/packages/squad-sdk/templates/skills/coordinator-init-mode/SKILL.md
@@ -39,8 +39,24 @@ No team exists yet. **Propose one — but DO NOT create any files until the user
 🔍  Fact Checker — (verifier)    Verification + Devil's Advocate
 ```
 
-5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu:
-   - **question:** *"Look right?"*
+5. Use the `ask_user` tool to confirm the roster. Provide choices so the user sees a selectable menu.
+
+   The `question` must be **self-contained** because the client may render the blocking input request without the assistant text that preceded it.
+
+   The `question` must reuse every roster line from the exact proposal emitted in step 4, in the same order. Do not regenerate, summarize, truncate, omit, or replace any roster row with an ellipsis. Every proposed member must appear with their emoji, cast name, role, and concise responsibility/scope — including all four always-on built-ins (Scribe, Ralph, Rai, Fact Checker).
+
+   Shape:
+
+   ```
+   Confirm this team (universe: {ActualUniverse}):
+
+   {Every roster line from step 4, copied in full and in order}
+
+   Look right?
+   ```
+
+   Never use a bare "Look right?" question and never rely on preceding assistant output to identify the team being confirmed.
+
    - **choices:** `["Yes, hire this team", "Add someone", "Change a role"]`
 
 **⚠️ STOP. Your response ENDS here. Do NOT proceed to Phase 2. Do NOT create any files or directories. Wait for the user's reply.**

--- a/test/squad-agent-roster.test.ts
+++ b/test/squad-agent-roster.test.ts
@@ -118,3 +118,103 @@ describe('coordinator-init-mode/SKILL.md — always-on roster instructions (post
     });
   }
 });
+
+/**
+ * Regression for bradygaster/squad#1454 — the Phase 1 ask_user confirmation
+ * must be self-contained. Some clients render the blocking input request
+ * without the preceding assistant text, so a bare "Look right?" leaves the
+ * user unable to see which team they are confirming.
+ *
+ * Counterpart of the shell-path fix in #1134 / #1107 for the Copilot
+ * custom-agent Init Mode path governed by this satellite skill.
+ */
+describe('coordinator-init-mode/SKILL.md — self-contained confirmation (#1454)', () => {
+  for (const rel of INIT_MODE_SKILL_TARGETS) {
+    describe(rel, () => {
+      const fullPath = path.join(REPO_ROOT, rel);
+      if (!existsSync(fullPath)) {
+        it.skip(`(file does not exist in this checkout: ${rel})`, () => {});
+        return;
+      }
+      const content = readFileSync(fullPath, 'utf-8');
+
+      // Narrow to Phase 1 confirmation through the STOP gate so assertions
+      // do not accidentally match Phase 2 / unrelated prose.
+      const phase1Confirm = (() => {
+        const step5 = content.split(/\n5\.\s+Use the `ask_user` tool/)[1] ?? '';
+        return step5.split(/\n##\s+Phase 2:/)[0] ?? '';
+      })();
+
+      it('Phase 1 confirmation still invokes ask_user', () => {
+        expect(content).toMatch(/5\.\s+Use the `ask_user` tool to confirm the roster/);
+        expect(phase1Confirm.length, 'could not extract Phase 1 confirmation section').toBeGreaterThan(0);
+      });
+
+      it('requires the ask_user question to be self-contained', () => {
+        expect(phase1Confirm).toMatch(/self-contained/i);
+        expect(phase1Confirm).toMatch(
+          /without the assistant text that preceded it|without.*preceding.*assistant/i,
+        );
+      });
+
+      it('requires the selected universe in the confirmation question', () => {
+        expect(phase1Confirm).toMatch(/universe/i);
+        expect(phase1Confirm).toMatch(/ActualUniverse|\{ActualUniverse\}|selected universe/i);
+      });
+
+      it('requires reusing every exact step-4 roster line (names, roles, scopes)', () => {
+        expect(phase1Confirm).toMatch(/every roster line|every proposed member/i);
+        expect(phase1Confirm).toMatch(/reuse|copy.*(?:exact|in full).*step 4|copied in full/i);
+        expect(phase1Confirm).toMatch(/cast name|emoji/i);
+        expect(phase1Confirm).toMatch(/role/i);
+        expect(phase1Confirm).toMatch(/responsibility|scope/i);
+      });
+
+      it('requires all four always-on built-ins in the confirmation roster', () => {
+        for (const builtin of ['Scribe', 'Ralph', 'Rai', 'Fact Checker']) {
+          expect(phase1Confirm, `${builtin} must appear in the confirmation question template`).toContain(
+            builtin,
+          );
+        }
+      });
+
+      it('forbids ellipsis, truncation, omission, and regenerating a divergent roster', () => {
+        expect(phase1Confirm).toMatch(
+          /do not.*(?:regenerate|summarize|truncate|omit|ellipsis)|never.*(?:ellipsis|truncate|omit|summarize)/i,
+        );
+
+        // Extract only the illustrative question fenced block so unrelated
+        // prose elsewhere in the skill may still use "..." later.
+        const questionTemplate = (() => {
+          const fenceMatch = phase1Confirm.match(/```[^\n]*\n([\s\S]*?)^\s*```/m);
+          return fenceMatch?.[1] ?? '';
+        })();
+        expect(questionTemplate.length, 'could not extract illustrative question block').toBeGreaterThan(0);
+        expect(questionTemplate).not.toMatch(/^\s*\.\.\.\s*$/m);
+        expect(questionTemplate).toMatch(/Every roster line from step 4/i);
+      });
+
+      it('explicitly forbids a bare Look right? and context-dependent confirmation', () => {
+        expect(phase1Confirm).toMatch(/Never use a bare ["']Look right\?["']/i);
+        expect(phase1Confirm).toMatch(
+          /never rely on preceding assistant output/i,
+        );
+      });
+
+      it('preserves confirmation choices and the Phase 1 STOP gate', () => {
+        expect(phase1Confirm).toMatch(/Yes,\s*hire this team/);
+        expect(phase1Confirm).toMatch(/Add someone/);
+        expect(phase1Confirm).toMatch(/Change a role/);
+        expect(phase1Confirm).toMatch(/STOP/);
+        expect(phase1Confirm).toMatch(/Do NOT proceed to Phase 2/i);
+        expect(phase1Confirm).toMatch(/Do NOT create any files/i);
+      });
+
+      it('keeps Phase 2 gated on affirmative confirmation', () => {
+        const phase2 = content.split(/\n##\s+Phase 2:/)[1] ?? '';
+        expect(phase2).toMatch(/Trigger:.*confirmation|affirmative/i);
+        expect(phase2).toMatch(/Do NOT enter Phase 2 until the user confirms/i);
+      });
+    });
+  }
+});


### PR DESCRIPTION
### What

Makes the first-time team confirmation request self-contained by including the selected universe and complete proposed roster directly in the blocking `ask_user` question.

### Why

The Init Mode skill previously emitted the roster as normal assistant text and then asked only “Look right?”. Some clients can display the blocking input request without preserving the preceding text, leaving the user unable to see which team they are confirming.

This is the custom-agent counterpart of the UX failure previously reported in #1107.

Closes #1454.

### How

- Updated the canonical `coordinator-init-mode` skill.
- Required the confirmation question to **reuse every exact roster line from the step-4 proposal** (same order; no regenerate/summarize/truncate/omit/ellipsis).
- Explicitly prohibited bare/context-dependent confirmation questions.
- Synchronized the CLI and SDK template mirrors via `node scripts/sync-skill-templates.mjs`.
- Added regression coverage across every shipped copy of the skill.
- Added patch changesets for the CLI and SDK packages.

---

### ⚠️ Quick Check
- [x] If SDK/CLI source files changed: completed the applicable Changeset step below (`npx changeset add` / `.changeset/*.md`, direct `CHANGELOG.md` entry for maintainers, or `skip-changelog` label for no user-facing changes)

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev` (not `main`)
- [x] Branch is up to date with `dev` (`git fetch upstream && git rebase upstream/dev`)
- [x] Verified diff contains only intended changes (`git diff --cached --stat`)
- [x] PR is **not** in draft mode (mark ready when checks pass)
- [x] Commit history is clean (squash fixups before review)

#### Build & Test
- [x] `npm run build` passes (`SKIP_BUILD_BUMP=1 npm run build`)
- [x] Targeted tests pass (`npx vitest run test/squad-agent-roster.test.ts` — 49 passed; `node --test test/init-flow.test.cjs` — 11 passed)
- [x] `npm test` — 7023 passed; 21 local failures. An untouched `upstream/dev` worktree reproduced 19 failures across the overlapping failing suites and the same environment-sensitive failure classes (REPL/Ink UX, scheduler timezone, observer flakiness, doctor timeout, template-sync CRLF). No failure referenced the changed skill or regression-test assertions. Upstream CI remains pending first-time fork approval.
- [x] `npm run lint` passes (type check clean)
- [x] `npm run lint:eslint` passes (0 errors; pre-existing warnings only)

#### Changeset
- [x] Changeset added (`.changeset/1454-init-confirmation-roster.md` for `@bradygaster/squad-cli` and `@bradygaster/squad-sdk`)

#### Docs
- [x] N/A — prompt/skill contract fix; no new user-facing docs surface

#### Exports
- [x] N/A — no new modules

### Validation

| Command | Result |
|---|---|
| `npx vitest run test/squad-agent-roster.test.ts` | **pass** — 49 tests |
| `node --test test/init-flow.test.cjs` | **pass** — 11 tests |
| `SKIP_BUILD_BUMP=1 npm run build` | **pass** |
| `npm test` | **7023 passed / 21 local failures** — untouched `upstream/dev` reproduced 19 failures on the overlapping suites / same failure classes; none involve `coordinator-init-mode` or this diff. Upstream CI pending fork workflow approval. |
| `npm run lint` | **pass** |
| `npm run lint:eslint` | **pass** (0 errors) |
| `git diff --check` | **pass** on committed files |

### Breaking Changes

None.

### Waivers

None.
