### PR TITLE
fix(sdk): wire FSStorageProvider rootDir in resolveSquadState, fix teamRoot='.' sentinel

### DIFF
--- a/.changeset/1555-fs-storage-rootdir.md
+++ b/.changeset/1555-fs-storage-rootdir.md
@@ -1,0 +1,5 @@
+---
+"@bradygaster/squad-sdk": patch
+---
+
+`resolveSquadState()` now constructs the local-backend `FSStorageProvider` with `rootDir` set to `paths.teamDir`, so its path-traversal guard actually validates state writes instead of no-op'ing on an unset rootDir. Also fixed `resolveSquadPaths()` treating a `config.teamRoot` of `"."` (the sentinel `squad externalize` writes) as remote mode, which pointed `teamDir` one level above `.squad/` — it now correctly falls through to local mode. Together these were breaking `squad_decide`/`squad_state_*` MCP tools on externalized projects with a "Path traversal blocked" error.

--- a/packages/squad-sdk/src/resolution.ts
+++ b/packages/squad-sdk/src/resolution.ts
@@ -365,8 +365,12 @@ export function resolveSquadPaths(startDir?: string): ResolvedSquadPaths | null 
   const isLegacy = name === '.ai-team';
   const config = loadDirConfig(projectDir);
 
-  if (config && config.teamRoot) {
+  if (config && config.teamRoot && config.teamRoot !== '.') {
     // Remote mode: teamDir resolved relative to the project root (parent of .squad/)
+    // '.' is the sentinel externalize.ts writes for "no separate team root" —
+    // falls through to local mode below instead of resolving to the parent
+    // of .squad/ (path.resolve(projectRoot, '.') === projectRoot, one level
+    // too high).
     const projectRoot = path.resolve(projectDir, '..');
     const teamDir = path.resolve(projectRoot, config.teamRoot);
     return {
@@ -847,8 +851,12 @@ export function resolveSquadState(startDir?: string, cliOverride?: StateBackendT
 
   // For local backend, use FSStorageProvider directly (more capable).
   // For git-notes/orphan, bridge via StateBackendStorageAdapter.
+  // rootDir is paths.teamDir (matches the squadRoot every local-backend
+  // caller — e.g. ToolRegistry in state-mcp.ts — builds its paths against),
+  // so the traversal guard actually validates instead of no-op'ing on an
+  // unset rootDir and letting a bad upstream path resolve silently.
   const stateStorage: StorageProvider = backend.name === 'local'
-    ? new FSStorageProvider()
+    ? new FSStorageProvider(paths.teamDir)
     : new StateBackendStorageAdapter(backend, paths.projectDir);
 
   return { paths, backend, repoRoot, storage: stateStorage };

--- a/test/state-backend.test.ts
+++ b/test/state-backend.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { execSync, execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
@@ -459,6 +459,51 @@ describe('resolveSquadState()', () => {
     const ctx = resolveSquadState(TMP);
     expect(ctx).not.toBeNull();
     expect(ctx!.storage.constructor.name).toBe('StateBackendStorageAdapter');
+  });
+
+  describe('#1555 regression: rootDir wiring + teamRoot=. sentinel', () => {
+    it('teamDir stays inside .squad/ when config.teamRoot is the "." sentinel externalize.ts writes', () => {
+      writeFileSync(join(squadDir(), 'config.json'), JSON.stringify({ version: 1, teamRoot: '.', projectKey: 'some-key', stateLocation: 'external' }));
+      const ctx = resolveSquadState(TMP);
+      expect(ctx).not.toBeNull();
+      // Before the fix this resolved one level too high (path.resolve(projectRoot, '.') === projectRoot,
+      // the parent of .squad/) because the truthy check on config.teamRoot didn't special-case '.'.
+      expect(ctx!.paths.mode).toBe('local');
+      expect(ctx!.paths.teamDir).toBe(squadDir());
+    });
+
+    it('local-backend storage rootDir is wired to teamDir, not left unset', () => {
+      writeFileSync(join(squadDir(), 'config.json'), JSON.stringify({ version: 1, teamRoot: '.' }));
+      const ctx = resolveSquadState(TMP);
+      expect(ctx).not.toBeNull();
+
+      // A key that escapes teamDir must now be rejected instead of the traversal
+      // guard silently no-op'ing on an unset rootDir.
+      expect(() => ctx!.storage.readSync(join(ctx!.paths.teamDir, '..', 'outside.md')))
+        .toThrow(/Path traversal blocked/);
+
+      // A key inside teamDir still round-trips normally.
+      ctx!.storage.writeSync(join(ctx!.paths.teamDir, 'agents', 'data', 'history.md'), '# Data\n');
+      expect(existsSync(join(squadDir(), 'agents', 'data', 'history.md'))).toBe(true);
+    });
+
+    it('squad_decide via ToolRegistry writes into .squad/decisions/inbox/, matching what state-mcp.ts wires up', async () => {
+      writeFileSync(join(squadDir(), 'config.json'), JSON.stringify({ version: 1, teamRoot: '.', projectKey: 'some-key', stateLocation: 'external' }));
+      const ctx = resolveSquadState(TMP);
+      expect(ctx).not.toBeNull();
+
+      // Same construction as createStateMcpToolRegistry() in state-mcp.ts.
+      const registry = new ToolRegistry(ctx!.paths.teamDir, undefined, ctx!.storage);
+      const decide = registry.getTool('squad_decide')!;
+      const result = await decide.handler({ author: 'test-agent', summary: 'Use FSStorageProvider rootDir', body: 'Confine local-backend writes to teamDir.' });
+
+      expect(result.resultType).toBe('success');
+      const inboxDir = join(squadDir(), 'decisions', 'inbox');
+      expect(existsSync(inboxDir)).toBe(true);
+      expect(readdirSync(inboxDir).length).toBeGreaterThan(0);
+      // Must not have landed one level up, in the repo root.
+      expect(existsSync(join(TMP, 'decisions'))).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
### What
`resolveSquadState()` now constructs the local-backend `FSStorageProvider` with `rootDir` set, and `resolveSquadPaths()` treats `config.teamRoot === '.'` as local mode instead of remote mode.

### Why
Fixes #1555

Two independent defects in the same path, both live on `dev`, both hit by `squad_decide`/`squad_state_*` (the MCP state tools wired up in `state-mcp.ts`):

1. `resolveSquadState()` built the local backend's storage as `new FSStorageProvider()` — no `rootDir`. `FSStorageProvider`'s traversal guard is `if (!this.rootDir) return filePath;` — an unset `rootDir` makes it a no-op, so it never validated anything. Every `squad_state_*`/`squad_decide` write just trusted whatever path got built upstream instead of confining it to `.squad/`.
2. `resolveSquadPaths()`'s remote-mode check is `if (config && config.teamRoot)`. `squad externalize` writes `teamRoot: '.'` into `config.json` as its "no separate team root" marker (`externalize.ts:99`) — but `'.'` is truthy, so this took the remote branch and computed `teamDir = path.resolve(projectRoot, '.')`, which is just `projectRoot` — one directory **above** `.squad/`, not `.squad/` itself.

Once (1) is fixed on its own, (2) turns into a live path-traversal rejection instead of a silent misplacement: `state-mcp.ts` builds `ToolRegistry(context.paths.teamDir, ...)`, every tool does `path.join(this.squadRoot, key)`, and with `teamDir` one level too high, those paths land outside the now-enforced `rootDir` — `squad_decide` starts throwing `Path traversal blocked: [team-root]\decisions\inbox\<file>.md`. Fixing both together is what actually gets state writes back to `.squad/decisions/inbox/` on an externalized project instead of either silently misplacing them or hard-failing.

### How
- `resolution.ts` `resolveSquadState()`: `new FSStorageProvider(paths.teamDir)` — matches what every local-backend caller already builds its paths against (e.g. `state-mcp.ts` passes `context.paths.teamDir` as `ToolRegistry`'s `squadRoot`).
- `resolution.ts` `resolveSquadPaths()`: `if (config && config.teamRoot && config.teamRoot !== '.')` — `'.'` now falls through to the existing local-mode branch (`teamDir: projectDir`), which is what it was always meant to mean.

### Testing
Added a `#1555 regression: rootDir wiring + teamRoot=. sentinel` block to `test/state-backend.test.ts`:
- `teamRoot: '.'` (the externalize.ts marker) resolves `mode: 'local'` and `teamDir === .squad/`, not the parent directory
- local-backend storage now rejects a path that escapes `teamDir` (`Path traversal blocked`) and still round-trips a path inside it — proves `rootDir` is actually wired, not just present
- an end-to-end run through `ToolRegistry` built the same way `state-mcp.ts` builds it (`new ToolRegistry(ctx.paths.teamDir, undefined, ctx.storage)`), calling the real `squad_decide` tool handler, asserting the decision file lands in `.squad/decisions/inbox/` and *not* one level up in the repo root

```
npx vitest run test/state-backend.test.ts
 Test Files  1 passed (1)
      Tests  147 passed (147)
```

Also ran the broader set of suites that touch `resolveSquadPaths`/`resolveSquadState` (dual-root resolver, effective-squad-dir, external-state, state-mcp, ensure-squad-path-dual, rc, copilot, export-import, extract, notes-promote, cast, consult, upgrade-state-backend, watch-notes-promote, mcp-spec-init, npm-registry-fallback):

```
Test Files  3 failed | 14 passed (17)
     Tests  3 failed | 343 passed (346)
```

All 3 failures (`copilot.test.ts`, `extract.test.ts`, `rc.test.ts`, each `module exports run* function`) are the same pre-existing cold dynamic-import 5s timeout as `watch.test.ts` hits on this box — confirmed by rerunning just those 3 files with `--testTimeout=20000`: all 58 tests pass. Not caused by this change.

`cd packages/squad-sdk && npm run build` then `cd packages/squad-cli && npm run build` (package-local, no root prebuild churn) — clean. `tsc --noEmit` clean on both packages. `eslint` on both changed files: 0 errors, resolution.ts's 43 warnings are the same pre-existing `n/no-sync` categories the file already had (0 new), state-backend.test.ts has 0.

Diff hygiene: `git diff` vs `git diff -w` identical, `git diff --check` clean — `resolution.ts` had drifted to CRLF on disk despite an LF-committed blob (same box quirk as usual), normalized back to LF and reverified against `git show HEAD:<path>` before staging.

---

### ⚠️ Quick Check
- [x] Changeset added: `.changeset/1555-fs-storage-rootdir.md` (patch `@bradygaster/squad-sdk`)

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev` (upstream, fresh fetch)
- [x] Branch is up to date with `dev`
- [x] Verified diff contains only intended changes (1 source + 1 test file + changeset)
- [x] PR is not in draft mode
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] `npm run build` (per-package) passes
- [x] `npm test` — targeted suite 147/147; broader 16-suite regression sweep 343/346 (3 pre-existing unrelated failures, proven)
- [x] `tsc --noEmit` clean
- [x] `eslint` — 0 errors, pre-existing warning categories only

#### Changeset
- [x] Changeset added (sdk patch)

#### Docs
- [x] N/A — internal correctness fix, no public API surface changed (`resolveSquadState`/`resolveSquadPaths` signatures unchanged)

#### Exports
- [x] N/A — no new modules or exports

---

### Breaking Changes
None. Both changes make existing, documented semantics (rootDir confinement; `teamRoot: '.'` meaning "no separate team root") actually hold — no signature or behavior change for any caller that wasn't already relying on the broken behavior.

### Waivers
None.
