### PR TITLE
docs/models: prefer newest per series (Opus 4.8), add GPT-5.6 IDs, fix Ralph free-model wording

### DIFF
--- a/.changeset/models-gpt56-fallback-ordering.md
+++ b/.changeset/models-gpt56-fallback-ordering.md
@@ -1,0 +1,15 @@
+---
+"@bradygaster/squad-sdk": patch
+---
+
+Prefer newest model per series in fallback chains, add GPT-5.6 IDs, fix Ralph free-model wording.
+
+Follow-up to #1444 (tamirdresher review comment — catalog follow-up):
+
+- `DEFAULT_FALLBACK_CHAINS.standard` and `MODELS.FALLBACK_CHAINS.standard` now lead with `claude-sonnet-5` (newest Sonnet; was `claude-sonnet-4.6`). Premium chains already led with `claude-opus-4.8` post-#1444.
+- Adds `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` to `MODEL_CATALOG` (tier: standard, githubCategory: powerful — mirrors `gpt-5.5`) and inserts them into the standard fallback chain. CLI-reachability validated 2026-07-13.
+- Updates shipped template assets (`model-selection-reference.md`, `ralph-circuit-breaker.md`, model-selection SKILL files) to match the current runtime chains and remove "Free — unlimited" / multiplier-table wording that no longer applies under usage-based billing.
+- Note: `MODELS.DEFAULT` (`claude-sonnet-4.6`) is intentionally unchanged — separate decision.
+- Note: `DOCS_NAME_TO_ID` entries for gpt-5.6 in `cli/commands/models.ts` are deferred until PR #1445 merges.
+
+Refs #1080, #1183.

--- a/.copilot/skills/model-selection/SKILL.md
+++ b/.copilot/skills/model-selection/SKILL.md
@@ -27,7 +27,7 @@ Check these layers in order — first match wins:
 | Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
 | Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
 | NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.6` | Premium | Vision capability required. Overrides cost rule. |
+| Visual/design work requiring image analysis | `claude-opus-4.8` | Premium | Vision capability required. Overrides cost rule. |
 
 **Role-to-model mapping** (applying cost-first principle):
 
@@ -38,7 +38,7 @@ Check these layers in order — first match wins:
 | Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
 | Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
 | Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.6` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
+| Designer / Visual | `claude-opus-4.8` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
 | DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
 | Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
 | Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
@@ -56,8 +56,8 @@ Check these layers in order — first match wins:
 If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
 
 ```
-Premium:  claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → (omit model param)
+Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 
@@ -90,10 +90,10 @@ If you've exhausted the fallback chain and reached nuclear fallback, omit the `m
 When spawning, include the model in your acknowledgment:
 
 ```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.6 · vision) — designing color system
+🔧 Fenster (claude-sonnet-5) — refactoring auth module
+🎨 Redfoot (claude-opus-4.8 · vision) — designing color system
 📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
+⚡ Keaton (claude-opus-4.8 · bumped for architecture) — reviewing proposal
 📝 McManus (claude-haiku-4.5 · fast) — updating docs
 ```
 
@@ -101,8 +101,8 @@ Include tier annotation only when the model was bumped or a specialist was chose
 
 ### Valid Models
 
-**Premium:** `claude-opus-4.6`, `claude-opus-4.7`, `claude-opus-4.8`
-**Standard:** `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.5`, `gemini-2.5-pro`
+**Premium:** `claude-opus-4.8`, `claude-opus-4.7`, `claude-opus-4.6`
+**Standard:** `claude-sonnet-5`, `claude-sonnet-4.6`, `claude-sonnet-4.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gemini-2.5-pro`
 **Fast/Cheap:** `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini`
 
 ## Examples

--- a/.copilot/skills/model-selection/SKILL.md
+++ b/.copilot/skills/model-selection/SKILL.md
@@ -57,7 +57,7 @@ If a spawn fails because the selected model is unavailable (plan restriction, or
 
 ```
 Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → gemini-2.5-pro → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/.squad-templates/model-selection-reference.md
+++ b/.squad-templates/model-selection-reference.md
@@ -51,7 +51,7 @@ If a spawn fails because the selected model is unavailable (plan restriction, or
 
 ```
 Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → gemini-2.5-pro → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/.squad-templates/model-selection-reference.md
+++ b/.squad-templates/model-selection-reference.md
@@ -21,7 +21,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 | Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
 | Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
 | NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.6` | Premium | Vision capability required. Overrides cost rule. |
+| Visual/design work requiring image analysis | `claude-opus-4.8` | Premium | Vision capability required. Overrides cost rule. |
 
 **Role-to-model mapping** (applying cost-first principle):
 
@@ -32,7 +32,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 | Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
 | Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
 | Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.6` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
+| Designer / Visual | `claude-opus-4.8` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
 | DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
 | Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
 | Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
@@ -50,8 +50,8 @@ Before spawning an agent, determine which model to use. Check these layers in or
 If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
 
 ```
-Premium:  claude-opus-4.6 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → (omit model param)
+Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 
@@ -85,10 +85,10 @@ If you've exhausted the fallback chain and reached nuclear fallback, omit the `m
 When spawning, include the model in your acknowledgment:
 
 ```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.6 · vision) — designing color system
+🔧 Fenster (claude-sonnet-5) — refactoring auth module
+🎨 Redfoot (claude-opus-4.8 · vision) — designing color system
 📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
+⚡ Keaton (claude-opus-4.8 · bumped for architecture) — reviewing proposal
 📝 McManus (claude-haiku-4.5 · fast) — updating docs
 ```
 
@@ -96,6 +96,6 @@ Include tier annotation only when the model was bumped or a specialist was chose
 
 **Valid models (current platform catalog):**
 
-Premium: `claude-opus-4.6`, `claude-opus-4.7`, `claude-opus-4.8`, `claude-opus-4.6-1m` (Internal only)
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.5`, `gemini-2.5-pro`
+Premium: `claude-opus-4.8`, `claude-opus-4.7`, `claude-opus-4.6`
+Standard: `claude-sonnet-5`, `claude-sonnet-4.6`, `claude-sonnet-4.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gemini-2.5-pro`
 Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini`

--- a/.squad-templates/ralph-circuit-breaker.md
+++ b/.squad-templates/ralph-circuit-breaker.md
@@ -1,21 +1,24 @@
 # Ralph Circuit Breaker — Model Rate Limit Fallback
 
 > Classic circuit breaker pattern (Hystrix / Polly / Resilience4j) applied to Copilot model selection.
-> When the preferred model hits rate limits, Ralph automatically degrades to free-tier models, then self-heals.
+> When the preferred model hits rate limits, Ralph automatically degrades to lower-cost models, then self-heals.
 
 ## Problem
 
 When running multiple Ralph instances across repos, Copilot model rate limits cause cascading failures.
-All Ralphs fail simultaneously when the preferred model (e.g., `claude-sonnet-4.6`) hits quota.
+All Ralphs fail simultaneously when the preferred model (e.g., `claude-sonnet-5`) hits quota.
 
-Premium models burn quota fast:
-| Model | Multiplier | Risk |
-|-------|-----------|------|
-| `claude-sonnet-4.6` | 1x | Moderate with many Ralphs |
-| `claude-opus-4.6` | 10x | High |
-| `gpt-5.4` | 50x | Very high |
-| `gpt-5.4-mini` | **0x** | **Free — unlimited** |
-| `gpt-5-mini` | **0x** | **Free — unlimited** |
+Under usage-based billing, all models incur cost — there are no "free" or unlimited models.
+Lightweight-category models have lower per-token cost and are therefore preferred for fallback,
+but they are still billed:
+
+| Model | Category | Cost profile |
+|-------|----------|--------------|
+| `claude-sonnet-5` | versatile | Moderate — standard-tier default |
+| `claude-opus-4.8` | powerful | Higher — reserve for premium work |
+| `gpt-5.4` | powerful | Higher — standard-tier specialist |
+| `gpt-5.4-mini` | lightweight | Lower-cost — preferred fallback |
+| `gpt-5-mini` | lightweight | Lowest-cost — final fallback |
 
 ## Circuit Breaker States
 
@@ -39,7 +42,7 @@ Premium models burn quota fast:
 - On rate limit error → transition to OPEN
 
 ### OPEN (rate limited — fallback active)
-- Fall back through the free-tier model chain:
+- Fall back through the lightweight-category model chain:
   1. `gpt-5.4-mini`
   2. `gpt-5-mini`
 - Start cooldown timer (default: 10 minutes)
@@ -55,7 +58,7 @@ Premium models burn quota fast:
 ```json
 {
   "state": "closed",
-  "preferredModel": "claude-sonnet-4.6",
+  "preferredModel": "claude-sonnet-5",
   "fallbackChain": ["gpt-5.4-mini", "gpt-5-mini"],
   "currentFallbackIndex": 0,
   "cooldownMinutes": 10,
@@ -84,7 +87,7 @@ function Get-CircuitBreakerState {
     if (-not (Test-Path $StateFile)) {
         $default = @{
             state              = "closed"
-            preferredModel     = "claude-sonnet-4.6"
+            preferredModel     = "claude-sonnet-5"
             fallbackChain      = @("gpt-5.4-mini", "gpt-5-mini")
             currentFallbackIndex = 0
             cooldownMinutes    = 10
@@ -291,8 +294,8 @@ Override defaults by editing `.squad/ralph-circuit-breaker.json`:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `preferredModel` | `claude-sonnet-4.6` | Model to use when circuit is closed |
-| `fallbackChain` | `["gpt-5.4-mini", "gpt-5-mini"]` | Ordered fallback models (all free-tier) |
+| `preferredModel` | `claude-sonnet-5` | Model to use when circuit is closed |
+| `fallbackChain` | `["gpt-5.4-mini", "gpt-5-mini"]` | Ordered fallback models (lightweight-category — lowest cost, still billed) |
 | `cooldownMinutes` | `10` | How long to wait before testing recovery |
 
 ## Metrics

--- a/.squad/skills/model-selection/SKILL.md
+++ b/.squad/skills/model-selection/SKILL.md
@@ -118,7 +118,7 @@ If a model is unavailable (rate limit, plan restriction), retry within the same 
 
 ```
 Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → gemini-2.5-pro → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/.squad/skills/model-selection/SKILL.md
+++ b/.squad/skills/model-selection/SKILL.md
@@ -59,7 +59,7 @@ Resolution is **first-match-wins** — the highest layer with a value wins.
 5. CHECK Layer 3: Determine task type:
    - Code (implementation, tests, refactoring, bug fixes) → `claude-sonnet-4.6`
    - Prompts, agent designs → `claude-sonnet-4.6`
-   - Visual/design with image analysis → `claude-opus-4.6`
+   - Visual/design with image analysis → `claude-opus-4.8`
    - Non-code (docs, planning, triage, changelogs) → `claude-haiku-4.5`
 6. FALLBACK Layer 4: `claude-haiku-4.5`
 7. INCLUDE model in spawn acknowledgment: `🔧 {Name} ({resolved_model}) — {task}`
@@ -117,8 +117,8 @@ After resolving the model and including it in the spawn template, this skill is 
 If a model is unavailable (rate limit, plan restriction), retry within the same tier:
 
 ```
-Premium:  claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → (omit model param)
+Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/packages/squad-cli/templates/model-selection-reference.md
+++ b/packages/squad-cli/templates/model-selection-reference.md
@@ -51,7 +51,7 @@ If a spawn fails because the selected model is unavailable (plan restriction, or
 
 ```
 Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → gemini-2.5-pro → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/packages/squad-cli/templates/model-selection-reference.md
+++ b/packages/squad-cli/templates/model-selection-reference.md
@@ -21,7 +21,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 | Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
 | Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
 | NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.6` | Premium | Vision capability required. Overrides cost rule. |
+| Visual/design work requiring image analysis | `claude-opus-4.8` | Premium | Vision capability required. Overrides cost rule. |
 
 **Role-to-model mapping** (applying cost-first principle):
 
@@ -32,7 +32,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 | Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
 | Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
 | Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.6` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
+| Designer / Visual | `claude-opus-4.8` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
 | DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
 | Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
 | Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
@@ -50,8 +50,8 @@ Before spawning an agent, determine which model to use. Check these layers in or
 If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
 
 ```
-Premium:  claude-opus-4.6 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → (omit model param)
+Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 
@@ -85,10 +85,10 @@ If you've exhausted the fallback chain and reached nuclear fallback, omit the `m
 When spawning, include the model in your acknowledgment:
 
 ```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.6 · vision) — designing color system
+🔧 Fenster (claude-sonnet-5) — refactoring auth module
+🎨 Redfoot (claude-opus-4.8 · vision) — designing color system
 📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
+⚡ Keaton (claude-opus-4.8 · bumped for architecture) — reviewing proposal
 📝 McManus (claude-haiku-4.5 · fast) — updating docs
 ```
 
@@ -96,6 +96,6 @@ Include tier annotation only when the model was bumped or a specialist was chose
 
 **Valid models (current platform catalog):**
 
-Premium: `claude-opus-4.6`, `claude-opus-4.7`, `claude-opus-4.8`, `claude-opus-4.6-1m` (Internal only)
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.5`, `gemini-2.5-pro`
+Premium: `claude-opus-4.8`, `claude-opus-4.7`, `claude-opus-4.6`
+Standard: `claude-sonnet-5`, `claude-sonnet-4.6`, `claude-sonnet-4.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gemini-2.5-pro`
 Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini`

--- a/packages/squad-cli/templates/ralph-circuit-breaker.md
+++ b/packages/squad-cli/templates/ralph-circuit-breaker.md
@@ -1,21 +1,24 @@
 # Ralph Circuit Breaker — Model Rate Limit Fallback
 
 > Classic circuit breaker pattern (Hystrix / Polly / Resilience4j) applied to Copilot model selection.
-> When the preferred model hits rate limits, Ralph automatically degrades to free-tier models, then self-heals.
+> When the preferred model hits rate limits, Ralph automatically degrades to lower-cost models, then self-heals.
 
 ## Problem
 
 When running multiple Ralph instances across repos, Copilot model rate limits cause cascading failures.
-All Ralphs fail simultaneously when the preferred model (e.g., `claude-sonnet-4.6`) hits quota.
+All Ralphs fail simultaneously when the preferred model (e.g., `claude-sonnet-5`) hits quota.
 
-Premium models burn quota fast:
-| Model | Multiplier | Risk |
-|-------|-----------|------|
-| `claude-sonnet-4.6` | 1x | Moderate with many Ralphs |
-| `claude-opus-4.6` | 10x | High |
-| `gpt-5.4` | 50x | Very high |
-| `gpt-5.4-mini` | **0x** | **Free — unlimited** |
-| `gpt-5-mini` | **0x** | **Free — unlimited** |
+Under usage-based billing, all models incur cost — there are no "free" or unlimited models.
+Lightweight-category models have lower per-token cost and are therefore preferred for fallback,
+but they are still billed:
+
+| Model | Category | Cost profile |
+|-------|----------|--------------|
+| `claude-sonnet-5` | versatile | Moderate — standard-tier default |
+| `claude-opus-4.8` | powerful | Higher — reserve for premium work |
+| `gpt-5.4` | powerful | Higher — standard-tier specialist |
+| `gpt-5.4-mini` | lightweight | Lower-cost — preferred fallback |
+| `gpt-5-mini` | lightweight | Lowest-cost — final fallback |
 
 ## Circuit Breaker States
 
@@ -39,7 +42,7 @@ Premium models burn quota fast:
 - On rate limit error → transition to OPEN
 
 ### OPEN (rate limited — fallback active)
-- Fall back through the free-tier model chain:
+- Fall back through the lightweight-category model chain:
   1. `gpt-5.4-mini`
   2. `gpt-5-mini`
 - Start cooldown timer (default: 10 minutes)
@@ -55,7 +58,7 @@ Premium models burn quota fast:
 ```json
 {
   "state": "closed",
-  "preferredModel": "claude-sonnet-4.6",
+  "preferredModel": "claude-sonnet-5",
   "fallbackChain": ["gpt-5.4-mini", "gpt-5-mini"],
   "currentFallbackIndex": 0,
   "cooldownMinutes": 10,
@@ -84,7 +87,7 @@ function Get-CircuitBreakerState {
     if (-not (Test-Path $StateFile)) {
         $default = @{
             state              = "closed"
-            preferredModel     = "claude-sonnet-4.6"
+            preferredModel     = "claude-sonnet-5"
             fallbackChain      = @("gpt-5.4-mini", "gpt-5-mini")
             currentFallbackIndex = 0
             cooldownMinutes    = 10
@@ -291,8 +294,8 @@ Override defaults by editing `.squad/ralph-circuit-breaker.json`:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `preferredModel` | `claude-sonnet-4.6` | Model to use when circuit is closed |
-| `fallbackChain` | `["gpt-5.4-mini", "gpt-5-mini"]` | Ordered fallback models (all free-tier) |
+| `preferredModel` | `claude-sonnet-5` | Model to use when circuit is closed |
+| `fallbackChain` | `["gpt-5.4-mini", "gpt-5-mini"]` | Ordered fallback models (lightweight-category — lowest cost, still billed) |
 | `cooldownMinutes` | `10` | How long to wait before testing recovery |
 
 ## Metrics

--- a/packages/squad-cli/templates/skills/model-selection/SKILL.md
+++ b/packages/squad-cli/templates/skills/model-selection/SKILL.md
@@ -118,7 +118,7 @@ If a model is unavailable (rate limit, plan restriction), retry within the same 
 
 ```
 Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → gemini-2.5-pro → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/packages/squad-cli/templates/skills/model-selection/SKILL.md
+++ b/packages/squad-cli/templates/skills/model-selection/SKILL.md
@@ -59,7 +59,7 @@ Resolution is **first-match-wins** — the highest layer with a value wins.
 5. CHECK Layer 3: Determine task type:
    - Code (implementation, tests, refactoring, bug fixes) → `claude-sonnet-4.6`
    - Prompts, agent designs → `claude-sonnet-4.6`
-   - Visual/design with image analysis → `claude-opus-4.6`
+   - Visual/design with image analysis → `claude-opus-4.8`
    - Non-code (docs, planning, triage, changelogs) → `claude-haiku-4.5`
 6. FALLBACK Layer 4: `claude-haiku-4.5`
 7. INCLUDE model in spawn acknowledgment: `🔧 {Name} ({resolved_model}) — {task}`
@@ -117,8 +117,8 @@ After resolving the model and including it in the spawn template, this skill is 
 If a model is unavailable (rate limit, plan restriction), retry within the same tier:
 
 ```
-Premium:  claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → (omit model param)
+Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/packages/squad-sdk/src/config/models.ts
+++ b/packages/squad-sdk/src/config/models.ts
@@ -174,7 +174,8 @@ export const MODEL_CATALOG: ModelInfo[] = [
     speed: 7,
   },
   // gpt-5.6 family — CLI-observed Standard-tier reachable models (2026-07-13).
-  // Tier: standard (quality axis); githubCategory: powerful (cost axis) — mirrors gpt-5.5.
+  // Tier: standard (quality axis). githubCategory per live Copilot API (canonical billing axis):
+  //   sol=powerful, terra=versatile, luna=lightweight.
   {
     id: 'gpt-5.6-sol',
     tier: 'standard',
@@ -190,20 +191,20 @@ export const MODEL_CATALOG: ModelInfo[] = [
     tier: 'standard',
     provider: 'openai',
     family: 'gpt',
-    githubCategory: 'powerful',
+    githubCategory: 'versatile',
     useCases: ['general purpose', 'code generation', 'analysis'],
-    cost: 6,
-    speed: 7,
+    cost: 5,
+    speed: 8,
   },
   {
     id: 'gpt-5.6-luna',
     tier: 'standard',
     provider: 'openai',
     family: 'gpt',
-    githubCategory: 'powerful',
+    githubCategory: 'lightweight',
     useCases: ['general purpose', 'code generation', 'analysis'],
-    cost: 6,
-    speed: 7,
+    cost: 3,
+    speed: 9,
   },
   {
     id: 'gpt-5.4',

--- a/packages/squad-sdk/src/config/models.ts
+++ b/packages/squad-sdk/src/config/models.ts
@@ -173,6 +173,38 @@ export const MODEL_CATALOG: ModelInfo[] = [
     cost: 6,
     speed: 7,
   },
+  // gpt-5.6 family — CLI-observed Standard-tier reachable models (2026-07-13).
+  // Tier: standard (quality axis); githubCategory: powerful (cost axis) — mirrors gpt-5.5.
+  {
+    id: 'gpt-5.6-sol',
+    tier: 'standard',
+    provider: 'openai',
+    family: 'gpt',
+    githubCategory: 'powerful',
+    useCases: ['general purpose', 'code generation', 'analysis'],
+    cost: 6,
+    speed: 7,
+  },
+  {
+    id: 'gpt-5.6-terra',
+    tier: 'standard',
+    provider: 'openai',
+    family: 'gpt',
+    githubCategory: 'powerful',
+    useCases: ['general purpose', 'code generation', 'analysis'],
+    cost: 6,
+    speed: 7,
+  },
+  {
+    id: 'gpt-5.6-luna',
+    tier: 'standard',
+    provider: 'openai',
+    family: 'gpt',
+    githubCategory: 'powerful',
+    useCases: ['general purpose', 'code generation', 'analysis'],
+    cost: 6,
+    speed: 7,
+  },
   {
     id: 'gpt-5.4',
     tier: 'standard',
@@ -244,12 +276,11 @@ export const MODEL_CATALOG: ModelInfo[] = [
 
 /**
  * Default fallback chains per tier — real, CLI-reachable IDs ordered by preference.
+ * Newest model in each series is first (tamirdresher PR #1444 follow-up, 2026-07-13).
  */
 export const DEFAULT_FALLBACK_CHAINS: Record<ModelTier, ModelId[]> = {
   premium: ['claude-opus-4.8', 'claude-opus-4.7', 'claude-opus-4.6', 'claude-sonnet-4.6'],
-  // claude-sonnet-4.6 leads as the established default (MODELS.DEFAULT); claude-sonnet-5 was
-  // newly added in this catalog refresh and is promoted to first fallback.
-  standard: ['claude-sonnet-4.6', 'claude-sonnet-5', 'gpt-5.4', 'gpt-5.3-codex', 'claude-sonnet-4.5', 'gemini-2.5-pro'],
+  standard: ['claude-sonnet-5', 'claude-sonnet-4.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.4', 'gpt-5.3-codex', 'claude-sonnet-4.5', 'gemini-2.5-pro'],
   fast: ['claude-haiku-4.5', 'gpt-5.4-mini', 'gpt-5-mini'],
 };
 

--- a/packages/squad-sdk/src/runtime/constants.ts
+++ b/packages/squad-sdk/src/runtime/constants.ts
@@ -19,7 +19,7 @@ export const MODELS = {
   /** Default tier for the model-selector Layer 4 fallback */
   SELECTOR_DEFAULT_TIER: 'fast',
 
-  /** Fallback chains by tier — ordered by preference */
+  /** Fallback chains by tier — ordered by preference (newest per series first) */
   FALLBACK_CHAINS: {
     premium: [
       'claude-opus-4.8',
@@ -27,11 +27,12 @@ export const MODELS = {
       'claude-opus-4.6',
       'claude-sonnet-4.6',
     ],
-  // claude-sonnet-4.6 leads as the established default (MODELS.DEFAULT); claude-sonnet-5 was
-  // newly added in this catalog refresh and is promoted to first fallback.
-  standard: [
-      'claude-sonnet-4.6',
+    standard: [
       'claude-sonnet-5',
+      'claude-sonnet-4.6',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
       'gpt-5.4',
       'gpt-5.3-codex',
       'claude-sonnet-4.5',

--- a/packages/squad-sdk/templates/model-selection-reference.md
+++ b/packages/squad-sdk/templates/model-selection-reference.md
@@ -51,7 +51,7 @@ If a spawn fails because the selected model is unavailable (plan restriction, or
 
 ```
 Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → gemini-2.5-pro → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/packages/squad-sdk/templates/model-selection-reference.md
+++ b/packages/squad-sdk/templates/model-selection-reference.md
@@ -21,7 +21,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 | Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
 | Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
 | NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.6` | Premium | Vision capability required. Overrides cost rule. |
+| Visual/design work requiring image analysis | `claude-opus-4.8` | Premium | Vision capability required. Overrides cost rule. |
 
 **Role-to-model mapping** (applying cost-first principle):
 
@@ -32,7 +32,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 | Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
 | Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
 | Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.6` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
+| Designer / Visual | `claude-opus-4.8` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
 | DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
 | Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
 | Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
@@ -50,8 +50,8 @@ Before spawning an agent, determine which model to use. Check these layers in or
 If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
 
 ```
-Premium:  claude-opus-4.6 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → (omit model param)
+Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 
@@ -85,10 +85,10 @@ If you've exhausted the fallback chain and reached nuclear fallback, omit the `m
 When spawning, include the model in your acknowledgment:
 
 ```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.6 · vision) — designing color system
+🔧 Fenster (claude-sonnet-5) — refactoring auth module
+🎨 Redfoot (claude-opus-4.8 · vision) — designing color system
 📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
+⚡ Keaton (claude-opus-4.8 · bumped for architecture) — reviewing proposal
 📝 McManus (claude-haiku-4.5 · fast) — updating docs
 ```
 
@@ -96,6 +96,6 @@ Include tier annotation only when the model was bumped or a specialist was chose
 
 **Valid models (current platform catalog):**
 
-Premium: `claude-opus-4.6`, `claude-opus-4.7`, `claude-opus-4.8`, `claude-opus-4.6-1m` (Internal only)
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.5`, `gemini-2.5-pro`
+Premium: `claude-opus-4.8`, `claude-opus-4.7`, `claude-opus-4.6`
+Standard: `claude-sonnet-5`, `claude-sonnet-4.6`, `claude-sonnet-4.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gemini-2.5-pro`
 Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini`

--- a/packages/squad-sdk/templates/ralph-circuit-breaker.md
+++ b/packages/squad-sdk/templates/ralph-circuit-breaker.md
@@ -1,21 +1,24 @@
 # Ralph Circuit Breaker — Model Rate Limit Fallback
 
 > Classic circuit breaker pattern (Hystrix / Polly / Resilience4j) applied to Copilot model selection.
-> When the preferred model hits rate limits, Ralph automatically degrades to free-tier models, then self-heals.
+> When the preferred model hits rate limits, Ralph automatically degrades to lower-cost models, then self-heals.
 
 ## Problem
 
 When running multiple Ralph instances across repos, Copilot model rate limits cause cascading failures.
-All Ralphs fail simultaneously when the preferred model (e.g., `claude-sonnet-4.6`) hits quota.
+All Ralphs fail simultaneously when the preferred model (e.g., `claude-sonnet-5`) hits quota.
 
-Premium models burn quota fast:
-| Model | Multiplier | Risk |
-|-------|-----------|------|
-| `claude-sonnet-4.6` | 1x | Moderate with many Ralphs |
-| `claude-opus-4.6` | 10x | High |
-| `gpt-5.4` | 50x | Very high |
-| `gpt-5.4-mini` | **0x** | **Free — unlimited** |
-| `gpt-5-mini` | **0x** | **Free — unlimited** |
+Under usage-based billing, all models incur cost — there are no "free" or unlimited models.
+Lightweight-category models have lower per-token cost and are therefore preferred for fallback,
+but they are still billed:
+
+| Model | Category | Cost profile |
+|-------|----------|--------------|
+| `claude-sonnet-5` | versatile | Moderate — standard-tier default |
+| `claude-opus-4.8` | powerful | Higher — reserve for premium work |
+| `gpt-5.4` | powerful | Higher — standard-tier specialist |
+| `gpt-5.4-mini` | lightweight | Lower-cost — preferred fallback |
+| `gpt-5-mini` | lightweight | Lowest-cost — final fallback |
 
 ## Circuit Breaker States
 
@@ -39,7 +42,7 @@ Premium models burn quota fast:
 - On rate limit error → transition to OPEN
 
 ### OPEN (rate limited — fallback active)
-- Fall back through the free-tier model chain:
+- Fall back through the lightweight-category model chain:
   1. `gpt-5.4-mini`
   2. `gpt-5-mini`
 - Start cooldown timer (default: 10 minutes)
@@ -55,7 +58,7 @@ Premium models burn quota fast:
 ```json
 {
   "state": "closed",
-  "preferredModel": "claude-sonnet-4.6",
+  "preferredModel": "claude-sonnet-5",
   "fallbackChain": ["gpt-5.4-mini", "gpt-5-mini"],
   "currentFallbackIndex": 0,
   "cooldownMinutes": 10,
@@ -84,7 +87,7 @@ function Get-CircuitBreakerState {
     if (-not (Test-Path $StateFile)) {
         $default = @{
             state              = "closed"
-            preferredModel     = "claude-sonnet-4.6"
+            preferredModel     = "claude-sonnet-5"
             fallbackChain      = @("gpt-5.4-mini", "gpt-5-mini")
             currentFallbackIndex = 0
             cooldownMinutes    = 10
@@ -291,8 +294,8 @@ Override defaults by editing `.squad/ralph-circuit-breaker.json`:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `preferredModel` | `claude-sonnet-4.6` | Model to use when circuit is closed |
-| `fallbackChain` | `["gpt-5.4-mini", "gpt-5-mini"]` | Ordered fallback models (all free-tier) |
+| `preferredModel` | `claude-sonnet-5` | Model to use when circuit is closed |
+| `fallbackChain` | `["gpt-5.4-mini", "gpt-5-mini"]` | Ordered fallback models (lightweight-category — lowest cost, still billed) |
 | `cooldownMinutes` | `10` | How long to wait before testing recovery |
 
 ## Metrics

--- a/packages/squad-sdk/templates/skills/model-selection/SKILL.md
+++ b/packages/squad-sdk/templates/skills/model-selection/SKILL.md
@@ -118,7 +118,7 @@ If a model is unavailable (rate limit, plan restriction), retry within the same 
 
 ```
 Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → gemini-2.5-pro → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/packages/squad-sdk/templates/skills/model-selection/SKILL.md
+++ b/packages/squad-sdk/templates/skills/model-selection/SKILL.md
@@ -59,7 +59,7 @@ Resolution is **first-match-wins** — the highest layer with a value wins.
 5. CHECK Layer 3: Determine task type:
    - Code (implementation, tests, refactoring, bug fixes) → `claude-sonnet-4.6`
    - Prompts, agent designs → `claude-sonnet-4.6`
-   - Visual/design with image analysis → `claude-opus-4.6`
+   - Visual/design with image analysis → `claude-opus-4.8`
    - Non-code (docs, planning, triage, changelogs) → `claude-haiku-4.5`
 6. FALLBACK Layer 4: `claude-haiku-4.5`
 7. INCLUDE model in spawn acknowledgment: `🔧 {Name} ({resolved_model}) — {task}`
@@ -117,8 +117,8 @@ After resolving the model and including it in the spawn template, this skill is 
 If a model is unavailable (rate limit, plan restriction), retry within the same tier:
 
 ```
-Premium:  claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-4.6 → gpt-5.4 → claude-sonnet-4.5 → gpt-5.3-codex → (omit model param)
+Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/templates/model-selection-reference.md
+++ b/templates/model-selection-reference.md
@@ -51,7 +51,7 @@ If a spawn fails because the selected model is unavailable (plan restriction, or
 
 ```
 Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
-Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.6-terra → gpt-5.6-luna → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → gemini-2.5-pro → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 

--- a/templates/model-selection-reference.md
+++ b/templates/model-selection-reference.md
@@ -21,7 +21,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 | Writing code (implementation, refactoring, test code, bug fixes) | `claude-sonnet-4.6` | Standard | Quality and accuracy matter for code. Use standard tier. |
 | Writing prompts or agent designs (structured text that functions like code) | `claude-sonnet-4.6` | Standard | Prompts are executable — treat like code. |
 | NOT writing code (docs, planning, triage, logs, changelogs, mechanical ops) | `claude-haiku-4.5` | Fast | Cost first. Haiku handles non-code tasks. |
-| Visual/design work requiring image analysis | `claude-opus-4.6` | Premium | Vision capability required. Overrides cost rule. |
+| Visual/design work requiring image analysis | `claude-opus-4.8` | Premium | Vision capability required. Overrides cost rule. |
 
 **Role-to-model mapping** (applying cost-first principle):
 
@@ -32,7 +32,7 @@ Before spawning an agent, determine which model to use. Check these layers in or
 | Lead / Architect | auto (per-task) | Mixed: code review needs quality, planning needs cost | Architecture proposals → premium; triage/planning → haiku |
 | Prompt Engineer | auto (per-task) | Mixed: prompt design is like code, research is not | Prompt architecture → sonnet; research/analysis → haiku |
 | Copilot SDK Expert | `claude-sonnet-4.6` | Technical analysis that often touches code | Pure research → `claude-haiku-4.5` |
-| Designer / Visual | `claude-opus-4.6` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
+| Designer / Visual | `claude-opus-4.8` | Vision-capable model required | — (never downgrade — vision is non-negotiable) |
 | DevRel / Writer | `claude-haiku-4.5` | Docs and writing — not code | — |
 | Scribe / Logger | `claude-haiku-4.5` | Mechanical file ops — cheapest possible | — (never bump Scribe) |
 | Git / Release | `claude-haiku-4.5` | Mechanical ops — changelogs, tags, version bumps | — (never bump mechanical ops) |
@@ -50,8 +50,8 @@ Before spawning an agent, determine which model to use. Check these layers in or
 If a spawn fails because the selected model is unavailable (plan restriction, org policy, rate limit, deprecation, or any other reason), silently retry with the next model in the chain. Do NOT tell the user about fallback attempts. Maximum 3 retries before jumping to the nuclear fallback.
 
 ```
-Premium:  claude-opus-4.6 → claude-sonnet-4.6 → claude-sonnet-4.5 → (omit model param)
-Standard: claude-sonnet-4.6 → claude-sonnet-4.5 → gpt-5.4 → gpt-5.3-codex → (omit model param)
+Premium:  claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → claude-sonnet-4.6 → (omit model param)
+Standard: claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → gpt-5.4 → gpt-5.3-codex → claude-sonnet-4.5 → (omit model param)
 Fast:     claude-haiku-4.5 → gpt-5.4-mini → gpt-5-mini → (omit model param)
 ```
 
@@ -85,10 +85,10 @@ If you've exhausted the fallback chain and reached nuclear fallback, omit the `m
 When spawning, include the model in your acknowledgment:
 
 ```
-🔧 Fenster (claude-sonnet-4.6) — refactoring auth module
-🎨 Redfoot (claude-opus-4.6 · vision) — designing color system
+🔧 Fenster (claude-sonnet-5) — refactoring auth module
+🎨 Redfoot (claude-opus-4.8 · vision) — designing color system
 📋 Scribe (claude-haiku-4.5 · fast) — logging session
-⚡ Keaton (claude-opus-4.6 · bumped for architecture) — reviewing proposal
+⚡ Keaton (claude-opus-4.8 · bumped for architecture) — reviewing proposal
 📝 McManus (claude-haiku-4.5 · fast) — updating docs
 ```
 
@@ -96,6 +96,6 @@ Include tier annotation only when the model was bumped or a specialist was chose
 
 **Valid models (current platform catalog):**
 
-Premium: `claude-opus-4.6`, `claude-opus-4.7`, `claude-opus-4.8`, `claude-opus-4.6-1m` (Internal only)
-Standard: `claude-sonnet-4.6`, `claude-sonnet-4.5`, `claude-sonnet-5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.5`, `gemini-2.5-pro`
+Premium: `claude-opus-4.8`, `claude-opus-4.7`, `claude-opus-4.6`
+Standard: `claude-sonnet-5`, `claude-sonnet-4.6`, `claude-sonnet-4.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gemini-2.5-pro`
 Fast/Cheap: `claude-haiku-4.5`, `gpt-5.4-mini`, `gpt-5-mini`

--- a/templates/ralph-circuit-breaker.md
+++ b/templates/ralph-circuit-breaker.md
@@ -1,21 +1,24 @@
 # Ralph Circuit Breaker — Model Rate Limit Fallback
 
 > Classic circuit breaker pattern (Hystrix / Polly / Resilience4j) applied to Copilot model selection.
-> When the preferred model hits rate limits, Ralph automatically degrades to free-tier models, then self-heals.
+> When the preferred model hits rate limits, Ralph automatically degrades to lower-cost models, then self-heals.
 
 ## Problem
 
 When running multiple Ralph instances across repos, Copilot model rate limits cause cascading failures.
-All Ralphs fail simultaneously when the preferred model (e.g., `claude-sonnet-4.6`) hits quota.
+All Ralphs fail simultaneously when the preferred model (e.g., `claude-sonnet-5`) hits quota.
 
-Premium models burn quota fast:
-| Model | Multiplier | Risk |
-|-------|-----------|------|
-| `claude-sonnet-4.6` | 1x | Moderate with many Ralphs |
-| `claude-opus-4.6` | 10x | High |
-| `gpt-5.4` | 50x | Very high |
-| `gpt-5.4-mini` | **0x** | **Free — unlimited** |
-| `gpt-5-mini` | **0x** | **Free — unlimited** |
+Under usage-based billing, all models incur cost — there are no "free" or unlimited models.
+Lightweight-category models have lower per-token cost and are therefore preferred for fallback,
+but they are still billed:
+
+| Model | Category | Cost profile |
+|-------|----------|--------------|
+| `claude-sonnet-5` | versatile | Moderate — standard-tier default |
+| `claude-opus-4.8` | powerful | Higher — reserve for premium work |
+| `gpt-5.4` | powerful | Higher — standard-tier specialist |
+| `gpt-5.4-mini` | lightweight | Lower-cost — preferred fallback |
+| `gpt-5-mini` | lightweight | Lowest-cost — final fallback |
 
 ## Circuit Breaker States
 
@@ -39,7 +42,7 @@ Premium models burn quota fast:
 - On rate limit error → transition to OPEN
 
 ### OPEN (rate limited — fallback active)
-- Fall back through the free-tier model chain:
+- Fall back through the lightweight-category model chain:
   1. `gpt-5.4-mini`
   2. `gpt-5-mini`
 - Start cooldown timer (default: 10 minutes)
@@ -55,7 +58,7 @@ Premium models burn quota fast:
 ```json
 {
   "state": "closed",
-  "preferredModel": "claude-sonnet-4.6",
+  "preferredModel": "claude-sonnet-5",
   "fallbackChain": ["gpt-5.4-mini", "gpt-5-mini"],
   "currentFallbackIndex": 0,
   "cooldownMinutes": 10,
@@ -84,7 +87,7 @@ function Get-CircuitBreakerState {
     if (-not (Test-Path $StateFile)) {
         $default = @{
             state              = "closed"
-            preferredModel     = "claude-sonnet-4.6"
+            preferredModel     = "claude-sonnet-5"
             fallbackChain      = @("gpt-5.4-mini", "gpt-5-mini")
             currentFallbackIndex = 0
             cooldownMinutes    = 10
@@ -291,8 +294,8 @@ Override defaults by editing `.squad/ralph-circuit-breaker.json`:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `preferredModel` | `claude-sonnet-4.6` | Model to use when circuit is closed |
-| `fallbackChain` | `["gpt-5.4-mini", "gpt-5-mini"]` | Ordered fallback models (all free-tier) |
+| `preferredModel` | `claude-sonnet-5` | Model to use when circuit is closed |
+| `fallbackChain` | `["gpt-5.4-mini", "gpt-5-mini"]` | Ordered fallback models (lightweight-category — lowest cost, still billed) |
 | `cooldownMinutes` | `10` | How long to wait before testing recovery |
 
 ## Metrics

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -339,9 +339,13 @@ describe('Per-Agent Model Selection (M1-9)', () => {
 
       const result = resolveModel(options);
 
+      // Chain reordered to prefer newest per series first (PR #1444 follow-up, tamirdresher request).
       expect(result.fallbackChain).toEqual([
-        'claude-sonnet-4.6',
         'claude-sonnet-5',
+        'claude-sonnet-4.6',
+        'gpt-5.6-sol',
+        'gpt-5.6-terra',
+        'gpt-5.6-luna',
         'gpt-5.4',
         'gpt-5.3-codex',
         'claude-sonnet-4.5',

--- a/test/catalog-refresh.test.ts
+++ b/test/catalog-refresh.test.ts
@@ -46,10 +46,9 @@ const DEAD_MODEL_IDS = [
 ];
 
 /**
- * The exact set of CLI-reachable seed model IDs (verified 2026-07-04). A
- * positive invariant: any unexpected reintroduction — including live-but-dropped
- * IDs like `claude-opus-4.5` — fails immediately, which a blocklist alone cannot
- * guarantee.
+ * The exact set of CLI-reachable seed model IDs.
+ * gpt-5.6-sol/terra/luna added 2026-07-13 (env-observed as Standard-tier
+ * reachable via Copilot CLI; tamirdresher follow-up request on PR #1444).
  */
 const EXPECTED_CATALOG_IDS = [
   'claude-haiku-4.5',
@@ -65,6 +64,9 @@ const EXPECTED_CATALOG_IDS = [
   'gpt-5.4',
   'gpt-5.4-mini',
   'gpt-5.5',
+  'gpt-5.6-luna',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
 ];
 
 const CONFIG_CHAINS = DEFAULT_FALLBACK_CHAINS as Record<string, string[]>;
@@ -115,6 +117,47 @@ describe('catalog refresh invariants (#1080/#1183)', () => {
     const actual = [...catalogIds].sort();
     const expected = [...EXPECTED_CATALOG_IDS].sort();
     expect(actual).toEqual(expected);
+  });
+
+  // ── Ordering invariants (tamirdresher PR #1444 follow-up) ──────────────────
+  // Prefer the NEWEST model in each series at [0]. Verified 2026-07-13.
+
+  it('config premium chain[0] is claude-opus-4.8 (newest Opus series)', () => {
+    expect(CONFIG_CHAINS.premium[0]).toBe('claude-opus-4.8');
+  });
+
+  it('config standard chain[0] is claude-sonnet-5 (newest Sonnet series)', () => {
+    expect(CONFIG_CHAINS.standard[0]).toBe('claude-sonnet-5');
+  });
+
+  it('runtime premium chain[0] is claude-opus-4.8 (newest Opus series)', () => {
+    expect(RUNTIME_CHAINS.premium[0]).toBe('claude-opus-4.8');
+  });
+
+  it('runtime standard chain[0] is claude-sonnet-5 (newest Sonnet series)', () => {
+    expect(RUNTIME_CHAINS.standard[0]).toBe('claude-sonnet-5');
+  });
+
+  // ── GPT-5.6 catalog membership (tamirdresher PR #1444 follow-up) ──────────
+
+  it('MODEL_CATALOG contains gpt-5.6-sol', () => {
+    expect(catalogIds.has('gpt-5.6-sol')).toBe(true);
+  });
+
+  it('MODEL_CATALOG contains gpt-5.6-terra', () => {
+    expect(catalogIds.has('gpt-5.6-terra')).toBe(true);
+  });
+
+  it('MODEL_CATALOG contains gpt-5.6-luna', () => {
+    expect(catalogIds.has('gpt-5.6-luna')).toBe(true);
+  });
+
+  it('gpt-5.6-sol appears in config standard fallback chain', () => {
+    expect(CONFIG_CHAINS.standard).toContain('gpt-5.6-sol');
+  });
+
+  it('gpt-5.6-sol appears in runtime standard fallback chain', () => {
+    expect(RUNTIME_CHAINS.standard).toContain('gpt-5.6-sol');
   });
 });
 

--- a/test/compat-v041.test.ts
+++ b/test/compat-v041.test.ts
@@ -487,7 +487,8 @@ describe('Compat v0.4.1: Model Catalog', () => {
   });
 
   it('standard fallback chain starts with sonnet', () => {
-    expect(DEFAULT_FALLBACK_CHAINS.standard[0]).toBe('claude-sonnet-4.6');
+    // Reordered to prefer newest Sonnet series first (PR #1444 follow-up, tamirdresher request).
+    expect(DEFAULT_FALLBACK_CHAINS.standard[0]).toBe('claude-sonnet-5');
   });
 
   it('fast fallback chain starts with haiku', () => {

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -76,7 +76,8 @@ describe('DEFAULT_FALLBACK_CHAINS', () => {
   });
 
   it('starts standard chain with sonnet', () => {
-    expect(DEFAULT_FALLBACK_CHAINS.standard[0]).toBe('claude-sonnet-4.6');
+    // Reordered to prefer newest Sonnet series first (PR #1444 follow-up, tamirdresher request).
+    expect(DEFAULT_FALLBACK_CHAINS.standard[0]).toBe('claude-sonnet-5');
   });
 
   it('starts fast chain with haiku', () => {


### PR DESCRIPTION
# docs/models: prefer newest per series (Opus 4.8), add GPT-5.6 IDs, fix Ralph free-model wording

## Context

Follow-up PR explicitly requested by @tamirdresher when he merged [#1444](https://github.com/bradygaster/squad/pull/1444).

> Reference comment: **https://github.com/bradygaster/squad/pull/1444#issuecomment-4954513635**

Tamir's three requests, addressed below.

---

## Relationship to #1445

Independent of the cost-policy PR #1445 — the two touch different files, so they can merge in **either order without conflict**. The only sequenced item is the deferred `DOCS_NAME_TO_ID` addition for the three GPT-5.6 IDs: that map lives in `packages/squad-cli/src/cli/commands/models.ts`, which #1445 owns, so it should land in a small follow-up **after #1445 merges**. This PR itself is self-contained and ready to merge independently.

---

## Item 1 — Prefer the NEWEST model per series in examples and fallback chains

> tamirdresher (bullet 1): *"Examples and fallback ordering should consistently prefer the NEWEST model in each series, INCLUDING Opus 4.8."*

**Code changes:**

| File | Change |
|------|--------|
| `packages/squad-sdk/src/config/models.ts` | `DEFAULT_FALLBACK_CHAINS.standard[0]` → `claude-sonnet-5` (was `claude-sonnet-4.6`) |
| `packages/squad-sdk/src/runtime/constants.ts` | `MODELS.FALLBACK_CHAINS.standard[0]` → `claude-sonnet-5` (same reorder) |

Premium chains already led with `claude-opus-4.8` after #1444 ✅

**Doc/template changes:** all `model-selection-reference.md` and `model-selection` SKILL files updated so that:

- Premium fallback example: `claude-opus-4.8 → claude-opus-4.7 → claude-opus-4.6 → ...`
- Standard fallback example: `claude-sonnet-5 → claude-sonnet-4.6 → gpt-5.6-sol → ...`
- Designer / visual role row: `claude-opus-4.8` (newest vision-capable model)
- Spawn acknowledgment examples: show latest models

**⚠️ MODELS.DEFAULT intentionally NOT changed:** `MODELS.DEFAULT` remains `claude-sonnet-4.6`. Changing the global default is higher-impact and should be a conscious, separate decision — it is explicitly out of scope here.

---

## Item 2 — Add GPT-5.6 model IDs (gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna)

> tamirdresher (bullet 2): *"Add the newly available GPT-5.6 model IDs after validating CLI reachability."*

**Reachability validation basis:** GPT-5.6 variants (sol, terra, luna) observed as Standard-tier picker-reachable models via the Copilot CLI catalog on 2026-07-13. Consistent with gpt-5.5, which is already in the seed.

**Code changes:**

| File | Change |
|------|--------|
| `packages/squad-sdk/src/config/models.ts` | 3 new `MODEL_CATALOG` entries: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` — `tier: 'standard'`, `githubCategory: 'powerful'` (mirrors `gpt-5.5` sibling) |
| `packages/squad-sdk/src/config/models.ts` | Added to `DEFAULT_FALLBACK_CHAINS.standard` (after `claude-sonnet-4.6`, before `gpt-5.4`) |
| `packages/squad-sdk/src/runtime/constants.ts` | Added to `MODELS.FALLBACK_CHAINS.standard` (same position) |

**Template changes:** all Valid Models lists in `model-selection-reference.md` and `model-selection` SKILL files updated to include `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` under Standard.

**⚠️ DOCS_NAME_TO_ID deferral:** the `DOCS_NAME_TO_ID` map in `packages/squad-cli/src/cli/commands/models.ts` is in draft PR #1445's diff. To avoid conflicts, gpt-5.6 entries to that map are deferred until #1445 merges (see "Relationship to #1445" above).

---

## Item 3 — Ralph circuit-breaker: replace "free models" wording

> tamirdresher (bullet 3): *"Update the Ralph circuit-breaker wording now that usage-based billing means there may no longer be 'free models'."*

**Changes to `.squad-templates/ralph-circuit-breaker.md`** (synced to all 3 template targets):

- **Removed:** multiplier table with `0x` / `"Free — unlimited"` language
- **Added:** usage-based billing framing — lightweight-category models are *lowest-cost, still billed*
- **Updated:** `preferredModel` example `claude-sonnet-4.6` → `claude-sonnet-5`
- **Updated:** fallback chain section header: "free-tier model chain" → "lightweight-category model chain"
- **Updated:** Configuration table: `"(all free-tier)"` → `"(lightweight-category — lowest cost, still billed)"`

---

## Tests

TDD approach: wrote failing tests first, then implemented.

- **Before implementation:** 8 failed | 8 passed (RED)
- **After implementation:** **16/16 passed (GREEN)**

New tests added to `test/catalog-refresh.test.ts`:

- `config/runtime premium chain[0] is claude-opus-4.8` (ordering invariant)
- `config/runtime standard chain[0] is claude-sonnet-5` (ordering invariant) ← was failing RED
- `MODEL_CATALOG contains gpt-5.6-sol/terra/luna` (membership) ← was failing RED
- `gpt-5.6-sol appears in config/runtime standard fallback chain` ← was failing RED

---

## Files changed

**Source (TDD-gated):**

- `packages/squad-sdk/src/config/models.ts`
- `packages/squad-sdk/src/runtime/constants.ts`
- `test/catalog-refresh.test.ts`

**Canonical templates (sync sources):**

- `.squad-templates/ralph-circuit-breaker.md`
- `.squad-templates/model-selection-reference.md`
- `.squad/skills/model-selection/SKILL.md`
- `.copilot/skills/model-selection/SKILL.md`

**Synced copies (generated via `sync-templates.mjs --sync` + `sync-skill-templates.mjs`):**

- `templates/ralph-circuit-breaker.md`
- `templates/model-selection-reference.md`
- `packages/squad-cli/templates/ralph-circuit-breaker.md`
- `packages/squad-cli/templates/model-selection-reference.md`
- `packages/squad-cli/templates/skills/model-selection/SKILL.md`
- `packages/squad-sdk/templates/ralph-circuit-breaker.md`
- `packages/squad-sdk/templates/model-selection-reference.md`
- `packages/squad-sdk/templates/skills/model-selection/SKILL.md`

---

## Refs

Closes follow-up from: https://github.com/bradygaster/squad/pull/1444#issuecomment-4954513635
Refs: #1080, #1183
Branch stacks on: `upstream/dev` (includes merged #1444)
