### PR TITLE
fix(workflow): atomic task-call contract in Plan Activate Step 2c (#1678)

### DIFF
--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -594,3 +594,41 @@ describe('gh-aw: Plan Activate hardening behaviors', () => {
     expect(content).toMatch(/degrade gracefully|graceful/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Test: Plan Activate atomic task-call contract (#1678 / run 31555893180)
+// ---------------------------------------------------------------------------
+
+describe('gh-aw: Plan Activate atomic task-call contract', () => {
+  const content = readFileSync(SQUAD_WORKFLOW, 'utf8');
+
+  it('2c contains explicit ATOMIC CONTRACT heading', () => {
+    expect(content).toMatch(/ATOMIC CONTRACT/i);
+  });
+
+  it('2c requires immediate call after each task body (one compose → one call)', () => {
+    // Must encode the sequential compose/call/verify pattern
+    expect(content).toMatch(/compose.*call.*verify|compose only that task.*call.*immediately/i);
+  });
+
+  it('2c explicitly forbids batching task bodies before calls', () => {
+    expect(content).toMatch(/DO NOT.*compose.*batch|DO NOT.*buffer|not.*compose.*multiple.*before/i);
+  });
+
+  it('2c task body is compact: one sentence scope, 1-2 acceptance criteria', () => {
+    expect(content).toMatch(/one sentence.*scope|1-2 acceptance criteria/i);
+  });
+
+  it('2d incomplete fallback calls report_incomplete with created/expected counts', () => {
+    expect(content).toContain('report_incomplete');
+    expect(content).toMatch(/created.*expected|expected.*created/i);
+  });
+
+  it('2d incomplete fallback never noops on count mismatch', () => {
+    expect(content).toMatch(/never noop/i);
+  });
+
+  it('2d states re-run is idempotent via title match', () => {
+    expect(content).toMatch(/idempotent via title match/i);
+  });
+});

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -743,14 +743,19 @@ Root → Epics → Tasks. Phase-specific: filter to matching phase heading.
 **⚠️ DO NOT STOP after epics. Tasks MUST follow immediately.**
 
 **2c. Create Task Issues:** `create-issue` per task in dependency order.
+
+> **⚠️ ATOMIC CONTRACT — strictly one task at a time:**
+> For each task: compose ONLY that task's body → call `create-issue` immediately → verify the returned issue number → then move to the next task.
+> **DO NOT** compose or buffer multiple task bodies before making calls. One compose → one call → one verify, repeated per task.
+
 - Title: task title
 - Labels: `squad` (0075ca), `squad:{agent}` (e4e669). No `size:*` labels unless policy says so.
-- Body: scope (2-3 sentences), acceptance criteria, context (parent epic, size, deps)
+- Body: one sentence describing scope; 1-2 acceptance criteria; one compact context line (parent epic, size, deps)
 - Parent: sub-issue of EPIC (not root)
 - Milestone: same as parent epic
 - Size: Project field if available, else body line
 
-**2d. Self-Validation:** Compare created counts vs expected. If mismatch: report partial activation with counts, note idempotent re-run.
+**2d. Self-Validation:** Compare created/recognized task count vs expected. If created count is below expected: call `report_incomplete` immediately with `created={N}`, `expected={M}`, and the last verified issue number — never noop. Re-runs are idempotent via title match.
 
 Labels must have descriptions and intentional colors.
 


### PR DESCRIPTION
## Root Cause

The watchdog fires ~20 s after the last visible model output. In the live failed canary run **31555893180**, the agent composed all task bodies in one reasoning burst _after_ epic creation completed — then the post-result idle window expired before the first `create-issue` task call was ever made.

## Exact Mitigation

Added an **ATOMIC CONTRACT** to Step 2c that mandates: compose **one** task body → call `create-issue` immediately → verify returned issue number → repeat. This breaks the silent inter-call gap that triggered the watchdog.

Also:
- **Compact body spec**: one-sentence scope, 1–2 acceptance criteria, one context line (parent, size, deps) — reduces per-task reasoning time
- **Step 2d fallback**: if created task count is below expected, immediately call `report_incomplete` with `created={N}`, `expected={M}`, and last verified issue number — never noop; re-runs are idempotent via title match

## Evidence — Run 31555893180

Watchdog fired after epic creation; zero task issues created. This patch eliminates the reasoning burst that caused the gap.

## Prompt Bytes

| File | Bytes |
|------|-------|
| workflows/squad.md | 34,017 |
| shared/squad.md | 6,688 |
| shared/planning-ontology.md | 15,231 |
| shared/planning-policy.md | 3,910 |
| **Total** | **59,846** |

Ceiling: ~80,000 B — **~20 KB headroom**.

## Tests

7 new focused tests added to `test/gh-aw-quality.test.ts`:
- Atomic CONTRACT heading present
- Immediate call after compose required
- Explicit no-batch rule
- Compact body (one sentence + 1–2 ACs)
- `report_incomplete` called with created/expected counts
- Never noop on mismatch
- Idempotent re-run via title match

All 44 tests pass (37 pre-existing + 7 new).

## Compile Status

`gh aw compile` not available in this environment; workflow markdown is valid. `.lock.yml` not regenerated (prompt-body-only change).

## Live Rerun

A live rerun on a fresh plan is still required to confirm end-to-end task creation completes before watchdog fires.

## Files Changed (2)

- `workflows/squad.md`
- `test/gh-aw-quality.test.ts`

## Notes

- Does **not** close #1678 (already closed)
- References live failed canary run 31555893180
- No changeset added; `skip-changelog` label applied