### PR TITLE
docs: show how to fix PATH for custom npm prefixes in installation troubleshooting

### DIFF
--- a/docs/src/content/docs/get-started/installation.md
+++ b/docs/src/content/docs/get-started/installation.md
@@ -160,16 +160,33 @@ export default defineConfig({
 
 ### `squad: command not found`
 
-Your npm global bin isn't in your PATH. Fix:
+Your npm global bin isn't in your PATH. This usually happens with a custom npm prefix (e.g. `npm config set prefix ~/.npm-global`). Diagnose:
 
 ```bash
 # Check if installed
 npm list -g @bradygaster/squad-cli
 
-# If installed but not found, check PATH:
-echo $PATH | grep npm          # macOS/Linux
-echo %PATH% | findstr npm      # Windows
+# Find where npm puts global commands
+npm prefix -g
 ```
+
+On macOS/Linux, `squad` is installed to `$(npm prefix -g)/bin`. On Windows, it's installed to the prefix directory itself (no `bin` subdirectory). If that directory isn't in your PATH, add it:
+
+**macOS/Linux** — add the bin directory to your shell profile:
+
+```bash
+echo 'export PATH="$(npm prefix -g)/bin:$PATH"' >> ~/.zshrc   # or ~/.bashrc
+source ~/.zshrc
+```
+
+**Windows (PowerShell)** — append the prefix to your user PATH:
+
+```powershell
+$npmPrefix = npm prefix -g
+[Environment]::SetEnvironmentVariable('Path', "$([Environment]::GetEnvironmentVariable('Path', 'User'));$npmPrefix", 'User')
+```
+
+Then open a new terminal and verify with `squad --version`.
 
 ### `Cannot find .squad/ directory`
 


### PR DESCRIPTION
### What
Replaces the diagnostics-only `squad: command not found` entry in `docs/src/content/docs/get-started/installation.md` with the actual fix: `npm prefix -g` to locate the global bin, then per-platform PATH instructions (shell profile export for macOS/Linux, `[Environment]::SetEnvironmentVariable` for Windows). Docs-only — no code change.

### Why
Fixes #1458

The section said "Fix:" but only showed diagnostic commands, so a user with a custom npm prefix could confirm the problem and still not know what to do about it. The old Windows line was also cmd syntax (`echo %PATH% | findstr npm`) that errors in PowerShell, the default shell the docs otherwise assume.

### Testing
- Verified live on Windows 11: `npm install -g --prefix <sandbox> @bradygaster/squad-cli` against the published package — the `squad.cmd` shim lands directly in the prefix root, no `bin\` subdirectory, which is why the doc now spells out the macOS/Linux vs Windows split
- The PowerShell snippet's `[Environment]::` calls syntax-checked with an ephemeral process-scope variable; the real `'User'`-scope write was not run against this machine's PATH, by design
- The bash export line dry-run in a subshell — `$(npm prefix -g)/bin` resolves and prepends as written
- `npm run lint:docs` (markdownlint + cspell) — 0 errors
- `git diff` vs `git diff -w` identical; file stays LF

---

### ⚠️ Quick Check
- [x] No changeset — docs-only change, no governed source/template paths touched

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev`
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes (single docs file, +21 −4)
- [x] PR is not in draft mode
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] `npm run lint:docs` passes
- [x] Build/tests N/A — no code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
