### PR TITLE
chore: ignore gh-aw run artifacts and local MCP config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ artifacts/
 
 # NOTE: .squad/casting/* is AUTHORITATIVE IDENTITY and MUST be committed to main.
 # Do not add .squad/casting/ to this ignore list.
+
+# gh-aw run artifacts (generated output, not committed)
+/run-artifacts/
+# Local MCP configuration (machine-specific, not committed)
+/.mcp.json


### PR DESCRIPTION
## Summary

Adds two `.gitignore` entries surfaced during the `bradygaster/squad-gh-aw-e2e-4` live demo recovery audit (branch `recovery/frozen-e2e-20260812`).

## Changes

```
.gitignore  +5 lines, 0 deletions
```

### Added ignore rules

| Pattern | What it covers |
|---------|----------------|
| `/run-artifacts/` | gh-aw runtime output produced during live workflow runs: `aw-prompts/`, MCP logs, `safe-outputs.jsonl`, `agent_output.json`, AIC usage cache. Generated, not a source artifact. |
| `/.mcp.json` | Machine-local MCP server configuration (`squad_state` server via `@bradygaster/squad-cli@insider`). Developer-environment-specific; should never be committed. |

Both paths were present as untracked files in the frozen E2E session worktree and are absent from all remote branches. Without these rules, a future `git add .` or inattentive staging could silently commit gigabytes of run logs or a machine-local config containing server addresses.

## Recovery context

The audit was performed on a detached-HEAD worktree frozen at `61cc6429` after a successful E2E run (5 epics, 12 tasks, 44/44 tests passing). Recovery examined every dirty/untracked path against a freshly fetched `origin/dev`. All other recovered content — `test/gh-aw-quality.test.ts` (634 lines) and `workflows/squad.md` — was confirmed byte-identical to `origin/dev` by FIDO checkpoint `e5320de9` and Procedures commit `13e6447d`; no re-commit was needed or made here.

## Validation

- `git check-ignore -v run-artifacts/` → `.gitignore:57:/run-artifacts/` ✅
- `git check-ignore -v .mcp.json` → `.gitignore:59:/.mcp.json` ✅
- `package.json` not ignored ✅
- 1 file changed, 5 insertions(+), 0 deletions ✅
- No product source, workflow, test, changeset, or squad-state files touched

## Scope

repo-health — ignore rules only. No changeset required (no package source modified).