### PR TITLE
fix(cli): watch's self-pull no longer abandons stashed local changes on pull failure

### DIFF
--- a/.changeset/fix-1639-self-pull-stash-loss.md
+++ b/.changeset/fix-1639-self-pull-stash-loss.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-cli": patch
+---
+
+Fix #1639: `squad watch`'s self-pull capability stashed uncommitted local changes before `git pull --ff-only`, but only popped the stash back if the pull succeeded — a thrown pull error (diverged history, no tracking branch, network failure) jumped past the pop and reported success anyway, leaving the user's local changes sitting in `git stash` with nothing in the round output saying so. Restructured so the stash-pop always runs regardless of pull outcome, and a stash that genuinely can't be restored now comes back as a failed capability result instead of a silent success.

--- a/packages/squad-cli/src/cli/commands/watch/capabilities/self-pull.ts
+++ b/packages/squad-cli/src/cli/commands/watch/capabilities/self-pull.ts
@@ -42,25 +42,48 @@ export class SelfPullCapability implements WatchCapability {
         }
       } catch { /* non-fatal — proceed without stash */ }
 
-      // Fetch + pull
-      await new Promise<void>((resolve, reject) => {
-        execFile('git', ['fetch', '--quiet'], { cwd }, (err) =>
-          err ? reject(err) : resolve(),
-        );
-      });
-      await new Promise<void>((resolve, reject) => {
-        execFile('git', ['pull', '--ff-only', '--quiet'], { cwd }, (err) =>
-          err ? reject(err) : resolve(),
-        );
-      });
+      // Fetch + pull. A thrown error here (no tracking branch, diverged
+      // history, network failure) must not skip the stash-pop below — a
+      // stash created above and never popped silently strips the user's
+      // uncommitted work out of the working tree while this still reports
+      // success further down.
+      let pullError: unknown;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          execFile('git', ['fetch', '--quiet'], { cwd }, (err) =>
+            err ? reject(err) : resolve(),
+          );
+        });
+        await new Promise<void>((resolve, reject) => {
+          execFile('git', ['pull', '--ff-only', '--quiet'], { cwd }, (err) =>
+            err ? reject(err) : resolve(),
+          );
+        });
+      } catch (err) {
+        pullError = err;
+      }
 
-      // Pop stash if we created one
+      // Pop stash if we created one — always attempted, regardless of
+      // whether fetch/pull above succeeded.
+      let stashRestored = !didStash;
       if (didStash) {
         try {
           execFileSync('git', ['stash', 'pop'], { cwd, encoding: 'utf-8' });
+          stashRestored = true;
         } catch {
-          console.log('⚠️  git stash pop failed (possible merge conflict) — changes remain in stash');
+          stashRestored = false;
         }
+      }
+
+      if (!stashRestored) {
+        const cause = pullError ? 'pull failed' : 'stash pop conflict';
+        const summary = `git pull left local changes stashed (${cause}) — run \`git stash pop\` in ${cwd} manually`;
+        console.log(`⚠️  ${summary}`);
+        return { success: false, summary };
+      }
+
+      if (pullError) {
+        return { success: true, summary: 'git pull skipped (not on tracking branch or conflicts)' };
       }
 
       // Check if watch source files changed

--- a/test/cli/watch-capabilities.test.ts
+++ b/test/cli/watch-capabilities.test.ts
@@ -669,7 +669,7 @@ describe('Watch Capabilities', () => {
         );
       });
 
-      it('handles stash pop failure gracefully (merge conflict)', async () => {
+      it('reports failure (not success) when stash pop conflicts — local changes stay stashed', async () => {
         mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
           const a = args as string[];
           if (a[0] === 'stash' && a[1] === 'pop') throw new Error('merge conflict');
@@ -682,11 +682,75 @@ describe('Watch Capabilities', () => {
         const consoleSpy = vi.spyOn(console, 'log');
         const cap = new SelfPullCapability();
         const result = await cap.execute(makeContext());
-        expect(result.success).toBe(true);
+        // A stash that can't be restored is a failure the round report must
+        // surface, not a silent success — the user's local changes are
+        // sitting in `git stash` with no indication anywhere else.
+        expect(result.success).toBe(false);
+        expect(result.summary).toContain('left local changes stashed');
         expect(consoleSpy).toHaveBeenCalledWith(
-          expect.stringContaining('stash pop failed'),
+          expect.stringContaining('left local changes stashed'),
         );
         consoleSpy.mockRestore();
+      });
+
+      // Regression (critical): before the fix, a fetch/pull failure threw
+      // past the stash-pop step entirely — `git stash pop` was never even
+      // attempted, so a dirty working tree got silently stashed and
+      // abandoned while the capability reported success. Fails on
+      // unfixed code (stashCalls never contains a 'pop' call here);
+      // passes with the fix (pop is always attempted after fetch/pull).
+      it('still attempts stash pop after a fetch/pull failure, and restores it when possible', async () => {
+        const stashCalls: string[][] = [];
+        mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+          const a = args as string[];
+          if (a[0] === 'stash') stashCalls.push([...a]);
+          if (a.includes('rev-parse')) return 'abc123\n';
+          if (a.includes('--porcelain')) return 'M file.txt\n';
+          return '';
+        });
+        mockExecFile.mockImplementation((...args: unknown[]) => {
+          const cb = findCallback(args);
+          if (cb) cb(new Error('not a fast-forward'));
+          return {};
+        });
+
+        const cap = new SelfPullCapability();
+        const result = await cap.execute(makeContext());
+
+        expect(stashCalls).toContainEqual(
+          expect.arrayContaining(['stash', 'pop']),
+        );
+        // Stash was successfully restored, so this is the same benign
+        // "pull skipped" outcome as a clean tree hitting the same pull
+        // failure — the user's local changes are back, nothing lost.
+        expect(result.success).toBe(true);
+        expect(result.summary).toContain('skipped');
+      });
+
+      // Regression (critical): the failure-safety invariant — if the stash
+      // genuinely cannot be restored after a pull failure, that must be a
+      // visible failure, not folded into the same "skipped" success message
+      // as the benign case above.
+      it('reports failure when both pull and stash pop fail — does not mask a stuck stash as "skipped"', async () => {
+        mockExecFileSync.mockImplementation((_cmd: unknown, args: unknown) => {
+          const a = args as string[];
+          if (a[0] === 'stash' && a[1] === 'pop') throw new Error('conflict after failed pull');
+          if (a[0] === 'stash') return '';
+          if (a.includes('rev-parse')) return 'abc123\n';
+          if (a.includes('--porcelain')) return 'M file.txt\n';
+          return '';
+        });
+        mockExecFile.mockImplementation((...args: unknown[]) => {
+          const cb = findCallback(args);
+          if (cb) cb(new Error('not a fast-forward'));
+          return {};
+        });
+
+        const cap = new SelfPullCapability();
+        const result = await cap.execute(makeContext());
+        expect(result.success).toBe(false);
+        expect(result.summary).toContain('pull failed');
+        expect(result.summary).toContain('left local changes stashed');
       });
 
       it('detects source changes and recommends restart', async () => {


### PR DESCRIPTION
### What
`SelfPullCapability.execute()` now always attempts `git stash pop` after fetch/pull, regardless of whether the pull succeeded, and reports failure (not success) when the stash genuinely can't be restored.

### Why
Closes #1639

Full repro and root cause are in the issue. Short version: the capability stashed uncommitted local changes before `git pull --ff-only`, but the pop only ran on the path where fetch+pull both succeeded — the whole method was one `try` block, so a thrown pull error (diverged history, no tracking branch, network blip) jumped straight to the outer `catch`, skipping the pop entirely, and that catch reported `{success: true, summary: 'git pull skipped ...'}`. The user's uncommitted work was left sitting in `git stash`, working tree looking clean, nothing in the round output saying so. Watch runs unattended, so this can happen more than once with no one watching.

### How
- `packages/squad-cli/src/cli/commands/watch/capabilities/self-pull.ts`: fetch/pull failure is now caught locally into `pullError` instead of via the outer catch. The stash-pop block runs unconditionally right after, tracked via `stashRestored`. If the stash isn't restored (pop threw, whether or not pull also failed), that's now `{success: false, summary: '...run \`git stash pop\` in <cwd> manually'}` so the watch loop's existing `⚠` warning line (`index.ts:490-492`) actually surfaces it. If pull failed but the stash *did* pop cleanly, behavior is unchanged from before — `{success: true, summary: 'git pull skipped (not on tracking branch or conflicts)'}`, since nothing was actually lost.
- Grepped the whole repo for other `'stash'` call sites — `self-pull.ts` is the only one. No sibling move path to fix.

### Testing
Real end-to-end repro (not mocked), against the actual bug scenario — diverged local branch with an uncommitted change on top, pull rejected as non-fast-forward:
```
CAPABILITY RESULT: {"success":true,"summary":"git pull skipped (not on tracking branch or conflicts)"}
STATUS AFTER:
 M file.txt

WORKING TREE FILE AFTER:
line1
local change
UNCOMMITTED WORK - MUST NOT BE LOST

STASH LIST AFTER: ""
```
Before the fix, the same setup produced `STATUS AFTER:` empty and the file content silently missing the last line, with it sitting in `git stash list` instead.

Added to `test/cli/watch-capabilities.test.ts` (existing `SelfPullCapability` describe block, same mock style as the rest of the file):
- Updated the existing "stash pop conflict" test — it asserted `success: true` before, which was the same silent-success bug in miniature; now asserts `success: false` and the surfaced summary.
- New: dirty tree + pull failure still calls `git stash pop` (fails on unfixed code — `stashCalls` never contains `['stash', 'pop']` there since the pop is unreachable) and comes back `success: true` once the stash is confirmed restored.
- New: dirty tree + pull failure + pop also failing → `success: false`, summary names both causes.
- Ran the two new/changed tests against unfixed `dev` first to confirm they fail (3 failures, exactly the ones exercising the bug), then against the fix (all pass).

```
npx vitest run test/cli/watch-capabilities.test.ts -t "SelfPullCapability"
 Test Files  1 passed (1)
      Tests  10 passed | 45 skipped (55)
```

Full `test/cli/watch-capabilities.test.ts`: 54/55 pass. The 1 failure (`ExecuteCapability > buildAgentPrompt > checks .squad/ralph-instructions.md inside teamRoot`) is a pre-existing Windows path-separator mismatch unrelated to this change — confirmed present on unmodified `dev` too (stashed my diff, reran, same failure).

Full-suite (`npx vitest run`, fresh `dist` for both packages): 108 failures / 7202 passed. None touch `self-pull` or `watch-capabilities`. Spot-checked `watch-health.test.ts` (11 failures in the full run, all `Test timed out in 5000ms`) — passes 11/11 clean in isolation, so that's resource contention under the full parallel run, not a real regression; it also has zero code relationship to `self-pull.ts` (only references the string `'self-pull'` in capability-name fixtures).

`npm run build -w packages/squad-cli` passes (after rebuilding `squad-sdk` first — its `dist` was stale on this box, unrelated to this PR, same class of issue as documented on prior PRs). `npx tsc --noEmit -p packages/squad-cli/tsconfig.json` clean. `eslint` on both changed files: 0 errors, 8 warnings — all pre-existing `n/no-sync`/`no-console` style warnings already present in this file's existing patterns, not new.

Diff hygiene: `git diff` vs `git diff -w` differ only in the fetch/pull block, which is exactly the 2-space reindent from wrapping it in the new local `try` — not stray whitespace. Both files are LF in this repo; verified no CRLF got introduced.

---

### ⚠️ Quick Check
- [x] Changeset added: `.changeset/fix-1639-self-pull-stash-loss.md` (patch `@bradygaster/squad-cli`)

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev`
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes (2 source/test files + changeset)
- [x] PR is not in draft mode
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] `npm run build -w packages/squad-cli` passes
- [x] `npm test` — targeted suite 10/10 (SelfPullCapability), full file 54/55 (1 pre-existing unrelated failure), full-suite baseline compared against unmodified `dev`
- [x] `npm run lint` passes (tsc clean)
- [x] `eslint` — 0 errors

#### Changeset
- [x] Changeset added (cli patch)

#### Docs
- [x] N/A — internal capability behavior fix, no public API/CLI surface changed

#### Exports
- [x] N/A

---

### Breaking Changes
None. `CapabilityResult.success` for this capability can now be `false` in a case it previously always reported `true` for — that's the fix, not a break: the watch loop already treats `success: false` as a normal per-round warning (`⚠` line), not a fatal error, same as every other capability.

### Waivers
None.