### PR TITLE
docs: production operations — observability, state backend selection, troubleshooting runbook

### DIFF
--- a/docs/src/content/docs/reference/state-backend-selection.md
+++ b/docs/src/content/docs/reference/state-backend-selection.md
@@ -120,20 +120,11 @@ git fetch origin squad-state:squad-state
 
 ## Known bug: FSStorageProvider `rootDir` (#1555)
 
-> ⚠️ **Open bug [#1555](https://github.com/bradygaster/squad/issues/1555):** `FSStorageProvider` resolves state paths relative to the Node.js process working directory rather than the volume mount path when `rootDir` is not set in `config.json`. This causes state writes to go to the wrong path when the process `cwd` does not match `/app/.squad/`.
+> ⚠️ **Open bug [#1555](https://github.com/bradygaster/squad/issues/1555):** `FSStorageProvider` is constructed without a `rootDir` argument in `resolveSquadState()`. All relative state keys resolve against the Node.js process working directory (the repo root) rather than `.squad/`, silently creating a shadow state tree that diverges from the authoritative `.squad/` copy agents actually read.
 >
-> **Workaround:** Explicitly set `rootDir` in `.squad/config.json`:
+> **There is no configuration-level workaround.** Because `FSStorageProvider` is constructed with zero arguments regardless of any user configuration, setting `rootDir` in `config.json` has no effect — the constructor call ignores it. This must be fixed in the SDK itself ([#1555](https://github.com/bradygaster/squad/issues/1555)).
 >
-> ```json
-> {
->   "version": 1,
->   "teamRoot": ".",
->   "stateBackend": "local",
->   "rootDir": "/app/.squad"
-> }
-> ```
->
-> This ensures Squad resolves state paths against the correct directory regardless of the process working directory. Track [#1555](https://github.com/bradygaster/squad/issues/1555) for a fix.
+> **Until #1555 is resolved:** Run only a single Squad replica. Avoid deployment paths where the MCP server process `cwd` differs from the volume mount path. Track [#1555](https://github.com/bradygaster/squad/issues/1555) for the fix.
 
 ---
 

--- a/docs/src/content/docs/scenarios/production-observability.md
+++ b/docs/src/content/docs/scenarios/production-observability.md
@@ -8,7 +8,7 @@ order: 26
 
 > ⚠️ **Experimental** — Squad is alpha software. APIs, commands, and behavior may change between releases.
 
-> 🔗 **Related:** [Aspire Dashboard](./aspire-dashboard) (local dev telemetry) · [Container Image — Env Var Contract](/squad/docs/reference/container-image/) · [#1144](https://github.com/bradygaster/squad/issues/1144) (embedded-host telemetry — tracked separately)
+> 🔗 **Related:** [Aspire Dashboard](./aspire-dashboard) (local dev telemetry) · [Production Troubleshooting Runbook](./production-troubleshooting) · [Container Image — Env Var Contract](/squad/docs/reference/container-image/) · [#1144](https://github.com/bradygaster/squad/issues/1144) (embedded-host telemetry — tracked separately)
 
 ---
 
@@ -205,8 +205,9 @@ Recommended alerts once traces are flowing to Azure Monitor or Grafana:
 
 | Signal | Recommended threshold | Alert type |
 |---|---|---|
-| `squad.agent.duration` p95 > 5 minutes | Warning | Metric alert |
-| `squad.issue.dispatch.errors` rate > 5/min | Critical | Log alert |
+| `squad.agent.duration` p95 > 5 minutes | Warning | Metric alert (histogram) |
+| `squad.agent.errors` rate > 5/min | Critical | Metric alert (counter) |
+| `squad.sessions.errors` rate > 5/min | Warning | Metric alert (counter) |
 | Pod OOM restarts > 2 in 10 min | Critical | Container Insights alert |
 | GitHub API 401 errors in structured logs | Critical | Log alert |
 | No spans received from service in 10 min | Warning | Availability alert |
@@ -217,7 +218,7 @@ Recommended alerts once traces are flowing to Azure Monitor or Grafana:
 
 When Kubernetes sends `SIGTERM`, Squad begins graceful shutdown. The default pod `terminationGracePeriodSeconds` is 30 seconds. If an agent is mid-task, in-flight work may be interrupted. Squad does not currently checkpoint in-progress tasks before shutdown.
 
-Mitigation: Set `terminationGracePeriodSeconds: 120` in your Deployment spec to give long-running agents time to finish. There is no guarantee all work completes — monitor `squad.agent.interrupted` spans in your telemetry backend to measure the impact.
+Mitigation: Set `terminationGracePeriodSeconds: 120` in your Deployment spec to give long-running agents time to finish. There is no guarantee all work completes — monitor `squad.coordinator.shutdown` spans and the `squad.agent.errors` counter in your telemetry backend to assess shutdown impact. Squad does not emit an interrupted-specific span; shutdown scope is visible only through these existing signals.
 
 ---
 

--- a/docs/src/content/docs/scenarios/production-troubleshooting.md
+++ b/docs/src/content/docs/scenarios/production-troubleshooting.md
@@ -47,7 +47,7 @@ Is the state backend accessible?
 Root causes in order of frequency:
 1. **KEDA not scaling** — queue depth below threshold or scaler unreachable
 2. **Wrong or missing env vars** — `GITHUB_TOKEN` absent or wrong scope
-3. **State backend inaccessible** — PVC mount failure or `rootDir` mismatch (#1555)
+3. **State backend inaccessible** — PVC mount failure or `FSStorageProvider` path bug (#1555)
 4. **GitHub API 401** — expired token, missing scope, or org SSO not enabled
 5. **No qualifying labels** — issues exist but labels don't match routing rules
 6. **Image pull failure** — ACR credentials expired or image tag not found
@@ -154,21 +154,13 @@ If the PVC mount is missing, the pod is writing state to the container's ephemer
 
 ### FSStorageProvider rootDir bug (#1555)
 
-If `kubectl exec -n squad <pod> -- ls /app/.squad` shows the correct files but Squad cannot find them, the process `cwd` does not match the volume mount path.
+If Squad logs show state files at the repo root (e.g., `agents/`, `log/`, `decisions.md` appearing at `/app/` rather than `/app/.squad/`), this is [#1555](https://github.com/bradygaster/squad/issues/1555): `FSStorageProvider` is constructed without a `rootDir` argument, so all state keys resolve against the process `cwd` (the repo root) instead of `.squad/`.
 
-**Workaround:**
+> ⚠️ **There is no configuration-level workaround for #1555.** Setting `rootDir` in `config.json` has no effect — `FSStorageProvider` ignores constructor arguments in the affected code path. This must be fixed in the SDK itself.
+>
+> **Mitigation until #1555 is resolved:** Run only a single Squad replica. Avoid deployment shapes where the MCP server process `cwd` differs from the intended state path. Track [#1555](https://github.com/bradygaster/squad/issues/1555) for status.
 
-```json
-// /app/.squad/config.json
-{
-  "version": 1,
-  "teamRoot": ".",
-  "stateBackend": "local",
-  "rootDir": "/app/.squad"
-}
-```
-
-See [State Backend Selection — Known bug #1555](/squad/docs/reference/state-backend-selection/#known-bug-fsstorageprovider-rootdir-1555) for details.
+See [State Backend Selection — Known bug #1555](/squad/docs/reference/state-backend-selection/#known-bug-fsstorageprovider-rootdir-1555) for background.
 
 ### `squad-state` branch push rejected (two-layer / orphan)
 
@@ -319,5 +311,5 @@ Open an issue at [bradygaster/squad](https://github.com/bradygaster/squad/issues
 |---|---|
 | [#1144](https://github.com/bradygaster/squad/issues/1144) | Embedded host (copilot-sdk) telemetry not available in production — agents must use Squad CLI container mode |
 | [#1402](https://github.com/bradygaster/squad/issues/1402) | External state backend for multi-pod deployments — not yet GA |
-| [#1555](https://github.com/bradygaster/squad/issues/1555) | FSStorageProvider `rootDir` bug — workaround documented above |
+| [#1555](https://github.com/bradygaster/squad/issues/1555) | FSStorageProvider `rootDir` bug — no configuration-level workaround; run single replica and track issue for fix |
 | [#1577](https://github.com/bradygaster/squad/issues/1577) | HTTP health/readiness endpoints — not yet implemented |


### PR DESCRIPTION
## Summary

Implements [#1568](https://github.com/bradygaster/squad/issues/1568) — three new production operations docs pages built on the canonical `reference/container-image.md` from #1575.

Working as **Telemetry (Aspire & Observability)**.

> ⚠️ **GNC Revision (2026-08-02)** — Revised by GNC (Node.js Runtime) as independent revision owner after FIDO rejection. Original author Telemetry locked out. Changes: (1) removed fabricated `squad.issue.dispatch.errors` and `squad.agent.interrupted` metrics/spans — replaced with source-verified `squad.agent.errors` (counter), `squad.sessions.errors` (counter), and `squad.coordinator.shutdown` (span); (2) removed invalid `rootDir` config workaround for #1555 — issue source confirms no configuration-level workaround exists; (3) added production-observability → production-troubleshooting cross-link.

> **Conflict Resolution (2026-08-02, GNC):** Rebased onto `origin/dev` after #1578 merged. #1578 carried the original docs content into dev; GNC rebased the branch to apply only the FIDO-corrected revision (commit `555250e5`) on top of dev. All `.squad/` orchestration/log/decisions artifacts are excluded from this PR's diff — the final diff relative to dev contains only the 3 corrected docs files (`production-observability.md`, `state-backend-selection.md`, `production-troubleshooting.md`). Force-with-lease push was used as required by the rebase.

---

## Pages Delivered

### A — `scenarios/production-observability.md`
- Local `squad aspire` vs. production cluster telemetry — explicitly documented: the Aspire Dashboard does **not** run in Kubernetes; do not point OTLP at localhost in containers
- OTLP flow diagram: Squad pod → OTel Collector → Azure Monitor / Application Insights or Managed Grafana
- Only verified `OTEL_*` variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`) — no fabricated env vars
- Minimal OTel Collector ConfigMap example (OTLP → Azure Monitor exporter); marked experimental, validated against first-party schema references
- Starter Grafana PromQL panel for `squad.agent.duration` histogram; caveat on metric name stability
- Structured stdout → Log Analytics KQL query
- PII / log redaction advisory (Squad does not redact — filter at Collector/Log Analytics)
- "No traces appear" 7-step troubleshooting checklist (firewall, protocol, auth headers, NetworkPolicy, private endpoint)
- Dashboards/alerting signal table: **source-verified metrics only** — `squad.agent.duration` (histogram), `squad.agent.errors` (counter), `squad.sessions.errors` (counter). Fabricated `squad.issue.dispatch.errors` removed.
- Graceful shutdown: references `squad.coordinator.shutdown` span and `squad.agent.errors` counter. Fabricated `squad.agent.interrupted` span removed.
- Cross-link added: production-observability ↔ production-troubleshooting
- Incident collection steps + escalation links
- Attribution: Tamir Dresher posts credited

### B — `reference/state-backend-selection.md`
- Decision matrix: local dev / single-pod-no-PVC / single-pod-PVC / multi-pod / CI — with recommended backend per shape
- **Canonical write-contention/data-loss warning block** — all three built-in backends are single-writer; multi-pod concurrent writes cause data loss or push rejections
- PVC config example (ReadWriteOnce Azure Disk); RWX Azure Files caveat
- Backup/restore procedures for local+PVC and two-layer backends
- **#1555 section corrected** — invalid `rootDir` config workaround removed. Issue #1555 source states: "there is no configuration-level workaround — this must be fixed in the SDK itself." Section now accurately states this and advises single-replica / avoid affected path.
- Multi-pod external state gap — cross-links #1402 and [External State](/squad/docs/features/external-state/)
- Persistence comparison table across all backends

### C — `scenarios/production-troubleshooting.md`
- "Agent not picking up issues" decision tree — 7 root causes covering KEDA, env vars, state backend, GitHub auth, labels, image pull, OOM
- Startup/CLI path: exit patterns, missing .squad/, CLI binary not found
- GitHub auth: 401/403/SSO, rate-limit fleet budgeting, token rotation
- OTEL export: cross-links production-observability.md checklist + quick kubectl commands
- State backend: PVC mount check, **#1555 section corrected** — invalid workaround removed, accurate "no configuration-level workaround" statement added per issue source
- KEDA scaler: `kubectl describe scaledobject`, external scaler health, trigger verification, token check
- Image pull: 4 error patterns with ACR-specific fixes
- OOM: Container Insights KQL, memory limit increase, Log Analytics KQL
- Deep readiness absence (#1577): explicit warning block — no /healthz or /readyz; operator mitigation via log alerting
- kubectl command examples for ≥4 failure modes (startup, auth, KEDA, image pull)
- Diagnostic collection script (logs, describe, events, ScaledObject)
- Relation to #1144, #1402, #1555, #1577

---

## Validation

- `markdownlint-cli2`: **0 errors** (174 files)
- `cspell`: **0 issues** (173 files)
- `npm run test`: Pre-existing baseline failures only — no regressions from this PR:
  - **`docs-build.test.ts` guide count (11 vs 10):** Pre-existing from #1574 (`agent-framework-integration.md`). Dev baseline expects 10 guides; 11 exist. This PR does not modify that test or add guides — baseline mismatch left for planned nav integration PR.
  - `cli-packaging-smoke.test.ts`: npm install blocked by corporate network — pre-existing.
  - Other CLI failures: pre-existing on dev branch, unrelated to docs changes.
- No Astro build run locally (npm network blocked; CI will validate)

---

## Limitations / Open Items

- Astro docs build was not run locally due to npm network restriction — CI will validate HTML output and any broken internal links
- Azure Monitor OTLP endpoint URL format noted as subject to change; first-party doc link provided for operators to verify
- `squad.agent.duration` metric name marked as potentially unstable until OTEL instrumentation stabilizes
- No new Kubernetes Deployment manifests added (these belong to #1566); only the minimal OTel Collector ConfigMap was included as an illustrative example with first-party schema references
- External state backend (#1402) not yet GA — matrix documents current state accurately

⚠️ Needs squad member review before merging (🟡 task — GNC revision of Telemetry scope; RETRO and Handbook approvals previously recorded).

Closes #1568