### PR TITLE
fix(cli): externalize/internalize corrupt binary files under .squad/

### DIFF
--- a/.changeset/fix-externalize-binary-corruption.md
+++ b/.changeset/fix-externalize-binary-corruption.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+Fix `squad externalize`/`internalize` corrupting non-UTF-8 files under `.squad/`. Both commands copied files through a UTF-8 string round-trip (`readSync`/`writeSync`), which replaced every byte >= 0x80 with U+FFFD and, because the source was deleted right after, destroyed the only intact copy. They now copy bytes via `storage.copySync`, so binary state (diagrams, archives, a future SQLite state db) survives the round trip intact.

--- a/packages/squad-cli/src/cli/commands/externalize.ts
+++ b/packages/squad-cli/src/cli/commands/externalize.ts
@@ -70,11 +70,9 @@ export function runExternalize(projectDir: string, projectKey?: string): void {
       copyDirRecursive(src, dest);
       storage.deleteDirSync?.(src);
     } else {
-      const content = storage.readSync(src);
-      if (content != null) {
-        storage.mkdirSync(path.dirname(dest), { recursive: true });
-        storage.writeSync(dest, content);
-      }
+      // Copy bytes, not a UTF-8 string round-trip — readSync/writeSync
+      // corrupts any non-UTF-8 file, and the source is deleted right after.
+      storage.copySync(src, dest);
       storage.deleteSync?.(src);
     }
     movedCount++;
@@ -158,10 +156,8 @@ export function runInternalize(projectDir: string): void {
     if (storage.isDirectorySync(src)) {
       copyDirRecursive(src, dest);
     } else {
-      const content = storage.readSync(src);
-      if (content != null) {
-        storage.writeSync(dest, content);
-      }
+      // Byte-accurate copy (see externalize branch above).
+      storage.copySync(src, dest);
     }
     movedCount++;
   }
@@ -206,10 +202,8 @@ function copyDirRecursive(src: string, dest: string): void {
     if (storage.isDirectorySync(srcPath)) {
       copyDirRecursive(srcPath, destPath);
     } else {
-      const content = storage.readSync(srcPath);
-      if (content != null) {
-        storage.writeSync(destPath, content);
-      }
+      // Byte-accurate copy (see externalize branch above).
+      storage.copySync(srcPath, destPath);
     }
   }
 }

--- a/test/external-state.test.ts
+++ b/test/external-state.test.ts
@@ -248,6 +248,30 @@ describe('runExternalize / runInternalize', () => {
     expect(readFileSync(path.join(squadDir, 'log', 'session.md'), 'utf-8')).toBe('## Session 1\n');
   });
 
+  // T4b: binary files survive externalize → internalize byte-for-byte (#1489)
+  it('preserves non-UTF-8 binary files across the round-trip', () => {
+    // Every byte value 0x00–0xFF: invalid as UTF-8, so a string round-trip
+    // would replace bytes >= 0x80 with U+FFFD and change the length.
+    const original = Buffer.alloc(256);
+    for (let i = 0; i < 256; i++) original[i] = i;
+    const assetsDir = path.join(squadDir, 'assets');
+    mkdirSync(assetsDir, { recursive: true });
+    writeFileSync(path.join(assetsDir, 'diagram.png'), original);
+
+    runExternalize(projectDir);
+
+    // The externalized copy must be identical bytes, not a lossy decode.
+    const key = deriveProjectKey(projectDir);
+    const externalDir = resolveExternalStateDir(key, false);
+    const externalized = readFileSync(path.join(externalDir, 'assets', 'diagram.png'));
+    expect(externalized.equals(original)).toBe(true);
+
+    runInternalize(projectDir);
+
+    const restored = readFileSync(path.join(squadDir, 'assets', 'diagram.png'));
+    expect(restored.equals(original)).toBe(true);
+  });
+
   // T5: runInternalize cleans config — external-state fields removed
   it('removes stateLocation/projectKey/teamRoot from config after internalize', () => {
     // Seed config with an extra field so config.json survives (not deleted)


### PR DESCRIPTION
Fixes #1489.

`squad externalize` (and `internalize`) copy every file under `.squad/` by reading it as a UTF-8 string and writing the string back out. Any byte >= 0x80 gets decoded to U+FFFD on the way in, so non-UTF-8 files come out corrupted — and since externalize deletes the source right after the copy, the only intact copy is gone. internalize copies back through the same lossy path, so the round trip never restores the original.

Core state is markdown/JSON today so text-only projects don't hit this, but it bites any binary a user or agent keeps under `.squad/` (diagrams/screenshots referenced from decisions, PDFs, archives), and it would destroy the whole state db the moment `SqliteStorageProvider` (`.squad/squad.db`) becomes reachable.

The fix swaps the three `readSync`/`writeSync` copy sites — the externalize file branch, the internalize file branch, and `copyDirRecursive` — for `storage.copySync`, which is `copyFileSync` underneath and already does the recursive mkdir for the destination. Byte-for-byte copy, no string decode.

## Test

Added a regression in `test/external-state.test.ts` that writes a file containing every byte value 0x00–0xFF (invalid UTF-8), runs externalize then internalize, and asserts the externalized copy and the restored copy are both byte-identical to the original. It fails on `main` (`Buffer.equals` is false — the 256-byte file comes back 512 bytes with U+FFFD) and passes with this change. Full `test/external-state.test.ts` suite is green (19 tests), and `tsc --noEmit` on both packages is clean.
