### PR TITLE
fix(cli): follow externalized state in squad copilot and squad rc

### DIFF
--- a/.changeset/fix-1397-1398-external-state-reads.md
+++ b/.changeset/fix-1397-1398-external-state-reads.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+`squad copilot` and `squad rc` now follow externalized state: roster reads and writes go to the external state dir when `.squad/config.json` has the `stateLocation: external` marker, instead of always using the local `.squad/team.md`.

--- a/packages/squad-cli/src/cli/commands/copilot.ts
+++ b/packages/squad-cli/src/cli/commands/copilot.ts
@@ -8,7 +8,7 @@ import { FSStorageProvider } from '@bradygaster/squad-sdk';
 
 const storage = new FSStorageProvider();
 import { success, dim, bold, info, BOLD, RESET, DIM } from '../core/output.js';
-import { detectSquadDir } from '../core/detect-squad-dir.js';
+import { effectiveSquadDir } from '../core/effective-squad-dir.js';
 import {
   readTeamMd,
   writeTeamMd,
@@ -27,15 +27,15 @@ export interface CopilotFlags {
  * Run copilot command
  */
 export async function runCopilot(dest: string, flags: CopilotFlags): Promise<void> {
-  const squadDirInfo = detectSquadDir(dest);
-  const squadDir = squadDirInfo.path;
+  // Roster lives in the effective state dir when state is externalized (#1397)
+  const { stateDir } = effectiveSquadDir(dest);
 
-  // Ensure squad directory exists
-  if (!storage.existsSync(squadDir)) {
+  // Ensure squad state exists
+  if (!storage.existsSync(stateDir)) {
     throw new Error('No squad found — run init first, then add the copilot agent.');
   }
 
-  let content = readTeamMd(squadDir);
+  let content = readTeamMd(stateDir);
   const copilotExists = hasCopilot(content);
 
   // Remove copilot
@@ -47,7 +47,7 @@ export async function runCopilot(dest: string, flags: CopilotFlags): Promise<voi
     
     // Remove the Coding Agent section
     content = removeCopilotSection(content);
-    writeTeamMd(squadDir, content);
+    writeTeamMd(stateDir, content);
     success('Removed @copilot from the team roster');
 
     // Remove copilot-instructions.md
@@ -63,7 +63,7 @@ export async function runCopilot(dest: string, flags: CopilotFlags): Promise<voi
   if (copilotExists) {
     if (flags.autoAssign) {
       content = setAutoAssign(content, true);
-      writeTeamMd(squadDir, content);
+      writeTeamMd(stateDir, content);
       success('Enabled @copilot auto-assign');
     } else {
       console.log(`${DIM}@copilot is already on the team${RESET}`);
@@ -73,7 +73,7 @@ export async function runCopilot(dest: string, flags: CopilotFlags): Promise<voi
 
   // Add copilot
   content = insertCopilotSection(content, flags.autoAssign);
-  writeTeamMd(squadDir, content);
+  writeTeamMd(stateDir, content);
   success('Added @copilot (Coding Agent) to team roster');
   
   if (flags.autoAssign) {

--- a/packages/squad-cli/src/cli/commands/rc.ts
+++ b/packages/squad-cli/src/cli/commands/rc.ts
@@ -13,6 +13,7 @@ import { FSStorageProvider, RemoteBridge } from '@bradygaster/squad-sdk';
 
 const storage = new FSStorageProvider();
 import type { RemoteBridgeConfig } from '@bradygaster/squad-sdk';
+import { resolveStateDir } from '../core/effective-squad-dir.js';
 import {
   isDevtunnelAvailable,
   createTunnel,
@@ -32,6 +33,25 @@ export interface RCOptions {
   tunnel: boolean;
   port: number;
   path?: string;
+}
+
+/**
+ * Load the agent roster from team.md, following the externalized state
+ * marker when present (#1398). The passed `squadDir` stays the local
+ * working-tree dir — only the team.md read is redirected.
+ */
+export function loadRosterAgents(squadDir: string): Array<{ name: string; role: string }> {
+  const agents: Array<{ name: string; role: string }> = [];
+  const stateDir = resolveStateDir(squadDir);
+  const teamMd = storage.readSync(path.join(stateDir, 'team.md')) ?? '';
+  const memberLines = teamMd.split('\n').filter(l => l.startsWith('|') && l.includes('Active'));
+  for (const line of memberLines) {
+    const cols = line.split('|').map(c => c.trim()).filter(Boolean);
+    if (cols.length >= 2 && cols[0] !== 'Name') {
+      agents.push({ name: cols[0]!, role: cols[1]! });
+    }
+  }
+  return agents;
 }
 
 export async function runRC(cwd: string, options: RCOptions): Promise<void> {
@@ -55,14 +75,7 @@ export async function runRC(cwd: string, options: RCOptions): Promise<void> {
   const agents: Array<{name: string; role: string}> = [];
   if (squadDir) {
     try {
-      const teamMd = storage.readSync(path.join(squadDir, 'team.md')) ?? '';
-      const memberLines = teamMd.split('\n').filter(l => l.startsWith('|') && l.includes('Active'));
-      for (const line of memberLines) {
-        const cols = line.split('|').map(c => c.trim()).filter(Boolean);
-        if (cols.length >= 2 && cols[0] !== 'Name') {
-          agents.push({ name: cols[0]!, role: cols[1]! });
-        }
-      }
+      agents.push(...loadRosterAgents(squadDir));
       console.log(`  ${GREEN}✓${RESET} Loaded ${agents.length} agents from team.md\n`);
     } catch {
       console.log(`  ${YELLOW}⚠${RESET} Could not read team.md\n`);

--- a/test/cli/copilot.test.ts
+++ b/test/cli/copilot.test.ts
@@ -4,7 +4,7 @@
  * Tests module exports and error handling for missing squad directory.
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
@@ -62,5 +62,67 @@ describe('CLI: copilot command', () => {
 
     // Should return without throwing
     await expect(runCopilot(TEST_ROOT, {})).resolves.toBeUndefined();
+  });
+});
+
+describe('CLI: copilot with externalized state (#1397)', () => {
+  const EXT_GLOBAL = join(tmpdir(), `.test-cli-copilot-ext-global-${randomBytes(4).toString('hex')}`);
+  const EXT_PROJECT_KEY = `test-copilot-ext-${randomBytes(4).toString('hex')}`;
+  const externalStateDir = join(EXT_GLOBAL, 'squad', 'projects', EXT_PROJECT_KEY);
+  const origAppData = process.env['APPDATA'];
+  const origXdgConfig = process.env['XDG_CONFIG_HOME'];
+
+  beforeEach(() => {
+    if (existsSync(TEST_ROOT)) rmSync(TEST_ROOT, { recursive: true, force: true });
+    if (existsSync(EXT_GLOBAL)) rmSync(EXT_GLOBAL, { recursive: true, force: true });
+
+    // Point resolveGlobalSquadPath() inside EXT_GLOBAL (not the real user dir)
+    if (process.platform === 'win32') {
+      process.env['APPDATA'] = EXT_GLOBAL;
+    } else {
+      process.env['XDG_CONFIG_HOME'] = EXT_GLOBAL;
+    }
+
+    // Local repo: thin .squad/ holding only the marker `squad externalize` leaves behind
+    mkdirSync(join(TEST_ROOT, '.squad'), { recursive: true });
+    writeFileSync(
+      join(TEST_ROOT, '.squad', 'config.json'),
+      JSON.stringify({ version: 1, teamRoot: '.', projectKey: EXT_PROJECT_KEY, stateLocation: 'external' }, null, 2)
+    );
+
+    // External state dir: the real roster
+    mkdirSync(externalStateDir, { recursive: true });
+    writeFileSync(join(externalStateDir, 'team.md'), '# Team\n\n## Members\n\n## Project Context\n');
+  });
+
+  afterEach(() => {
+    if (origAppData === undefined) delete process.env['APPDATA'];
+    else process.env['APPDATA'] = origAppData;
+    if (origXdgConfig === undefined) delete process.env['XDG_CONFIG_HOME'];
+    else process.env['XDG_CONFIG_HOME'] = origXdgConfig;
+
+    if (existsSync(TEST_ROOT)) rmSync(TEST_ROOT, { recursive: true, force: true });
+    if (existsSync(EXT_GLOBAL)) rmSync(EXT_GLOBAL, { recursive: true, force: true });
+  });
+
+  it('adds copilot to the external team.md, not a local copy', async () => {
+    const { runCopilot } = await import('@bradygaster/squad-cli/commands/copilot');
+
+    await runCopilot(TEST_ROOT, {});
+
+    const external = readFileSync(join(externalStateDir, 'team.md'), 'utf-8');
+    expect(external).toContain('Coding Agent');
+    // The marker-only local .squad/ must not grow a team.md
+    expect(existsSync(join(TEST_ROOT, '.squad', 'team.md'))).toBe(false);
+  });
+
+  it('removes copilot from the external team.md with --off', async () => {
+    const { runCopilot } = await import('@bradygaster/squad-cli/commands/copilot');
+
+    await runCopilot(TEST_ROOT, {});
+    await runCopilot(TEST_ROOT, { off: true });
+
+    const external = readFileSync(join(externalStateDir, 'team.md'), 'utf-8');
+    expect(external).not.toContain('🤖 Coding Agent');
   });
 });

--- a/test/cli/rc.test.ts
+++ b/test/cli/rc.test.ts
@@ -459,3 +459,72 @@ describe('CLI: rc command', () => {
     });
   });
 });
+
+describe('loadRosterAgents — externalized state (#1398)', () => {
+  const suffix = Math.random().toString(36).slice(2, 10);
+  const ROOT = path.join(os.tmpdir(), `.test-rc-roster-${suffix}`);
+  const EXT_GLOBAL = path.join(os.tmpdir(), `.test-rc-roster-global-${suffix}`);
+  const PROJECT_KEY = `test-rc-ext-${suffix}`;
+  const externalStateDir = path.join(EXT_GLOBAL, 'squad', 'projects', PROJECT_KEY);
+  const origAppData = process.env['APPDATA'];
+  const origXdgConfig = process.env['XDG_CONFIG_HOME'];
+  const ROSTER_MD =
+    '# Team\n\n| Name | Role | Status |\n|------|------|--------|\n| Kovash | Lead | Active |\n| Edie | Dev | Active |\n';
+
+  beforeEach(() => {
+    for (const d of [ROOT, EXT_GLOBAL]) {
+      if (fs.existsSync(d)) fs.rmSync(d, { recursive: true, force: true });
+    }
+    fs.mkdirSync(path.join(ROOT, '.squad'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (origAppData === undefined) delete process.env['APPDATA'];
+    else process.env['APPDATA'] = origAppData;
+    if (origXdgConfig === undefined) delete process.env['XDG_CONFIG_HOME'];
+    else process.env['XDG_CONFIG_HOME'] = origXdgConfig;
+
+    for (const d of [ROOT, EXT_GLOBAL]) {
+      if (fs.existsSync(d)) fs.rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  it('reads the roster from local .squad when state is not externalized', async () => {
+    const { loadRosterAgents } = await import('@bradygaster/squad-cli/commands/rc');
+    fs.writeFileSync(path.join(ROOT, '.squad', 'team.md'), ROSTER_MD);
+
+    const agents = loadRosterAgents(path.join(ROOT, '.squad'));
+
+    expect(agents).toEqual([
+      { name: 'Kovash', role: 'Lead' },
+      { name: 'Edie', role: 'Dev' },
+    ]);
+  });
+
+  it('follows the stateLocation marker to the external team.md', async () => {
+    const { loadRosterAgents } = await import('@bradygaster/squad-cli/commands/rc');
+
+    // Point resolveGlobalSquadPath() inside EXT_GLOBAL (not the real user dir)
+    if (process.platform === 'win32') {
+      process.env['APPDATA'] = EXT_GLOBAL;
+    } else {
+      process.env['XDG_CONFIG_HOME'] = EXT_GLOBAL;
+    }
+
+    fs.writeFileSync(
+      path.join(ROOT, '.squad', 'config.json'),
+      JSON.stringify({ version: 1, teamRoot: '.', projectKey: PROJECT_KEY, stateLocation: 'external' })
+    );
+    // Stale local roster that must NOT win over the external one
+    fs.writeFileSync(path.join(ROOT, '.squad', 'team.md'), '# Team\n| Stale | Old | Active |\n');
+    fs.mkdirSync(externalStateDir, { recursive: true });
+    fs.writeFileSync(path.join(externalStateDir, 'team.md'), ROSTER_MD);
+
+    const agents = loadRosterAgents(path.join(ROOT, '.squad'));
+
+    expect(agents).toEqual([
+      { name: 'Kovash', role: 'Lead' },
+      { name: 'Edie', role: 'Dev' },
+    ]);
+  });
+});


### PR DESCRIPTION
### What
`squad copilot` and `squad rc` now follow the `stateLocation: external` marker: roster reads and writes go to the external state dir instead of the local `.squad/team.md`.

### Why
Closes #1397
Closes #1398
Part of #1402

After `squad externalize`, both commands kept operating on the working-tree copy. `squad copilot` edited (or, on add, effectively scaffolded) a local roster the externalized project never reads — the real team.md in the external dir never learned about @copilot. `squad rc` loaded its agent list from the same dead file, so the remote UI showed an empty or stale roster.

### How
- `commands/copilot.ts`: resolves through `effectiveSquadDir()` — the same external-state-aware resolution already used by export, build, loop, plugin, watch, and doctor (#1443 precedent) — and reads/writes `team.md` in the effective state dir. The `.github/copilot-instructions.md` copy is a working-tree file and is untouched.
- `commands/rc.ts`: the roster load moves into an exported `loadRosterAgents(squadDir)` that routes the `team.md` read through `resolveStateDir()`. Deliberately narrow: the `squadDir` passed to `RemoteBridge` stays the local path, because the bridge derives the copilot session cwd from it by stripping the `/.squad` suffix (`packages/squad-sdk/src/remote/bridge.ts`) — handing it the external state dir would point ACP sessions at the wrong directory. Only the read is redirected.
- Legacy `.ai-team` behavior is unchanged in both commands — no external marker there, resolution falls through to the local path.
- #1399 (`squad cast` agent discovery) is not in this PR; it crosses into squad-sdk's `resolveSquadPaths`/`LocalAgentSource` and lands separately.

### Testing
- `test/cli/copilot.test.ts`: two new tests against a marker-only `.squad/` + external state dir (the layout `squad externalize` leaves behind, same APPDATA/XDG override pattern as the #1443 export tests): add writes the Coding Agent section to the external `team.md` and does not grow a local one; `--off` removes it from the external file.
- `test/cli/rc.test.ts`: two new tests for `loadRosterAgents` — local read without the marker, and the marker redirecting to the external `team.md` while a stale local roster is present (the stale copy must lose).
- `npm run build` — passes. `npm run lint` (tsc) — passes. `npm run lint:eslint` — 0 errors (pre-existing warnings only).
- `npx vitest run test/cli/copilot.test.ts test/cli/rc.test.ts test/cli/export-import.test.ts` — all four new tests pass; the export suite (adjacent feature area) passes.
- Known local-env caveat: the first `module exports …` test in each of these two files times out at 5s on this Windows box — verified byte-identical failures on a clean `upstream/dev` checkout with a clean build (stash + rebuild + rerun), so it's the documented pre-existing cold-import flakiness (same class as noted on #1440), not this change. All other 51 tests in the two files pass.
- rc.ts is committed with CRLF endings; edits preserve CRLF per CONTRIBUTING's line-ending rule, so `git diff --check` reports CR on added lines — expected for this file, no mixed endings introduced (`git ls-files --eol`: `i/crlf w/crlf`).

---

### ⚠️ Quick Check
- [x] Changeset added: `.changeset/fix-1397-1398-external-state-reads.md` (patch bump, `@bradygaster/squad-cli` only)

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev`
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes (`git diff --cached --stat` + `git diff -w` whitespace pass)
- [x] PR is not in draft mode
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] `npm run build` passes
- [x] `npm test` passes (see testing notes for the pre-existing local cold-import timeouts)
- [x] `npm run lint` passes (type check clean)
- [x] `npm run lint:eslint` passes (0 errors)

#### Changeset
- [x] Changeset added (patch, `@bradygaster/squad-cli`)

#### Docs
- [x] N/A — behavior fix inside existing commands, no new user-facing surface

#### Exports
- [x] N/A — `loadRosterAgents` is a named export from `commands/rc`, which already has a subpath export; no new module

---

### Breaking Changes
None. Projects without the external marker resolve to the local `.squad/` exactly as before.

### Waivers
None.