### PR TITLE
feat(workflows): descriptive run names for Squad actions

### DIFF
--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1,5 +1,6 @@
 ---
 name: Squad
+run-name: "Squad — ${{ github.event.inputs.command || github.event.comment.body || github.event.issue.title || 'run' }}"
 description: Cast, connect, or adopt a Squad AI team for your repository
 emoji: "🧑‍🤝‍🧑"
 private: false


### PR DESCRIPTION
Adds `run-name` to show the triggering command in the Actions tab:

- `Squad — /squad research`
- `Squad — /squad plan accept`  
- `Squad — cast` (dispatch)

Instead of just 'Squad' for every run.

**Note:** If gh-aw doesn't support `run-name` in the schema, this will error on install and we'll need an alternative approach.