### PR TITLE
Upgrade Squad.Agents.AI Copilot SDK (rebased from #1560)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,15 +25,15 @@
       "$(NuGetPackageRoot)/github.copilot.sdk/$(_MicrosoftAgentsAICopilotSdkVersion)/build/GitHub.Copilot.SDK.targets"
       and, when $(_MicrosoftAgentsAICopilotSdkVersion) is unset, defaults it to the SDK
       version the adapter itself was packed against, its nuspec's dependency FLOOR
-      (1.0.5 for Microsoft.Agents.AI.GitHub.Copilot 1.14.0-rc1), NOT the version this repo
-      actually depends on ($(SquadCopilotSdkVersion), i.e. 1.0.7). Left unset, any project
+      (still 1.0.5 in Microsoft.Agents.AI.GitHub.Copilot 1.15.0-rc1), NOT the version this repo
+      actually depends on ($(SquadCopilotSdkVersion)). Left unset, any project
       that pulls in the adapter WITHOUT a direct PackageReference to GitHub.Copilot.SDK
       (test/Squad.Agents.AI.Tests, src/Squad.Agents.AI/samples/Squad.Agents.AI.Sample here,
       and any real external NuGet consumer of Squad.Agents.AI) downloads and bundles the
       OLDER Copilot CLI build pinned to SDK 1.0.5 (Copilot CLI 1.0.67) instead of the CLI
-      pinned to SDK 1.0.7 (Copilot CLI 1.0.71); verified against this repo's own CI logs
+      pinned to this repo's requested SDK / CLI pair; verified against the repo's own CI logs
       for PR #1519 (run 29856026557): "Build package" (src/Squad.Agents.AI, which DOES have
-      the direct PackageReference) downloaded CLI 1.0.71, while "Build tests" and
+      the direct PackageReference) downloaded the requested CLI, while "Build tests" and
       "Build sample" (no direct PackageReference) downloaded CLI 1.0.67, on both
       ubuntu-latest and windows-latest.
 
@@ -51,14 +51,15 @@
       (generated at pack time from this same property, see Squad.Agents.AI.csproj)
       unconditionally overwrites it again for real external consumers.
 
-      Excluded for the Squad.Agents.AI project itself: it already gets the right SDK
-      version via its own direct PackageReference to GitHub.Copilot.SDK (whose build/
-      import happens unconditionally, ahead of the adapter's fallback), so setting the
-      override there too would just make NuGet import the SAME
-      github.copilot.sdk/$(SquadCopilotSdkVersion)/build/GitHub.Copilot.SDK.targets file
-      twice, and MSBuild warns (MSB4011) about the resulting harmless-but-noisy duplicate
-      import.
+      This override is applied to the package project itself too because the MAF buildTransitive bridge otherwise
+      imports the SDK targets a second time using its packaged floor (1.0.5), which can override the direct
+      reference during target execution. A duplicate-import warning is acceptable; the
+      important invariant is that every project resolves the same SDK-backed native payload rather than the
+      adapter's stale floor.
+
+
     -->
-    <_MicrosoftAgentsAICopilotSdkVersion Condition="'$(MSBuildProjectName)' != 'Squad.Agents.AI'">$(SquadCopilotSdkVersion)</_MicrosoftAgentsAICopilotSdkVersion>
+    <_MicrosoftAgentsAICopilotSdkVersion>$(SquadCopilotSdkVersion)</_MicrosoftAgentsAICopilotSdkVersion>
   </PropertyGroup>
 </Project>
+

--- a/src/Squad.Agents.AI/Squad.Agents.AI.csproj
+++ b/src/Squad.Agents.AI/Squad.Agents.AI.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!--
-      Prerelease because Microsoft.Agents.AI.GitHub.Copilot 1.14.0-rc1 (below) is itself a
+      Prerelease because Microsoft.Agents.AI.GitHub.Copilot 1.15.0-rc1 (below) is itself a
       prerelease package. A STABLE Squad.Agents.AI depending on a prerelease package makes
       `dotnet pack` emit NU5104 ("A stable release ... should not have a prerelease
       dependency"). Prior releases (0.2.0 through 0.5.5) stayed stable and carried that


### PR DESCRIPTION
Cherry-pick of PR #1560 by @tamirdresher, rebased onto current dev.

The package version bumps (.csproj) were superseded by subsequent dependabot updates on dev (1.16.0, Extensions 10.0.10/10.8.3), so this PR carries only the meaningful changes:
- **Directory.Build.props**: Removes the MSBuildProjectName exclusion condition so _MicrosoftAgentsAICopilotSdkVersion is set universally (including for Squad.Agents.AI itself), preventing the MAF buildTransitive bridge from importing stale SDK targets.
- **Squad.Agents.AI.csproj**: Comment update referencing 1.15.0-rc1.

Original PR: #1560
Supersedes #1560

Co-authored-by: Tamir Dresher <tamird@microsoft.com>