### PR TITLE
docs(templates): warn before parallel background spawns in a shared worktree

### DIFF
--- a/.changeset/fix-1014-parallel-spawn-warning.md
+++ b/.changeset/fix-1014-parallel-spawn-warning.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+Coordinator template now warns before launching 2+ parallel background agents in a shared worktree: global-scope git operations (stash/clean/restore) from one agent can silently delete another agent's untracked files. Warn-only — worktree mode remains opt-in. The worktree reference no longer claims shared-worktree concurrency is safe when agents touch different files.

--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -509,6 +509,17 @@ When the user gives any task, the Coordinator MUST:
    ```
 5. **Chain follow-ups.** When background agents complete, immediately assess: does this unblock more work? Launch it without waiting for the user to ask.
 
+**Shared-worktree guard.** Before spawning 2+ background agents in one turn, check whether worktree mode is active (see Pre-Spawn: Worktree Setup). If it is NOT, show the user this warning before launching:
+
+```
+⚠️ Launching {N} parallel background agents in a shared worktree.
+   Global-scope git operations (stash, clean, restore) from one agent can
+   silently delete another agent's untracked files. Enable worktree mode
+   for per-stream isolation, or accept the risk for this wave.
+```
+
+Warn once per session, then proceed — this is a caution, not a gate.
+
 **Example — "Team, build the login page":**
 - Turn 1: Spawn {Lead} (architecture), {Frontend} (UI), {Backend} (API), {Tester} (test cases from spec) — ALL background, ALL in one tool call
 - Collect results. Scribe merges decisions.

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -509,6 +509,17 @@ When the user gives any task, the Coordinator MUST:
    ```
 5. **Chain follow-ups.** When background agents complete, immediately assess: does this unblock more work? Launch it without waiting for the user to ask.
 
+**Shared-worktree guard.** Before spawning 2+ background agents in one turn, check whether worktree mode is active (see Pre-Spawn: Worktree Setup). If it is NOT, show the user this warning before launching:
+
+```
+⚠️ Launching {N} parallel background agents in a shared worktree.
+   Global-scope git operations (stash, clean, restore) from one agent can
+   silently delete another agent's untracked files. Enable worktree mode
+   for per-stream isolation, or accept the risk for this wave.
+```
+
+Warn once per session, then proceed — this is a caution, not a gate.
+
 **Example — "Team, build the login page":**
 - Turn 1: Spawn {Lead} (architecture), {Frontend} (UI), {Backend} (API), {Tester} (test cases from spec) — ALL background, ALL in one tool call
 - Collect results. Scribe merges decisions.

--- a/.squad-templates/worktree-reference.md
+++ b/.squad-templates/worktree-reference.md
@@ -71,7 +71,7 @@ When worktree mode is enabled, the coordinator creates dedicated worktrees for i
 - Before creating a new worktree, check if one exists for the same issue
 - `git worktree list` shows all active worktrees
 - If found, reuse it (cd to the path, verify branch is correct, `git pull` to sync)
-- Multiple agents can work in the same worktree concurrently if they modify different files
+- Multiple agents can work in the same worktree concurrently if they modify different files. Untracked files are still at risk: a global `git stash` / `git clean` from one agent can delete another agent's not-yet-committed files — prefer per-issue worktrees for parallel background work
 
 **Cleanup:**
 - After a PR is merged, the worktree should be removed

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -509,6 +509,17 @@ When the user gives any task, the Coordinator MUST:
    ```
 5. **Chain follow-ups.** When background agents complete, immediately assess: does this unblock more work? Launch it without waiting for the user to ask.
 
+**Shared-worktree guard.** Before spawning 2+ background agents in one turn, check whether worktree mode is active (see Pre-Spawn: Worktree Setup). If it is NOT, show the user this warning before launching:
+
+```
+⚠️ Launching {N} parallel background agents in a shared worktree.
+   Global-scope git operations (stash, clean, restore) from one agent can
+   silently delete another agent's untracked files. Enable worktree mode
+   for per-stream isolation, or accept the risk for this wave.
+```
+
+Warn once per session, then proceed — this is a caution, not a gate.
+
 **Example — "Team, build the login page":**
 - Turn 1: Spawn {Lead} (architecture), {Frontend} (UI), {Backend} (API), {Tester} (test cases from spec) — ALL background, ALL in one tool call
 - Collect results. Scribe merges decisions.

--- a/packages/squad-cli/templates/worktree-reference.md
+++ b/packages/squad-cli/templates/worktree-reference.md
@@ -71,7 +71,7 @@ When worktree mode is enabled, the coordinator creates dedicated worktrees for i
 - Before creating a new worktree, check if one exists for the same issue
 - `git worktree list` shows all active worktrees
 - If found, reuse it (cd to the path, verify branch is correct, `git pull` to sync)
-- Multiple agents can work in the same worktree concurrently if they modify different files
+- Multiple agents can work in the same worktree concurrently if they modify different files. Untracked files are still at risk: a global `git stash` / `git clean` from one agent can delete another agent's not-yet-committed files — prefer per-issue worktrees for parallel background work
 
 **Cleanup:**
 - After a PR is merged, the worktree should be removed

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -509,6 +509,17 @@ When the user gives any task, the Coordinator MUST:
    ```
 5. **Chain follow-ups.** When background agents complete, immediately assess: does this unblock more work? Launch it without waiting for the user to ask.
 
+**Shared-worktree guard.** Before spawning 2+ background agents in one turn, check whether worktree mode is active (see Pre-Spawn: Worktree Setup). If it is NOT, show the user this warning before launching:
+
+```
+⚠️ Launching {N} parallel background agents in a shared worktree.
+   Global-scope git operations (stash, clean, restore) from one agent can
+   silently delete another agent's untracked files. Enable worktree mode
+   for per-stream isolation, or accept the risk for this wave.
+```
+
+Warn once per session, then proceed — this is a caution, not a gate.
+
 **Example — "Team, build the login page":**
 - Turn 1: Spawn {Lead} (architecture), {Frontend} (UI), {Backend} (API), {Tester} (test cases from spec) — ALL background, ALL in one tool call
 - Collect results. Scribe merges decisions.

--- a/packages/squad-sdk/templates/worktree-reference.md
+++ b/packages/squad-sdk/templates/worktree-reference.md
@@ -71,7 +71,7 @@ When worktree mode is enabled, the coordinator creates dedicated worktrees for i
 - Before creating a new worktree, check if one exists for the same issue
 - `git worktree list` shows all active worktrees
 - If found, reuse it (cd to the path, verify branch is correct, `git pull` to sync)
-- Multiple agents can work in the same worktree concurrently if they modify different files
+- Multiple agents can work in the same worktree concurrently if they modify different files. Untracked files are still at risk: a global `git stash` / `git clean` from one agent can delete another agent's not-yet-committed files — prefer per-issue worktrees for parallel background work
 
 **Cleanup:**
 - After a PR is merged, the worktree should be removed

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -509,6 +509,17 @@ When the user gives any task, the Coordinator MUST:
    ```
 5. **Chain follow-ups.** When background agents complete, immediately assess: does this unblock more work? Launch it without waiting for the user to ask.
 
+**Shared-worktree guard.** Before spawning 2+ background agents in one turn, check whether worktree mode is active (see Pre-Spawn: Worktree Setup). If it is NOT, show the user this warning before launching:
+
+```
+⚠️ Launching {N} parallel background agents in a shared worktree.
+   Global-scope git operations (stash, clean, restore) from one agent can
+   silently delete another agent's untracked files. Enable worktree mode
+   for per-stream isolation, or accept the risk for this wave.
+```
+
+Warn once per session, then proceed — this is a caution, not a gate.
+
 **Example — "Team, build the login page":**
 - Turn 1: Spawn {Lead} (architecture), {Frontend} (UI), {Backend} (API), {Tester} (test cases from spec) — ALL background, ALL in one tool call
 - Collect results. Scribe merges decisions.

--- a/templates/worktree-reference.md
+++ b/templates/worktree-reference.md
@@ -71,7 +71,7 @@ When worktree mode is enabled, the coordinator creates dedicated worktrees for i
 - Before creating a new worktree, check if one exists for the same issue
 - `git worktree list` shows all active worktrees
 - If found, reuse it (cd to the path, verify branch is correct, `git pull` to sync)
-- Multiple agents can work in the same worktree concurrently if they modify different files
+- Multiple agents can work in the same worktree concurrently if they modify different files. Untracked files are still at risk: a global `git stash` / `git clean` from one agent can delete another agent's not-yet-committed files — prefer per-issue worktrees for parallel background work
 
 **Cleanup:**
 - After a PR is merged, the worktree should be removed

--- a/test/ci/parallel-spawn-warning.test.ts
+++ b/test/ci/parallel-spawn-warning.test.ts
@@ -1,0 +1,64 @@
+/**
+ * CI tests for the shared-worktree spawn warning (#1014).
+ *
+ * A real incident showed that parallel background agents on a shared
+ * worktree can silently lose untracked files to another stream's global
+ * git operations (stash/clean/restore). The coordinator template must
+ * warn before launching 2+ background agents without worktree isolation,
+ * and the worktree reference must not claim shared-worktree concurrency
+ * is safe for untracked files.
+ *
+ * Canonical source: .squad-templates/
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '../..');
+
+function readTemplate(relPath: string): string {
+  return readFileSync(resolve(ROOT, relPath), 'utf-8');
+}
+
+describe('shared-worktree spawn warning contract (#1014)', () => {
+  const squadTemplate = readTemplate('.squad-templates/squad.agent.md');
+  const worktreeReference = readTemplate('.squad-templates/worktree-reference.md');
+
+  it('keeps the shared-worktree guard inside the Parallel Fan-Out section', () => {
+    const fanOut = squadTemplate.slice(
+      squadTemplate.indexOf('### Parallel Fan-Out'),
+      squadTemplate.indexOf('### Shared File Architecture'),
+    );
+
+    expect(fanOut).toContain('**Shared-worktree guard.**');
+    expect(fanOut).toContain('2+ background agents');
+    expect(fanOut).toContain('Pre-Spawn: Worktree Setup');
+    expect(fanOut).toContain('untracked files');
+    expect(fanOut).toContain('a caution, not a gate');
+  });
+
+  it('warns about stash/clean/restore specifically', () => {
+    expect(squadTemplate).toContain('stash, clean, restore');
+  });
+
+  it('worktree reference no longer claims shared-worktree concurrency is safe for untracked files', () => {
+    expect(worktreeReference).toContain('Untracked files are still at risk');
+  });
+
+  it('all governed copies of the coordinator template carry the guard', () => {
+    const copies = [
+      '.github/agents/squad.agent.md',
+      'templates/squad.agent.md.template',
+      'packages/squad-cli/templates/squad.agent.md.template',
+      'packages/squad-sdk/templates/squad.agent.md.template',
+    ];
+    for (const copy of copies) {
+      expect(readTemplate(copy), `${copy} is missing the shared-worktree guard`).toContain(
+        '**Shared-worktree guard.**',
+      );
+    }
+  });
+});


### PR DESCRIPTION
### What
The coordinator template's Parallel Fan-Out section now includes a shared-worktree guard: before spawning 2+ background agents in one turn without worktree mode, the coordinator shows the user a one-shot warning about the git race, then proceeds. Warn-only — no behavior change, no auto-isolation.

### Why
Closes #1014

The issue documents a real incident: two background agents on one worktree, agent B's commit workflow ran a global `git stash`, and agent A's three untracked files vanished mid-session. Git doesn't error — only the in-session context remembers the files existed. The failure is probabilistic (fires only when one stream has untracked files at the exact moment another runs stash/clean/restore), so teams parallelize happily until it bites, then lose trust in parallelism entirely.

This ships the issue author's own Option A. Option B (auto-enable worktree isolation at N≥2 spawns) stays a follow-up — it changes spawn behavior and costs coordination overhead, which deserves its own discussion.

One correction against the issue text: the sample warning there references `SQUAD_WORKTREES=1` / `worktrees: true`, but no such flag exists in the codebase — worktree isolation is governance-driven (worktree mode via the Pre-Spawn: Worktree Setup section and worktree-reference.md). The added warning points at the real mechanism instead of inventing a config surface.

### How
- `.squad-templates/squad.agent.md` (canonical): a `**Shared-worktree guard.**` block at the end of the Parallel Fan-Out MUST-list — check worktree mode, warn once per session when off, proceed after warning ("a caution, not a gate"). Warning text names the exact failure (stash/clean/restore eating another agent's untracked files).
- `.squad-templates/worktree-reference.md`: the "multiple agents can work in the same worktree concurrently if they modify different files" line now carries the untracked-files caveat — that safety claim never covered untracked files, which is exactly what the incident hit.
- Propagated via `node scripts/sync-templates.mjs --sync` to all governed copies: `.github/agents/squad.agent.md`, `templates/`, `packages/squad-cli/templates/`, `packages/squad-sdk/templates/` (5 agent.md copies, 4 worktree-reference copies — byte-identical, `test/template-sync.test.ts` parity passes).

### Testing
- New `test/ci/parallel-spawn-warning.test.ts` (4 tests, same structural pattern as `test/ci/datetime-template.test.ts`): guard present inside the Parallel Fan-Out section specifically, stash/clean/restore named, the worktree-reference caveat present, and all governed copies carrying the guard.
- `npx vitest run test/ci/parallel-spawn-warning.test.ts test/template-sync.test.ts` — 253 passed.
- Per CONTRIBUTING, `.squad-templates/*.md` changes call for an E2E template session on top of unit tests. Copilot CLI isn't available in this environment, so that run hasn't happened — flagging honestly rather than claiming it. The change is purely additive guidance text (no spawn-template variables, no conditional blocks touched), so the structural tests cover what's mechanically checkable; happy to run the E2E matrix on a machine with copilot if wanted before merge.
- Diff hygiene: `git diff` vs `git diff -w` identical; the sync script's known CRLF churn on unrelated workflow-wiring files was reverted before commit — the diff is 11 files, +129/−4, all of it the guard, the caveat, the test, and the changeset.

---

### ⚠️ Quick Check
- [x] Changeset added: `.changeset/fix-1014-parallel-spawn-warning.md` (patch, both packages — governed template paths ship in both)

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev`
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes
- [x] PR is not in draft mode
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] `npm run build` — N/A for template text, passes regardless
- [x] Targeted tests pass (253 across the new test + template-sync parity)
- [x] `npm run lint` passes
- [x] `npm run lint:eslint` — 0 errors on the new test file

#### Changeset
- [x] Changeset added (patch, both packages)

#### Docs
- [x] N/A — the change IS coordinator/reference documentation

#### Exports
- [x] N/A

---

### Breaking Changes
None. Warn-only; shared-worktree mode keeps working exactly as before.

### Waivers
E2E template session not run in this environment (no copilot CLI) — see Testing.