### PR TITLE
fix(release): pin squad-sdk to the exact published version in publish-cli

### DIFF
--- a/.github/workflows/squad-npm-publish.yml
+++ b/.github/workflows/squad-npm-publish.yml
@@ -341,6 +341,23 @@ jobs:
             echo "::error::Cannot verify SDK dependency is resolvable — aborting CLI publish to prevent #1203"
             exit 1
           fi
+      - name: "Pin squad-sdk dependency to the exact published version (#1588)"
+        run: |
+          # Source keeps a floor range (">=x.y.z") so local workspace installs
+          # still resolve the in-repo SDK. That range is unbounded upward
+          # though, so a CLI version pinned by a downstream consumer silently
+          # picks up whatever SDK version is newest at their install time.
+          # Rewrite the published package.json to an exact pin so a given CLI
+          # version always resolves the same SDK version it shipped with.
+          PKG_VERSION="${{ steps.version.outputs.version }}"
+          node -e "
+            const fs = require('fs');
+            const path = 'packages/squad-cli/package.json';
+            const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+            pkg.dependencies['@bradygaster/squad-sdk'] = '$PKG_VERSION';
+            fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+            console.log('Pinned @bradygaster/squad-sdk dependency to ' + '$PKG_VERSION');
+          "
       - name: Build squad-sdk (required for CLI project references)
         run: npm -w packages/squad-sdk run build
       - name: Build squad-cli


### PR DESCRIPTION
### What
`squad-npm-publish.yml`'s `publish-cli` job now rewrites the published `packages/squad-cli/package.json`'s `@bradygaster/squad-sdk` dependency to an exact version pin, right before build/publish.

### Why
Closes #1588

`packages/squad-cli/package.json` declares `"@bradygaster/squad-sdk": ">=0.11.0"` — a floor, no ceiling. Pinning a CLI version (`npx @bradygaster/squad-cli@0.11.0`) doesn't pin the SDK it installs, since `*`/`>=` both float to whatever's latest on the registry at install time. The SDK carries the presets and agent charters, so the first `0.12.0` SDK publish silently changes behavior for every consumer pinned to `squad-cli@0.11.0`, with no version bump visible anywhere and no way to roll back by pinning. That's exactly the failure mode CI version pinning (e.g. the gh-aw shared component's `SQUAD_CLI_VERSION`) exists to prevent.

Went with the fix the issue itself suggested: pin exact at publish time, keep the floor range in source. Skipped the `workspace:*` idea also mentioned in the issue — npm doesn't support that protocol (it's pnpm/yarn syntax), committing it would make `npm install` try to fetch a package literally named `workspace:*` and fail. This repo already handles workspace resolution the normal npm-workspaces way (root `workspaces: ["packages/*"]`), which doesn't care what semver range is declared as long as the local version satisfies it — so leaving the floor range in source doesn't need to change for local dev to keep working.

### How
- `.github/workflows/squad-npm-publish.yml`: new step `Pin squad-sdk dependency to the exact published version (#1588)` in the `publish-cli` job, between the existing `#1203` resolvability check and the SDK build step. Rewrites `packages/squad-cli/package.json`'s SDK dependency to `steps.version.outputs.version` — the same version string already used by every other step in this job (`Determine version`, `Verify package version matches target`), and the same value `publish-sdk` just published and verified is live on the registry (this job `needs: [..., publish-sdk]`). Follows the exact same `node -e "... '$VAR' ..."` bash-into-node interpolation style `squad-version-promote.yml` already uses for its own package.json rewrites, rather than inventing a new convention.

### Testing
- Dry-ran the exact transformation logic against a scratch copy of `packages/squad-cli/package.json` (real run, not hypothetical):
  ```
  === BEFORE ===
  194:    "@bradygaster/squad-sdk": ">=0.11.0",
  Pinned @bradygaster/squad-sdk dependency to 0.12.0
  === AFTER ===
  194:    "@bradygaster/squad-sdk": "0.12.0",
  === full file still valid JSON? ===
  valid JSON
  ```
  Confirms the rewrite lands the right field, produces valid JSON, and preserves the file's existing 2-space formatting.
- No `actionlint`/`shellcheck` available locally on this Windows box — this repo's `Workflow Lint` job runs both against `.github/workflows/**` on every PR that touches it, so CI is the real check here.
- `git diff` vs `git diff -w` identical, no whitespace-only hunks. File has no CRLF (plain LF), untouched by that concern.

---

### ⚠️ Quick Check
- [x] No changeset — this PR only touches `.github/workflows/squad-npm-publish.yml`. The repo's own changelog-gate regex (`SDK_CLI_PATH_REGEX` in `squad-ci.yml`) is scoped to `packages/squad-*/src|templates`, `.squad-templates/`, `templates/`, and agent charters — `.github/workflows/` isn't in it, and `PR_REQUIREMENTS.md` lists "Infrastructure (CI, GitHub Actions, workflows)" under "What Is NOT User-Facing". Structural exemption, not a waiver.

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev`
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes (single workflow file, +17)
- [x] PR is not in draft mode
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] No source/test code changed — workflow-only. Logic dry-run above; YAML/shellcheck validated by this repo's `Workflow Lint` CI job.

#### Changeset
- [x] N/A — structural exemption, see Quick Check above

#### Docs
- [x] N/A — no public API/CLI surface changed

#### Exports
- [x] N/A

---

### Breaking Changes
None. Published CLI package.json content changes (exact pin instead of a floor range) but the semver range this replaces already permitted that exact version — nothing that installs today stops resolving.

### Waivers
None.