### PR TITLE
fix(release): correct package name in rename-hire-to-cast changeset

### DIFF
--- a/.changeset/rename-hire-to-cast.md
+++ b/.changeset/rename-hire-to-cast.md
@@ -1,5 +1,5 @@
 ---
-"squad-cli": minor
+"@bradygaster/squad-cli": minor
 ---
 
 Rename `hire` command to `cast` in CLI help and documentation. The `hire` command continues to work as a silent alias (like `cls`/`clear` in PowerShell) — no deprecation, no warnings, it just does the same thing. All user-facing text now presents `cast` as the canonical verb because we're casting agents, not hiring humans.


### PR DESCRIPTION
### What
`.changeset/rename-hire-to-cast.md` declared the bare package name `squad-cli`, which is not a
workspace package. Corrected to the real scoped name `@bradygaster/squad-cli` — matching every
other fragment in `.changeset/`. One line, one file.

### Why
`@changesets/assemble-release-plan` (behind `changeset status` / `changeset version`) resolves
each fragment's package against the workspace. `squad-cli` resolves to nothing and throws:

```
Found changeset rename-hire-to-cast for package squad-cli which is not in the workspace
```

so the `hire → cast` changelog entry and its `minor` bump would be lost at release. Verified
against `@changesets/assemble-release-plan` v6: before → throws; after → resolves
`@bradygaster/squad-cli@minor` cleanly.

### Scope
- One line in one file; no other changesets or CI touched.
- No accompanying changeset needed — the diff touches only `.changeset/`, which the CHANGELOG
  gate treats as "not applicable" (only `packages/squad-(sdk|cli)/src/` and governed template
  paths require one).
- Optional follow-up (not in this PR): a `changeset status` check in CI would catch this class
  of error before release.

Closes #1467

Powered By Elad Coding Assistant
