### PR TITLE
docs: clarify gh-aw files to commit

### DIFF
--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -33,7 +33,8 @@ gh aw add bradygaster/squad/workflows/squad.md@dev
 gh aw compile
 
 # 5. Commit and push the workflow source, imports, and lock file
-git add .gitattributes \
+git add -- \
+  .gitattributes \
   .github/aw/actions-lock.json \
   .github/workflows/squad.md \
   .github/workflows/shared/squad.md \
@@ -109,7 +110,8 @@ lock file is what GitHub Actions actually executes.
 ### Commit the workflow files
 
 ```bash
-git add .gitattributes \
+git add -- \
+  .gitattributes \
   .github/aw/actions-lock.json \
   .github/workflows/squad.md \
   .github/workflows/shared/squad.md \

--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -27,8 +27,12 @@ gh aw add bradygaster/squad/workflows/squad.md@dev
 # 3. Compile the workflow to a lock file
 gh aw compile
 
-# 4. Commit and push the compiled workflow
-git add .github/workflows/squad.lock.yml
+# 4. Commit and push the workflow source, imports, and lock file
+git add .gitattributes \
+  .github/aw/actions-lock.json \
+  .github/workflows/squad.md \
+  .github/workflows/shared/squad.md \
+  .github/workflows/squad.lock.yml
 git commit -m "ci: add Squad agentic workflow"
 git push
 
@@ -76,12 +80,32 @@ Compiling resolves the workflow definition (including the shared bootstrap
 component) into a deterministic `.github/workflows/squad.lock.yml` file. This
 lock file is what GitHub Actions actually executes.
 
-### Commit the lock file
+### Commit the workflow files
 
 ```bash
-git add .github/workflows/squad.lock.yml
+git add .gitattributes \
+  .github/aw/actions-lock.json \
+  .github/workflows/squad.md \
+  .github/workflows/shared/squad.md \
+  .github/workflows/squad.lock.yml
 git commit -m "ci: add Squad agentic workflow"
 git push
+```
+
+The source and imported shared workflow must be present so `gh aw` can verify
+that the compiled lock file is current. The action lock and attributes files
+keep compilation reproducible and identify generated workflow files.
+
+Downloaded workflow audit data under `.github/aw/logs/` is local diagnostic
+output and should not be committed. The `gh aw logs` and `gh aw audit` commands
+normally create `.github/aw/logs/.gitignore`; if it is missing, add:
+
+```gitignore
+# Ignore all downloaded workflow logs
+*
+
+# But keep this file
+!.gitignore
 ```
 
 Once pushed, the `/squad` slash command is live on your repo.

--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -15,19 +15,24 @@ This guide covers setup, every slash command, and daily usage patterns.
 
 ## Quick start
 
-Five steps from zero to a working Squad team:
+Six steps from zero to a working Squad team:
 
 ```bash
 # 1. Install the gh-aw extension (one-time)
 gh extension install github/gh-aw
 
-# 2. Add the Squad workflow to your repo
+# 2. Allow GitHub Actions to create pull requests
+gh api --method PUT repos/{owner}/{repo}/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=true
+
+# 3. Add the Squad workflow to your repo
 gh aw add bradygaster/squad/workflows/squad.md@dev
 
-# 3. Compile the workflow to a lock file
+# 4. Compile the workflow to a lock file
 gh aw compile
 
-# 4. Commit and push the workflow source, imports, and lock file
+# 5. Commit and push the workflow source, imports, and lock file
 git add .gitattributes \
   .github/aw/actions-lock.json \
   .github/workflows/squad.md \
@@ -36,7 +41,7 @@ git add .gitattributes \
 git commit -m "ci: add Squad agentic workflow"
 git push
 
-# 5. Open an issue and type /squad cast — done!
+# 6. Open an issue and type /squad cast — done!
 ```
 
 After pushing, open an issue in your repo and write `/squad cast` in the body or
@@ -56,6 +61,27 @@ and opens a PR with the result.
 ---
 
 ## Setup
+
+### Allow workflow-created pull requests
+
+Squad opens pull requests through GitHub Actions. Enable this repository setting
+under **Settings → Actions → General → Workflow permissions → Allow GitHub
+Actions to create and approve pull requests**.
+
+You can also enable it from the command line while keeping the default workflow
+token read-only:
+
+```bash
+gh api --method PUT repos/{owner}/{repo}/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=true
+```
+
+Replace `{owner}` and `{repo}` with the repository owner and name. Without this
+setting, Squad pushes the generated branch but falls back to an issue containing
+a link for you to create the pull request manually. A manually created pull
+request is authored by your account, and GitHub does not allow authors to
+approve their own pull requests.
 
 ### Install the workflow
 


### PR DESCRIPTION
## Summary
- Update the gh-aw quick start to commit the workflow source and imported shared workflow alongside the compiled lock file
- Include generated action pinning metadata for reproducible compilation
- Document that downloaded workflow audit logs should remain ignored

## Why
Committing only `.github/workflows/squad.lock.yml` causes the runtime lock check to fail with `E009 CONFIG_HASH_MISMATCH` because `.github/workflows/squad.md` is unavailable for hash verification.

## Validation
- `git diff --check`