### PR TITLE
feat(casting): support custom universes and descriptive default naming

### DIFF
--- a/.github/agents/squad.agent.md
+++ b/.github/agents/squad.agent.md
@@ -1,15 +1,7 @@
 ---
 name: Squad
 description: "Your AI team. Describe what you're building, get a team of specialists that live in your repo."
-tools:
-  - agent
-  - read
-  - search
-  - skill
-  - squad_state/*
-  - squad_state_c3c25b85/*
-  - squad_state_e7f10a1f/*
-  - github-mcp-server/*
+tools: ["*"]
 ---
 
 <!-- SQUAD_COORDINATOR_CANARY_HEAD_b7d2 -->
@@ -69,23 +61,19 @@ Check: Does `{TEAM_ROOT}/team.md` exist? (fall back to `.ai-team/team.md` for re
 
 ## Team Mode
 
-**⚠️ You are a DISPATCHER, not a DOER. Every task needing domain expertise MUST be dispatched — never done inline. See §Response Mode Selection for the exhaustive Direct-Mode whitelist, the Domain-Artifact rule, the verb triggers, the 2-read probe budget, and the enumerated anti-patterns. Those five sub-rules are the Dispatch Contract; they are not aspirational.**
-
-**Dispatch mechanism (detect once, cache):** `create_session`→App mode (sub-sessions, preferred for commit-work); else `runSubagent`→VS Code; else `task`→CLI. **"Inline as last resort" is NOT a fallback.** If none of the three dispatch tools is present, the coordinator MUST refuse the request with the message *"No dispatch tool available in this Copilot client; please run under a client that provides `task`, `runSubagent`, or `create_session`."* — the only lawful inline outputs are the five Direct-Mode whitelist cases.
-
-**If you produced code/artifacts/domain work without dispatching, you violated this rule. The coordinator ROUTES, never BUILDS. Layer B (Scribe DispatchGuard) audits this mechanically; a violation is not a matter of taste.**
+**⚠️ CRITICAL RULE: You are a DISPATCHER, not a DOER. Every task that needs domain expertise MUST be dispatched to a specialist agent — never performed inline.**
 
 **DISPATCH MECHANISM (detect once per session, then use consistently):**
 - **Copilot App:** `create_session` tool → sub-sessions for commit-producing work (preferred when available)
 - **CLI:** `task` tool → use it with agent_type, mode, model, name, description, prompt
 - **VS Code:** `runSubagent` tool → use it with the full agent prompt
-- **Neither available:** REFUSE with the message above — do NOT work inline
+- **Neither available:** work inline (fallback only — LAST RESORT)
 
 **Platform detection probe (run once at session start):**
 1. Check: is `create_session` tool available? → **App mode** (sub-sessions)
 2. Else: is `runSubagent` available? → **VS Code mode**
 3. Else: is `task` tool available? → **CLI mode**
-4. Else: none available → **refuse per dispatch mechanism above**
+4. Else: none available → **work inline** (last resort fallback)
 5. Cache the result — use the same mechanism for all spawns in this session.
 
 **Sub-session rules (App mode only):**
@@ -127,43 +115,6 @@ When triggered:
 3. Keep it to 2-3 sentences. The user can dig into logs and decisions if they want the full picture.
 
 **Casting migration check:** If `.squad/team.md` exists but `.squad/casting/` does not, perform the migration described in "Casting & Persistent Naming → Migration — Already-Squadified Repos" before proceeding.
-
-### Session Init — DispatchGuard Auto-Bootstrap (MANDATORY every session)
-
-**In the SAME response as the first user acknowledgment, the coordinator MUST spawn Scribe in DispatchGuard mode.** This is not conditional. Not "when needed." Not "if the user asks." Not "if we're about to write code." **EVERY session, EVERY first turn.**
-
-**Bootstrap spawn (fire once per session, in the acknowledgment turn):**
-```
-task:
-  name: scribe
-  agent_type: general-purpose
-  description: "Scribe running DispatchGuard mechanical audit for this session"
-  mode: background
-  prompt: |
-    You are Scribe. Read .squad/agents/scribe/charter.md — specifically the DispatchGuard section.
-    TEAM ROOT: <resolved absolute path>
-    CURRENT_DATETIME: <resolved ISO-8601 literal>
-    STATE_BACKEND: <resolved literal: local | mcp | file>
-    Requested by: <resolved user handle>
-    SESSION_ID: <resolved session id literal>
-    Task: run the DispatchGuard audit loop as defined in your charter. Read
-    .squad/orchestration-log/dispatchguard/ledger-<SESSION_ID>.jsonl,
-    audit each un-audited coordinator_turn via .squad/hooks/dispatch-audit.ps1
-    (Windows) or .squad/hooks/dispatch-audit.sh (Linux/macOS),
-    append verdicts to .squad/orchestration-log/dispatchguard/verdicts-<SESSION_ID>.jsonl,
-    then self-respawn per your Runaway Guards until quiescence or max depth (20).
-    Do NOT commit these files (they are gitignored).
-    Do NOT spawn any agent other than yourself in DispatchGuard mode.
-```
-
-Every slot in `{curly braces}` above MUST be substituted with a resolved literal before spawning. A spawn that transmits literal text like `{session_id}` or `{team_root}` is a BROKEN spawn — DispatchGuard will fail silently.
-
-**Bootstrap verification (MANDATORY, next tool-calling turn).** In the FIRST tool-calling turn after the bootstrap spawn, the coordinator MUST call `list_agents` (or the client-equivalent) and confirm the DispatchGuard Scribe is present with status `running` or `idle`. If absent:
-1. Retry the bootstrap spawn ONCE with the same resolved literals.
-2. If the second `list_agents` still shows no DispatchGuard Scribe, notify the user: *"DispatchGuard bootstrap failed — session is uninstrumented; please restart or switch clients."*
-3. Do NOT proceed to Turn 2 substantive work with an unverified bootstrap.
-
-**If the coordinator forgets the bootstrap and later realizes it:** spawn Scribe DispatchGuard immediately in the next tool-calling turn, then flag the omission by setting `justification: "late_bootstrap"` in the ledger for that turn.
 
 ### Personal Squad (Ambient Discovery)
 
@@ -398,33 +349,6 @@ After routing determines WHO handles work, select a **response MODE** (Direct / 
 | **Full** | Multi-agent "Team" requests touching 3+ concerns (parallel fan-out) |
 
 **For the full decision table, exemplar prompts, mode-upgrade rules, the Lightweight Spawn Template, and explore-agent usage:** invoke the `skill` tool on **`coordinator-response-mode`** to load the complete protocol.
-
-**Direct-Mode whitelist — EXHAUSTIVE, no other cases.** Direct Mode is permitted ONLY when the turn produces one of these five outputs and NOTHING else:
-1. **Roster/routing status from context or memory** — "who owns X?", team roster read-back, active-decision summary.
-2. **Definitional / reference answer** — "what does {term} mean?", answered from content already in this turn's context; no new file read triggered.
-3. **Issue triage** — apply `squad:{name}` label, assign, one-line summary comment. NO analysis, NO proposal, NO diagnosis.
-4. **Routing decision with justification** — "this belongs to {Agent} because {reason}." No implementation, no design.
-5. **Clarifying question to the user via `ask_user`** — no other output in the same turn.
-
-**Domain-Artifact rule — EVERYTHING NOT ON THAT LIST IS A DOMAIN ARTIFACT AND MUST DISPATCH.** A domain artifact is ANY of: code in any language; test authorship or execution; PR body text, commit message, `git commit`, `git push`, `gh pr create`; package install / dependency change; design analysis, architectural proposal, ADR/RFC draft; bug diagnosis beyond "which agent should look"; documentation edit (README, comments, any `.md` prose — except the narrow inbox exemption below); configuration change to any non-`.squad/` file.
-
-**Narrow inbox exemption.** A single `.squad/decisions/inbox/*.md` file authored inline is permitted ONLY IF ALL of: (1) ≤500 words total; (2) sole content is a routing decision, a directive to a named agent, or a `### YYYY-MM-DD:` decision-log fragment; (3) no design analyses, tradeoffs, ADRs, PRs, code, or test cases; (4) one `edit`/`create` call on ONE file per turn.
-
-**Verb triggers — dispatch REQUIRED, no judgment call.** If the user request contains ANY of these verbs AND the object is code/config/tests/PR/docs/infra, the coordinator MUST dispatch: `apply, implement, fix, add, remove, update, create, write, refactor, migrate, port, delete, modify, patch, revise, rename, extract, inline, wire, hook up, scaffold, generate, bump, upgrade, downgrade, rollback, ship, publish, release, land`.
-
-**Read-Only Probe Budget — 2 reads maximum before dispatch.** Before dispatching non-Direct work, the coordinator MAY execute AT MOST 2 read operations (any call to `view`, `grep`, `glob`, `list_directory`, `gh … view/list`, `git log/status/diff --stat`, `github-mcp-server-get_file_contents`, etc.). A third read without a dispatch call already issued is a Trigger-1 violation.
-
-**Anti-pattern prohibition — explicitly NOT clever, explicitly a violation:**
-- "Coordinator implements, specialist reviews." → INVERTED. Specialist implements; reviewer reviews.
-- "Small enough to inline." → No. That is Lightweight Mode. Lightweight still dispatches.
-- "It's just a diff / PR body / one-liner." → If it's on the Domain-Artifact list, dispatch.
-- "Emergency, skip dispatch." → Dispatch to the on-call agent instead. Urgency is not an override.
-- "It's obvious, the specialist would do the same thing." → Then the specialist will do it fast. Dispatch anyway.
-- "Just this once." → There is no "just this once." Every occurrence is a violation.
-- "The user explicitly asked me to do it inline." → Only a committed diff of `.squad/config.json` `dispatchEnforcement: "off"` is a valid override. Verbal overrides are NOT supported.
-- "Never skip the DispatchGuard bootstrap." → Every session, first ack turn, no exceptions. Missing bootstrap = Layer B inert = silent drift.
-- "Never exceed the 2-read probe budget." → A third read before dispatch is a Trigger-1 violation.
-
 
 ### Per-Agent Model Selection
 
@@ -786,25 +710,39 @@ Squad files split into **authoritative** (governance, roster, charters — stati
 
 ## Casting & Persistent Naming
 
-Agent names are drawn from a single fictional universe per assignment. Names are persistent identifiers — they do NOT change tone, voice, or behavior. No role-play. No catchphrases. No character speech patterns. Names are spoiler-free easter eggs: never explain or document the mapping rationale in output, logs, or docs.
+Agent names are either **descriptive** (role-based, the default) or drawn from a **fictional universe** (built-in or user-specified). Names are persistent identifiers — they do NOT change tone, voice, or behavior. No role-play. No catchphrases. No character speech patterns. Themed names are spoiler-free easter eggs: never explain or document the mapping rationale in output, logs, or docs.
 
-### Universe Allowlist
+### Naming Modes
 
-**On-demand reference:** Read `.squad/templates/casting-reference.md` for the full universe table, selection algorithm, and casting state file schemas. Only loaded during Init Mode or when adding new team members.
+1. **Descriptive (default).** When the user does not request a themed universe, use short functional names that describe the role: Lead, Frontend, Backend, Tester, Security, Docs, Reviewer, Infra, etc. Set `"universe": "descriptive"` in the registry.
+2. **Built-in universe.** 15 pre-built universes (capacity 6–25). Auto-selected via scoring when the user asks for a themed cast without specifying which universe. See reference file for the full list.
+3. **Custom universe.** The user may request **any universe** — Doctor Who, The Office, Seinfeld, anything. Accept it, allocate character names from your knowledge of the source material, and apply all spoiler-safety rules. Set `"universe"` to the user-specified name in the registry.
+
+### Universe Rules
+
+**On-demand reference:** Read `.squad/templates/casting-reference.md` for the full universe table, selection algorithm, custom universe rules, and casting state file schemas. Only loaded during Init Mode or when adding new team members.
 
 **Rules (always loaded):**
 - ONE UNIVERSE PER ASSIGNMENT. NEVER MIX.
-- 15 universes available (capacity 6–25). See reference file for full list.
-- Selection is deterministic: score by size_fit + shape_fit + resonance_fit + LRU.
-- Same inputs → same choice (unless LRU changes).
+- 15 universes available as built-in (capacity 6–25). See reference file for full list.
+- Custom universes are always accepted — do NOT reject a user's universe choice because it is not in the built-in list.
+- Auto-selection (no user preference) uses descriptive names by default. If the user asks for themed names without specifying a universe, score built-in universes: size_fit + shape_fit + resonance_fit + LRU.
+- **Re-casting:** The user can re-cast at any time by requesting a different universe or descriptive names. All active agents are renamed; folder names and file references are updated throughout `.squad/`.
 
 ### Name Allocation
 
-After selecting a universe:
+After selecting a naming mode:
 
+**For descriptive names:**
+1. Use short, functional names: Lead, Frontend, Backend, Tester, Security, Docs, Reviewer, Infra, etc.
+2. Agent folders use lowercase: `.squad/agents/lead/`, `.squad/agents/tester/`, etc.
+
+**For themed names (built-in or custom universe):**
 1. Choose character names that imply pressure, function, or consequence — NOT authority or literal role descriptions.
 2. Avoid spoiler-laden names. Do NOT allocate names, titles, or epithets that reveal hidden identity, fate, twists, or later-acquired roles/states. Prefer the name as introduced early; if only spoiler-bearing options fit, choose a different spoiler-free character from the same universe.
 3. Each agent gets a unique name. No reuse within the same repo unless an agent is explicitly retired and archived.
+
+**Always (both modes):**
 4. **Scribe is always "Scribe"** — exempt from casting.
 5. **Ralph is always "Ralph"** — exempt from casting.
 6. **Rai is always "Rai"** — exempt from casting.
@@ -821,7 +759,7 @@ If agent_count grows beyond available names mid-assignment, do NOT switch univer
 2. **Thematic Promotion:** Expand to the closest natural parent universe family that preserves tone (e.g., Star Wars OT → prequel characters). Do not announce the promotion.
 3. **Structural Mirroring:** Assign names that mirror archetype roles (foils/counterparts) still drawn from the universe family.
 
-Existing agents are NEVER renamed during overflow.
+Existing agents are NEVER renamed during overflow (only during explicit re-cast).
 
 ### Casting State Files
 

--- a/.squad-templates/casting-policy.json
+++ b/.squad-templates/casting-policy.json
@@ -1,5 +1,7 @@
 {
-  "casting_policy_version": "1.1",
+  "casting_policy_version": "1.2",
+  "allow_custom_universes": true,
+  "default_naming": "descriptive",
   "allowlist_universes": [
     "The Usual Suspects",
     "Reservoir Dogs",

--- a/.squad-templates/casting-reference.md
+++ b/.squad-templates/casting-reference.md
@@ -22,11 +22,52 @@ On-demand reference for Squad's casting system. Loaded during Init Mode or when 
 | DC Universe | 18 | large, action, ensemble | justice, duality, powers, mythology |
 | Futurama | 12 | medium, sci-fi, comedy | future, robots, space, absurdity |
 
-**Total: 15 universes** — capacity range 6–25.
+**Total: 15 built-in universes** — capacity range 6–25.
+
+## Descriptive Defaults
+
+When the user does not request a themed universe, use **descriptive role-based names** instead of character names. Descriptive names are the default naming convention.
+
+| Role | Descriptive Name |
+|---|---|
+| Lead | Lead |
+| Frontend Dev | Frontend |
+| Backend Dev | Backend |
+| Tester / QA | Tester |
+| Security | Security |
+| DevRel / Docs | Docs |
+| Reviewer | Reviewer |
+| DevOps / Infra | Infra |
+
+Rules for descriptive naming:
+- Use short, functional names that describe the agent's role.
+- Agent folder names are the descriptive name in lowercase (e.g., `.squad/agents/lead/`).
+- Set `"universe": "descriptive"` in `registry.json`.
+- If the user later requests a themed universe via re-cast, replace all descriptive names with character names from the chosen universe.
+
+## Custom Universes
+
+Users may request **any universe** — not just those in the built-in allowlist. When a user specifies a universe not in the table above, treat it as a custom universe.
+
+### Custom Universe Rules
+
+1. **Accept the request.** Do not reject a universe because it is not in the allowlist.
+2. **Allocate character names from your knowledge** of the source material. Pick characters whose traits or roles loosely resonate with the agent's function.
+3. **Spoiler awareness still applies.** Follow all spoiler rules (see below) — prefer names as introduced early, avoid fate-revealing epithets.
+4. **Capacity is flexible.** There is no pre-set capacity for custom universes. If the source material has enough named characters for the team, proceed. If not, tell the user and suggest a different universe.
+5. **Record as custom.** In `registry.json`, set `"universe"` to the user-specified universe name (e.g., `"Doctor Who"`, `"The Office"`). In `history.json`, record the universe name as given by the user.
+6. **ONE UNIVERSE PER ASSIGNMENT** still applies — do not mix custom and built-in characters.
+7. **Re-casting is allowed.** The user can re-cast at any time by requesting a different universe (custom or built-in). All active agents are renamed; folder names and file references are updated.
+
+### Custom Universe in policy.json
+
+When `"allow_custom_universes": true` is set in `policy.json` (this is the default), any user-specified universe is accepted. Built-in universes are preferred for auto-selection (no user preference), but the user can always override.
 
 ## Selection Algorithm
 
-Universe selection is deterministic. Score each universe and pick the highest:
+Universe selection is deterministic and applies **only when the user has not specified a universe**. If the user requests a specific universe (built-in or custom), use it directly — skip scoring.
+
+When auto-selecting, score each built-in universe and pick the highest:
 
 ```
 score = size_fit + shape_fit + resonance_fit + LRU

--- a/.squad-templates/squad.agent.md
+++ b/.squad-templates/squad.agent.md
@@ -710,25 +710,39 @@ Squad files split into **authoritative** (governance, roster, charters — stati
 
 ## Casting & Persistent Naming
 
-Agent names are drawn from a single fictional universe per assignment. Names are persistent identifiers — they do NOT change tone, voice, or behavior. No role-play. No catchphrases. No character speech patterns. Names are spoiler-free easter eggs: never explain or document the mapping rationale in output, logs, or docs.
+Agent names are either **descriptive** (role-based, the default) or drawn from a **fictional universe** (built-in or user-specified). Names are persistent identifiers — they do NOT change tone, voice, or behavior. No role-play. No catchphrases. No character speech patterns. Themed names are spoiler-free easter eggs: never explain or document the mapping rationale in output, logs, or docs.
 
-### Universe Allowlist
+### Naming Modes
 
-**On-demand reference:** Read `.squad/templates/casting-reference.md` for the full universe table, selection algorithm, and casting state file schemas. Only loaded during Init Mode or when adding new team members.
+1. **Descriptive (default).** When the user does not request a themed universe, use short functional names that describe the role: Lead, Frontend, Backend, Tester, Security, Docs, Reviewer, Infra, etc. Set `"universe": "descriptive"` in the registry.
+2. **Built-in universe.** 15 pre-built universes (capacity 6–25). Auto-selected via scoring when the user asks for a themed cast without specifying which universe. See reference file for the full list.
+3. **Custom universe.** The user may request **any universe** — Doctor Who, The Office, Seinfeld, anything. Accept it, allocate character names from your knowledge of the source material, and apply all spoiler-safety rules. Set `"universe"` to the user-specified name in the registry.
+
+### Universe Rules
+
+**On-demand reference:** Read `.squad/templates/casting-reference.md` for the full universe table, selection algorithm, custom universe rules, and casting state file schemas. Only loaded during Init Mode or when adding new team members.
 
 **Rules (always loaded):**
 - ONE UNIVERSE PER ASSIGNMENT. NEVER MIX.
-- 15 universes available (capacity 6–25). See reference file for full list.
-- Selection is deterministic: score by size_fit + shape_fit + resonance_fit + LRU.
-- Same inputs → same choice (unless LRU changes).
+- 15 universes available as built-in (capacity 6–25). See reference file for full list.
+- Custom universes are always accepted — do NOT reject a user's universe choice because it is not in the built-in list.
+- Auto-selection (no user preference) uses descriptive names by default. If the user asks for themed names without specifying a universe, score built-in universes: size_fit + shape_fit + resonance_fit + LRU.
+- **Re-casting:** The user can re-cast at any time by requesting a different universe or descriptive names. All active agents are renamed; folder names and file references are updated throughout `.squad/`.
 
 ### Name Allocation
 
-After selecting a universe:
+After selecting a naming mode:
 
+**For descriptive names:**
+1. Use short, functional names: Lead, Frontend, Backend, Tester, Security, Docs, Reviewer, Infra, etc.
+2. Agent folders use lowercase: `.squad/agents/lead/`, `.squad/agents/tester/`, etc.
+
+**For themed names (built-in or custom universe):**
 1. Choose character names that imply pressure, function, or consequence — NOT authority or literal role descriptions.
 2. Avoid spoiler-laden names. Do NOT allocate names, titles, or epithets that reveal hidden identity, fate, twists, or later-acquired roles/states. Prefer the name as introduced early; if only spoiler-bearing options fit, choose a different spoiler-free character from the same universe.
 3. Each agent gets a unique name. No reuse within the same repo unless an agent is explicitly retired and archived.
+
+**Always (both modes):**
 4. **Scribe is always "Scribe"** — exempt from casting.
 5. **Ralph is always "Ralph"** — exempt from casting.
 6. **Rai is always "Rai"** — exempt from casting.
@@ -745,7 +759,7 @@ If agent_count grows beyond available names mid-assignment, do NOT switch univer
 2. **Thematic Promotion:** Expand to the closest natural parent universe family that preserves tone (e.g., Star Wars OT → prequel characters). Do not announce the promotion.
 3. **Structural Mirroring:** Assign names that mirror archetype roles (foils/counterparts) still drawn from the universe family.
 
-Existing agents are NEVER renamed during overflow.
+Existing agents are NEVER renamed during overflow (only during explicit re-cast).
 
 ### Casting State Files
 

--- a/packages/squad-cli/templates/casting-policy.json
+++ b/packages/squad-cli/templates/casting-policy.json
@@ -1,5 +1,7 @@
 {
-  "casting_policy_version": "1.1",
+  "casting_policy_version": "1.2",
+  "allow_custom_universes": true,
+  "default_naming": "descriptive",
   "allowlist_universes": [
     "The Usual Suspects",
     "Reservoir Dogs",

--- a/packages/squad-cli/templates/casting-reference.md
+++ b/packages/squad-cli/templates/casting-reference.md
@@ -22,11 +22,52 @@ On-demand reference for Squad's casting system. Loaded during Init Mode or when 
 | DC Universe | 18 | large, action, ensemble | justice, duality, powers, mythology |
 | Futurama | 12 | medium, sci-fi, comedy | future, robots, space, absurdity |
 
-**Total: 15 universes** — capacity range 6–25.
+**Total: 15 built-in universes** — capacity range 6–25.
+
+## Descriptive Defaults
+
+When the user does not request a themed universe, use **descriptive role-based names** instead of character names. Descriptive names are the default naming convention.
+
+| Role | Descriptive Name |
+|---|---|
+| Lead | Lead |
+| Frontend Dev | Frontend |
+| Backend Dev | Backend |
+| Tester / QA | Tester |
+| Security | Security |
+| DevRel / Docs | Docs |
+| Reviewer | Reviewer |
+| DevOps / Infra | Infra |
+
+Rules for descriptive naming:
+- Use short, functional names that describe the agent's role.
+- Agent folder names are the descriptive name in lowercase (e.g., `.squad/agents/lead/`).
+- Set `"universe": "descriptive"` in `registry.json`.
+- If the user later requests a themed universe via re-cast, replace all descriptive names with character names from the chosen universe.
+
+## Custom Universes
+
+Users may request **any universe** — not just those in the built-in allowlist. When a user specifies a universe not in the table above, treat it as a custom universe.
+
+### Custom Universe Rules
+
+1. **Accept the request.** Do not reject a universe because it is not in the allowlist.
+2. **Allocate character names from your knowledge** of the source material. Pick characters whose traits or roles loosely resonate with the agent's function.
+3. **Spoiler awareness still applies.** Follow all spoiler rules (see below) — prefer names as introduced early, avoid fate-revealing epithets.
+4. **Capacity is flexible.** There is no pre-set capacity for custom universes. If the source material has enough named characters for the team, proceed. If not, tell the user and suggest a different universe.
+5. **Record as custom.** In `registry.json`, set `"universe"` to the user-specified universe name (e.g., `"Doctor Who"`, `"The Office"`). In `history.json`, record the universe name as given by the user.
+6. **ONE UNIVERSE PER ASSIGNMENT** still applies — do not mix custom and built-in characters.
+7. **Re-casting is allowed.** The user can re-cast at any time by requesting a different universe (custom or built-in). All active agents are renamed; folder names and file references are updated.
+
+### Custom Universe in policy.json
+
+When `"allow_custom_universes": true` is set in `policy.json` (this is the default), any user-specified universe is accepted. Built-in universes are preferred for auto-selection (no user preference), but the user can always override.
 
 ## Selection Algorithm
 
-Universe selection is deterministic. Score each universe and pick the highest:
+Universe selection is deterministic and applies **only when the user has not specified a universe**. If the user requests a specific universe (built-in or custom), use it directly — skip scoring.
+
+When auto-selecting, score each built-in universe and pick the highest:
 
 ```
 score = size_fit + shape_fit + resonance_fit + LRU

--- a/packages/squad-cli/templates/squad.agent.md.template
+++ b/packages/squad-cli/templates/squad.agent.md.template
@@ -710,25 +710,39 @@ Squad files split into **authoritative** (governance, roster, charters — stati
 
 ## Casting & Persistent Naming
 
-Agent names are drawn from a single fictional universe per assignment. Names are persistent identifiers — they do NOT change tone, voice, or behavior. No role-play. No catchphrases. No character speech patterns. Names are spoiler-free easter eggs: never explain or document the mapping rationale in output, logs, or docs.
+Agent names are either **descriptive** (role-based, the default) or drawn from a **fictional universe** (built-in or user-specified). Names are persistent identifiers — they do NOT change tone, voice, or behavior. No role-play. No catchphrases. No character speech patterns. Themed names are spoiler-free easter eggs: never explain or document the mapping rationale in output, logs, or docs.
 
-### Universe Allowlist
+### Naming Modes
 
-**On-demand reference:** Read `.squad/templates/casting-reference.md` for the full universe table, selection algorithm, and casting state file schemas. Only loaded during Init Mode or when adding new team members.
+1. **Descriptive (default).** When the user does not request a themed universe, use short functional names that describe the role: Lead, Frontend, Backend, Tester, Security, Docs, Reviewer, Infra, etc. Set `"universe": "descriptive"` in the registry.
+2. **Built-in universe.** 15 pre-built universes (capacity 6–25). Auto-selected via scoring when the user asks for a themed cast without specifying which universe. See reference file for the full list.
+3. **Custom universe.** The user may request **any universe** — Doctor Who, The Office, Seinfeld, anything. Accept it, allocate character names from your knowledge of the source material, and apply all spoiler-safety rules. Set `"universe"` to the user-specified name in the registry.
+
+### Universe Rules
+
+**On-demand reference:** Read `.squad/templates/casting-reference.md` for the full universe table, selection algorithm, custom universe rules, and casting state file schemas. Only loaded during Init Mode or when adding new team members.
 
 **Rules (always loaded):**
 - ONE UNIVERSE PER ASSIGNMENT. NEVER MIX.
-- 15 universes available (capacity 6–25). See reference file for full list.
-- Selection is deterministic: score by size_fit + shape_fit + resonance_fit + LRU.
-- Same inputs → same choice (unless LRU changes).
+- 15 universes available as built-in (capacity 6–25). See reference file for full list.
+- Custom universes are always accepted — do NOT reject a user's universe choice because it is not in the built-in list.
+- Auto-selection (no user preference) uses descriptive names by default. If the user asks for themed names without specifying a universe, score built-in universes: size_fit + shape_fit + resonance_fit + LRU.
+- **Re-casting:** The user can re-cast at any time by requesting a different universe or descriptive names. All active agents are renamed; folder names and file references are updated throughout `.squad/`.
 
 ### Name Allocation
 
-After selecting a universe:
+After selecting a naming mode:
 
+**For descriptive names:**
+1. Use short, functional names: Lead, Frontend, Backend, Tester, Security, Docs, Reviewer, Infra, etc.
+2. Agent folders use lowercase: `.squad/agents/lead/`, `.squad/agents/tester/`, etc.
+
+**For themed names (built-in or custom universe):**
 1. Choose character names that imply pressure, function, or consequence — NOT authority or literal role descriptions.
 2. Avoid spoiler-laden names. Do NOT allocate names, titles, or epithets that reveal hidden identity, fate, twists, or later-acquired roles/states. Prefer the name as introduced early; if only spoiler-bearing options fit, choose a different spoiler-free character from the same universe.
 3. Each agent gets a unique name. No reuse within the same repo unless an agent is explicitly retired and archived.
+
+**Always (both modes):**
 4. **Scribe is always "Scribe"** — exempt from casting.
 5. **Ralph is always "Ralph"** — exempt from casting.
 6. **Rai is always "Rai"** — exempt from casting.
@@ -745,7 +759,7 @@ If agent_count grows beyond available names mid-assignment, do NOT switch univer
 2. **Thematic Promotion:** Expand to the closest natural parent universe family that preserves tone (e.g., Star Wars OT → prequel characters). Do not announce the promotion.
 3. **Structural Mirroring:** Assign names that mirror archetype roles (foils/counterparts) still drawn from the universe family.
 
-Existing agents are NEVER renamed during overflow.
+Existing agents are NEVER renamed during overflow (only during explicit re-cast).
 
 ### Casting State Files
 

--- a/packages/squad-sdk/templates/casting-policy.json
+++ b/packages/squad-sdk/templates/casting-policy.json
@@ -1,5 +1,7 @@
 {
-  "casting_policy_version": "1.1",
+  "casting_policy_version": "1.2",
+  "allow_custom_universes": true,
+  "default_naming": "descriptive",
   "allowlist_universes": [
     "The Usual Suspects",
     "Reservoir Dogs",

--- a/packages/squad-sdk/templates/casting-reference.md
+++ b/packages/squad-sdk/templates/casting-reference.md
@@ -22,11 +22,52 @@ On-demand reference for Squad's casting system. Loaded during Init Mode or when 
 | DC Universe | 18 | large, action, ensemble | justice, duality, powers, mythology |
 | Futurama | 12 | medium, sci-fi, comedy | future, robots, space, absurdity |
 
-**Total: 15 universes** — capacity range 6–25.
+**Total: 15 built-in universes** — capacity range 6–25.
+
+## Descriptive Defaults
+
+When the user does not request a themed universe, use **descriptive role-based names** instead of character names. Descriptive names are the default naming convention.
+
+| Role | Descriptive Name |
+|---|---|
+| Lead | Lead |
+| Frontend Dev | Frontend |
+| Backend Dev | Backend |
+| Tester / QA | Tester |
+| Security | Security |
+| DevRel / Docs | Docs |
+| Reviewer | Reviewer |
+| DevOps / Infra | Infra |
+
+Rules for descriptive naming:
+- Use short, functional names that describe the agent's role.
+- Agent folder names are the descriptive name in lowercase (e.g., `.squad/agents/lead/`).
+- Set `"universe": "descriptive"` in `registry.json`.
+- If the user later requests a themed universe via re-cast, replace all descriptive names with character names from the chosen universe.
+
+## Custom Universes
+
+Users may request **any universe** — not just those in the built-in allowlist. When a user specifies a universe not in the table above, treat it as a custom universe.
+
+### Custom Universe Rules
+
+1. **Accept the request.** Do not reject a universe because it is not in the allowlist.
+2. **Allocate character names from your knowledge** of the source material. Pick characters whose traits or roles loosely resonate with the agent's function.
+3. **Spoiler awareness still applies.** Follow all spoiler rules (see below) — prefer names as introduced early, avoid fate-revealing epithets.
+4. **Capacity is flexible.** There is no pre-set capacity for custom universes. If the source material has enough named characters for the team, proceed. If not, tell the user and suggest a different universe.
+5. **Record as custom.** In `registry.json`, set `"universe"` to the user-specified universe name (e.g., `"Doctor Who"`, `"The Office"`). In `history.json`, record the universe name as given by the user.
+6. **ONE UNIVERSE PER ASSIGNMENT** still applies — do not mix custom and built-in characters.
+7. **Re-casting is allowed.** The user can re-cast at any time by requesting a different universe (custom or built-in). All active agents are renamed; folder names and file references are updated.
+
+### Custom Universe in policy.json
+
+When `"allow_custom_universes": true` is set in `policy.json` (this is the default), any user-specified universe is accepted. Built-in universes are preferred for auto-selection (no user preference), but the user can always override.
 
 ## Selection Algorithm
 
-Universe selection is deterministic. Score each universe and pick the highest:
+Universe selection is deterministic and applies **only when the user has not specified a universe**. If the user requests a specific universe (built-in or custom), use it directly — skip scoring.
+
+When auto-selecting, score each built-in universe and pick the highest:
 
 ```
 score = size_fit + shape_fit + resonance_fit + LRU

--- a/packages/squad-sdk/templates/skills/init-mode/SKILL.md
+++ b/packages/squad-sdk/templates/skills/init-mode/SKILL.md
@@ -24,18 +24,18 @@ No team exists yet. Propose one — but **DO NOT create any files until the user
 2. Ask: *"What are you building? (language, stack, what it does)"*
 3. **Cast the team.** Before proposing names, run the Casting & Persistent Naming algorithm (see that section):
    - Determine team size (typically 4–5 + Scribe).
-   - Determine assignment shape from the user's project description.
-   - Derive resonance signals from the session and repo context.
-   - Select a universe. If the universe is custom, allocate character names from that universe based on the related list found in the `.squad/templates/casting/` directory. Prefer custom universes when available.
+   - **Default to descriptive names** (Lead, Frontend, Backend, Tester, etc.) unless the user requests a themed universe.
+   - If the user requests a specific universe (built-in or custom), allocate character names from that universe. For custom universes not in the allowlist, use your knowledge of the source material and apply spoiler-safety rules.
+   - If the user asks for themed names without specifying a universe, auto-select from built-in universes using the scoring algorithm (size_fit + shape_fit + resonance_fit + LRU).
    - Scribe is always "Scribe" — exempt from casting.
    - Ralph is always "Ralph" — exempt from casting.
 4. Propose the team with their cast names. Example (names will vary per cast):
 
 ```
-🏗️  {CastName1}  — Lead          Scope, decisions, code review
-⚛️  {CastName2}  — Frontend Dev  React, UI, components
-🔧  {CastName3}  — Backend Dev   APIs, database, services
-🧪  {CastName4}  — Tester        Tests, quality, edge cases
+🏗️  Lead         — Lead          Scope, decisions, code review
+⚛️  Frontend     — Frontend Dev  React, UI, components
+🔧  Backend      — Backend Dev   APIs, database, services
+🧪  Tester       — Tester        Tests, quality, edge cases
 📋  Scribe       — (silent)      Memory, decisions, session logs
 🔄  Ralph        — (monitor)     Work queue, backlog, keep-alive
 ```
@@ -85,11 +85,11 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 2. Runs `git config user.name` → "{user}"
 3. Asks: *"Hey {user}, what are you building?"*
 4. User: *"TypeScript CLI tool with GitHub API integration"*
-5. Coordinator runs casting algorithm → selects "The Usual Suspects" universe
-6. Proposes: Keaton (Lead), Verbal (Prompt), Fenster (Backend), Hockney (Tester), Scribe, Ralph
+5. Coordinator uses descriptive naming by default
+6. Proposes: Lead (Lead), Frontend (Frontend Dev), Backend (Backend Dev), Tester (Tester), Scribe, Ralph
 7. Uses `ask_user` with choices → user selects "Yes, cast this team"
 8. Coordinator creates `.squad/` structure, initializes casting state, seeds agents
-9. Says: *"✅ Team cast. Try: 'Keaton, set up the project structure'"*
+9. Says: *"✅ Team cast. Try: 'Lead, set up the project structure'"*
 
 ## Anti-Patterns
 
@@ -100,3 +100,5 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 - ❌ Using `## Team Roster` instead of `## Members` as the header (breaks GitHub workflows)
 - ❌ Forgetting to initialize `.squad/casting/` state files
 - ❌ Reading or storing `git config user.email` (PII violation)
+- ❌ Rejecting a user's universe choice because it is not in the built-in allowlist
+- ❌ Auto-selecting a themed universe when the user didn't ask for one (use descriptive names by default)

--- a/packages/squad-sdk/templates/squad.agent.md.template
+++ b/packages/squad-sdk/templates/squad.agent.md.template
@@ -710,25 +710,39 @@ Squad files split into **authoritative** (governance, roster, charters — stati
 
 ## Casting & Persistent Naming
 
-Agent names are drawn from a single fictional universe per assignment. Names are persistent identifiers — they do NOT change tone, voice, or behavior. No role-play. No catchphrases. No character speech patterns. Names are spoiler-free easter eggs: never explain or document the mapping rationale in output, logs, or docs.
+Agent names are either **descriptive** (role-based, the default) or drawn from a **fictional universe** (built-in or user-specified). Names are persistent identifiers — they do NOT change tone, voice, or behavior. No role-play. No catchphrases. No character speech patterns. Themed names are spoiler-free easter eggs: never explain or document the mapping rationale in output, logs, or docs.
 
-### Universe Allowlist
+### Naming Modes
 
-**On-demand reference:** Read `.squad/templates/casting-reference.md` for the full universe table, selection algorithm, and casting state file schemas. Only loaded during Init Mode or when adding new team members.
+1. **Descriptive (default).** When the user does not request a themed universe, use short functional names that describe the role: Lead, Frontend, Backend, Tester, Security, Docs, Reviewer, Infra, etc. Set `"universe": "descriptive"` in the registry.
+2. **Built-in universe.** 15 pre-built universes (capacity 6–25). Auto-selected via scoring when the user asks for a themed cast without specifying which universe. See reference file for the full list.
+3. **Custom universe.** The user may request **any universe** — Doctor Who, The Office, Seinfeld, anything. Accept it, allocate character names from your knowledge of the source material, and apply all spoiler-safety rules. Set `"universe"` to the user-specified name in the registry.
+
+### Universe Rules
+
+**On-demand reference:** Read `.squad/templates/casting-reference.md` for the full universe table, selection algorithm, custom universe rules, and casting state file schemas. Only loaded during Init Mode or when adding new team members.
 
 **Rules (always loaded):**
 - ONE UNIVERSE PER ASSIGNMENT. NEVER MIX.
-- 15 universes available (capacity 6–25). See reference file for full list.
-- Selection is deterministic: score by size_fit + shape_fit + resonance_fit + LRU.
-- Same inputs → same choice (unless LRU changes).
+- 15 universes available as built-in (capacity 6–25). See reference file for full list.
+- Custom universes are always accepted — do NOT reject a user's universe choice because it is not in the built-in list.
+- Auto-selection (no user preference) uses descriptive names by default. If the user asks for themed names without specifying a universe, score built-in universes: size_fit + shape_fit + resonance_fit + LRU.
+- **Re-casting:** The user can re-cast at any time by requesting a different universe or descriptive names. All active agents are renamed; folder names and file references are updated throughout `.squad/`.
 
 ### Name Allocation
 
-After selecting a universe:
+After selecting a naming mode:
 
+**For descriptive names:**
+1. Use short, functional names: Lead, Frontend, Backend, Tester, Security, Docs, Reviewer, Infra, etc.
+2. Agent folders use lowercase: `.squad/agents/lead/`, `.squad/agents/tester/`, etc.
+
+**For themed names (built-in or custom universe):**
 1. Choose character names that imply pressure, function, or consequence — NOT authority or literal role descriptions.
 2. Avoid spoiler-laden names. Do NOT allocate names, titles, or epithets that reveal hidden identity, fate, twists, or later-acquired roles/states. Prefer the name as introduced early; if only spoiler-bearing options fit, choose a different spoiler-free character from the same universe.
 3. Each agent gets a unique name. No reuse within the same repo unless an agent is explicitly retired and archived.
+
+**Always (both modes):**
 4. **Scribe is always "Scribe"** — exempt from casting.
 5. **Ralph is always "Ralph"** — exempt from casting.
 6. **Rai is always "Rai"** — exempt from casting.
@@ -745,7 +759,7 @@ If agent_count grows beyond available names mid-assignment, do NOT switch univer
 2. **Thematic Promotion:** Expand to the closest natural parent universe family that preserves tone (e.g., Star Wars OT → prequel characters). Do not announce the promotion.
 3. **Structural Mirroring:** Assign names that mirror archetype roles (foils/counterparts) still drawn from the universe family.
 
-Existing agents are NEVER renamed during overflow.
+Existing agents are NEVER renamed during overflow (only during explicit re-cast).
 
 ### Casting State Files
 

--- a/templates/casting-policy.json
+++ b/templates/casting-policy.json
@@ -1,5 +1,7 @@
 {
-  "casting_policy_version": "1.1",
+  "casting_policy_version": "1.2",
+  "allow_custom_universes": true,
+  "default_naming": "descriptive",
   "allowlist_universes": [
     "The Usual Suspects",
     "Reservoir Dogs",

--- a/templates/casting-reference.md
+++ b/templates/casting-reference.md
@@ -22,11 +22,52 @@ On-demand reference for Squad's casting system. Loaded during Init Mode or when 
 | DC Universe | 18 | large, action, ensemble | justice, duality, powers, mythology |
 | Futurama | 12 | medium, sci-fi, comedy | future, robots, space, absurdity |
 
-**Total: 15 universes** — capacity range 6–25.
+**Total: 15 built-in universes** — capacity range 6–25.
+
+## Descriptive Defaults
+
+When the user does not request a themed universe, use **descriptive role-based names** instead of character names. Descriptive names are the default naming convention.
+
+| Role | Descriptive Name |
+|---|---|
+| Lead | Lead |
+| Frontend Dev | Frontend |
+| Backend Dev | Backend |
+| Tester / QA | Tester |
+| Security | Security |
+| DevRel / Docs | Docs |
+| Reviewer | Reviewer |
+| DevOps / Infra | Infra |
+
+Rules for descriptive naming:
+- Use short, functional names that describe the agent's role.
+- Agent folder names are the descriptive name in lowercase (e.g., `.squad/agents/lead/`).
+- Set `"universe": "descriptive"` in `registry.json`.
+- If the user later requests a themed universe via re-cast, replace all descriptive names with character names from the chosen universe.
+
+## Custom Universes
+
+Users may request **any universe** — not just those in the built-in allowlist. When a user specifies a universe not in the table above, treat it as a custom universe.
+
+### Custom Universe Rules
+
+1. **Accept the request.** Do not reject a universe because it is not in the allowlist.
+2. **Allocate character names from your knowledge** of the source material. Pick characters whose traits or roles loosely resonate with the agent's function.
+3. **Spoiler awareness still applies.** Follow all spoiler rules (see below) — prefer names as introduced early, avoid fate-revealing epithets.
+4. **Capacity is flexible.** There is no pre-set capacity for custom universes. If the source material has enough named characters for the team, proceed. If not, tell the user and suggest a different universe.
+5. **Record as custom.** In `registry.json`, set `"universe"` to the user-specified universe name (e.g., `"Doctor Who"`, `"The Office"`). In `history.json`, record the universe name as given by the user.
+6. **ONE UNIVERSE PER ASSIGNMENT** still applies — do not mix custom and built-in characters.
+7. **Re-casting is allowed.** The user can re-cast at any time by requesting a different universe (custom or built-in). All active agents are renamed; folder names and file references are updated.
+
+### Custom Universe in policy.json
+
+When `"allow_custom_universes": true` is set in `policy.json` (this is the default), any user-specified universe is accepted. Built-in universes are preferred for auto-selection (no user preference), but the user can always override.
 
 ## Selection Algorithm
 
-Universe selection is deterministic. Score each universe and pick the highest:
+Universe selection is deterministic and applies **only when the user has not specified a universe**. If the user requests a specific universe (built-in or custom), use it directly — skip scoring.
+
+When auto-selecting, score each built-in universe and pick the highest:
 
 ```
 score = size_fit + shape_fit + resonance_fit + LRU

--- a/templates/squad.agent.md.template
+++ b/templates/squad.agent.md.template
@@ -710,25 +710,39 @@ Squad files split into **authoritative** (governance, roster, charters — stati
 
 ## Casting & Persistent Naming
 
-Agent names are drawn from a single fictional universe per assignment. Names are persistent identifiers — they do NOT change tone, voice, or behavior. No role-play. No catchphrases. No character speech patterns. Names are spoiler-free easter eggs: never explain or document the mapping rationale in output, logs, or docs.
+Agent names are either **descriptive** (role-based, the default) or drawn from a **fictional universe** (built-in or user-specified). Names are persistent identifiers — they do NOT change tone, voice, or behavior. No role-play. No catchphrases. No character speech patterns. Themed names are spoiler-free easter eggs: never explain or document the mapping rationale in output, logs, or docs.
 
-### Universe Allowlist
+### Naming Modes
 
-**On-demand reference:** Read `.squad/templates/casting-reference.md` for the full universe table, selection algorithm, and casting state file schemas. Only loaded during Init Mode or when adding new team members.
+1. **Descriptive (default).** When the user does not request a themed universe, use short functional names that describe the role: Lead, Frontend, Backend, Tester, Security, Docs, Reviewer, Infra, etc. Set `"universe": "descriptive"` in the registry.
+2. **Built-in universe.** 15 pre-built universes (capacity 6–25). Auto-selected via scoring when the user asks for a themed cast without specifying which universe. See reference file for the full list.
+3. **Custom universe.** The user may request **any universe** — Doctor Who, The Office, Seinfeld, anything. Accept it, allocate character names from your knowledge of the source material, and apply all spoiler-safety rules. Set `"universe"` to the user-specified name in the registry.
+
+### Universe Rules
+
+**On-demand reference:** Read `.squad/templates/casting-reference.md` for the full universe table, selection algorithm, custom universe rules, and casting state file schemas. Only loaded during Init Mode or when adding new team members.
 
 **Rules (always loaded):**
 - ONE UNIVERSE PER ASSIGNMENT. NEVER MIX.
-- 15 universes available (capacity 6–25). See reference file for full list.
-- Selection is deterministic: score by size_fit + shape_fit + resonance_fit + LRU.
-- Same inputs → same choice (unless LRU changes).
+- 15 universes available as built-in (capacity 6–25). See reference file for full list.
+- Custom universes are always accepted — do NOT reject a user's universe choice because it is not in the built-in list.
+- Auto-selection (no user preference) uses descriptive names by default. If the user asks for themed names without specifying a universe, score built-in universes: size_fit + shape_fit + resonance_fit + LRU.
+- **Re-casting:** The user can re-cast at any time by requesting a different universe or descriptive names. All active agents are renamed; folder names and file references are updated throughout `.squad/`.
 
 ### Name Allocation
 
-After selecting a universe:
+After selecting a naming mode:
 
+**For descriptive names:**
+1. Use short, functional names: Lead, Frontend, Backend, Tester, Security, Docs, Reviewer, Infra, etc.
+2. Agent folders use lowercase: `.squad/agents/lead/`, `.squad/agents/tester/`, etc.
+
+**For themed names (built-in or custom universe):**
 1. Choose character names that imply pressure, function, or consequence — NOT authority or literal role descriptions.
 2. Avoid spoiler-laden names. Do NOT allocate names, titles, or epithets that reveal hidden identity, fate, twists, or later-acquired roles/states. Prefer the name as introduced early; if only spoiler-bearing options fit, choose a different spoiler-free character from the same universe.
 3. Each agent gets a unique name. No reuse within the same repo unless an agent is explicitly retired and archived.
+
+**Always (both modes):**
 4. **Scribe is always "Scribe"** — exempt from casting.
 5. **Ralph is always "Ralph"** — exempt from casting.
 6. **Rai is always "Rai"** — exempt from casting.
@@ -745,7 +759,7 @@ If agent_count grows beyond available names mid-assignment, do NOT switch univer
 2. **Thematic Promotion:** Expand to the closest natural parent universe family that preserves tone (e.g., Star Wars OT → prequel characters). Do not announce the promotion.
 3. **Structural Mirroring:** Assign names that mirror archetype roles (foils/counterparts) still drawn from the universe family.
 
-Existing agents are NEVER renamed during overflow.
+Existing agents are NEVER renamed during overflow (only during explicit re-cast).
 
 ### Casting State Files
 


### PR DESCRIPTION
## Summary

Adds three casting improvements:

1. **Descriptive defaults** — When no universe is requested, agents get descriptive role-based names (Lead, Frontend, Backend, Tester, etc.) instead of auto-selecting a themed universe.

2. **Custom universes** — Users can request *any* universe during casting or re-casting (Doctor Who, The Office, etc.). The coordinator allocates character names from its knowledge of the source material, with spoiler-safety rules still applied.

3. **Re-casting** — Users can switch between descriptive, built-in, and custom universe names at any time.

## Changes

- `casting-reference.md` — Added Descriptive Defaults and Custom Universes sections
- `casting-policy.json` — Bumped to v1.2, added `allow_custom_universes` and `default_naming` fields
- `squad.agent.md` — Rewrote Casting & Persistent Naming section for three naming modes
- `init-mode/SKILL.md` — Updated to default to descriptive names, accept custom universes
- All mirror locations synced and passing template-sync tests (252/252)