### PR TITLE
ci: refresh GitHub Actions with immutable pins

### DIFF
--- a/.github/workflows/squad-docs-links.yml
+++ b/.github/workflows/squad-docs-links.yml
@@ -13,7 +13,7 @@ jobs:
       
       - name: Check external links
         id: lychee
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 #v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 #v2
         with:
           args: >-
             --verbose

--- a/.github/workflows/squad-version-promote.yml
+++ b/.github/workflows/squad-version-promote.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       # ── Checkout & git setup ────────────────────────────────────────────────
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Recreates the safe, verifiable portions of #1473 without introducing any mutable `uses:` references, so the repository's SHA-pinning policy is preserved.

## Diff (only two lines change)

- `.github/workflows/squad-docs-links.yml`
  - `lycheeverse/lychee-action`: `8646ba30535128ac92d33dfc9133794bfdd9b411` → `e7477775783ea5526144ba13e8db5eec57747ce8` (tag `v2`)
- `.github/workflows/squad-version-promote.yml`
  - `actions/checkout`: `@v4` → `@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` (tag `v7`) — the same pinned SHA already used elsewhere in this repo

## Why not just merge #1473?

#1473 reintroduced mutable references (`@v2`, `@v4`, `@v6`), which the codebase has deliberately moved away from. This PR keeps only the two useful updates and applies them as immutable pins with the `#v2` / `#v7` comment for humans.

## Verification

Each SHA was resolved against GitHub's authoritative tag refs and confirmed to be the current commit for the intended release:

- `GET repos/lycheeverse/lychee-action/git/refs/tags/v2` → `e7477775783ea5526144ba13e8db5eec57747ce8`
- `GET repos/actions/checkout/git/refs/tags/v7` → `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`

Additional local validation performed on the two changed files:

- `git diff --check` — no whitespace errors
- `git diff --stat` — exactly 2 files, 2 insertions, 2 deletions
- PyYAML `safe_load` of both files — parsed successfully
- Every `uses:` in both workflows verified to be a 40-hex SHA pin (not a mutable ref)

Only two lines change in the diff, and no `uses:` line in either file resolves to a mutable ref.