### PR TITLE
fix(workflows): revert issues permission to read

### DIFF
--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -19,7 +19,7 @@ on:
 permissions:
   contents: read
   copilot-requests: write
-  issues: write
+  issues: read
   pull-requests: read
 network:
   allowed:


### PR DESCRIPTION
gh-aw doesn't allow `issues: write` directly — issue creation goes through `safe-outputs: create-issue` instead. Reverts to `issues: read`.