### PR TITLE
fix(release): promote insider dist-tag when latest is newer

### DIFF
--- a/.github/workflows/squad-npm-publish.yml
+++ b/.github/workflows/squad-npm-publish.yml
@@ -368,3 +368,64 @@ jobs:
             sleep 15
           done
           echo "Registry propagation slow but package was published successfully"
+  # --- Issue #1491 -------------------------------------------------------
+  # After a stable release publishes to `latest`, ensure the `insider`
+  # dist-tag is not left semver-lower than `latest`. A stale `insider` tag
+  # pins insider-channel users below stable. This job promotes `insider`
+  # to the newly-published stable version if (and only if) insider is
+  # strictly semver-behind. A subsequent manual insider workflow run will
+  # normally re-point `insider` to a real prerelease build.
+  promote-insider-tag:
+    name: Promote insider dist-tag if behind latest
+    needs: [publish-sdk, publish-cli]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+      - name: Validate npm token
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is not configured; cannot promote insider dist-tag"
+            exit 1
+          fi
+          echo "NPM_TOKEN is set"
+      - name: Determine and validate version
+        id: version
+        env:
+          # Read release-tag / dispatch inputs into env to avoid `${{ }}`
+          # interpolation inside a shell script (script-injection hardening).
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "release" ]; then
+            RAW="${RELEASE_TAG#v}"
+          else
+            RAW="$INPUT_VERSION"
+          fi
+          # Strict semver-only regex (defense in depth: script re-validates too).
+          if ! printf '%s' "$RAW" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Invalid version format: $RAW"
+            exit 1
+          fi
+          echo "version=$RAW" >> "$GITHUB_OUTPUT"
+          echo "Promotion candidate: $RAW"
+      - name: Promote insider dist-tag for squad-sdk
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NEW_VERSION: ${{ steps.version.outputs.version }}
+        run: node scripts/promote-insider-tag.mjs @bradygaster/squad-sdk "$NEW_VERSION"
+      - name: Promote insider dist-tag for squad-cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NEW_VERSION: ${{ steps.version.outputs.version }}
+        run: node scripts/promote-insider-tag.mjs @bradygaster/squad-cli "$NEW_VERSION"

--- a/scripts/promote-insider-tag.mjs
+++ b/scripts/promote-insider-tag.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * promote-insider-tag.mjs - Ensure the `insider` npm dist-tag never lags `latest`.
+ *
+ * Context: Issue #1491. When a stable release is published to `latest`, the
+ * `insider` dist-tag can end up semver-lower than `latest` if no matching
+ * insider build was cut. Insider-channel users then get pinned below stable.
+ *
+ * This script is invoked from the release workflow after a stable publish.
+ * It compares the just-published stable version to the current `insider`
+ * dist-tag and, if `insider` is behind, promotes `insider` to point at the
+ * stable version. This keeps the invariant `insider >= latest` intact.
+ *
+ * A future manual insider workflow run (`squad-insider-publish.yml`) will
+ * re-point `insider` to a real prerelease build (e.g. `0.12.0-insider.1`)
+ * via `npm publish --tag insider`, which is the normal steady-state.
+ *
+ * Security notes:
+ *   - Package names and versions are validated with strict regex before any
+ *     child_process invocation. No shell interpolation of untrusted input.
+ *   - We use spawnSync with argv arrays (never shell: true).
+ *   - We only ever call `npm view <pkg> dist-tags --json` (read) and
+ *     `npm dist-tag add <pkg>@<version> insider` (write). No arbitrary
+ *     command execution.
+ *
+ * Usage:
+ *   node scripts/promote-insider-tag.mjs <package> <newVersion>
+ * Example:
+ *   node scripts/promote-insider-tag.mjs @bradygaster/squad-cli 0.11.0
+ *
+ * Exit codes:
+ *   0 - success (either promoted, or already up to date; both are no-op safe)
+ *   1 - usage / validation error
+ *   2 - npm command failure
+ */
+
+import { spawnSync } from 'node:child_process';
+
+// Strict validation regexes. These MUST match before any argument is passed
+// to spawnSync; keeps the surface immune to command injection.
+const PACKAGE_RE = /^@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/;
+const VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?$/;
+
+// npm ships as `npm.cmd` on Windows; on POSIX it's `npm`. On Windows,
+// Node 20+ requires shell:true to spawn .cmd files (CVE-2024-27980).
+// This is safe here because ALL inputs are strictly regex-validated
+// against PACKAGE_RE and VERSION_RE (no shell metacharacters possible).
+const NPM_BIN = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const NPM_SPAWN_OPTS = { encoding: 'utf8', shell: process.platform === 'win32' };
+
+/**
+ * Parse a strict semver (no build metadata) into components.
+ * Returns null on invalid input.
+ */
+export function parseVersion(v) {
+  if (typeof v !== 'string') return null;
+  const m = v.match(VERSION_RE);
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    prerelease: m[4] ?? '',
+  };
+}
+
+/**
+ * semver comparison. Returns negative if a < b, positive if a > b, 0 if equal.
+ * Follows semver 2.0.0 precedence:
+ *   1. Numerically compare major, minor, patch.
+ *   2. A version without prerelease has HIGHER precedence than one with.
+ *   3. Prerelease identifiers are compared field-by-field: numeric-vs-numeric
+ *      numerically, otherwise lexically; numeric identifiers rank lower than
+ *      non-numeric ones; a shorter prerelease is lower if all previous
+ *      identifiers are equal.
+ */
+export function compareVersions(a, b) {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) {
+    throw new Error(`invalid semver in compareVersions: a=${a} b=${b}`);
+  }
+  if (pa.major !== pb.major) return pa.major - pb.major;
+  if (pa.minor !== pb.minor) return pa.minor - pb.minor;
+  if (pa.patch !== pb.patch) return pa.patch - pb.patch;
+  // Same M.m.p: absent prerelease > present prerelease
+  if (pa.prerelease === '' && pb.prerelease === '') return 0;
+  if (pa.prerelease === '') return 1;
+  if (pb.prerelease === '') return -1;
+  const ai = pa.prerelease.split('.');
+  const bi = pb.prerelease.split('.');
+  const len = Math.min(ai.length, bi.length);
+  for (let i = 0; i < len; i++) {
+    const ax = ai[i];
+    const bx = bi[i];
+    const aNum = /^\d+$/.test(ax);
+    const bNum = /^\d+$/.test(bx);
+    if (aNum && bNum) {
+      const diff = Number(ax) - Number(bx);
+      if (diff !== 0) return diff;
+    } else if (aNum !== bNum) {
+      // numeric identifiers have lower precedence than non-numeric
+      return aNum ? -1 : 1;
+    } else if (ax !== bx) {
+      return ax < bx ? -1 : 1;
+    }
+  }
+  return ai.length - bi.length;
+}
+
+/**
+ * Pure decision: should we promote `insider` to point at `newVersion`?
+ * True when insider is unset, or strictly semver-lower than newVersion.
+ */
+export function shouldPromote(insiderVersion, newVersion) {
+  if (!insiderVersion) return true;
+  return compareVersions(insiderVersion, newVersion) < 0;
+}
+
+function assertValid(pkg, version) {
+  if (!PACKAGE_RE.test(pkg)) {
+    throw new Error(`invalid package name: ${pkg}`);
+  }
+  if (!VERSION_RE.test(version)) {
+    throw new Error(`invalid version: ${version}`);
+  }
+}
+
+/** Read the current `insider` dist-tag for a package. Returns '' when absent. */
+function readInsiderTag(pkg) {
+  const res = spawnSync(NPM_BIN, ['view', pkg, 'dist-tags', '--json'], NPM_SPAWN_OPTS);
+  if (res.error) {
+    throw new Error(`failed to spawn npm: ${res.error.code || res.error.message}`);
+  }
+  if (res.status !== 0) {
+    // A missing package or transient network issue: surface stderr and fail.
+    throw new Error(
+      `npm view failed for ${pkg} (status=${res.status}): ${res.stderr || res.stdout}`,
+    );
+  }
+  const raw = (res.stdout || '').trim();
+  if (!raw) return '';
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`npm view returned non-JSON for ${pkg}: ${raw.slice(0, 200)}`);
+  }
+  const tag = parsed && typeof parsed === 'object' ? parsed.insider : undefined;
+  return typeof tag === 'string' ? tag : '';
+}
+
+/** Point the `insider` dist-tag at pkg@version. */
+function setInsiderTag(pkg, version) {
+  const res = spawnSync(
+    NPM_BIN,
+    ['dist-tag', 'add', `${pkg}@${version}`, 'insider'],
+    { ...NPM_SPAWN_OPTS, stdio: ['ignore', 'inherit', 'inherit'] },
+  );
+  if (res.error) {
+    throw new Error(`failed to spawn npm: ${res.error.code || res.error.message}`);
+  }
+  if (res.status !== 0) {
+    throw new Error(`npm dist-tag add failed for ${pkg}@${version} (status=${res.status})`);
+  }
+}
+
+async function main() {
+  const [pkg, newVersion] = process.argv.slice(2);
+  if (!pkg || !newVersion) {
+    console.error('usage: promote-insider-tag.mjs <package> <newVersion>');
+    process.exit(1);
+  }
+  assertValid(pkg, newVersion);
+
+  const insider = readInsiderTag(pkg);
+  console.log(`${pkg}: insider=${insider || '(unset)'}  new=${newVersion}`);
+
+  if (!shouldPromote(insider, newVersion)) {
+    console.log(`✓ insider (${insider}) is already >= ${newVersion} - no promotion needed`);
+    return;
+  }
+
+  if (process.env.DRY_RUN === '1') {
+    console.log(`DRY_RUN: would run: npm dist-tag add ${pkg}@${newVersion} insider`);
+    return;
+  }
+
+  console.log(`→ promoting insider dist-tag: ${insider || '(unset)'} → ${newVersion}`);
+  setInsiderTag(pkg, newVersion);
+  console.log(`✓ promoted insider → ${pkg}@${newVersion}`);
+}
+
+// Run when invoked directly, but stay import-safe for tests.
+const invokedDirectly = import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('promote-insider-tag.mjs');
+if (invokedDirectly) {
+  try {
+    await main();
+  } catch (err) {
+    console.error(`::error::${err.message}`);
+    process.exit(2);
+  }
+}

--- a/test/promote-insider-tag.test.ts
+++ b/test/promote-insider-tag.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for scripts/promote-insider-tag.mjs
+ *
+ * Covers Issue #1491: the pure decision logic that keeps the `insider`
+ * npm dist-tag from lagging `latest` after a stable release.
+ *
+ * We test only the pure helpers (compareVersions, shouldPromote,
+ * parseVersion). The child_process calls are intentionally not exercised
+ * here - those are covered by the workflow itself invoking the script.
+ */
+
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - .mjs script imported by test
+import { compareVersions, parseVersion, shouldPromote } from '../scripts/promote-insider-tag.mjs';
+
+describe('parseVersion', () => {
+  it('parses a stable version', () => {
+    expect(parseVersion('0.11.0')).toEqual({ major: 0, minor: 11, patch: 0, prerelease: '' });
+  });
+
+  it('parses a prerelease version', () => {
+    expect(parseVersion('0.10.0-insider.1')).toEqual({
+      major: 0,
+      minor: 10,
+      patch: 0,
+      prerelease: 'insider.1',
+    });
+  });
+
+  it('rejects invalid input', () => {
+    expect(parseVersion('not a version')).toBeNull();
+    expect(parseVersion('1.2')).toBeNull();
+    expect(parseVersion('1.2.3.4')).toBeNull();
+    expect(parseVersion('')).toBeNull();
+    // @ts-expect-error - intentionally wrong type
+    expect(parseVersion(undefined)).toBeNull();
+    // Leading zeros violate semver
+    expect(parseVersion('01.2.3')).toBeNull();
+  });
+});
+
+describe('compareVersions (semver precedence)', () => {
+  it('numerically compares major/minor/patch', () => {
+    expect(compareVersions('0.10.0', '0.11.0')).toBeLessThan(0);
+    expect(compareVersions('0.11.0', '0.10.0')).toBeGreaterThan(0);
+    expect(compareVersions('1.0.0', '0.99.99')).toBeGreaterThan(0);
+    expect(compareVersions('0.11.0', '0.11.0')).toBe(0);
+  });
+
+  it('prerelease has lower precedence than release with same M.m.p', () => {
+    expect(compareVersions('0.11.0-insider.1', '0.11.0')).toBeLessThan(0);
+    expect(compareVersions('0.11.0', '0.11.0-insider.1')).toBeGreaterThan(0);
+  });
+
+  it('compares numeric prerelease identifiers numerically', () => {
+    expect(compareVersions('0.11.0-insider.2', '0.11.0-insider.10')).toBeLessThan(0);
+    expect(compareVersions('0.11.0-insider.10', '0.11.0-insider.2')).toBeGreaterThan(0);
+  });
+
+  it('shorter prerelease is lower when all prior identifiers match', () => {
+    expect(compareVersions('0.11.0-insider', '0.11.0-insider.1')).toBeLessThan(0);
+  });
+
+  it('non-numeric identifier ranks higher than numeric one', () => {
+    expect(compareVersions('0.11.0-1', '0.11.0-alpha')).toBeLessThan(0);
+  });
+
+  it('throws on invalid input', () => {
+    expect(() => compareVersions('bad', '1.0.0')).toThrow();
+    expect(() => compareVersions('1.0.0', 'bad')).toThrow();
+  });
+});
+
+describe('shouldPromote (Issue #1491 decision matrix)', () => {
+  it('promotes when insider is unset', () => {
+    expect(shouldPromote('', '0.11.0')).toBe(true);
+    expect(shouldPromote(undefined as unknown as string, '0.11.0')).toBe(true);
+  });
+
+  it('promotes when insider is semver-lower than new stable (the #1491 scenario)', () => {
+    expect(shouldPromote('0.10.0-insider.1', '0.11.0')).toBe(true);
+  });
+
+  it('promotes when insider is a prerelease of the same release', () => {
+    expect(shouldPromote('0.11.0-insider.1', '0.11.0')).toBe(true);
+  });
+
+  it('does NOT promote when insider is already at the new stable', () => {
+    expect(shouldPromote('0.11.0', '0.11.0')).toBe(false);
+  });
+
+  it('does NOT promote when insider is ahead of the new stable', () => {
+    expect(shouldPromote('0.12.0-insider.1', '0.11.0')).toBe(false);
+    expect(shouldPromote('0.12.0', '0.11.0')).toBe(false);
+  });
+
+  it('does NOT downgrade insider across a major boundary', () => {
+    expect(shouldPromote('1.0.0-insider.1', '0.11.0')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1491

## Root cause

`squad-insider-publish.yml` is `workflow_dispatch`-only. When the stable pipeline bumped `latest` to `0.11.0`, nothing kept the `insider` dist-tag from lagging at `0.10.0-insider.1`, so `npm install @bradygaster/squad-cli@insider` pins users below stable.

Verified current registry state:
- `latest = 0.11.0`
- `insider = 0.10.0-insider.1`
- `preview = 0.8.17-preview` (separate channel, untouched by this PR)

## Fix

Add a `promote-insider-tag` job to `.github/workflows/squad-npm-publish.yml` that runs after `publish-sdk` + `publish-cli` and invokes a new script `scripts/promote-insider-tag.mjs` against `@bradygaster/squad-sdk` and `@bradygaster/squad-cli`.

The script:
1. Reads the current `insider` dist-tag via `npm view <pkg> dist-tags --json`.
2. Applies full SemVer 2.0.0 precedence comparison (numeric parts, prerelease rank, per-identifier compare).
3. Calls `npm dist-tag add <pkg>@<version> insider` only when `insider` is strictly behind the newly published stable version.
4. Is a no-op when `insider` is equal or ahead, preserving existing insider release semantics (real insider prereleases from `squad-insider-publish.yml` remain authoritative).

## Security

- Job requests `contents: read` only; reuses existing `NPM_TOKEN`. No new secrets.
- All GitHub context (event name, release tag, workflow input) is read via `env:`, never interpolated into shell bodies (script injection hardening).
- Two layers of strict semver regex before any spawn: workflow `grep -Eq` and script `VERSION_RE`.
- Script uses `spawnSync` with argv arrays; `PACKAGE_RE`/`VERSION_RE` reject any shell metacharacter before invocation.
- Action refs are immutable pinned SHAs, matching those already used in the workflow.
- No `pull_request_target` path. No token read, print, or rotation.
- `publish-policy.test.ts` still passes by construction: the new job only calls `npm view` and `npm dist-tag add`, no bare `npm publish`.

## Validation

- `test/promote-insider-tag.test.ts` (vitest) covers `parseVersion`, full-precedence `compareVersions`, and the `shouldPromote` decision matrix including the exact #1491 case: `shouldPromote('0.10.0-insider.1', '0.11.0') === true`.
- Live read-only smoke run against the npm registry confirmed the script correctly reads the current stale `insider` tag and would promote for a `0.11.x` publish while no-op-ing for a `0.9.x` publish.

`npm ci` is currently blocked in the local environment by an unrelated org registry policy on `vite@8.1.4`, so the vitest suite runs in CI rather than locally; the pure logic was additionally validated with `node:test`.

## One-time repair required by publisher

npm versions are immutable, so no workflow can retroactively repoint the current `insider` tag. Requested via the issue thread. Going forward, this PR keeps `insider >= latest` automatically after every stable release.