### PR TITLE
feat(gh-aw): use parent issue as casting brief for /squad cast

### DIFF
--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -110,6 +110,35 @@ Cast mode analyzes the target repository, composes a specialist team, assigns
 character names from a fictional universe, generates full `.squad/` scaffolding,
 and opens a PR introducing the new team.
 
+##### Step 0: Brief Resolution
+
+Before analyzing the repo, determine the **primary casting input** by evaluating
+two signals: the parent issue body (`github.event.issue.body`) and the repository
+content (README, file structure, etc.).
+
+**Priority cascade:**
+
+| Repo Signal | Issue Signal | Result |
+|-------------|-------------|--------|
+| Empty/bare | Empty/no body | **Noop** — post a comment (see below), stop |
+| Empty/bare | Has content | **Issue wins** — cast from the issue description |
+| Has content | Has content | **Merge** — repo is base context, issue augments or overrides |
+| Has content | Empty/minimal | **Repo wins** — standard cast behavior |
+| Any | Explicit SOT signal | **Issue is SOT** — user intent overrides, repo validates only |
+
+"Explicit SOT signal" means the issue body reads like a team spec — explicit role
+lists, team-size declarations, operating-model descriptions, or language that
+signals "this is what I want." Infer this from structure and detail level.
+
+**Noop handling:** When both inputs are empty, use the `add-comment` safe-output
+to post: "Nothing to cast from — the repo has no substantive content and the
+issue has no casting brief. Add a README describing your project, or write your
+desired team composition in this issue body, then re-run `/squad cast`." Then
+stop — do not proceed to Step 1 or open a PR.
+
+Carry the cascade result forward: it determines whether Step 1's repo analysis
+is the primary input, an augmenting signal, or a validation-only pass.
+
 ##### Step 1: Repo Analysis
 
 Analyze the repository to understand what kind of team it needs:

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -113,8 +113,10 @@ and opens a PR introducing the new team.
 ##### Step 0: Brief Resolution
 
 Before analyzing the repo, determine the **primary casting input** by evaluating
-two signals: the parent issue body (`github.event.issue.body`) and the repository
-content (README, file structure, etc.).
+two signals: the parent issue title and body (`github.event.issue.title` +
+`github.event.issue.body`) and the repository content (README, file structure,
+etc.). Both title and body contribute to the casting brief — a non-empty title
+with an empty body is still a valid issue signal.
 
 **Priority cascade:**
 
@@ -124,9 +126,9 @@ content (README, file structure, etc.).
 | Empty/bare | Has content | **Issue wins** — cast from the issue description |
 | Has content | Has content | **Merge** — repo is base context, issue augments or overrides |
 | Has content | Empty/minimal | **Repo wins** — standard cast behavior |
-| Any | Explicit SOT signal | **Issue is SOT** — user intent overrides, repo validates only |
+| Any | Explicit source-of-truth signal | **Issue is source of truth** — user intent overrides, repo validates only |
 
-"Explicit SOT signal" means the issue body reads like a team spec — explicit role
+"Explicit source-of-truth signal" means the issue body reads like a team spec — explicit role
 lists, team-size declarations, operating-model descriptions, or language that
 signals "this is what I want." Infer this from structure and detail level.
 


### PR DESCRIPTION
## Summary

Adds **Step 0: Brief Resolution** to Cast mode in `workflows/squad.md`, inserted before the existing Step 1 (Repo Analysis).

This step evaluates two signals — the parent issue body and the repository content — and applies a priority cascade to determine which is the primary casting input:

| Repo Signal | Issue Signal | Result |
|-------------|-------------|--------|
| Empty | Empty | **Noop** — comment + stop |
| Empty | Rich brief | **Issue wins** |
| Has content | Has content | **Merge** — repo base, issue augments |
| Has content | Empty | **Repo wins** (current behavior) |
| Any | Explicit SOT signal | **Issue is SOT** — user intent overrides |

The noop case posts a helpful comment via `add-comment` and stops without opening a PR.

All existing steps (1–6) remain unchanged — Brief Resolution just sets context for how downstream steps use the repo analysis.

Closes #1634