### PR TITLE
docs: align external-state page with actual externalize/internalize behavior

### DIFF
--- a/docs/src/content/docs/features/external-state.md
+++ b/docs/src/content/docs/features/external-state.md
@@ -94,13 +94,16 @@ squad externalize
 **What happens:**
 1. Resolves platform-specific global path (e.g., `~/Library/Application Support/squad/projects/my-repo/`)
 2. Moves `.squad/` contents to global path
-3. Creates thin marker file `.squad/config.json` in working tree:
+3. Creates thin marker file `.squad/config.json` in working tree (existing config fields are preserved):
    ```json
    {
+     "version": 1,
+     "teamRoot": ".",
+     "projectKey": "my-repo",
      "stateLocation": "external"
    }
    ```
-4. Adds `.squad/` to `.gitignore` (if not already present)
+4. Adds `.squad/config.json` to `.gitignore` (if not already present) — the marker is machine-specific and must not be committed
 
 **After externalization:**
 - Working tree has only `.squad/config.json` (gitignored marker)
@@ -119,9 +122,9 @@ squad internalize
 
 **What happens:**
 1. Reads marker file to find external state location
-2. Moves state from global directory back to `.squad/`
-3. Removes marker file
-4. Removes `.squad/` from `.gitignore`
+2. Copies state from the global directory back to `.squad/` (the external copy is left in place)
+3. Removes the external-state fields (`stateLocation`, `teamRoot`, `projectKey`) from `.squad/config.json` — the file is deleted when no other settings remain
+4. Leaves `.gitignore` unchanged
 
 **After internalization:**
 - `.squad/` lives in working tree again
@@ -136,19 +139,22 @@ The thin marker file `.squad/config.json` tracks state location:
 
 ```json
 {
+  "version": 1,
+  "teamRoot": ".",
+  "projectKey": "my-repo",
   "stateLocation": "external"
 }
 ```
 
-| Value | Meaning |
+| `stateLocation` | Meaning |
 |-------|---------|
-| `"internal"` | State lives in working tree (`.squad/` in repo) |
+| absent (or no marker file) | State lives in working tree (`.squad/` in repo) |
 | `"external"` | State lives in global directory (platform-specific path) |
 
 **Notes:**
 - Marker file is created by `squad externalize`
 - Marker file is gitignored — not committed to repo
-- Marker file is removed by `squad internalize`
+- `squad internalize` removes the external-state fields from the file (and deletes it when nothing else remains)
 
 ---
 
@@ -210,19 +216,19 @@ No cross-repo state pollution.
 
 ## Git Integration
 
-After externalization, `.squad/` is gitignored. Only the thin marker file exists in the working tree:
+After externalization, only the thin marker file exists in the working tree, and it is gitignored:
 
 ```bash
 $ git status
 On branch feature-branch
-Untracked files:
-  .squad/config.json    # gitignored marker — not committed
+nothing to commit, working tree clean
+# .squad/config.json exists on disk but is gitignored — not committed
 ```
 
 This means:
 - PRs never show squad state changes
 - Branch switches don't affect squad data
-- `git clean -fdx` doesn't delete squad state
+- `git clean -fdx` doesn't delete squad state (it lives outside the repo — though it does remove the gitignored marker, which `squad externalize` can recreate)
 
 ---
 


### PR DESCRIPTION
### What
Corrects `docs/src/content/docs/features/external-state.md` to describe what `squad externalize` / `squad internalize` actually do. Docs-only — no code change.

### Why
Closes #1400
Part of #1402

The issue offered two resolutions (change the code or fix the docs). Making externalize ignore all of `.squad/` — or making internalize edit `.gitignore` — is a behavior decision for maintainers, so this PR takes the safe half: document current behavior. If the intended behavior is the old docs text, that's a code change someone can still make later; the docs would then be a small revert.

What was wrong, per source in `packages/squad-cli/src/cli/commands/externalize.ts`:
- "Adds `.squad/` to `.gitignore`" → externalize only appends a `.squad/config.json` ignore block (`ensureGitignored`), never `.squad/`
- "Removes `.squad/` from `.gitignore`" → `runInternalize` has no gitignore cleanup at all
- Marker JSON example showed only `stateLocation` → the command writes `version`/`teamRoot`/`projectKey` too (and `projectKey` is the repo basename slug from `deriveProjectKey`, not a hashed id)
- The `stateLocation` table listed an `"internal"` value → never written; internalize deletes the field (and the file, when nothing else remains), absence means internal
- "Moves state ... back" → internalize copies; the external dir is left in place (#1401 tracks move-vs-copy semantics)
- The `git status` sample showed the gitignored marker under "Untracked files" — gitignored files don't appear there

### Testing
- `npm run lint:docs` (markdownlint + cspell) — 0 errors, 0 spelling issues
- Every corrected statement traced to the current source (`externalize.ts`, `resolution.ts`'s `deriveProjectKey`)
- `git diff` vs `git diff -w` identical — no whitespace-only hunks

---

### ⚠️ Quick Check
- [x] No changeset — docs-only change, no governed source/template paths touched

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev`
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes (single docs file, +18 −12)
- [x] PR is not in draft mode
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] `npm run lint:docs` passes
- [x] Build/tests N/A — no code changed

#### Changeset
- [x] N/A — docs only

#### Docs
- [x] This is the docs change

#### Exports
- [x] N/A

---

### Breaking Changes
None.

### Waivers
None.