### PR TITLE
fix(security): stop unsafe-git scanner flagging prose in append-only squad logs

### DIFF
--- a/scripts/security-review.mjs
+++ b/scripts/security-review.mjs
@@ -174,6 +174,21 @@ for (const file of jstsFiles) {
 }
 
 // 4. Unsafe git operations
+//
+// Excluded paths: append-only memory/log files that document history and prohibitions.
+// These are never executed — they record what happened, not what to do.
+// Instruction surfaces (.github/copilot-instructions.md, agent charters, squad.agent.md,
+// team.md, routing.md) are deliberately kept in scope: a malicious PR could replace a
+// prohibition with an instruction, and we want the scanner to catch that.
+// .squad/log/ and .squad/orchestration-log/ are gitignored (never in PR diffs) but
+// listed here for documentation completeness.
+const UNSAFE_GIT_EXCLUDED_PATHS = [
+  /^\.squad\/decisions\.md$/,
+  /^\.squad\/agents\/.+\/history\.md$/,
+  /^\.squad\/log\//,
+  /^\.squad\/orchestration-log\//,
+];
+
 const GIT_UNSAFE_PATTERNS = [
   { pattern: /git\s+add\s+\./, label: 'git add .' },
   { pattern: /git\s+add\s+-A/, label: 'git add -A' },
@@ -183,6 +198,7 @@ const GIT_UNSAFE_PATTERNS = [
 ];
 
 for (const file of changedFiles) {
+  if (UNSAFE_GIT_EXCLUDED_PATHS.some((p) => p.test(file))) continue;
   const added = addedByFile.get(file) || [];
   for (const { line, text } of added) {
     for (const { pattern, label } of GIT_UNSAFE_PATTERNS) {


### PR DESCRIPTION
## Problem

`scripts/security-review.mjs` check #4 (`unsafe-git`) iterates over **every** changed file with no file-type filter — unlike the other checks, which scope to `workflowFiles` or `jstsFiles`. Any markdown file containing the literal string `git add .` on an added line is reported as an **error**.

This fires on prose that *documents the prohibition*. Concretely, it blocked #1558 by flagging Squad's own decision log:

```json
{
  "category": "unsafe-git",
  "severity": "error",
  "message": "Unsafe git operation: `git add .` ...",
  "file": ".squad/decisions.md",
  "line": 257
}
```

…where line ~262 reads:

> **What:** Added mandatory Git Safety section to copilot-instructions.md: prohibits `git add .`, requires feature branches and PRs …

The scanner flagged the very rule it was documenting.

**Why it surfaced now:** `.squad/decisions/inbox/` is gitignored, so inbox entries never appeared in PR diffs. Once Scribe merged them into `.squad/decisions.md`, those lines became `+` lines for the first time.

## Fix

Adds `UNSAFE_GIT_EXCLUDED_PATHS` and skips the `unsafe-git` check for **append-only memory/log files** — records of what happened, never executed:

- `.squad/decisions.md`
- `.squad/agents/*/history.md`
- `.squad/log/**`, `.squad/orchestration-log/**` (gitignored; listed defensively)

**Deliberately still in scope — instruction surfaces:**

- `.github/copilot-instructions.md`
- `.squad/agents/*/charter.md`, `.squad/team.md`, `.squad/routing.md`, `squad.agent.md`
- `.squad/templates/**`

A malicious PR could swap a prohibition for an instruction in those files, so they must stay scannable. The line is drawn at files that are *structurally* append-only versus files agents read as active instructions.

## Verification

Detection still works — a probe file with `git add .` and `git push --force` was correctly caught:

```
"file": "scripts/__scan-probe.sh", "line": 3  → git add .
"file": "scripts/__scan-probe.sh", "line": 4  → git push --force
🔒 Security review: 2 error(s).
```

Probe was deleted; no trace remains. Running the patched scanner against this PR's own diff returns `✅ No security concerns found.`

## Why this is a separate PR

`squad-repo-health.yml` uses `pull_request_target` and **checks out the base branch** for trusted scripts (correct — it prevents fork PRs from executing arbitrary code with a write token). That means CI always runs the `dev` copy of `security-review.mjs`, so this fix cannot take effect on the PR that contains it. It has to land on `dev` first.

**Merge order:** this PR → then #1558 goes green.

## Known limitation (not fixed here)

The pattern `/git\s+add\s+\./` also matches *scoped* paths like `git add .squad/`, which is the safe, recommended form. That is a pattern-precision bug distinct from this scoping bug — filed as follow-up rather than bundled in.

Refs #1556
