### PR TITLE
feat: add ADR lifecycle manager skill

### DIFF
--- a/.changeset/add-adr-lifecycle-manager-skill.md
+++ b/.changeset/add-adr-lifecycle-manager-skill.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+Ship the ADR lifecycle manager as a built-in skill for lead and architect roles across CLI and SDK initialization.

--- a/.squad/skills/adr-lifecycle-manager/SKILL.md
+++ b/.squad/skills/adr-lifecycle-manager/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: adr-lifecycle-manager
+description: "Manage architecture decision records (ADRs) end-to-end: decide if an ADR is needed, draft from template, assign strict next numbering, update toc/index, move status Proposed to Accepted, and handle amendment, deprecation, or supersession paths. Use for ADR creation, governance, lifecycle updates, and ADR hygiene audits."
+domain: architecture, governance
+triggers: [ADR, architecture decision record, architecture decision, supersede, deprecate, amendment]
+roles: [lead, architect]
+argument-hint: "Describe the decision and desired ADR action: create, accept, amend, deprecate, supersede, or audit."
+user-invocable: true
+disable-model-invocation: false
+---
+
+# ADR Lifecycle Manager
+
+Use this skill to keep ADRs consistent, discoverable, and audit-friendly.
+
+## When To Use
+
+- You changed architecture, deployment topology, data model, auth model, or tool/API contracts.
+- A PR introduces a design decision and you need to decide whether to create an ADR.
+- You need to create a new ADR and register it in the repo index/toc.
+- You need to transition ADR status (Proposed, Accepted, Deprecated, Superseded).
+- You need to choose between inline amendment and supersession.
+- You want an ADR hygiene review (naming, numbering, links, metadata parity).
+
+## Inputs To Collect
+
+- Decision summary (one sentence).
+- Scope and impacted components.
+- ADR action: new, status-change, amendment, deprecation, supersession, or audit.
+- Proposed title slug (verb-phrase-slug).
+- Any ADR references (supersedes, superseded-by).
+- PR context (if status should flip to Accepted).
+- ADR directory and index/toc files for the current repo.
+- Discover ADR files by searching common locations first: docs/decisions, docs/adr, adr.
+- Discover index/toc files by searching common names in the ADR area: README.md, index.md, toc.yml, toc.md.
+- If multiple candidates exist or none are found, ask the user to confirm before editing.
+
+## Workflow
+
+1. Run ADR need-check.
+2. If ADR is required, choose lifecycle path.
+3. Execute path-specific edits and consistency checks.
+4. Return a completion report with changed files and unresolved decisions.
+
+## Step 1: ADR Need-Check
+
+Create an ADR if any apply:
+
+- A future engineer would ask why this approach was chosen.
+- The decision constrains future decisions.
+- A reasonable alternative was rejected.
+- Cross-team contracts are affected.
+- Compliance, security, SLO, or cost is affected.
+
+Skip ADR when all apply:
+
+- Change is small, reversible, and local to one PR.
+- Covered by existing policy, standard, or ADR.
+- It is a temporary experiment/workaround with known end-of-life.
+
+If skipped, output:
+
+- ADR not required.
+- Rationale (1-3 bullets).
+- Optional backlog follow-up if the decision may become long-lived.
+
+## Step 2: Select Lifecycle Path
+
+- Before selecting a path for new ADR work, run a conflict pre-check against existing ADR titles, tags, and decision statements.
+- If conflict pre-check indicates duplicate or overlap, select amendment, deprecation, or supersession instead of new.
+- If no ADR directory or index/toc files exist (first ADR in repo), ask for confirmation and scaffold ADR directory, initial index (README.md or index.md), and toc file before continuing.
+- new: Draft new ADR in Proposed state only after conflict pre-check confirms a net-new decision.
+- status-change: Update status only (typically Proposed to Accepted after merge).
+- amendment: Add dated inline note to existing accepted ADR.
+- deprecation: Mark ADR as Deprecated with reason and migration note.
+- supersession: Create replacement ADR and cross-link old/new records.
+- audit: Validate index, toc, frontmatter, and link parity.
+
+## Step 3: Execute Path
+
+### Path A - New ADR
+
+1. Determine file name format: NNNN-verb-phrase-slug.md.
+2. Pick the strict next available number from the ADR index (no NEXT placeholders by default).
+3. Look for a template file in the ADR directory (for example template.md).
+4. If no template is found, ask the user for the template path before proceeding.
+5. Copy the located template to the new ADR file.
+6. Fill Context, Considered Options, Decision, and Consequences.
+7. Set frontmatter status to Proposed.
+8. Add entry to toc.yml.
+9. Add row to ADR index in README.md immediately after adding the new ADR.
+10. Run consistency checks (see Quality Gate).
+
+### Path B - Status Change
+
+1. Confirm triggering event (for Accepted, PR merged).
+2. Validate transition before editing:
+   - Allowed transitions: Proposed to Accepted, Accepted to Deprecated, Accepted to Superseded.
+   - Any other transition is invalid; inform the user and suggest amendment, deprecation, or supersession as appropriate.
+3. Update ADR frontmatter status.
+4. Ensure index row status matches.
+5. Keep ADR body immutable unless an amendment note is intentionally added.
+
+### Path C - Amendment
+
+1. Keep existing accepted ADR content unchanged.
+2. Add a dated note in body format:
+   - `> [YYYY-MM-DD] Updated: ...`
+3. Do not change the original decision statement unless superseding.
+4. If consequences changed materially, recommend supersession path.
+
+### Path D - Deprecation
+
+1. Set status to Deprecated.
+2. Add deprecation reason and current operational guidance.
+3. Update index row status.
+4. If replacement exists, prefer supersession path and link it.
+
+### Path E - Supersession
+
+1. Create new ADR using Path A.
+2. In new ADR frontmatter set `supersedes: [NNNN]`.
+3. In old ADR set `status: Superseded` and `superseded-by: [MMMM]`.
+4. Update index rows for both ADRs.
+5. Ensure date/order/title consistency across file, toc, and index.
+
+### Path F - Audit
+
+Validate:
+
+- Name format NNNN-verb-phrase-slug.md.
+- Number uniqueness and monotonic ordering.
+- Every ADR appears in both toc and index.
+- Status values are from allowed set.
+- Supersession links are bidirectional and valid.
+- No accepted ADR has untracked substantive rewrites.
+
+## Quality Gate (Completion Criteria)
+
+A lifecycle action is complete only when all are true:
+
+- ADR file content and frontmatter are valid for selected path.
+- toc and index are updated and consistent.
+- For new ADRs, conflict scan was performed and any impacted existing ADRs were updated.
+- Status transitions follow lifecycle policy.
+- Supersession/deprecation metadata is complete when applicable.
+- Output includes exact files changed and a short rationale.
+
+## Response Format
+
+Return results in this structure:
+
+1. Decision: ADR required or not required.
+2. Path: new, status-change, amendment, deprecation, supersession, or audit.
+3. Actions Completed: concise checklist.
+4. Files Updated: explicit file paths.
+5. Open Items: missing inputs, approvals, or merge dependencies.
+
+## Example Prompts
+
+- `/adr-lifecycle-manager Create an ADR for changing deployment topology from single-region to active-active.`
+- `/adr-lifecycle-manager Mark ADR 0012 as Accepted after PR merge and sync toc/index.`
+- `/adr-lifecycle-manager Supersede ADR 0007 with a decision to replace polling with callbacks.`
+- `/adr-lifecycle-manager Audit ADR docs for numbering, status, and link consistency.`

--- a/docs/proposals/adr-lifecycle-manager-skill.md
+++ b/docs/proposals/adr-lifecycle-manager-skill.md
@@ -1,0 +1,52 @@
+# Proposal: ADR Lifecycle Manager Skill
+
+**Author:** Squad
+**Date:** 2026-07-29
+**Status:** Proposal
+
+---
+
+## Problem Statement
+
+Squad routes architecture decisions to its lead/architect role, but it does not ship a reusable procedure for creating, accepting, amending, deprecating, superseding, or auditing architecture decision records. Teams must recreate ADR lifecycle rules in prompts or apply them inconsistently.
+
+## Proposed Approach
+
+Ship `adr-lifecycle-manager` as a manifest-curated built-in skill. Keep the skill in `.squad/skills/` as the canonical source, synchronize it to the CLI and SDK template packages, and install it at `.github/skills/adr-lifecycle-manager/SKILL.md` during init and upgrade.
+
+Use the existing skill metadata contract:
+
+- `domain: architecture, governance`
+- ADR lifecycle trigger phrases
+- `roles: [lead, architect]`
+
+The existing skill registry then adds role affinity for architecture agents without new coordinator wiring or runtime behavior.
+
+## Fit with Existing Architecture
+
+- Procedures owns the skill and prompt contract.
+- Flight owns architecture governance and proposal review.
+- `TEMPLATE_MANIFEST` remains the CLI init/upgrade manifest.
+- `MANIFEST_SKILL_NAMES` remains the SDK init manifest.
+- `scripts/sync-skill-templates.mjs` remains the canonical distribution path.
+
+## What Changes
+
+- Add the canonical ADR lifecycle skill under `.squad/skills/`.
+- Register the skill in CLI and SDK manifests.
+- Synchronize the CLI and SDK template packages.
+- Add tests for manifest registration, template presence, and lead/architect role affinity.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| CLI and SDK manifests drift | Test both manifests and use the existing sync tool. |
+| Skill is installed but never selected | Parse the shipped template and assert ADR trigger plus architecture-role affinity. |
+| Repository-specific ADR conventions differ | The skill discovers local ADR directories/templates and asks before scaffolding ambiguous layouts. |
+
+## Out of Scope
+
+- Changing ADR file formats in existing repositories.
+- Adding a new architecture role or coordinator routing mechanism.
+- Automatically accepting ADRs before their triggering change is merged.

--- a/packages/squad-cli/src/cli/core/templates.ts
+++ b/packages/squad-cli/src/cli/core/templates.ts
@@ -317,6 +317,12 @@ export const TEMPLATE_MANIFEST: TemplateFile[] = [
     overwriteOnUpgrade: true,
     description: 'Init Mode two-phase protocol — propose team (Phase 1) then create .squad/ scaffolding (Phase 2)',
   },
+  {
+    source: 'skills/adr-lifecycle-manager/SKILL.md',
+    destination: '../.github/skills/adr-lifecycle-manager/SKILL.md',
+    overwriteOnUpgrade: true,
+    description: 'ADR lifecycle governance for architecture agents',
+  },
 
   // Session init reference (squad-owned, coordinator reads at session start)
   {

--- a/packages/squad-cli/templates/skills/adr-lifecycle-manager/SKILL.md
+++ b/packages/squad-cli/templates/skills/adr-lifecycle-manager/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: adr-lifecycle-manager
+description: "Manage architecture decision records (ADRs) end-to-end: decide if an ADR is needed, draft from template, assign strict next numbering, update toc/index, move status Proposed to Accepted, and handle amendment, deprecation, or supersession paths. Use for ADR creation, governance, lifecycle updates, and ADR hygiene audits."
+domain: architecture, governance
+triggers: [ADR, architecture decision record, architecture decision, supersede, deprecate, amendment]
+roles: [lead, architect]
+argument-hint: "Describe the decision and desired ADR action: create, accept, amend, deprecate, supersede, or audit."
+user-invocable: true
+disable-model-invocation: false
+---
+
+# ADR Lifecycle Manager
+
+Use this skill to keep ADRs consistent, discoverable, and audit-friendly.
+
+## When To Use
+
+- You changed architecture, deployment topology, data model, auth model, or tool/API contracts.
+- A PR introduces a design decision and you need to decide whether to create an ADR.
+- You need to create a new ADR and register it in the repo index/toc.
+- You need to transition ADR status (Proposed, Accepted, Deprecated, Superseded).
+- You need to choose between inline amendment and supersession.
+- You want an ADR hygiene review (naming, numbering, links, metadata parity).
+
+## Inputs To Collect
+
+- Decision summary (one sentence).
+- Scope and impacted components.
+- ADR action: new, status-change, amendment, deprecation, supersession, or audit.
+- Proposed title slug (verb-phrase-slug).
+- Any ADR references (supersedes, superseded-by).
+- PR context (if status should flip to Accepted).
+- ADR directory and index/toc files for the current repo.
+- Discover ADR files by searching common locations first: docs/decisions, docs/adr, adr.
+- Discover index/toc files by searching common names in the ADR area: README.md, index.md, toc.yml, toc.md.
+- If multiple candidates exist or none are found, ask the user to confirm before editing.
+
+## Workflow
+
+1. Run ADR need-check.
+2. If ADR is required, choose lifecycle path.
+3. Execute path-specific edits and consistency checks.
+4. Return a completion report with changed files and unresolved decisions.
+
+## Step 1: ADR Need-Check
+
+Create an ADR if any apply:
+
+- A future engineer would ask why this approach was chosen.
+- The decision constrains future decisions.
+- A reasonable alternative was rejected.
+- Cross-team contracts are affected.
+- Compliance, security, SLO, or cost is affected.
+
+Skip ADR when all apply:
+
+- Change is small, reversible, and local to one PR.
+- Covered by existing policy, standard, or ADR.
+- It is a temporary experiment/workaround with known end-of-life.
+
+If skipped, output:
+
+- ADR not required.
+- Rationale (1-3 bullets).
+- Optional backlog follow-up if the decision may become long-lived.
+
+## Step 2: Select Lifecycle Path
+
+- Before selecting a path for new ADR work, run a conflict pre-check against existing ADR titles, tags, and decision statements.
+- If conflict pre-check indicates duplicate or overlap, select amendment, deprecation, or supersession instead of new.
+- If no ADR directory or index/toc files exist (first ADR in repo), ask for confirmation and scaffold ADR directory, initial index (README.md or index.md), and toc file before continuing.
+- new: Draft new ADR in Proposed state only after conflict pre-check confirms a net-new decision.
+- status-change: Update status only (typically Proposed to Accepted after merge).
+- amendment: Add dated inline note to existing accepted ADR.
+- deprecation: Mark ADR as Deprecated with reason and migration note.
+- supersession: Create replacement ADR and cross-link old/new records.
+- audit: Validate index, toc, frontmatter, and link parity.
+
+## Step 3: Execute Path
+
+### Path A - New ADR
+
+1. Determine file name format: NNNN-verb-phrase-slug.md.
+2. Pick the strict next available number from the ADR index (no NEXT placeholders by default).
+3. Look for a template file in the ADR directory (for example template.md).
+4. If no template is found, ask the user for the template path before proceeding.
+5. Copy the located template to the new ADR file.
+6. Fill Context, Considered Options, Decision, and Consequences.
+7. Set frontmatter status to Proposed.
+8. Add entry to toc.yml.
+9. Add row to ADR index in README.md immediately after adding the new ADR.
+10. Run consistency checks (see Quality Gate).
+
+### Path B - Status Change
+
+1. Confirm triggering event (for Accepted, PR merged).
+2. Validate transition before editing:
+   - Allowed transitions: Proposed to Accepted, Accepted to Deprecated, Accepted to Superseded.
+   - Any other transition is invalid; inform the user and suggest amendment, deprecation, or supersession as appropriate.
+3. Update ADR frontmatter status.
+4. Ensure index row status matches.
+5. Keep ADR body immutable unless an amendment note is intentionally added.
+
+### Path C - Amendment
+
+1. Keep existing accepted ADR content unchanged.
+2. Add a dated note in body format:
+   - `> [YYYY-MM-DD] Updated: ...`
+3. Do not change the original decision statement unless superseding.
+4. If consequences changed materially, recommend supersession path.
+
+### Path D - Deprecation
+
+1. Set status to Deprecated.
+2. Add deprecation reason and current operational guidance.
+3. Update index row status.
+4. If replacement exists, prefer supersession path and link it.
+
+### Path E - Supersession
+
+1. Create new ADR using Path A.
+2. In new ADR frontmatter set `supersedes: [NNNN]`.
+3. In old ADR set `status: Superseded` and `superseded-by: [MMMM]`.
+4. Update index rows for both ADRs.
+5. Ensure date/order/title consistency across file, toc, and index.
+
+### Path F - Audit
+
+Validate:
+
+- Name format NNNN-verb-phrase-slug.md.
+- Number uniqueness and monotonic ordering.
+- Every ADR appears in both toc and index.
+- Status values are from allowed set.
+- Supersession links are bidirectional and valid.
+- No accepted ADR has untracked substantive rewrites.
+
+## Quality Gate (Completion Criteria)
+
+A lifecycle action is complete only when all are true:
+
+- ADR file content and frontmatter are valid for selected path.
+- toc and index are updated and consistent.
+- For new ADRs, conflict scan was performed and any impacted existing ADRs were updated.
+- Status transitions follow lifecycle policy.
+- Supersession/deprecation metadata is complete when applicable.
+- Output includes exact files changed and a short rationale.
+
+## Response Format
+
+Return results in this structure:
+
+1. Decision: ADR required or not required.
+2. Path: new, status-change, amendment, deprecation, supersession, or audit.
+3. Actions Completed: concise checklist.
+4. Files Updated: explicit file paths.
+5. Open Items: missing inputs, approvals, or merge dependencies.
+
+## Example Prompts
+
+- `/adr-lifecycle-manager Create an ADR for changing deployment topology from single-region to active-active.`
+- `/adr-lifecycle-manager Mark ADR 0012 as Accepted after PR merge and sync toc/index.`
+- `/adr-lifecycle-manager Supersede ADR 0007 with a decision to replace polling with callbacks.`
+- `/adr-lifecycle-manager Audit ADR docs for numbering, status, and link consistency.`

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -54,6 +54,7 @@ export const MANIFEST_SKILL_NAMES = [
   'coordinator-source-of-truth',
   'coordinator-response-mode',
   'coordinator-init-mode',
+  'adr-lifecycle-manager',
 ] as const;
 
 // ============================================================================

--- a/packages/squad-sdk/templates/skills/adr-lifecycle-manager/SKILL.md
+++ b/packages/squad-sdk/templates/skills/adr-lifecycle-manager/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: adr-lifecycle-manager
+description: "Manage architecture decision records (ADRs) end-to-end: decide if an ADR is needed, draft from template, assign strict next numbering, update toc/index, move status Proposed to Accepted, and handle amendment, deprecation, or supersession paths. Use for ADR creation, governance, lifecycle updates, and ADR hygiene audits."
+domain: architecture, governance
+triggers: [ADR, architecture decision record, architecture decision, supersede, deprecate, amendment]
+roles: [lead, architect]
+argument-hint: "Describe the decision and desired ADR action: create, accept, amend, deprecate, supersede, or audit."
+user-invocable: true
+disable-model-invocation: false
+---
+
+# ADR Lifecycle Manager
+
+Use this skill to keep ADRs consistent, discoverable, and audit-friendly.
+
+## When To Use
+
+- You changed architecture, deployment topology, data model, auth model, or tool/API contracts.
+- A PR introduces a design decision and you need to decide whether to create an ADR.
+- You need to create a new ADR and register it in the repo index/toc.
+- You need to transition ADR status (Proposed, Accepted, Deprecated, Superseded).
+- You need to choose between inline amendment and supersession.
+- You want an ADR hygiene review (naming, numbering, links, metadata parity).
+
+## Inputs To Collect
+
+- Decision summary (one sentence).
+- Scope and impacted components.
+- ADR action: new, status-change, amendment, deprecation, supersession, or audit.
+- Proposed title slug (verb-phrase-slug).
+- Any ADR references (supersedes, superseded-by).
+- PR context (if status should flip to Accepted).
+- ADR directory and index/toc files for the current repo.
+- Discover ADR files by searching common locations first: docs/decisions, docs/adr, adr.
+- Discover index/toc files by searching common names in the ADR area: README.md, index.md, toc.yml, toc.md.
+- If multiple candidates exist or none are found, ask the user to confirm before editing.
+
+## Workflow
+
+1. Run ADR need-check.
+2. If ADR is required, choose lifecycle path.
+3. Execute path-specific edits and consistency checks.
+4. Return a completion report with changed files and unresolved decisions.
+
+## Step 1: ADR Need-Check
+
+Create an ADR if any apply:
+
+- A future engineer would ask why this approach was chosen.
+- The decision constrains future decisions.
+- A reasonable alternative was rejected.
+- Cross-team contracts are affected.
+- Compliance, security, SLO, or cost is affected.
+
+Skip ADR when all apply:
+
+- Change is small, reversible, and local to one PR.
+- Covered by existing policy, standard, or ADR.
+- It is a temporary experiment/workaround with known end-of-life.
+
+If skipped, output:
+
+- ADR not required.
+- Rationale (1-3 bullets).
+- Optional backlog follow-up if the decision may become long-lived.
+
+## Step 2: Select Lifecycle Path
+
+- Before selecting a path for new ADR work, run a conflict pre-check against existing ADR titles, tags, and decision statements.
+- If conflict pre-check indicates duplicate or overlap, select amendment, deprecation, or supersession instead of new.
+- If no ADR directory or index/toc files exist (first ADR in repo), ask for confirmation and scaffold ADR directory, initial index (README.md or index.md), and toc file before continuing.
+- new: Draft new ADR in Proposed state only after conflict pre-check confirms a net-new decision.
+- status-change: Update status only (typically Proposed to Accepted after merge).
+- amendment: Add dated inline note to existing accepted ADR.
+- deprecation: Mark ADR as Deprecated with reason and migration note.
+- supersession: Create replacement ADR and cross-link old/new records.
+- audit: Validate index, toc, frontmatter, and link parity.
+
+## Step 3: Execute Path
+
+### Path A - New ADR
+
+1. Determine file name format: NNNN-verb-phrase-slug.md.
+2. Pick the strict next available number from the ADR index (no NEXT placeholders by default).
+3. Look for a template file in the ADR directory (for example template.md).
+4. If no template is found, ask the user for the template path before proceeding.
+5. Copy the located template to the new ADR file.
+6. Fill Context, Considered Options, Decision, and Consequences.
+7. Set frontmatter status to Proposed.
+8. Add entry to toc.yml.
+9. Add row to ADR index in README.md immediately after adding the new ADR.
+10. Run consistency checks (see Quality Gate).
+
+### Path B - Status Change
+
+1. Confirm triggering event (for Accepted, PR merged).
+2. Validate transition before editing:
+   - Allowed transitions: Proposed to Accepted, Accepted to Deprecated, Accepted to Superseded.
+   - Any other transition is invalid; inform the user and suggest amendment, deprecation, or supersession as appropriate.
+3. Update ADR frontmatter status.
+4. Ensure index row status matches.
+5. Keep ADR body immutable unless an amendment note is intentionally added.
+
+### Path C - Amendment
+
+1. Keep existing accepted ADR content unchanged.
+2. Add a dated note in body format:
+   - `> [YYYY-MM-DD] Updated: ...`
+3. Do not change the original decision statement unless superseding.
+4. If consequences changed materially, recommend supersession path.
+
+### Path D - Deprecation
+
+1. Set status to Deprecated.
+2. Add deprecation reason and current operational guidance.
+3. Update index row status.
+4. If replacement exists, prefer supersession path and link it.
+
+### Path E - Supersession
+
+1. Create new ADR using Path A.
+2. In new ADR frontmatter set `supersedes: [NNNN]`.
+3. In old ADR set `status: Superseded` and `superseded-by: [MMMM]`.
+4. Update index rows for both ADRs.
+5. Ensure date/order/title consistency across file, toc, and index.
+
+### Path F - Audit
+
+Validate:
+
+- Name format NNNN-verb-phrase-slug.md.
+- Number uniqueness and monotonic ordering.
+- Every ADR appears in both toc and index.
+- Status values are from allowed set.
+- Supersession links are bidirectional and valid.
+- No accepted ADR has untracked substantive rewrites.
+
+## Quality Gate (Completion Criteria)
+
+A lifecycle action is complete only when all are true:
+
+- ADR file content and frontmatter are valid for selected path.
+- toc and index are updated and consistent.
+- For new ADRs, conflict scan was performed and any impacted existing ADRs were updated.
+- Status transitions follow lifecycle policy.
+- Supersession/deprecation metadata is complete when applicable.
+- Output includes exact files changed and a short rationale.
+
+## Response Format
+
+Return results in this structure:
+
+1. Decision: ADR required or not required.
+2. Path: new, status-change, amendment, deprecation, supersession, or audit.
+3. Actions Completed: concise checklist.
+4. Files Updated: explicit file paths.
+5. Open Items: missing inputs, approvals, or merge dependencies.
+
+## Example Prompts
+
+- `/adr-lifecycle-manager Create an ADR for changing deployment topology from single-region to active-active.`
+- `/adr-lifecycle-manager Mark ADR 0012 as Accepted after PR merge and sync toc/index.`
+- `/adr-lifecycle-manager Supersede ADR 0007 with a decision to replace polling with callbacks.`
+- `/adr-lifecycle-manager Audit ADR docs for numbering, status, and link consistency.`

--- a/test/builtin-skills.test.ts
+++ b/test/builtin-skills.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { TEMPLATE_MANIFEST } from '../packages/squad-cli/src/cli/core/templates.js';
-import { existsSync } from 'node:fs';
+import { MANIFEST_SKILL_NAMES } from '@bradygaster/squad-sdk/config';
+import { SkillRegistry, parseSkillFile } from '@bradygaster/squad-sdk/skills';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
 // Use __dirname for reliable resolution regardless of working directory
@@ -16,6 +18,7 @@ const EXPECTED_BUILTIN_SKILLS = [
   'reviewer-protocol',
   'test-discipline',
   'agent-collaboration',
+  'adr-lifecycle-manager',
 ];
 
 // Unit tests for the skill manifest declarations. End-to-end scaffolding
@@ -32,6 +35,15 @@ describe('built-in skills in TEMPLATE_MANIFEST', () => {
     for (const expected of EXPECTED_BUILTIN_SKILLS) {
       expect(skillNames, `missing skill: ${expected}`).toContain(expected);
     }
+  });
+
+  it('keeps CLI and SDK skill manifests in sync', () => {
+    const cliSkillNames = skillEntries.map(entry => {
+      const match = entry.destination.match(/skills\/([^/]+)\//);
+      return match ? match[1] : '';
+    });
+
+    expect(cliSkillNames.sort()).toEqual([...MANIFEST_SKILL_NAMES].sort());
   });
 
   it('all skill entries have overwriteOnUpgrade: true (squad-owned)', () => {
@@ -55,5 +67,31 @@ describe('built-in skills in TEMPLATE_MANIFEST', () => {
 
   it(`ships at least ${EXPECTED_BUILTIN_SKILLS.length} skills`, () => {
     expect(skillEntries.length).toBeGreaterThanOrEqual(EXPECTED_BUILTIN_SKILLS.length);
+  });
+
+  it('routes ADR lifecycle work to architecture roles', () => {
+    const skillPath = path.join(
+      TEMPLATES_DIR,
+      'skills',
+      'adr-lifecycle-manager',
+      'SKILL.md',
+    );
+    const skill = parseSkillFile(
+      'adr-lifecycle-manager',
+      readFileSync(skillPath, 'utf8'),
+    );
+
+    expect(skill).toBeDefined();
+    expect(skill!.agentRoles).toEqual(['lead', 'architect']);
+
+    const registry = new SkillRegistry();
+    registry.registerSkill(skill!);
+
+    for (const role of ['lead', 'architect']) {
+      const match = registry
+        .matchSkills('Create an ADR for this architecture decision', role)
+        .find(result => result.skill.id === 'adr-lifecycle-manager');
+      expect(match?.reason).toContain(`role affinity: ${role}`);
+    }
   });
 });


### PR DESCRIPTION
### What

Adds `adr-lifecycle-manager` as a built-in Squad skill for lead and architect roles across CLI and SDK initialization.

### Why

Squad routes architecture decisions to architecture roles but does not currently ship a consistent workflow for creating, accepting, amending, deprecating, superseding, and auditing architecture decision records.

### How

The skill is maintained under `.squad/skills`, distributed through the existing CLI and SDK manifests, and synchronized into both template trees. Existing `roles: [lead, architect]` metadata provides architecture-role affinity without new coordinator wiring. Focused tests cover manifest parity, template presence, parsing, and role routing.

---

### Quick Check
- [x] Changeset added for CLI and SDK changes

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev`
- [x] Branch is up to date with `dev`
- [x] Diff contains only intended changes
- [ ] PR is not in draft mode
- [x] Commit history is clean

#### Build & Test
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] `npm run lint` passes
- [ ] `npm run lint:eslint` passes
- [x] Focused manifest and role-routing checks pass
- [x] Template synchronization verified

#### Changeset
- [x] Changeset added for `@bradygaster/squad-cli` and `@bradygaster/squad-sdk`

#### Docs
- [x] Architecture proposal added
- [ ] README feature documentation

#### Exports
- [x] N/A - no new SDK module

---

### Breaking Changes

None.

### Waivers

None.