### PR TITLE
fix(workflow): add triage breadcrumb and next-action to lifecycle state

### DIFF
--- a/workflows/shared/planning-ontology.md
+++ b/workflows/shared/planning-ontology.md
@@ -322,7 +322,7 @@ This comment is created on first transition and updated on every subsequent tran
 |-------|--------|----------|---------|
 | Intent | ✅ Done | (issue body) | <date> |
 | Research | ✅ Done | <comment link> | <date> |
-| Triage | ⏳ In Progress | — | <date> |
+| Triage | ✅ Done | <comment link> | <date> |
 | Program Plan | ⬚ Pending | — | — |
 | Implementation Plan | ⬚ Pending | — | — |
 | Validation | ⬚ Pending | — | — |
@@ -330,7 +330,7 @@ This comment is created on first transition and updated on every subsequent tran
 | Impl Accepted | ⬚ Pending | — | — |
 | Activated | ⬚ Pending | — | — |
 
-**Current state:** Triaging
+**Current state:** Triaged
 **Last command:** `/squad triage` by @user at <timestamp>
 **Next action:** `/squad plan program` — create a program plan from triage dispositions
 **Also available:** `/squad triage revise <feedback>` — adjust triage before planning

--- a/workflows/shared/planning-ontology.md
+++ b/workflows/shared/planning-ontology.md
@@ -332,6 +332,8 @@ This comment is created on first transition and updated on every subsequent tran
 
 **Current state:** Triaging
 **Last command:** `/squad triage` by @user at <timestamp>
+**Next action:** `/squad plan program` — create a program plan from triage dispositions
+**Also available:** `/squad triage revise <feedback>` — adjust triage before planning
 ```
 
 Status icons: `✅ Done` · `⏳ In Progress` · `⬚ Pending` · `❌ Failed` · `⏭ Skipped`

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1777,7 +1777,7 @@ Record the current timestamp. Set `Current state: Validated` (on pass) or
 `Current state: Validation failed` (on fail) and
 `Last command: /squad plan validate`.
 On PASS: Set `**Next action:**` to `/squad plan accept implementation` — approve the implementation plan.
-On FAIL: Set `**Next action:**` to `Fix issues, then /squad plan validate` — re-run validation.
+On FAIL: Set `**Next action:**` to `/squad plan validate` — fix the reported issues, then re-run validation.
 
 ##### Step 5: Surface Next Action
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -850,7 +850,8 @@ This marker is machine-readable and non-negotiable. Without it, subsequent phase
 {What the squad should do — sequencing suggestions, approach options, things to avoid}
 
 ### Next Step
-> Reply `/squad plan` to generate a detailed execution plan with sub-issues based on these findings.
+> Reply `/squad triage` to classify these findings into work items, decisions, and exclusions.
+> Or reply `/squad plan` to skip triage and generate a combined plan directly (fast path).
 ```
 
 Tailor the sections to the research scope — omit sections that don't apply, add
@@ -1204,6 +1205,8 @@ This marker is machine-readable and non-negotiable. Without it, subsequent phase
 
 Set the Triage row to `✅ Done` and record the
 current timestamp. Set `Current state: Triaged` and `Last command: /squad triage`.
+Set `**Next action:**` to `/squad plan program` — create a program plan from triage dispositions.
+Set `**Also available:**` to `/squad triage revise <feedback>` — adjust triage before planning.
 
 Do NOT create issues or PRs. Triage mode is read-only + comment.
 
@@ -1421,6 +1424,8 @@ Search for the `<!-- squad-lifecycle-state -->` comment on the issue. If it exis
 update it; if not, create it. Set the Program Plan row to `✅ Done` and record the
 current timestamp. Set `Current state: Program Planned` and
 `Last command: /squad plan program`.
+Set `**Next action:**` to `/squad plan accept scope` — approve the program scope.
+Set `**Also available:**` to `/squad plan program revise <feedback>` — adjust the program plan.
 
 Do NOT create issues, milestones, or PRs. Plan Program mode is read-only + comment.
 
@@ -1484,6 +1489,8 @@ prepended.
 Update the `<!-- squad-lifecycle-state -->` comment. Keep Program Plan as
 `✅ Done` (it's a revision, not a new phase). Update the timestamp and set
 `Last command: /squad plan program revise`.
+Set `**Next action:**` to `/squad plan accept scope` — approve the program scope.
+Set `**Also available:**` to `/squad plan program revise <feedback>` — adjust the program plan again.
 
 If a `<!-- squad-scope-accepted-v1 -->` was invalidated (override case), set
 the Scope Accepted row back to `⬚ Pending`.
@@ -1630,6 +1637,8 @@ Search for the `<!-- squad-lifecycle-state -->` comment on the issue. If it exis
 update it; if not, create it. Set the Implementation Plan row to `✅ Done` and
 record the current timestamp. Set `Current state: Implementation planned` and
 `Last command: /squad plan implementation`.
+Set `**Next action:**` to `/squad plan validate` — run validation checks.
+Set `**Also available:**` to `/squad plan accept implementation` — approve the implementation plan directly.
 
 Do NOT create issues or PRs. Plan Implementation mode only posts a comment.
 
@@ -1767,6 +1776,8 @@ exists, update it; if not, create it. Set the Validation row:
 Record the current timestamp. Set `Current state: Validated` (on pass) or
 `Current state: Validation failed` (on fail) and
 `Last command: /squad plan validate`.
+On PASS: Set `**Next action:**` to `/squad plan accept implementation` — approve the implementation plan.
+On FAIL: Set `**Next action:**` to `Fix issues, then /squad plan validate` — re-run validation.
 
 ##### Step 5: Surface Next Action
 
@@ -1842,6 +1853,7 @@ This marker is machine-readable and non-negotiable. Without it, subsequent phase
 Update the `<!-- squad-lifecycle-state -->` comment. Set the Scope Accepted row
 to `✅ Done`. Set `Current state: Scope accepted` and
 `Last command: /squad plan accept scope`.
+Set `**Next action:**` to `/squad plan implementation` — create the implementation plan.
 
 End with: *"Scope approved. Reply `/squad plan implementation` to create the
 implementation plan."*
@@ -1930,6 +1942,7 @@ This marker is machine-readable and non-negotiable. Without it, subsequent phase
 Update the `<!-- squad-lifecycle-state -->` comment. Set the Impl Accepted row
 to `✅ Done`. Set `Current state: Implementation accepted` and
 `Last command: /squad plan accept implementation`.
+Set `**Next action:**` to `/squad plan activate` — create issues and begin execution.
 
 End with: *"Implementation approved. Reply `/squad plan activate` to create
 issues and begin execution."*
@@ -2138,6 +2151,7 @@ with full hierarchy (Root → Epics → Tasks) and assigned to their respective 
 Update the `<!-- squad-lifecycle-state -->` comment. Set the Activated row
 to `✅ Done`. Set `Current state: Activated` and
 `Last command: /squad plan activate`.
+(Terminal state — no `**Next action:**` or `**Also available:**` fields needed.)
 
 End with: *"✅ Plan activated — {n} issues created. The squad is ready to
 begin work."*


### PR DESCRIPTION
## Summary

Two targeted discoverability improvements to the agentic SDLC workflow:

### 1. Research → Triage breadcrumb (Closes #1667)

The Research mode "Next Step" now mentions both paths:
- **Granular:** `/squad triage` — classify findings into work items, decisions, and exclusions
- **Fast path:** `/squad plan` — skip triage and generate a combined plan directly

Previously it only showed the fast path, which misdirected users at the very first transition of the granular SDLC flow.

### 2. Lifecycle state `Next action` field (Closes #1668)

- `**Next action:**` — the primary next command with a brief description
- `**Also available:**` — alternative valid commands (when applicable)

This turns the lifecycle comment from "where am I" into "where am I + what's next", enabling any agent reading the issue to proactively suggest the correct next command without reasoning through the full state machine.

## Changes

| File | What changed |
|------|-------------|
| `workflows/squad.md` | Research Next Step updated; all 8 "Update Lifecycle Summary" steps now set next-action fields |
| `workflows/shared/planning-ontology.md` | Section 5 lifecycle template extended with the new fields |

## Testing

These are workflow prompt changes (not code). Verification will happen during Brady's end-to-end test of the gh-aw SDLC flow.

Closes #1667
Closes #1668