### PR TITLE
feat(gh-aw): ship Squad modes with verified consumer bootstrap (#1613-#1618)

### DIFF
--- a/.github/actions/squad-init/action.yml
+++ b/.github/actions/squad-init/action.yml
@@ -50,6 +50,14 @@ inputs:
     description: 'Directory to run squad init in'
     required: false
     default: '.'
+  mode:
+    description: 'Init mode: default runs squad init, connect fetches from a remote source'
+    required: false
+    default: 'default'
+  source:
+    description: 'Remote squad source (owner/repo) for connect mode. Only used when mode=connect.'
+    required: false
+    default: ''
 
 outputs:
   squad-path:
@@ -70,6 +78,8 @@ runs:
         INPUT_BACKEND: ${{ inputs.state-backend }}
         INPUT_REPO: ${{ inputs.repository }}
         INPUT_SKIP_INIT: ${{ inputs.skip-init }}
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_SOURCE: ${{ inputs.source }}
       run: |
         set -euo pipefail
         # These values reach a shell command below, so constrain them tightly.
@@ -90,6 +100,18 @@ runs:
         fi
         if [ "${INPUT_SKIP_INIT}" != "true" ] && [ "${INPUT_SKIP_INIT}" != "false" ]; then
           echo "::error::skip-init must be 'true' or 'false'"
+          exit 1
+        fi
+        if [ "${INPUT_MODE}" != "default" ] && [ "${INPUT_MODE}" != "connect" ]; then
+          echo "::error::mode must be 'default' or 'connect'"
+          exit 1
+        fi
+        if [ "${INPUT_MODE}" = "connect" ] && [ -z "${INPUT_SOURCE}" ]; then
+          echo "::error::source is required when mode=connect"
+          exit 1
+        fi
+        if [ -n "${INPUT_SOURCE}" ] && ! echo "${INPUT_SOURCE}" | LC_ALL=C grep -qE '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+          echo "::error::source must be in owner/repo form"
           exit 1
         fi
 
@@ -146,8 +168,52 @@ runs:
         "${SQUAD_BIN}" --version > /dev/null
         echo "Squad $("${SQUAD_BIN}" --version) installed and runnable without npm"
 
+    - name: Fetch remote squad (connect mode)
+      if: inputs.mode == 'connect' && inputs.skip-init != 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        INPUT_SOURCE: ${{ inputs.source }}
+      run: |
+        set -euo pipefail
+        echo "::group::Fetching squad from ${INPUT_SOURCE}"
+        # Create .squad/config.json pointer
+        mkdir -p .squad
+        cat > .squad/config.json <<EOF
+        {
+          "squadSource": "${INPUT_SOURCE}",
+          "mode": "connect",
+          "connectedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        }
+        EOF
+        # Fetch .squad/ from remote via gh API
+        # Download team.md, routing.md from source
+        for path in team.md routing.md; do
+          content=$(gh api "repos/${INPUT_SOURCE}/contents/.squad/${path}" --jq '.content' 2>/dev/null | base64 -d) || true
+          if [ -n "${content}" ]; then
+            echo "${content}" > ".squad/${path}"
+          fi
+        done
+        # Fetch agent charters
+        agents=$(gh api "repos/${INPUT_SOURCE}/contents/.squad/agents" --jq '.[].name' 2>/dev/null) || true
+        for agent in ${agents}; do
+          charter=$(gh api "repos/${INPUT_SOURCE}/contents/.squad/agents/${agent}/charter.md" --jq '.content' 2>/dev/null | base64 -d) || true
+          if [ -n "${charter}" ]; then
+            mkdir -p ".squad/agents/${agent}"
+            echo "${charter}" > ".squad/agents/${agent}/charter.md"
+          fi
+        done
+        # Fetch squad.agent.md
+        agent_md=$(gh api "repos/${INPUT_SOURCE}/contents/.github/agents/squad.agent.md" --jq '.content' 2>/dev/null | base64 -d) || true
+        if [ -n "${agent_md}" ]; then
+          mkdir -p .github/agents
+          echo "${agent_md}" > .github/agents/squad.agent.md
+        fi
+        echo "::endgroup::"
+        echo "Squad connected from ${INPUT_SOURCE}"
+
     - name: Run squad init
-      if: inputs.skip-init != 'true'
+      if: inputs.skip-init != 'true' && inputs.mode != 'connect'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:

--- a/.github/actions/squad-init/action.yml
+++ b/.github/actions/squad-init/action.yml
@@ -50,14 +50,6 @@ inputs:
     description: 'Directory to run squad init in'
     required: false
     default: '.'
-  mode:
-    description: 'Init mode: default runs squad init, connect fetches from a remote source'
-    required: false
-    default: 'default'
-  source:
-    description: 'Remote squad source (owner/repo) for connect mode. Only used when mode=connect.'
-    required: false
-    default: ''
 
 outputs:
   squad-path:
@@ -78,8 +70,6 @@ runs:
         INPUT_BACKEND: ${{ inputs.state-backend }}
         INPUT_REPO: ${{ inputs.repository }}
         INPUT_SKIP_INIT: ${{ inputs.skip-init }}
-        INPUT_MODE: ${{ inputs.mode }}
-        INPUT_SOURCE: ${{ inputs.source }}
       run: |
         set -euo pipefail
         # These values reach a shell command below, so constrain them tightly.
@@ -100,18 +90,6 @@ runs:
         fi
         if [ "${INPUT_SKIP_INIT}" != "true" ] && [ "${INPUT_SKIP_INIT}" != "false" ]; then
           echo "::error::skip-init must be 'true' or 'false'"
-          exit 1
-        fi
-        if [ "${INPUT_MODE}" != "default" ] && [ "${INPUT_MODE}" != "connect" ]; then
-          echo "::error::mode must be 'default' or 'connect'"
-          exit 1
-        fi
-        if [ "${INPUT_MODE}" = "connect" ] && [ -z "${INPUT_SOURCE}" ]; then
-          echo "::error::source is required when mode=connect"
-          exit 1
-        fi
-        if [ -n "${INPUT_SOURCE}" ] && ! echo "${INPUT_SOURCE}" | LC_ALL=C grep -qE '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
-          echo "::error::source must be in owner/repo form"
           exit 1
         fi
 
@@ -168,52 +146,8 @@ runs:
         "${SQUAD_BIN}" --version > /dev/null
         echo "Squad $("${SQUAD_BIN}" --version) installed and runnable without npm"
 
-    - name: Fetch remote squad (connect mode)
-      if: inputs.mode == 'connect' && inputs.skip-init != 'true'
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      env:
-        INPUT_SOURCE: ${{ inputs.source }}
-      run: |
-        set -euo pipefail
-        echo "::group::Fetching squad from ${INPUT_SOURCE}"
-        # Create .squad/config.json pointer
-        mkdir -p .squad
-        cat > .squad/config.json <<EOF
-        {
-          "squadSource": "${INPUT_SOURCE}",
-          "mode": "connect",
-          "connectedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-        }
-        EOF
-        # Fetch .squad/ from remote via gh API
-        # Download team.md, routing.md from source
-        for path in team.md routing.md; do
-          content=$(gh api "repos/${INPUT_SOURCE}/contents/.squad/${path}" --jq '.content' 2>/dev/null | base64 -d) || true
-          if [ -n "${content}" ]; then
-            echo "${content}" > ".squad/${path}"
-          fi
-        done
-        # Fetch agent charters
-        agents=$(gh api "repos/${INPUT_SOURCE}/contents/.squad/agents" --jq '.[].name' 2>/dev/null) || true
-        for agent in ${agents}; do
-          charter=$(gh api "repos/${INPUT_SOURCE}/contents/.squad/agents/${agent}/charter.md" --jq '.content' 2>/dev/null | base64 -d) || true
-          if [ -n "${charter}" ]; then
-            mkdir -p ".squad/agents/${agent}"
-            echo "${charter}" > ".squad/agents/${agent}/charter.md"
-          fi
-        done
-        # Fetch squad.agent.md
-        agent_md=$(gh api "repos/${INPUT_SOURCE}/contents/.github/agents/squad.agent.md" --jq '.content' 2>/dev/null | base64 -d) || true
-        if [ -n "${agent_md}" ]; then
-          mkdir -p .github/agents
-          echo "${agent_md}" > .github/agents/squad.agent.md
-        fi
-        echo "::endgroup::"
-        echo "Squad connected from ${INPUT_SOURCE}"
-
     - name: Run squad init
-      if: inputs.skip-init != 'true' && inputs.mode != 'connect'
+      if: inputs.skip-init != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -14,7 +14,7 @@
 # The Squad CLI is never installed or executed in the agent job — only the files it
 # produces (`.squad/` team state and `.github/agents/squad.agent.md`) are restored
 # there. This is deliberate: gh-aw's network firewall only constrains the agent job,
-# so all install/network work happens in the unrestricted activation job.
+# so the npm install and initialization happen in the unrestricted activation job.
 #
 # Usage (as an import in your gh-aw workflow):
 #   imports:
@@ -45,7 +45,7 @@
 #
 # Optional custom Squad CLI version:
 #   vars.SQUAD_CLI_VERSION
-#   Default is determined by the squad-init composite action (latest release).
+#   Default is 0.11.0.
 #
 # State backend is pinned to `local`: the compiled agent invocation passes
 # `--disable-builtin-mcps`, so Squad's `state-mcp` bridge does not load. A non-local
@@ -53,6 +53,7 @@
 # from a fresh `squad init`.
 engine:
   id: copilot
+  version: 1.0.78
   agent: squad
 
 jobs:
@@ -67,30 +68,11 @@ jobs:
           private-key: ${{ secrets.SQUAD_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ vars.SQUAD_GITHUB_APP_OWNER }}
 
-      - name: Detect existing squad config
-        id: detect-config
-        shell: bash
-        run: |
-          if [ -f .squad/config.json ]; then
-            mode=$(jq -r '.mode // "default"' .squad/config.json)
-            source=$(jq -r '.squadSource // ""' .squad/config.json)
-            echo "mode=${mode}" >> "$GITHUB_OUTPUT"
-            echo "source=${source}" >> "$GITHUB_OUTPUT"
-          else
-            echo "mode=default" >> "$GITHUB_OUTPUT"
-            echo "source=" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Initialize Squad team
-        uses: bradygaster/squad/.github/actions/squad-init@main
-        with:
-          version: ${{ vars.SQUAD_CLI_VERSION || 'latest' }}
-          preset: default
-          state-backend: local
-          mode: ${{ steps.detect-config.outputs.mode }}
-          source: ${{ steps.detect-config.outputs.source }}
         env:
+          SQUAD_CLI_VERSION: ${{ vars.SQUAD_CLI_VERSION || '0.11.0' }}
           GH_TOKEN: ${{ steps.squad-app-token.outputs.token || secrets.SQUAD_GITHUB_TOKEN || github.token }}
+        run: npx --yes "@bradygaster/squad-cli@${SQUAD_CLI_VERSION:-0.11.0}" init --preset default --state-backend local
 
       - name: Upload Squad state artifact
         if: success()
@@ -122,18 +104,14 @@ agent sandbox:
 
 1. **`jobs.activation.pre-steps`** — the repository is already checked out by the
    activation job. This step optionally mints a GitHub App installation token (or
-   uses a supplied PAT), runs Squad initialization via the `squad-init` composite
-   action (from bradygaster/squad/.github/actions/squad-init@dev — the npm-free
-   replacement for `npx @bradygaster/squad-cli`), and uploads the resulting
-   `.squad/` team state plus `.github/agents/squad.agent.md` as a `squad-state`
-   artifact — all inside the activation job with unrestricted egress.
+   uses a supplied PAT), runs the pinned `@bradygaster/squad-cli` package, and
+   uploads the resulting `.squad/` team state plus
+   `.github/agents/squad.agent.md` as a `squad-state` artifact — all inside the
+   activation job with unrestricted egress.
 
 2. **`steps:`** (agent job) — downloads the `squad-state` artifact and restores it
    into the workspace. The Squad CLI is never installed here; only the files it
    produced are needed.
-
-Key difference from the .github/workflows/shared/ version: this file uses the
-squad-init composite action instead of npx, eliminating the npm registry dependency.
 
 -->
 
@@ -142,7 +120,7 @@ squad-init composite action instead of npx, eliminating the npm registry depende
 Squad's team state (`.squad/`) and its Copilot custom agent
 (`.github/agents/squad.agent.md`) were initialized during activation and restored
 into this checkout before you started — do **not** install Squad or run `squad init`
-yourself, and do **not** try to reach the npm registry.
+yourself.
 
 - Verify `.squad/team.md` exists before delegating work to the team. If it is
   missing, the activation-job bootstrap step failed — call `noop` and explain

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -72,7 +72,7 @@ jobs:
           owner: ${{ vars.SQUAD_GITHUB_APP_OWNER }}
 
       - name: Initialize Squad team
-        uses: bradygaster/squad/.github/actions/squad-init@dev
+        uses: bradygaster/squad/.github/actions/squad-init@main
         with:
           version: ${{ vars.SQUAD_CLI_VERSION || 'latest' }}
           preset: default
@@ -89,7 +89,7 @@ jobs:
           path: |
             .squad
             .github/agents/squad.agent.md
-          if-no-files-found: ignore
+          if-no-files-found: error
           retention-days: 1
 
 steps:

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -55,10 +55,6 @@ engine:
   id: copilot
   agent: squad
 
-ambient-folders:
-  - ".squad"
-  - ".github/agents"
-
 jobs:
   activation:
     pre-steps:

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -71,12 +71,28 @@ jobs:
           private-key: ${{ secrets.SQUAD_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ vars.SQUAD_GITHUB_APP_OWNER }}
 
+      - name: Detect existing squad config
+        id: detect-config
+        shell: bash
+        run: |
+          if [ -f .squad/config.json ]; then
+            mode=$(jq -r '.mode // "default"' .squad/config.json)
+            source=$(jq -r '.squadSource // ""' .squad/config.json)
+            echo "mode=${mode}" >> "$GITHUB_OUTPUT"
+            echo "source=${source}" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=default" >> "$GITHUB_OUTPUT"
+            echo "source=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Initialize Squad team
         uses: bradygaster/squad/.github/actions/squad-init@main
         with:
           version: ${{ vars.SQUAD_CLI_VERSION || 'latest' }}
           preset: default
           state-backend: local
+          mode: ${{ steps.detect-config.outputs.mode }}
+          source: ${{ steps.detect-config.outputs.source }}
         env:
           GH_TOKEN: ${{ steps.squad-app-token.outputs.token || secrets.SQUAD_GITHUB_TOKEN || github.token }}
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -10,6 +10,11 @@ on:
       - issue_comment
       - pull_request_review_comment
   workflow_dispatch:
+    inputs:
+      command:
+        description: 'Squad command (e.g., cast, connect org/repo, adopt org/repo, status)'
+        required: false
+        default: 'cast'
 permissions:
   contents: write
   issues: write
@@ -175,7 +180,7 @@ Select a fictional universe and assign character names:
    ```json
    {
      "agents": {
-       "role-id": {
+       "{lowercase-name}": {
          "created_at": "2026-08-05T19:00:00.000Z",
          "persistent_name": "CharacterName",
          "universe": "Universe Name",
@@ -212,12 +217,20 @@ Create or replace the following files and directories:
    ## Members
    | Name | Role | Charter | Status |
    |------|------|---------|--------|
-   | {Name} | {Role} | `.squad/agents/{id}/charter.md` | ✅ Active |
+   | {Name} | {Role} | `.squad/agents/{lowercase-name}/charter.md` | ✅ Active |
    | Scribe | Session Logger | — | 📋 Silent |
    | Ralph | Work Monitor | — | 🔄 Monitor |
+
+   ## Coding Agent
+
+   <!-- copilot-auto-assign: false -->
+
+   | Name | Role | Charter | Status |
+   |------|------|---------|--------|
+   | @copilot | Coding Agent | — | 🤖 Coding Agent |
    ```
 
-2. **`.squad/agents/{id}/charter.md`** for each agent — minimal charter:
+2. **`.squad/agents/{lowercase-name}/charter.md`** for each agent — minimal charter:
    ```markdown
    # {Name} — {Role}
 
@@ -274,7 +287,7 @@ tailored to this repository.
 
 | Name | Role | Specialty | How to Talk to Them |
 |------|------|-----------|---------------------|
-| {emoji} {Name} | {Role} | {area of expertise} | `squad:{id}` label or mention in issue |
+| {emoji} {Name} | {Role} | {area of expertise} | `squad:{lowercase-name}` label or mention in issue |
 | ... | ... | ... | ... |
 
 ### Always-On Support
@@ -586,12 +599,12 @@ existing squad. It preserves the current universe and avoids name conflicts.
 ##### Step 5: Generate or Regenerate Charter
 
 **For new members:**
-1. Create `.squad/agents/{id}/charter.md` using the standard charter template
+1. Create `.squad/agents/{lowercase-name}/charter.md` using the standard charter template
    from Cast Mode Step 4. Tailor expertise, ownership, and boundaries to the
    specified specialty.
 
 **For modifications (rename/modify):**
-1. Read the existing charter at `.squad/agents/{id}/charter.md`.
+1. Read the existing charter at `.squad/agents/{lowercase-name}/charter.md`.
 2. Regenerate the charter with the new focus/specialty while preserving:
    - The assigned character name (persistent identity)
    - The `created_at` timestamp in the registry
@@ -615,12 +628,12 @@ Determine context-aware behavior based on the trigger location:
   Post a comment on the PR noting the addition/modification.
 - **Triggered on an issue or non-Squad PR:**
   Open a new pull request using the `create-pull-request` safe-output:
-  - **Branch:** `squad/cast-member-{id}`
+  - **Branch:** `squad/cast-member-{lowercase-name}`
   - **Title:** `[squad] Add {Name} — {Role}` (or `Modify {Name}` for updates)
   - **Body:** Describe the new/updated member, their role, and how to route
     work to them.
   - **Files to include:** `.squad/team.md`, `.squad/routing.md`,
-    `.squad/casting/registry.json`, `.squad/agents/{id}/charter.md`,
+    `.squad/casting/registry.json`, `.squad/agents/{lowercase-name}/charter.md`,
     `meet-the-squad.md`
 
 Stage only the affected files. Do NOT commit unrelated changes.
@@ -647,13 +660,12 @@ charter, and updates all squad files to reflect the removal.
 
 ##### Step 2: Archive Charter
 
-1. Create `.squad/agents/_alumni/` directory if it does not exist.
-2. Move `.squad/agents/{id}/charter.md` to `.squad/agents/_alumni/{id}.md`.
-3. Add a frontmatter note to the archived charter:
+1. Create `.squad/agents/_alumni/{lowercase-name}/` directory if it does not exist.
+2. Move the entire `.squad/agents/{lowercase-name}/` directory to `.squad/agents/_alumni/{lowercase-name}/`.
+3. Add a retirement header to the archived `charter.md`:
    ```markdown
    <!-- Retired: {ISO-8601 timestamp} | Previously: {Name} — {Role} -->
    ```
-4. Remove the now-empty `.squad/agents/{id}/` directory.
 
 ##### Step 3: Update Squad Files
 
@@ -674,14 +686,14 @@ Same context-aware behavior as Cast Member mode:
   Post a comment noting the retirement.
 - **Triggered on an issue or non-Squad PR:**
   Open a new pull request using the `create-pull-request` safe-output:
-  - **Branch:** `squad/retire-{id}`
+  - **Branch:** `squad/retire-{lowercase-name}`
   - **Title:** `[squad] Retire {Name} — {Role}`
   - **Body:** Explain who was retired, that their charter is archived in
     `_alumni/`, and note any routing rules that may need a replacement.
   - **Files to include:** `.squad/team.md`, `.squad/routing.md`,
-    `.squad/casting/registry.json`, `.squad/agents/_alumni/{id}.md`,
+    `.squad/casting/registry.json`, `.squad/agents/_alumni/{lowercase-name}/`,
     `meet-the-squad.md`
-  - **Files to delete:** `.squad/agents/{id}/charter.md`
+  - **Files to delete:** `.squad/agents/{lowercase-name}/`
 
 Stage only the affected files. Do NOT commit unrelated changes.
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -39,6 +39,18 @@ safe-outputs:
 Invoked via `/squad <mode> [options]` in issue comments or PR review comments,
 or manually via workflow_dispatch.
 
+## Trigger Context
+
+Access the slash command text from the GitHub event payload:
+
+- **Issue comment:** `github.event.comment.body` — the full comment text
+- **PR review comment:** `github.event.comment.body` — the full comment text
+- **Workflow dispatch:** `github.event.inputs.command` — manual input (default: `cast`)
+
+The activation job already ran `squad init --preset default`, which produced a
+generic 5-agent team (lead, reviewer, devrel, security, docs) in `.squad/`. Cast
+mode REPLACES this scaffolding with a team tailored to the repository.
+
 ## Modes
 
 Parse the slash command text to determine the mode:
@@ -55,55 +67,306 @@ Parse the slash command text to determine the mode:
 
 ## Task
 
-<!-- TODO: Full implementation in #1614-#1617 -->
-
 ### 1. Parse Command
 
-Extract mode and arguments from the slash command text. Default to `cast` if
-no subcommand is provided.
+Extract the mode and arguments from the slash command text:
+
+1. Read the trigger comment body from the event payload.
+2. Strip the `/squad` prefix and trim whitespace.
+3. Match the first word against known modes: `cast`, `connect`, `adopt`,
+   `cast-member`, `retire`, `status`.
+4. If no subcommand is provided or the text is empty, default to `cast`.
+5. Store any remaining text as arguments for the matched mode.
 
 ### 2. Execute Mode
 
-#### Cast Mode
-<!-- TODO: Full implementation in #1614 -->
+---
 
-1. Analyze the repository structure, languages, and conventions
-2. Run `squad init` via the squad-init composite action
-3. Generate `meet-the-squad.md` introducing the cast team
-4. Open a PR with the `.squad/` directory and `meet-the-squad.md`
+#### Cast Mode
+
+Cast mode analyzes the target repository, composes a specialist team, assigns
+character names from a fictional universe, generates full `.squad/` scaffolding,
+and opens a PR introducing the new team.
+
+##### Step 1: Repo Analysis
+
+Analyze the repository to understand what kind of team it needs:
+
+1. **Languages & frameworks** — Read file extensions, `package.json`,
+   `requirements.txt`, `go.mod`, `Cargo.toml`, `*.csproj`, etc. Identify the
+   primary language(s) and frameworks (React, Next.js, FastAPI, Rails, etc.).
+2. **Project structure** — Examine top-level directories. Note patterns like
+   `src/`, `lib/`, `packages/` (monorepo), `apps/`, `services/`, `docs/`.
+3. **CI/CD** — Check `.github/workflows/`, `Makefile`, `Dockerfile`,
+   `docker-compose.yml`. Note existing automation.
+4. **Testing** — Look for test directories, test config files (`vitest.config`,
+   `jest.config`, `pytest.ini`, `.mocharc`).
+5. **Documentation** — Check for `docs/`, `README.md` quality, API docs,
+   OpenAPI specs.
+6. **Existing tooling** — Note linters, formatters, pre-commit hooks, release
+   automation (changesets, semantic-release).
+7. **README & purpose** — Read the README to understand what the project does,
+   its domain, and its audience.
+
+Produce a mental summary: project type, primary technologies, team size needed
+(typically 4–7 agents), and which specialist roles would add the most value.
+
+##### Step 2: Team Composition
+
+Based on the analysis, decide which roles the team needs. Every team gets a
+**Lead** (coordinator/architect). Then allocate specialists based on the repo:
+
+| Signal | Suggested Role |
+|--------|---------------|
+| Frontend framework (React, Vue, Svelte) | Frontend Engineer |
+| Backend/API code (Express, FastAPI, gRPC) | Backend Engineer |
+| Database schemas, migrations | Data Engineer |
+| Test suites, coverage config | Test Engineer |
+| CI/CD workflows, Docker | DevOps / Platform |
+| Security-sensitive code (auth, crypto) | Security Engineer |
+| Docs site, README, tutorials | DevRel / Docs |
+| Multiple packages/services | Integration Engineer |
+| ML models, data pipelines | ML Engineer |
+| Mobile (React Native, Swift, Kotlin) | Mobile Engineer |
+
+**Guidelines:**
+- Target 4–7 agents. Fewer for small repos, more for large monorepos.
+- Every team needs at minimum: Lead + 2 specialists + 1 quality role (tester or reviewer).
+- Avoid redundant roles — merge "reviewer" into Lead for small teams.
+- The built-in agents Scribe (session logger), Ralph (work monitor), and Rai
+  (interactive coach) are always present and do NOT count toward team composition.
+
+##### Step 3: Universe & Name Allocation
+
+Select a fictional universe and assign character names:
+
+1. **Count agents** — determine team size from Step 2.
+2. **Select universe** — choose from the allowlist below. Pick a universe whose
+   capacity fits the team size with minimal waste. Use shape tags and resonance
+   signals to find thematic alignment with the project domain.
+
+   | Universe | Capacity | Shape |
+   |----------|----------|-------|
+   | The Usual Suspects | 6 | small, noir, ensemble |
+   | Reservoir Dogs | 8 | small, noir, ensemble |
+   | Alien | 8 | small, sci-fi, survival |
+   | The Goonies | 8 | small, adventure, ensemble |
+   | The Matrix | 10 | medium, sci-fi, cyberpunk |
+   | Firefly | 10 | medium, sci-fi, western |
+   | Star Wars | 12 | medium, sci-fi, epic |
+   | Breaking Bad | 12 | medium, drama, tension |
+   | Futurama | 12 | medium, sci-fi, comedy |
+   | Ocean's Eleven | 14 | medium, heist, ensemble |
+   | Arrested Development | 15 | medium, comedy, ensemble |
+   | Lost | 18 | large, mystery, ensemble |
+   | DC Universe | 18 | large, action, ensemble |
+   | The Simpsons | 20 | large, comedy, ensemble |
+   | Marvel Cinematic Universe | 25 | large, action, ensemble |
+
+3. **Assign names** following these rules:
+   - One universe per assignment — never mix universes.
+   - Choose names that imply pressure, function, or consequence — NOT authority.
+   - Avoid spoiler-laden names (no hidden identities, fate reveals, or
+     later-acquired titles). Prefer early-introduction names.
+   - Scribe, Ralph, and Rai are exempt — they keep their built-in names.
+   - Each agent gets a unique name within the repo.
+
+4. **Record the mapping** in `.squad/casting/registry.json`:
+   ```json
+   {
+     "agents": {
+       "role-id": {
+         "created_at": "2026-08-05T19:00:00.000Z",
+         "persistent_name": "CharacterName",
+         "universe": "Universe Name",
+         "legacy_named": false,
+         "status": "active"
+       }
+     }
+   }
+   ```
+
+5. **Initialize casting history** in `.squad/casting/history.json`:
+   ```json
+   {
+     "universe_usage_history": [
+       { "universe": "Universe Name", "assigned_at": "ISO-8601", "agent_count": 5 }
+     ],
+     "assignment_cast_snapshots": {}
+   }
+   ```
+
+##### Step 4: Generate Scaffolding
+
+Create or replace the following files and directories:
+
+1. **`.squad/team.md`** — Full team roster:
+   ```markdown
+   # {Repo Name} Squad
+
+   ## Coordinator
+   | Name | Role | Notes |
+   |------|------|-------|
+   | Squad | Coordinator | Routes work, enforces handoffs |
+
+   ## Members
+   | Name | Role | Charter | Status |
+   |------|------|---------|--------|
+   | {Name} | {Role} | `.squad/agents/{id}/charter.md` | ✅ Active |
+   | Scribe | Session Logger | — | 📋 Silent |
+   | Ralph | Work Monitor | — | 🔄 Monitor |
+   ```
+
+2. **`.squad/agents/{id}/charter.md`** for each agent — minimal charter:
+   ```markdown
+   # {Name} — {Role}
+
+   > {One-line personality description}
+
+   ## Identity
+   - **Name:** {Name}
+   - **Role:** {Role}
+   - **Expertise:** {comma-separated areas}
+   - **Style:** {personality in a few words}
+
+   ## What I Own
+   - {area of responsibility 1}
+   - {area of responsibility 2}
+
+   ## Boundaries
+   **I handle:** {domain scope}
+   **I don't handle:** {out-of-scope areas}
+
+   ## Model
+   Preferred: auto
+   ```
+
+3. **`.squad/routing.md`** — Work routing table mapping domains to agents.
+
+4. **`.squad/casting/registry.json`** — As defined in Step 3.
+
+5. **`.squad/casting/history.json`** — As defined in Step 3.
+
+6. **`.squad/casting/policy.json`** — Copy the standard casting policy with
+   all 15 universes allowlisted.
+
+7. **`.squad/decisions/`** — Create the directory (empty initially).
+
+8. **`.github/agents/squad.agent.md`** — The Squad coordinator custom agent.
+   This file was already created by `squad init` in the activation job. Verify
+   it exists and include it in the PR output — it is what makes the Squad
+   coordinator work as a Copilot custom agent.
+
+##### Step 5: Generate meet-the-squad.md
+
+Create `meet-the-squad.md` at the repository root. This file introduces the
+team in a friendly, readable format:
+
+```markdown
+# 🧑‍🤝‍🧑 Meet Your Squad
+
+> Your AI development team, powered by [Squad](https://github.com/bradygaster/squad).
+
+## The Team
+
+This squad was cast from **{Universe Name}** — a team of {N} specialists
+tailored to this repository.
+
+| Name | Role | What They Own |
+|------|------|---------------|
+| {Name} | {Role} | {brief ownership summary} |
+| ... | ... | ... |
+
+### Always-On Support
+
+| Name | Role | Notes |
+|------|------|-------|
+| Scribe | Session Logger | Tracks all agent sessions silently |
+| Ralph | Work Monitor | Watches the backlog and alerts on stale work |
+
+## How It Works
+
+Each squad member has a **charter** (`.squad/agents/{name}/charter.md`) that
+defines their expertise, boundaries, and personality. Work is routed to the
+right specialist automatically via `.squad/routing.md`.
+
+## Getting Started
+
+- View the full roster: `.squad/team.md`
+- See routing rules: `.squad/routing.md`
+- Customize a member: `/squad cast-member <name> <changes>`
+- Check status: `/squad status`
+
+---
+
+*Cast on {date} for {owner}/{repo}*
+```
+
+##### Step 6: Open PR
+
+Open a pull request using the `create-pull-request` safe-output:
+
+- **Branch:** `squad/cast-{short-repo-name}` (e.g., `squad/cast-my-app`)
+- **Title:** `[squad] Cast your Squad — {brief repo description}`
+- **Body:** Summary of the team composition, universe chosen, and links to key
+  files (team.md, routing.md, meet-the-squad.md).
+- **Labels:** `squad` (applied automatically by safe-outputs)
+- **Files to include:**
+  - `.squad/` (entire directory)
+  - `.github/agents/squad.agent.md`
+  - `meet-the-squad.md`
+
+Stage only the files listed above. Do NOT commit unrelated changes.
+
+---
 
 #### Connect Mode
 <!-- TODO: Full implementation in #1615 -->
 
-1. Validate the provided `<source>` URL or repo reference
-2. Write `.squad/config.json` with `squadSource` pointing to the remote team
-3. Open a PR with the configuration change
+Connect mode links a repository to an existing Squad source (remote team
+configuration). Not yet implemented — reply with a comment explaining that
+Connect mode is coming soon and link to the Squad repository for updates.
+
+---
 
 #### Adopt Mode
 <!-- TODO: Full implementation in #1616 -->
 
-1. Fetch squad configuration from the provided `<url>`
-2. Copy `.squad/` directory contents into the local repository
-3. Run any necessary migrations or version checks
-4. Open a PR with the adopted squad configuration
+Adopt mode pulls a complete squad configuration from a remote URL and installs
+it locally. Not yet implemented — reply with a comment explaining that Adopt
+mode is coming soon.
+
+---
 
 #### Cast Member Mutation
 <!-- TODO: Full implementation in #1617 -->
 
-1. Parse the member specification from arguments
-2. Modify the existing squad (add, update, or mutate the specified member)
-3. Push changes to a PR branch
+Cast Member mode adds or modifies a single team member in an existing squad.
+Not yet implemented — reply with a comment explaining that Cast Member mutations
+are coming soon.
+
+---
 
 #### Retire Mode
 <!-- TODO: Full implementation in #1617 -->
 
-1. Locate the named member in `.squad/agents/`
-2. Remove from roster in `team.md` and routing table
-3. Archive the agent's charter and history
-4. Push changes to a PR branch
+Retire mode removes a named team member, archives their charter, and updates
+the roster. Not yet implemented — reply with a comment explaining that Retire
+mode is coming soon.
+
+---
 
 #### Status Mode
 
-1. Read `.squad/team.md` and parse the roster
-2. Report team composition: members, roles, and status
-3. Post a comment summarizing the current squad state
+Status mode reports the current team composition. It is read-only and does not
+open a PR.
+
+1. Check if `.squad/team.md` exists. If not, reply with a comment stating that
+   no squad has been cast for this repository yet and suggest running `/squad cast`.
+2. Read `.squad/team.md` and parse the members table.
+3. Read `.squad/casting/registry.json` to get universe and name mappings.
+4. Post a comment on the triggering issue/PR with:
+   - Team name and universe
+   - Member count (active / total)
+   - Table of active members: name, role, status
+   - Link to `.squad/team.md` for full details

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -36,7 +36,6 @@ safe-outputs:
     labels: [squad]
     max: 3
     expires: 14
-    close-older-prs: false
 ---
 
 # Squad — Unified `/squad` Slash Command

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -378,38 +378,312 @@ Stage only the files listed above. Do NOT commit unrelated changes.
 ---
 
 #### Connect Mode
-<!-- TODO: Full implementation in #1615 -->
 
-Connect mode links a repository to an existing Squad source (remote team
-configuration). Not yet implemented — reply with a comment explaining that
-Connect mode is coming soon and link to the Squad repository for updates.
+Connect mode links a repository to an externally managed Squad source. It
+commits only a lightweight config pointer — squad files are never stored in the
+target repo. The `shared/squad.md` bootstrap component pulls remote squad files
+at activation time.
+
+##### Step 1: Parse Source URL
+
+1. Extract the source argument from the parsed command text (e.g.,
+   `/squad connect org/repo` → `org/repo`).
+2. Normalize the source to `owner/repo` format. Accept both full GitHub URLs
+   (`https://github.com/org/repo`) and shorthand (`org/repo`).
+3. If no source argument is provided, post a comment explaining correct usage:
+   `/squad connect <owner/repo>` and stop.
+
+##### Step 2: Validate Source Accessibility
+
+1. Run `gh api repos/{owner}/{repo}/contents/.squad/team.md --jq .name` to
+   verify the source repo exists and contains a `.squad/` directory.
+2. If the API call fails with a 404 or permission error:
+   - Post a comment on the triggering issue/PR explaining the error:
+     > ❌ Could not access `{source}`. Please verify:
+     > - The repository exists and is not private (or the app has access)
+     > - The `SQUAD_GITHUB_APP_*` secrets are configured correctly
+     > - The source repo contains a `.squad/` directory
+   - Stop execution — do not open a PR.
+3. If accessible, continue to Step 3.
+
+##### Step 3: Write Config Pointer
+
+1. Create `.squad/config.json` with the following content:
+   ```json
+   {
+     "squadSource": "{owner}/{repo}",
+     "mode": "connect",
+     "connectedAt": "{ISO-8601 timestamp}"
+   }
+   ```
+2. This is the ONLY `.squad/` file committed to the target repo. All other squad
+   files are resolved at runtime from the source.
+
+##### Step 4: Generate meet-the-squad.md
+
+Create `meet-the-squad.md` at the repository root. Use the standard template
+from Step 5 of Cast Mode with the Connect mode rationale block:
+
+```markdown
+This squad is externally managed — connected from `{source}`. Local changes
+will be overwritten on the next sync. To customize, disconnect first with
+`/squad cast`.
+```
+
+Include a note that the team roster is managed in the source repo and link to
+`https://github.com/{source}/.squad/team.md` for details.
+
+##### Step 5: Open PR
+
+Open a pull request using the `create-pull-request` safe-output:
+
+- **Branch:** `squad/connect-{short-repo-name}`
+- **Title:** `[squad] Connect to {source}`
+- **Body:** Explain that the repo is now linked to an external squad source.
+  Note that squad files are fetched at activation time — nothing else is
+  committed locally. Link to the source repo.
+- **Files to include:**
+  - `.squad/config.json`
+  - `meet-the-squad.md`
+
+Stage only the files listed above. Do NOT commit `.squad/agents/`, `.squad/team.md`,
+or any other scaffolding — those live in the source repo.
 
 ---
 
 #### Adopt Mode
-<!-- TODO: Full implementation in #1616 -->
 
-Adopt mode pulls a complete squad configuration from a remote URL and installs
-it locally. Not yet implemented — reply with a comment explaining that Adopt
-mode is coming soon.
+Adopt mode fetches a complete squad definition from a remote source and commits
+it locally. Unlike Connect mode, everything is owned by the target repo — there
+is no ongoing sync. The user can freely customize after adoption.
+
+##### Step 1: Parse Source URL
+
+1. Extract the source argument from the parsed command text (e.g.,
+   `/squad adopt org/repo` → `org/repo`).
+2. Normalize the source to `owner/repo` format. Accept both full GitHub URLs
+   and shorthand notation.
+3. If no source argument is provided, post a comment explaining correct usage:
+   `/squad adopt <owner/repo>` and stop.
+
+##### Step 2: Validate & Fetch Source
+
+1. Run `gh api repos/{owner}/{repo}/contents/.squad --jq '.[].name'` to verify
+   the source repo is accessible and contains a `.squad/` directory.
+2. If the API call fails with a 404 or permission error:
+   - Post a comment on the triggering issue/PR explaining the error:
+     > ❌ Could not access `{source}`. Please verify:
+     > - The repository exists and is not private (or the app has access)
+     > - The `SQUAD_GITHUB_APP_*` secrets are configured correctly
+     > - The source repo contains a `.squad/` directory
+   - Stop execution — do not open a PR.
+3. Clone or download the `.squad/` directory contents from the source repo using
+   `gh api` to fetch each file recursively.
+4. Also fetch `.github/agents/squad.agent.md` from the source if it exists.
+
+##### Step 3: Install Scaffolding Locally
+
+1. Copy the entire `.squad/` directory into the target repo workspace, replacing
+   any existing scaffolding from `squad init`.
+2. Copy `.github/agents/squad.agent.md` into position.
+3. Write `.squad/config.json` with:
+   ```json
+   {
+     "squadSource": "{owner}/{repo}",
+     "mode": "adopt",
+     "adoptedAt": "{ISO-8601 timestamp}"
+   }
+   ```
+
+##### Step 4: Adapt Repo-Specific References
+
+1. Read the target repo structure (top-level dirs, package files, CI config).
+2. Update `.squad/routing.md` to reference paths and patterns that actually
+   exist in the target repo (e.g., if source routing references `packages/`
+   but target uses `src/`, adjust accordingly).
+3. If any charter references source-repo-specific files or directories, update
+   those paths to match the target repo's structure.
+
+##### Step 5: Generate meet-the-squad.md
+
+Create `meet-the-squad.md` at the repository root. Use the standard template
+from Step 5 of Cast Mode with the Adopt mode rationale block:
+
+```markdown
+This squad was adopted from `{source}` and is now locally owned. You can
+freely modify charters, add members, or re-cast. The original source is
+no longer tracked.
+```
+
+Include the full team table from the adopted `.squad/team.md`.
+
+##### Step 6: Auto-Include copilot-setup-steps.yml
+
+Same as Cast Mode Step 6. Check if `.github/workflows/copilot-setup-steps.yml`
+exists. If missing, generate one appropriate for the target repo's detected
+language/toolchain and include it in the PR.
+
+##### Step 7: Open PR
+
+Open a pull request using the `create-pull-request` safe-output:
+
+- **Branch:** `squad/adopt-{short-repo-name}`
+- **Title:** `[squad] Adopt squad from {source}`
+- **Body:** Explain that the full squad was adopted from the source and is now
+  locally owned. List the team members adopted, the universe, and note that
+  routing was adapted for this repo's structure.
+- **Files to include:**
+  - `.squad/` (entire directory)
+  - `.github/agents/squad.agent.md`
+  - `meet-the-squad.md`
+  - `.github/workflows/copilot-setup-steps.yml` (only if generated in Step 6)
+
+Stage only the files listed above. Do NOT commit unrelated changes.
 
 ---
 
 #### Cast Member Mutation
-<!-- TODO: Full implementation in #1617 -->
 
-Cast Member mode adds or modifies a single team member in an existing squad.
-Not yet implemented — reply with a comment explaining that Cast Member mutations
-are coming soon.
+Cast Member mode adds, modifies, or renames a single team member within an
+existing squad. It preserves the current universe and avoids name conflicts.
+
+**Subcommands:**
+- `/squad cast-member <description>` — Add a new member with the described specialty
+- `/squad cast-member rename <name> to <new-focus>` — Modify an existing member
+- `/squad cast-member modify <name> to <change>` — Modify an existing member
+
+##### Step 1: Parse the Spec
+
+1. Extract the description or subcommand from the argument text.
+2. Determine the operation:
+   - If text starts with `rename` or `modify`: this is a member modification.
+     Parse `<name>` (the existing member) and `<change>` (the new focus).
+   - Otherwise: this is a new member addition. The full text describes the
+     desired role/specialty.
+
+##### Step 2: Validate Existing Squad
+
+1. Verify `.squad/team.md` and `.squad/casting/registry.json` exist. If not,
+   post a comment suggesting `/squad cast` first and stop.
+2. Read the current registry to load active members, universe, and used names.
+
+##### Step 3: Check for Duplicates (New Member Only)
+
+1. Compare the requested specialty against existing active members' roles.
+2. If a substantially similar role already exists, post a comment asking the
+   user to confirm or suggesting they modify the existing member instead.
+   Include the conflicting member's name and role.
+
+##### Step 4: Allocate Identity (New Member Only)
+
+1. Read `.squad/casting/registry.json` to determine the active universe.
+2. Select an unused character name from the same universe that thematically
+   fits the new role. Follow the same naming rules as Cast Mode Step 3
+   (pressure/function over authority, no spoilers, early-introduction names).
+3. If the universe has no remaining capacity, post a comment explaining the
+   universe is full and suggest retiring a member first or re-casting.
+
+##### Step 5: Generate or Regenerate Charter
+
+**For new members:**
+1. Create `.squad/agents/{id}/charter.md` using the standard charter template
+   from Cast Mode Step 4. Tailor expertise, ownership, and boundaries to the
+   specified specialty.
+
+**For modifications (rename/modify):**
+1. Read the existing charter at `.squad/agents/{id}/charter.md`.
+2. Regenerate the charter with the new focus/specialty while preserving:
+   - The assigned character name (persistent identity)
+   - The `created_at` timestamp in the registry
+3. Update expertise, ownership areas, and boundaries to reflect the new focus.
+
+##### Step 6: Update Squad Files
+
+1. **`.squad/team.md`** — Add (or update) the member row in the Members table.
+2. **`.squad/routing.md`** — Add (or update) routing rules for the member's
+   domain. For modifications, update the domain mapping if it changed.
+3. **`.squad/casting/registry.json`** — Add the new entry (or update the
+   existing entry for modifications). Preserve `created_at` for modifications.
+4. **`meet-the-squad.md`** — Add (or update) the member in the team table.
+
+##### Step 7: Open PR or Push Commit
+
+Determine context-aware behavior based on the trigger location:
+
+- **Triggered on a Squad PR** (a PR with the `squad` label on a `squad/*` branch):
+  Push a new commit to the existing PR branch with the member changes.
+  Post a comment on the PR noting the addition/modification.
+- **Triggered on an issue or non-Squad PR:**
+  Open a new pull request using the `create-pull-request` safe-output:
+  - **Branch:** `squad/cast-member-{id}`
+  - **Title:** `[squad] Add {Name} — {Role}` (or `Modify {Name}` for updates)
+  - **Body:** Describe the new/updated member, their role, and how to route
+    work to them.
+  - **Files to include:** `.squad/team.md`, `.squad/routing.md`,
+    `.squad/casting/registry.json`, `.squad/agents/{id}/charter.md`,
+    `meet-the-squad.md`
+
+Stage only the affected files. Do NOT commit unrelated changes.
 
 ---
 
 #### Retire Mode
-<!-- TODO: Full implementation in #1617 -->
 
-Retire mode removes a named team member, archives their charter, and updates
-the roster. Not yet implemented — reply with a comment explaining that Retire
-mode is coming soon.
+Retire mode removes a named team member from the active roster, archives their
+charter, and updates all squad files to reflect the removal.
+
+##### Step 1: Identify Target Member
+
+1. Extract the name or role argument from `/squad retire <name-or-role>`.
+2. Read `.squad/casting/registry.json` and `.squad/team.md`.
+3. Match the argument against:
+   - Exact character name (case-insensitive)
+   - Role title (partial match acceptable)
+   - Agent ID (kebab-case identifier)
+4. If no match is found, post a comment listing active members and ask the
+   user to clarify which member to retire.
+5. If multiple matches are found, post a comment listing the ambiguous matches
+   and ask for clarification.
+
+##### Step 2: Archive Charter
+
+1. Create `.squad/agents/_alumni/` directory if it does not exist.
+2. Move `.squad/agents/{id}/charter.md` to `.squad/agents/_alumni/{id}.md`.
+3. Add a frontmatter note to the archived charter:
+   ```markdown
+   <!-- Retired: {ISO-8601 timestamp} | Previously: {Name} — {Role} -->
+   ```
+4. Remove the now-empty `.squad/agents/{id}/` directory.
+
+##### Step 3: Update Squad Files
+
+1. **`.squad/casting/registry.json`** — Set the member's `status` to `"retired"`
+   and add a `retired_at` timestamp. Do NOT delete the entry (preserves history).
+2. **`.squad/team.md`** — Remove the member row from the active Members table.
+   Optionally add an Alumni section if one doesn't exist.
+3. **`.squad/routing.md`** — Remove or reassign routing rules that pointed to
+   the retired member. If their domain is still needed, note it as unassigned
+   or suggest the user cast a replacement.
+4. **`meet-the-squad.md`** — Remove the member from the team table.
+
+##### Step 4: Open PR or Push Commit
+
+Same context-aware behavior as Cast Member mode:
+
+- **Triggered on a Squad PR:** Push a commit to the existing PR branch.
+  Post a comment noting the retirement.
+- **Triggered on an issue or non-Squad PR:**
+  Open a new pull request using the `create-pull-request` safe-output:
+  - **Branch:** `squad/retire-{id}`
+  - **Title:** `[squad] Retire {Name} — {Role}`
+  - **Body:** Explain who was retired, that their charter is archived in
+    `_alumni/`, and note any routing rules that may need a replacement.
+  - **Files to include:** `.squad/team.md`, `.squad/routing.md`,
+    `.squad/casting/registry.json`, `.squad/agents/_alumni/{id}.md`,
+    `meet-the-squad.md`
+  - **Files to delete:** `.squad/agents/{id}/charter.md`
+
+Stage only the affected files. Do NOT commit unrelated changes.
 
 ---
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -16,9 +16,7 @@ on:
         required: false
         default: 'cast'
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
   copilot-requests: write
 network:
   allowed:
@@ -36,6 +34,11 @@ safe-outputs:
     labels: [squad]
     max: 3
     expires: 14
+  create-issue:
+    labels: [squad]
+    max: 5
+  add-comment:
+    max: 10
 ---
 
 # Squad — Unified `/squad` Slash Command
@@ -623,8 +626,9 @@ existing squad. It preserves the current universe and avoids name conflicts.
 Determine context-aware behavior based on the trigger location:
 
 - **Triggered on a Squad PR** (a PR with the `squad` label on a `squad/*` branch):
-  Push a new commit to the existing PR branch with the member changes.
-  Post a comment on the PR noting the addition/modification.
+  Open a follow-up pull request using the `create-pull-request` safe-output targeting
+  the existing PR branch with the member changes.
+  Post a comment on the PR using the `add-comment` safe-output noting the addition/modification.
 - **Triggered on an issue or non-Squad PR:**
   Open a new pull request using the `create-pull-request` safe-output:
   - **Branch:** `squad/cast-member-{lowercase-name}`
@@ -681,8 +685,9 @@ charter, and updates all squad files to reflect the removal.
 
 Same context-aware behavior as Cast Member mode:
 
-- **Triggered on a Squad PR:** Push a commit to the existing PR branch.
-  Post a comment noting the retirement.
+- **Triggered on a Squad PR:** Open a follow-up pull request using the
+  `create-pull-request` safe-output targeting the existing PR branch.
+  Post a comment using the `add-comment` safe-output noting the retirement.
 - **Triggered on an issue or non-Squad PR:**
   Open a new pull request using the `create-pull-request` safe-output:
   - **Branch:** `squad/retire-{lowercase-name}`

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -18,6 +18,8 @@ on:
 permissions:
   contents: read
   copilot-requests: write
+  issues: read
+  pull-requests: read
 network:
   allowed:
     - defaults

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -2,7 +2,7 @@
 name: Squad
 description: Cast, connect, or adopt a Squad AI team for your repository
 emoji: "🧑‍🤝‍🧑"
-private: true
+private: false
 on:
   slash_command:
     name: squad

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -272,37 +272,93 @@ team in a friendly, readable format:
 This squad was cast from **{Universe Name}** — a team of {N} specialists
 tailored to this repository.
 
-| Name | Role | What They Own |
-|------|------|---------------|
-| {Name} | {Role} | {brief ownership summary} |
-| ... | ... | ... |
+| Name | Role | Specialty | How to Talk to Them |
+|------|------|-----------|---------------------|
+| {emoji} {Name} | {Role} | {area of expertise} | `squad:{id}` label or mention in issue |
+| ... | ... | ... | ... |
 
 ### Always-On Support
 
-| Name | Role | Notes |
-|------|------|-------|
-| Scribe | Session Logger | Tracks all agent sessions silently |
-| Ralph | Work Monitor | Watches the backlog and alerts on stale work |
+| Name | Role | Specialty | How to Talk to Them |
+|------|------|-----------|---------------------|
+| 📋 Scribe | Session Logger | Tracking all agent sessions | Automatic — never needs explicit routing |
+| 🔄 Ralph | Work Monitor | Backlog health and stale work alerts | Automatic — watches for idle work |
 
-## How It Works
+## How to Work With Your Squad
 
-Each squad member has a **charter** (`.squad/agents/{name}/charter.md`) that
-defines their expertise, boundaries, and personality. Work is routed to the
-right specialist automatically via `.squad/routing.md`.
+### Label-Based Assignment
 
-## Getting Started
+Apply a `squad:{name}` label to any issue or PR to route it directly to that
+specialist. For example, `squad:fido` sends work to your test engineer.
 
-- View the full roster: `.squad/team.md`
-- See routing rules: `.squad/routing.md`
-- Customize a member: `/squad cast-member <name> <changes>`
-- Check status: `/squad status`
+### Iteration Commands
+
+| Command | What It Does |
+|---------|--------------|
+| `/squad cast` | Re-cast the full team (replaces current squad) |
+| `/squad cast-member <spec>` | Add or modify a single team member |
+| `/squad retire <name>` | Remove a team member from the roster |
+| `/squad status` | Check current team composition and health |
+
+### Routing
+
+Work is routed automatically via `.squad/routing.md`. Each member has a
+**charter** (`.squad/agents/{name}/charter.md`) defining their expertise,
+boundaries, and personality.
+
+## What Happened Here
+
+{mode_rationale_block}
 
 ---
 
 *Cast on {date} for {owner}/{repo}*
 ```
 
-##### Step 6: Open PR
+**Mode-specific content for `{mode_rationale_block}`:**
+
+- **Cast mode:** Include full analysis rationale:
+  ```markdown
+  This team was assembled based on automated analysis of your repository:
+
+  - **Languages detected:** {languages}
+  - **Repo structure:** {structure summary, e.g., monorepo, single-package, etc.}
+  - **CI/CD patterns:** {CI tools found, e.g., GitHub Actions, Docker, etc.}
+  - **Rationale:** {why these roles were chosen over alternatives}
+  ```
+
+- **Connect mode:**
+  ```markdown
+  This squad is externally managed — connected from `{source}`. Local changes
+  will be overwritten on the next sync. To customize, disconnect first with
+  `/squad cast`.
+  ```
+
+- **Adopt mode:**
+  ```markdown
+  This squad was adopted from `{url}` and is now locally owned. You can
+  freely modify charters, add members, or re-cast. The original source is
+  no longer tracked.
+  ```
+
+##### Step 6: Auto-Include copilot-setup-steps.yml
+
+Check if `.github/workflows/copilot-setup-steps.yml` exists in the repository.
+
+If **missing:**
+1. Generate a `copilot-setup-steps.yml` appropriate for the detected language/toolchain:
+   - For Node.js projects: include `actions/setup-node@v4` + `npm ci`
+   - For Python projects: include `actions/setup-python@v5` + `pip install`
+   - For Go projects: include `actions/setup-go@v5`
+   - For other/mixed: include a minimal checkout-only version
+2. Place it at `.github/workflows/copilot-setup-steps.yml`
+3. Include it in the PR files (see Step 7)
+4. Mention in the PR body: "Also included `copilot-setup-steps.yml` since it was
+   missing — this enables the Copilot coding agent to work with your squad immediately."
+
+If **present:** Do nothing. Never overwrite an existing setup steps file.
+
+##### Step 7: Open PR
 
 Open a pull request using the `create-pull-request` safe-output:
 
@@ -315,6 +371,7 @@ Open a pull request using the `create-pull-request` safe-output:
   - `.squad/` (entire directory)
   - `.github/agents/squad.agent.md`
   - `meet-the-squad.md`
+  - `.github/workflows/copilot-setup-steps.yml` (only if generated in Step 6)
 
 Stage only the files listed above. Do NOT commit unrelated changes.
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -41,7 +41,6 @@ safe-outputs:
     allowed-files:
       - ".squad/**"
       - ".github/agents/squad.agent.md"
-      - ".github/workflows/copilot-setup-steps.yml"
       - "meet-the-squad.md"
     protected-files: allowed
     max-patch-files: 500
@@ -70,6 +69,9 @@ Access the slash command text from the GitHub event payload:
 The activation job already ran `squad init --preset default`, which produced a
 generic 5-agent team (lead, reviewer, devrel, security, docs) in `.squad/`. Cast
 mode REPLACES this scaffolding with a team tailored to the repository.
+
+This workflow does not create or modify files under `.github/workflows/`.
+Repository owners must configure Copilot setup steps separately when needed.
 
 ## Modes
 
@@ -371,24 +373,7 @@ boundaries, and personality.
   no longer tracked.
   ```
 
-##### Step 6: Auto-Include copilot-setup-steps.yml
-
-Check if `.github/workflows/copilot-setup-steps.yml` exists in the repository.
-
-If **missing:**
-1. Generate a `copilot-setup-steps.yml` appropriate for the detected language/toolchain:
-   - For Node.js projects: include `actions/setup-node@v4` + `npm ci`
-   - For Python projects: include `actions/setup-python@v5` + `pip install`
-   - For Go projects: include `actions/setup-go@v5`
-   - For other/mixed: include a minimal checkout-only version
-2. Place it at `.github/workflows/copilot-setup-steps.yml`
-3. Include it in the PR files (see Step 7)
-4. Mention in the PR body: "Also included `copilot-setup-steps.yml` since it was
-   missing — this enables the Copilot coding agent to work with your squad immediately."
-
-If **present:** Do nothing. Never overwrite an existing setup steps file.
-
-##### Step 7: Open PR
+##### Step 6: Open PR
 
 Open a pull request using the `create-pull-request` safe-output:
 
@@ -401,7 +386,6 @@ Open a pull request using the `create-pull-request` safe-output:
   - `.squad/` (entire directory)
   - `.github/agents/squad.agent.md`
   - `meet-the-squad.md`
-  - `.github/workflows/copilot-setup-steps.yml` (only if generated in Step 6)
 
 Stage only the files listed above. Do NOT commit unrelated changes.
 
@@ -545,13 +529,7 @@ no longer tracked.
 
 Include the full team table from the adopted `.squad/team.md`.
 
-##### Step 6: Auto-Include copilot-setup-steps.yml
-
-Same as Cast Mode Step 6. Check if `.github/workflows/copilot-setup-steps.yml`
-exists. If missing, generate one appropriate for the target repo's detected
-language/toolchain and include it in the PR.
-
-##### Step 7: Open PR
+##### Step 6: Open PR
 
 Open a pull request using the `create-pull-request` safe-output:
 
@@ -564,7 +542,6 @@ Open a pull request using the `create-pull-request` safe-output:
   - `.squad/` (entire directory)
   - `.github/agents/squad.agent.md`
   - `meet-the-squad.md`
-  - `.github/workflows/copilot-setup-steps.yml` (only if generated in Step 6)
 
 Stage only the files listed above. Do NOT commit unrelated changes.
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -7,6 +7,7 @@ on:
   slash_command:
     name: squad
     events:
+      - issues
       - issue_comment
       - pull_request_review_comment
   workflow_dispatch:
@@ -35,7 +36,16 @@ safe-outputs:
     title-prefix: "[squad] "
     labels: [squad]
     max: 3
-    expires: 14
+    allowed-base-branches:
+      - "squad/*"
+    allowed-files:
+      - ".squad/**"
+      - ".github/agents/squad.agent.md"
+      - ".github/workflows/copilot-setup-steps.yml"
+      - "meet-the-squad.md"
+    protected-files: allowed
+    max-patch-files: 500
+    expires: 14d
   create-issue:
     labels: [squad]
     max: 5
@@ -45,13 +55,14 @@ safe-outputs:
 
 # Squad — Unified `/squad` Slash Command
 
-Invoked via `/squad <mode> [options]` in issue comments or PR review comments,
-or manually via workflow_dispatch.
+Invoked via `/squad <mode> [options]` in issue bodies, issue comments, or PR
+review comments, or manually via workflow_dispatch.
 
 ## Trigger Context
 
 Access the slash command text from the GitHub event payload:
 
+- **Issue body:** `github.event.issue.body` — the full issue description
 - **Issue comment:** `github.event.comment.body` — the full comment text
 - **PR review comment:** `github.event.comment.body` — the full comment text
 - **Workflow dispatch:** `github.event.inputs.command` — manual input (default: `cast`)
@@ -80,7 +91,7 @@ Parse the slash command text to determine the mode:
 
 Extract the mode and arguments from the slash command text:
 
-1. Read the trigger comment body from the event payload.
+1. Read the trigger body from the event payload described above.
 2. Strip the `/squad` prefix and trim whitespace.
 3. Match the first word against known modes: `cast`, `connect`, `adopt`,
    `cast-member`, `retire`, `status`.
@@ -143,7 +154,7 @@ Based on the analysis, decide which roles the team needs. Every team gets a
 - Every team needs at minimum: Lead + 2 specialists + 1 quality role (tester or reviewer).
 - Avoid redundant roles — merge "reviewer" into Lead for small teams.
 - The built-in agents Scribe (session logger), Ralph (work monitor), and Rai
-  (interactive coach) are always present and do NOT count toward team composition.
+  (RAI reviewer) are always present and do NOT count toward team composition.
 
 ##### Step 3: Universe & Name Allocation
 
@@ -224,6 +235,7 @@ Create or replace the following files and directories:
    | {Name} | {Role} | `.squad/agents/{lowercase-name}/charter.md` | ✅ Active |
    | Scribe | Session Logger | — | 📋 Silent |
    | Ralph | Work Monitor | — | 🔄 Monitor |
+   | Rai | RAI Reviewer | — | 🛡️ RAI |
 
    ## Coding Agent
 
@@ -300,6 +312,7 @@ tailored to this repository.
 |------|------|-----------|---------------------|
 | 📋 Scribe | Session Logger | Tracking all agent sessions | Automatic — never needs explicit routing |
 | 🔄 Ralph | Work Monitor | Backlog health and stale work alerts | Automatic — watches for idle work |
+| 🛡️ Rai | RAI Reviewer | Responsible AI and safety review | Automatic — reviews high-risk output |
 
 ## How to Work With Your Squad
 
@@ -320,7 +333,7 @@ specialist. For example, `squad:fido` sends work to your test engineer.
 ### Routing
 
 Work is routed automatically via `.squad/routing.md`. Each member has a
-**charter** (`.squad/agents/{name}/charter.md`) defining their expertise,
+**charter** (`.squad/agents/{lowercase-name}/charter.md`) defining their expertise,
 boundaries, and personality.
 
 ## What Happened Here
@@ -417,8 +430,7 @@ at activation time.
 2. If the API call fails with a 404 or permission error:
    - Post a comment on the triggering issue/PR explaining the error:
      > ❌ Could not access `{source}`. Please verify:
-     > - The repository exists and is not private (or the app has access)
-     > - The `SQUAD_GITHUB_APP_*` secrets are configured correctly
+     > - The repository exists and is accessible to this workflow's GitHub tool
      > - The source repo contains a `.squad/` directory
    - Stop execution — do not open a PR.
 3. If accessible, continue to Step 3.
@@ -490,8 +502,7 @@ is no ongoing sync. The user can freely customize after adoption.
 2. If the API call fails with a 404 or permission error:
    - Post a comment on the triggering issue/PR explaining the error:
      > ❌ Could not access `{source}`. Please verify:
-     > - The repository exists and is not private (or the app has access)
-     > - The `SQUAD_GITHUB_APP_*` secrets are configured correctly
+     > - The repository exists and is accessible to this workflow's GitHub tool
      > - The source repo contains a `.squad/` directory
    - Stop execution — do not open a PR.
 3. Clone or download the `.squad/` directory contents from the source repo using


### PR DESCRIPTION
## Summary

Ships the complete `/squad` Agentic Workflow prompt for Cast, Connect, Adopt, Cast Member, Retire, and Status modes, including tailored team scaffolding and `meet-the-squad.md`.

This revision also applies the consumer configuration proven end-to-end in [`bradygaster/squad-gh-aw-test`](https://github.com/bradygaster/squad-gh-aw-test):

- Accepts `/squad` from issue bodies, issue comments, PR review comments, and manual dispatch.
- Initializes with `npx --yes "@bradygaster/squad-cli@${SQUAD_CLI_VERSION:-0.11.0}" init --preset default --state-backend local` in the unrestricted activation job.
- Defaults `SQUAD_CLI_VERSION` to `0.11.0`, with a repository-variable override.
- Constrains pull-request output to Squad-owned files, permits required protected paths, caps patches at 500 files, and expires staged output after 14 days.
- Allows dynamic PR bases only for `squad/*` branches, which Cast Member and Retire use for follow-up PRs against an existing Squad branch.
- Keeps `engine.version: 1.0.78` while this source is compiled with gh-aw v0.85.4; the toolcache executable-path fix in [github/gh-aw#50908](https://github.com/github/gh-aw/pull/50908) first appears in v0.86.0.
- Restores `.github/actions/squad-init/action.yml` to the base branch. The workflow does not use the composite action because Squad v0.11.0 has no release assets.

The successful consumer run opened [`bradygaster/squad-gh-aw-test#19`](https://github.com/bradygaster/squad-gh-aw-test/pull/19).

Copilot setup steps remain a separate repository prerequisite. This workflow intentionally does not create or modify `.github/workflows/**`, avoiding the GitHub App-only `workflows: write` permission required by gh-aw's `allow-workflows` mode.

## Security review

The compiled workflow references the optional restricted secrets `SQUAD_GITHUB_APP_PRIVATE_KEY` and `SQUAD_GITHUB_TOKEN`. Both were reviewed: the private key is consumed only by `actions/create-github-app-token@v3.2.0`, and the fallback token is exposed only as `GH_TOKEN` to the activation bootstrap. No redirect changes were introduced. Agent writes remain mediated by gh-aw safe outputs and the explicit file allowlist.

## Validation

- `gh aw compile workflows/squad.md --no-emit --approve` (gh-aw v0.85.4)
- `node --test test/workflows.test.cjs` (27 passing)
- `npm run build --ignore-scripts`

Closes #1613
Closes #1614
Closes #1615
Closes #1616
Closes #1617
Closes #1618