### PR TITLE
feat(gh-aw): auto-cast and guide resumable work from one issue

### DIFF
--- a/.github/agents.md
+++ b/.github/agents.md
@@ -1,5 +1,5 @@
 ---
-description: Agent-facing guide to using Squad — the multi-agent team orchestrator for GitHub Copilot. Covers installation, slash commands, planning lifecycle, artifact markers, and safe-output constraints.
+description: Agent-facing guide to using Squad — the multi-agent team orchestrator for GitHub Copilot. Covers installation, slash commands, planning lifecycle, structured artifacts, and safe-output constraints.
 ---
 
 # Using Squad in This Repository
@@ -92,19 +92,19 @@ All commands are issued as comments on a GitHub issue. Prefix: `/squad`.
 
 | Command | Purpose | Preconditions | Repo artifacts | User sees |
 |---------|---------|---------------|----------------|-----------|
-| `/squad research` | Deep-dive analysis of the issue and repository | Issue exists with intent | Comment with `<!-- squad-research-v1 -->` marker | Structured research findings |
-| `/squad triage` | Classify research findings into work, decisions, and exclusions | Research artifact exists | Comment with `<!-- squad-triage-v1 -->` marker | Categorized findings table |
-| `/squad triage revise <feedback>` | Adjust triage dispositions based on feedback | Triage artifact exists | Updated comment with `<!-- squad-triage-v1 -->` marker | Revised triage |
-| `/squad plan` | Generate combined program + implementation plan (fast path) | Triage artifact exists | Comments with `<!-- squad-program-v1 -->` and `<!-- squad-implementation-v1 -->` markers | Both plans in sequence |
-| `/squad plan program` | Generate high-level program plan with epics and milestones | Triage artifact exists | Comment with `<!-- squad-program-v1 -->` marker | Epics, milestones, user stories |
-| `/squad plan program revise <feedback>` | Adjust program plan based on feedback | Program plan artifact exists | Updated comment with `<!-- squad-program-v1 -->` marker | Revised program plan |
-| `/squad plan implementation` | Decompose program plan into PR-sized tasks | Program plan artifact exists | Comment with `<!-- squad-implementation-v1 -->` marker | Task breakdown with deps and sizing |
-| `/squad plan validate` | Run structural readiness checks on the plan | Implementation plan artifact exists | Comment with `<!-- squad-validation-v1 -->` marker | Pass/fail checklist |
+| `/squad research` | Deep-dive analysis of the issue and repository | Issue exists with intent | Comment with `squad_artifact: research` data | Structured research findings |
+| `/squad triage` | Classify research findings into work, decisions, and exclusions | Research artifact exists | Comment with `squad_artifact: triage` data | Categorized findings table |
+| `/squad triage revise <feedback>` | Adjust triage dispositions based on feedback | Triage artifact exists | Updated `triage` artifact | Revised triage |
+| `/squad plan` | Generate combined program + implementation plan (fast path) | Triage artifact exists | Comment with `squad_artifact: plan` data | Combined plan |
+| `/squad plan program` | Generate high-level program plan with epics and milestones | Triage artifact exists | Comment with `squad_artifact: program` data | Epics, milestones, user stories |
+| `/squad plan program revise <feedback>` | Adjust program plan based on feedback | Program plan artifact exists | Updated `program` artifact | Revised program plan |
+| `/squad plan implementation` | Decompose program plan into PR-sized tasks | Program plan artifact exists | Comment with `squad_artifact: implementation` data | Task breakdown with deps and sizing |
+| `/squad plan validate` | Run structural readiness checks on the plan | Implementation plan artifact exists | Comment with `squad_artifact: validation` data | Pass/fail checklist |
 | `/squad plan revise <feedback>` | Revise the current plan based on feedback | Program or implementation plan exists | Updated plan artifact | Revised plan |
-| `/squad plan accept` | Accept scope + implementation + activate (fast path) | Implementation plan + validation pass | Comments with `<!-- squad-scope-accepted-v1 -->`, `<!-- squad-impl-accepted-v1 -->`, `<!-- squad-activated-v1 -->` markers; issues created | Acceptance confirmations + issue links |
-| `/squad plan accept scope` | Approve the program plan's scope | Program plan artifact exists | Comment with `<!-- squad-scope-accepted-v1 -->` marker | Scope lock confirmation |
-| `/squad plan accept implementation` | Approve the implementation plan | Implementation plan + validation pass | Comment with `<!-- squad-impl-accepted-v1 -->` marker | Implementation lock confirmation |
-| `/squad plan activate` | Create GitHub issues from accepted plan | Both scope and implementation accepted | Issues + milestones + labels created; comment with `<!-- squad-activated-v1 -->` marker | Issue links and summary |
+| `/squad plan accept` | Accept scope + implementation + activate (fast path) | Implementation plan + validation pass | Structured acceptance/activation artifacts; issues created | Acceptance confirmations + issue links |
+| `/squad plan accept scope` | Approve the program plan's scope | Program plan artifact exists | Comment with `squad_artifact: scope-accepted` data | Scope lock confirmation |
+| `/squad plan accept implementation` | Approve the implementation plan | Implementation plan + validation pass | Comment with `squad_artifact: impl-accepted` data | Implementation lock confirmation |
+| `/squad plan activate` | Create GitHub issues from accepted plan | Both scope and implementation accepted | Issues + milestones + labels; `activated` artifact | Issue links and summary |
 
 ---
 
@@ -126,18 +126,18 @@ idle
 
 ### Stage-by-Stage Reference
 
-| Stage | Command | Artifact marker | Location | Idempotent? |
-|-------|---------|-----------------|----------|-------------|
+| Stage | Command | `squad_artifact` | Location | Idempotent? |
+|-------|---------|------------------|----------|-------------|
 | Intent | (issue body) | — | Issue description | N/A |
-| Research | `/squad research` | `<!-- squad-research-v1 -->` | Issue comment | Yes — re-running replaces previous |
-| Triage | `/squad triage` | `<!-- squad-triage-v1 -->` | Issue comment | Yes |
-| Program Plan | `/squad plan program` | `<!-- squad-program-v1 -->` | Issue comment | Yes |
-| Implementation Plan | `/squad plan implementation` | `<!-- squad-implementation-v1 -->` | Issue comment | Yes |
-| Validation | `/squad plan validate` | `<!-- squad-validation-v1 -->` | Issue comment | Yes |
-| Scope Acceptance | `/squad plan accept scope` | `<!-- squad-scope-accepted-v1 -->` | Issue comment | No — locks scope |
-| Impl Acceptance | `/squad plan accept implementation` | `<!-- squad-impl-accepted-v1 -->` | Issue comment | No — locks implementation |
-| Activation | `/squad plan activate` | `<!-- squad-activated-v1 -->` | Issue comment | No — creates issues |
-| Lifecycle State | (auto-updated) | `<!-- squad-lifecycle-state -->` | Issue comment | Auto-maintained |
+| Research | `/squad research` | `research` | Issue comment | Yes — re-running replaces previous |
+| Triage | `/squad triage` | `triage` | Issue comment | Yes |
+| Program Plan | `/squad plan program` | `program` | Issue comment | Yes |
+| Implementation Plan | `/squad plan implementation` | `implementation` | Issue comment | Yes |
+| Validation | `/squad plan validate` | `validation` | Issue comment | Yes |
+| Scope Acceptance | `/squad plan accept scope` | `scope-accepted` | Issue comment | No — locks scope |
+| Impl Acceptance | `/squad plan accept implementation` | `impl-accepted` | Issue comment | No — locks implementation |
+| Activation | `/squad plan activate` | `activated` | Issue comment | No — creates issues |
+| Lifecycle State | (auto-updated) | `lifecycle-state` | Issue comment | Auto-maintained |
 
 **Idempotency note:** Research, triage, plans, and validation can be re-run safely — each re-run replaces the previous artifact. Acceptance and activation are one-way transitions.
 
@@ -197,7 +197,7 @@ Created during activation to group epics by delivery phase.
 
 ### Comments
 
-Structured planning artifacts posted as issue comments. Each contains an HTML marker (listed above) for programmatic identification.
+Structured planning artifacts are posted as human-readable issue comments. gh-aw appends a validated `Structured data:` JSON block for programmatic identification.
 
 ### Pull requests
 
@@ -245,9 +245,9 @@ GitHub Agentic Workflows enforce output limits per run to prevent runaway mutati
 
 | Output type | Maximum per run | Notes |
 |-------------|----------------|-------|
-| `create-issue` | 20 | For large decompositions, split into multiple plan/accept cycles |
+| `create-issue` | 75 | For large decompositions, split into multiple plan/accept cycles |
 | `create-pull-request` | 3 | Cast, cast-member, and retire each produce one PR |
-| `add-comment` | 10 | Planning artifacts are posted as comments |
+| `add-comment` | 20 | Planning artifacts are posted as comments |
 
 ### Implications
 
@@ -259,22 +259,19 @@ GitHub Agentic Workflows enforce output limits per run to prevent runaway mutati
 
 ---
 
-## Key Markers for Programmatic Access
+## Structured Data for Programmatic Access
 
-When scanning issue comments for Squad artifacts, search for these HTML comment markers:
+Every planning artifact uses the gh-aw safe-output data envelope:
 
-```
-<!-- squad-research-v1 -->
-<!-- squad-triage-v1 -->
-<!-- squad-program-v1 -->
-<!-- squad-implementation-v1 -->
-<!-- squad-validation-v1 -->
-<!-- squad-scope-accepted-v1 -->
-<!-- squad-impl-accepted-v1 -->
-<!-- squad-activated-v1 -->
-<!-- squad-lifecycle-state -->
+```json
+{
+  "squad_artifact": "research",
+  "schema_version": "1",
+  "origin_issue": 123,
+  "phases": []
+}
 ```
 
-Each marker appears at the top of its respective comment body. To find the latest artifact of a given type, scan comments in reverse chronological order and take the first match.
+gh-aw appends the envelope as a `Structured data:` fenced JSON block. `phases` is empty except on phase-state artifacts, where it contains the accumulated phase numbers. Paginate all comments, parse the JSON, match the current `origin_issue` and desired `squad_artifact`, then take the newest match.
 
-> **Fast-path markers** (`squad-plan-v1`, `squad-plan-accepted`) also exist for legacy/simplified compatibility. See the planning ontology §6 (Backward Compatibility) for the full marker registry.
+HTML comments are not Squad state: gh-aw removes them from compiled prompts and sanitized safe-output bodies. See the planning ontology §4 for the complete artifact registry.

--- a/docs/demo-agentic-sdlc-walkthrough.md
+++ b/docs/demo-agentic-sdlc-walkthrough.md
@@ -5,6 +5,8 @@
 > **Scenario:** Add real-time notifications via SignalR to a .NET Aspire app using the Squad agentic SDLC  
 > **Prerequisite:** The presenter has a fresh .NET Aspire app (AppHost, ServiceDefaults, WebFrontend, ApiService) and has installed the Squad workflow via `gh aw add bradygaster/squad/workflows/squad.md@latest`. No squad has been cast yet.
 
+Planning comments remain human-readable. For programmatic discovery, gh-aw appends a validated `Structured data:` JSON block containing `squad_artifact`, `schema_version: "1"`, `origin_issue`, and a `phases` array. The screen excerpts below omit that footer for readability.
+
 ---
 
 ## Step 1: Cast the squad
@@ -29,9 +31,9 @@ Merge the PR to activate your team. Run `/squad status` afterward to verify.
 
 **Do:** Click the PR link, review the team composition in `meet-the-squad.md`, then merge.
 
-**Screen shows:** The PR merges. The casting issue closes (its job is done).
+**Screen shows:** The PR merges. The casting issue remains open until the user closes it.
 
-**Key point:** Casting is a one-time setup action — it gets its own issue so it can close cleanly. Your actual work intent goes in a separate issue that stays open throughout the SDLC lifecycle.
+**Key point:** Casting is a one-time setup action — it gets its own issue that the user closes after merge. Your actual work intent goes in a separate issue that stays open throughout the SDLC lifecycle.
 
 ---
 
@@ -74,7 +76,6 @@ to connected browser clients via SignalR.
 **Screen shows:** *(after ~30 seconds, a structured comment appears)*
 
 ```markdown
-<!-- squad-research-v1 -->
 ## 🔬 Squad Research — SignalR Notifications for Aspire App
 
 ### Summary
@@ -140,7 +141,6 @@ all four projects with careful registration in the AppHost resource model.
 **Screen shows:**
 
 ```markdown
-<!-- squad-triage-v1 -->
 ## 🔍 Squad Triage — Dispositions
 
 > Intent: Add real-time SignalR notifications to Aspire app
@@ -186,7 +186,6 @@ all four projects with careful registration in the AppHost resource model.
 **Screen shows:**
 
 ```markdown
-<!-- squad-program-v1 -->
 ## 📋 Squad Program Plan
 
 > Intent: Add real-time SignalR notifications to Aspire app
@@ -269,7 +268,6 @@ E1 (Hub) ──→ E2 (Aspire) ──→ E3 (Blazor UI)
 **Screen shows:** *(first, scope acceptance)*
 
 ```markdown
-<!-- squad-scope-accepted-v1 -->
 ## ✅ Scope Accepted
 
 - **Program plan version:** [comment link]
@@ -283,7 +281,6 @@ E1 (Hub) ──→ E2 (Aspire) ──→ E3 (Blazor UI)
 *(then, the implementation plan)*
 
 ```markdown
-<!-- squad-implementation-v1 -->
 ## 🔧 Squad Implementation Plan
 
 > Program: Real-Time Notification Infrastructure
@@ -341,7 +338,6 @@ E1 (Hub) ──→ E2 (Aspire) ──→ E3 (Blazor UI)
 **Screen shows:**
 
 ```markdown
-<!-- squad-validation-v1 -->
 ## ✅ Squad Plan Validation — PASSED
 
 > Validated: Program Plan + Implementation Plan
@@ -383,7 +379,6 @@ E1 (Hub) ──→ E2 (Aspire) ──→ E3 (Blazor UI)
 **Screen shows:** *(activation record)*
 
 ```markdown
-<!-- squad-activated-v1 -->
 ## ✅ Plan Activated — 4 epics, 7 tasks created
 
 - **Activated by:** @bradygaster
@@ -429,7 +424,6 @@ with full hierarchy (Root → Epics → Tasks) and assigned to their respective 
 **Screen shows:**
 
 ```markdown
-<!-- squad-lifecycle-state -->
 ## Planning Lifecycle
 
 | Phase | Status | Artifact | Updated |

--- a/test-fixtures/planning/aspiregregator/README.md
+++ b/test-fixtures/planning/aspiregregator/README.md
@@ -8,16 +8,16 @@ The Aspiregregator is a .NET Aspire community content aggregator application. Th
 
 ## Fixture Contents
 
-| File | Planning Phase | Marker |
-|------|---------------|--------|
+| File | Planning Phase | `squad_artifact` |
+|------|---------------|------------------|
 | `intent.md` | Intent (issue body) | — |
-| `research-output.md` | Research | `<!-- squad-research-v1 -->` |
-| `triage-output.md` | Triage | `<!-- squad-triage-v1 -->` |
-| `program-plan-output.md` | Program Plan | `<!-- squad-program-v1 -->` |
-| `implementation-plan-output.md` | Implementation Plan | `<!-- squad-implementation-v1 -->` |
-| `validation-output.md` | Validation | `<!-- squad-validation-v1 -->` |
-| `acceptance-outputs.md` | Scope + Impl + Activation | Three markers |
-| `lifecycle-state.md` | Lifecycle State | `<!-- squad-lifecycle-state -->` |
+| `research-output.md` | Research | `research` |
+| `triage-output.md` | Triage | `triage` |
+| `program-plan-output.md` | Program Plan | `program` |
+| `implementation-plan-output.md` | Implementation Plan | `implementation` |
+| `validation-output.md` | Validation | `validation` |
+| `acceptance-outputs.md` | Scope + Impl + Activation | Three structured artifacts |
+| `lifecycle-state.md` | Lifecycle State | `lifecycle-state` |
 | `assertions.md` | Test Assertions | — |
 
 ## How to Use for Regression Testing
@@ -25,14 +25,14 @@ The Aspiregregator is a .NET Aspire community content aggregator application. Th
 ### Manual Validation
 
 1. Compare each output file against the schema in `workflows/shared/planning-ontology.md`
-2. Verify all markers are present and well-formed
+2. Verify every `Structured data:` JSON block has `schema_version: "1"`, `origin_issue: 8`, `phases: []`, and the expected `squad_artifact`
 3. Confirm traceability: every task → epic → initiative → triage item
 
 ### Automated Validation
 
 Use `assertions.md` as a machine-checkable spec. A test harness should:
 
-1. Parse each fixture file for its expected marker
+1. Parse each fixture file's gh-aw `Structured data:` fenced JSON
 2. Validate internal structure matches the ontology schema
 3. Cross-reference items across phases (traceability)
 4. Verify dependency graph is a valid DAG

--- a/test-fixtures/planning/aspiregregator/acceptance-outputs.md
+++ b/test-fixtures/planning/aspiregregator/acceptance-outputs.md
@@ -1,4 +1,3 @@
-<!-- squad-scope-accepted-v1 -->
 ## Scope Accepted
 
 - **Program plan version:** #8 (comment-id: 2847301)
@@ -6,9 +5,18 @@
 - **Date:** 2026-07-15T14:22:00Z
 - **Notes:** Confirmed scope with both decisions resolved — Azure Table Storage for grain persistence, Blazor frontend deferred. Three milestones over six weeks is acceptable timeline.
 
+Structured data:
+```json
+{
+  "squad_artifact": "scope-accepted",
+  "schema_version": "1",
+  "origin_issue": 8,
+  "phases": []
+}
+```
+
 ---
 
-<!-- squad-impl-accepted-v1 -->
 ## Implementation Accepted
 
 - **Implementation plan version:** #8 (comment-id: 2847456)
@@ -17,9 +25,18 @@
 - **Date:** 2026-07-15T14:35:00Z
 - **Notes:** Task sizing looks right. The L-sized API rewiring task (Task 12) is the riskiest — contract tests in Phase 1 provide adequate safety net. Approved for activation.
 
+Structured data:
+```json
+{
+  "squad_artifact": "impl-accepted",
+  "schema_version": "1",
+  "origin_issue": 8,
+  "phases": []
+}
+```
+
 ---
 
-<!-- squad-activated-v1 -->
 ## Execution Activated
 
 - **Issues created:** 14
@@ -46,3 +63,13 @@
 
 Dependency order and phase assignments are reflected in the issue bodies.
 The squad is ready to begin work.
+
+Structured data:
+```json
+{
+  "squad_artifact": "activated",
+  "schema_version": "1",
+  "origin_issue": 8,
+  "phases": []
+}
+```

--- a/test-fixtures/planning/aspiregregator/assertions.md
+++ b/test-fixtures/planning/aspiregregator/assertions.md
@@ -3,27 +3,27 @@
 Machine-checkable assertions for validating the planning lifecycle fixture.
 A test harness should verify ALL assertions pass against the fixture files.
 
-## Marker Presence
+## Structured Artifact Presence
 
-- [ ] `research-output.md` contains exactly one `<!-- squad-research-v1 -->` marker
-- [ ] `triage-output.md` contains exactly one `<!-- squad-triage-v1 -->` marker
-- [ ] `program-plan-output.md` contains exactly one `<!-- squad-program-v1 -->` marker
-- [ ] `implementation-plan-output.md` contains exactly one `<!-- squad-implementation-v1 -->` marker
-- [ ] `validation-output.md` contains exactly one `<!-- squad-validation-v1 -->` marker
-- [ ] `acceptance-outputs.md` contains exactly one `<!-- squad-scope-accepted-v1 -->` marker
-- [ ] `acceptance-outputs.md` contains exactly one `<!-- squad-impl-accepted-v1 -->` marker
-- [ ] `acceptance-outputs.md` contains exactly one `<!-- squad-activated-v1 -->` marker
-- [ ] `lifecycle-state.md` contains exactly one `<!-- squad-lifecycle-state -->` marker
+- [ ] `research-output.md` contains exactly one structured artifact with `squad_artifact: research`
+- [ ] `triage-output.md` contains exactly one structured artifact with `squad_artifact: triage`
+- [ ] `program-plan-output.md` contains exactly one structured artifact with `squad_artifact: program`
+- [ ] `implementation-plan-output.md` contains exactly one structured artifact with `squad_artifact: implementation`
+- [ ] `validation-output.md` contains exactly one structured artifact with `squad_artifact: validation` and a human-readable `RESULT: PASS`
+- [ ] `acceptance-outputs.md` contains one each of `scope-accepted`, `impl-accepted`, and `activated`
+- [ ] `lifecycle-state.md` contains exactly one structured artifact with `squad_artifact: lifecycle-state`
+- [ ] Every structured artifact uses `schema_version: "1"`, `origin_issue: 8`, and `phases: []`
+- [ ] No fixture relies on a Squad HTML comment for machine state
 
-## Marker Ordering (Lifecycle Sequence)
+## Artifact Ordering (Lifecycle Sequence)
 
-- [ ] Research marker precedes Triage marker (by file creation order or embedded timestamps)
-- [ ] Triage marker precedes Program Plan marker
-- [ ] Program Plan marker precedes Implementation Plan marker
-- [ ] Implementation Plan marker precedes Validation marker
-- [ ] Validation marker precedes Scope Accepted marker
-- [ ] Scope Accepted marker precedes Impl Accepted marker
-- [ ] Impl Accepted marker precedes Activated marker
+- [ ] Research artifact precedes Triage artifact (by file creation order or embedded timestamps)
+- [ ] Triage artifact precedes Program Plan artifact
+- [ ] Program Plan artifact precedes Implementation Plan artifact
+- [ ] Implementation Plan artifact precedes Validation artifact
+- [ ] Validation artifact precedes Scope Accepted artifact
+- [ ] Scope Accepted artifact precedes Impl Accepted artifact
+- [ ] Impl Accepted artifact precedes Activated artifact
 - [ ] Lifecycle state shows all phases as `✅ Done` with monotonically increasing timestamps
 
 ## Traceability — No Orphaned Triage Items

--- a/test-fixtures/planning/aspiregregator/implementation-plan-output.md
+++ b/test-fixtures/planning/aspiregregator/implementation-plan-output.md
@@ -1,4 +1,3 @@
-<!-- squad-implementation-v1 -->
 ## Implementation Plan
 
 ### Tasks
@@ -47,3 +46,13 @@
   - `M2: Platform & Persistence` → Tasks 8, 9, 10, 11
   - `M3: Integration & Observability` → Tasks 12, 13, 14
 - **Labels:** `size:S`, `size:M`, `size:L` + `squad` + `squad:{agent}` _(label mode — see README for size_representation note)_
+
+Structured data:
+```json
+{
+  "squad_artifact": "implementation",
+  "schema_version": "1",
+  "origin_issue": 8,
+  "phases": []
+}
+```

--- a/test-fixtures/planning/aspiregregator/lifecycle-state.md
+++ b/test-fixtures/planning/aspiregregator/lifecycle-state.md
@@ -1,4 +1,3 @@
-<!-- squad-lifecycle-state -->
 ## Planning Lifecycle
 
 | Phase | Status | Artifact | Updated |
@@ -15,3 +14,13 @@
 
 **Current state:** Activated
 **Last command:** `/squad plan activate` by @bradygaster at 2026-07-15T14:36:00Z
+
+Structured data:
+```json
+{
+  "squad_artifact": "lifecycle-state",
+  "schema_version": "1",
+  "origin_issue": 8,
+  "phases": []
+}
+```

--- a/test-fixtures/planning/aspiregregator/program-plan-output.md
+++ b/test-fixtures/planning/aspiregregator/program-plan-output.md
@@ -1,4 +1,3 @@
-<!-- squad-program-v1 -->
 ## Program Plan
 
 ### Initiatives
@@ -71,3 +70,13 @@
   - Cosmos DB evaluation (decision resolved: Azure Table Storage selected)
   - Performance optimization beyond the 10% regression constraint
   - Multi-region deployment topology
+
+Structured data:
+```json
+{
+  "squad_artifact": "program",
+  "schema_version": "1",
+  "origin_issue": 8,
+  "phases": []
+}
+```

--- a/test-fixtures/planning/aspiregregator/research-output.md
+++ b/test-fixtures/planning/aspiregregator/research-output.md
@@ -1,4 +1,3 @@
-<!-- squad-research-v1 -->
 ## Research Findings
 
 ### Summary
@@ -77,3 +76,13 @@ This makes the modernization risky without adding test coverage first.
 - Adopt a vertical-slice approach: complete one grain end-to-end (persistence, telemetry, tests) then replicate pattern
 - Wire service discovery early — it simplifies the remaining integration work
 - Defer Blazor WASM frontend changes to a separate initiative (no coupling to backend modernization)
+
+Structured data:
+```json
+{
+  "squad_artifact": "research",
+  "schema_version": "1",
+  "origin_issue": 8,
+  "phases": []
+}
+```

--- a/test-fixtures/planning/aspiregregator/triage-output.md
+++ b/test-fixtures/planning/aspiregregator/triage-output.md
@@ -1,4 +1,3 @@
-<!-- squad-triage-v1 -->
 ## Triage Disposition
 
 ### Work Items (→ planning)
@@ -42,3 +41,13 @@
 - **Work items:** 16
 - **Decisions pending:** 2
 - **Excluded:** 3
+
+Structured data:
+```json
+{
+  "squad_artifact": "triage",
+  "schema_version": "1",
+  "origin_issue": 8,
+  "phases": []
+}
+```

--- a/test-fixtures/planning/aspiregregator/validation-output.md
+++ b/test-fixtures/planning/aspiregregator/validation-output.md
@@ -1,4 +1,3 @@
-<!-- squad-validation-v1 -->
 ## Plan Validation
 
 ### Result: ✅ PASS
@@ -57,3 +56,13 @@ Cycle detection: **No cycles found.** Longest path: Task 7 → 8 → 9 → 10 (l
 ### Diagnostics
 
 No issues found. Plan is ready for acceptance.
+
+Structured data:
+```json
+{
+  "squad_artifact": "validation",
+  "schema_version": "1",
+  "origin_issue": 8,
+  "phases": []
+}
+```

--- a/test/fixtures/team-guard/one-member-crlf.md
+++ b/test/fixtures/team-guard/one-member-crlf.md
@@ -1,0 +1,6 @@
+# Squad Team
+
+## Members
+| Name | Role | Charter path | Status |
+|------|------|--------------|--------|
+| Eecom | Core Dev | .squad/agents/eecom/charter.md | active |

--- a/test/fixtures/team-guard/one-member.md
+++ b/test/fixtures/team-guard/one-member.md
@@ -1,0 +1,6 @@
+# Squad Team
+
+## Members
+| Name | Role | Charter path | Status |
+|------|------|--------------|--------|
+| Eecom | Core Dev | .squad/agents/eecom/charter.md | active |

--- a/test/fixtures/team-guard/scaffold-crlf.md
+++ b/test/fixtures/team-guard/scaffold-crlf.md
@@ -1,0 +1,5 @@
+# Squad Team
+
+## Members
+| Name | Role | Charter path | Status |
+|------|------|--------------|--------|

--- a/test/fixtures/team-guard/scaffold.md
+++ b/test/fixtures/team-guard/scaffold.md
@@ -1,0 +1,5 @@
+# Squad Team
+
+## Members
+| Name | Role | Charter path | Status |
+|------|------|--------------|--------|

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -699,6 +699,8 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
     expect(content).toMatch(/open Cast PR.*found|cast PR.*found|Cast PR is found/i);
     // Exact --head matching truncates the branch name and never finds squad/cast-{repo}; must be forbidden
     expect(content).not.toMatch(/--head "squad\/cast-"/);
+    // squad/cast-member-* must be excluded so Cast Member PRs cannot satisfy Cast dedup
+    expect(content).toMatch(/startswith\("squad\/cast-member-"\).*\| not|\| not.*startswith\("squad\/cast-member-"\)/);
   });
 
   it('Cast PR dedup stops without opening a duplicate PR', () => {
@@ -755,11 +757,10 @@ describe('gh-aw: Team Guard roster-row detection logic (conceptual fixture cover
   const TEAM_GUARD_FIXTURES = join(process.cwd(), 'test', 'fixtures', 'team-guard');
 
   // Duplicate of the exact TG-1 shell snippet from workflows/squad.md (kept in sync).
-  // The snippet checks for a real member data row inside the ## Members section —
-  // neither the header row nor the separator row counts as TEAM_PRESENT.
+  // sub(/\r$/,"") normalizes CRLF so Windows-formatted team.md files are classified correctly.
   function runRosterCheck(filePath: string): string {
     return execSync(
-      `awk '/^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\\|/&&!/^\\|[-: |]*\\|$/&&!/\\| *Name *\\|/' '${filePath}' 2>/dev/null | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT`,
+      `awk '{sub(/\\r$/,"")} /^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\\|/&&!/^\\|[-: |]*\\|$/&&!/\\| *Name *\\|/' '${filePath}' 2>/dev/null | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT`,
       { shell: '/bin/sh', encoding: 'utf8' }
     ).trim();
   }
@@ -778,6 +779,14 @@ describe('gh-aw: Team Guard roster-row detection logic (conceptual fixture cover
 
   it('one real member data row → TEAM_PRESENT', () => {
     expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'one-member.md'))).toBe('TEAM_PRESENT');
+  });
+
+  it('CRLF scaffold/header-only (no data rows, Windows line endings) → TEAM_ABSENT', () => {
+    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'scaffold-crlf.md'))).toBe('TEAM_ABSENT');
+  });
+
+  it('CRLF one real member data row (Windows line endings) → TEAM_PRESENT', () => {
+    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'one-member-crlf.md'))).toBe('TEAM_PRESENT');
   });
 });
 
@@ -806,5 +815,64 @@ describe('gh-aw: canonical marker fields and no raw input interpolation (#1689 r
 
   it('{original_command} does not appear anywhere in workflow — only canonical command variables are used', () => {
     expect(content).not.toMatch(/\{original_command\}/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: Cast PR dedup jq filter — behavioral coverage (#1689 revision)
+// ---------------------------------------------------------------------------
+
+describe('gh-aw: Cast PR dedup jq filter behavioral coverage (#1689 revision)', () => {
+  const squadContent = readFileSync(SQUAD_WORKFLOW, 'utf8');
+
+  // Extract the exact --jq expression from squad.md so this test stays in sync.
+  function extractJqFilter(): string {
+    const m = squadContent.match(/--jq '([^']+)'/);
+    if (!m) throw new Error('Could not extract --jq filter from squad.md TG-3');
+    return m[1];
+  }
+
+  function runJqFilter(jsonInput: string, filter: string): string {
+    return execSync(
+      `echo '${jsonInput.replace(/'/g, "'\\''")}' | jq -r '${filter}'`,
+      { shell: '/bin/sh', encoding: 'utf8' }
+    ).trim();
+  }
+
+  it('extracts a jq filter from squad.md TG-3 block', () => {
+    expect(() => extractJqFilter()).not.toThrow();
+    const filter = extractJqFilter();
+    expect(filter).toMatch(/startswith/);
+    expect(filter).toMatch(/headRefName/);
+  });
+
+  it('real Cast branch (squad/cast-{repo}) satisfies the filter and returns the PR', () => {
+    const filter = extractJqFilter();
+    const prs = JSON.stringify([
+      { headRefName: 'squad/cast-myrepo', number: 42, url: 'https://github.com/org/repo/pull/42' },
+    ]);
+    const result = runJqFilter(prs, filter);
+    expect(result).toContain('"headRefName": "squad/cast-myrepo"');
+    expect(result).toContain('"number": 42');
+  });
+
+  it('Cast Member branch (squad/cast-member-*) is excluded and returns null', () => {
+    const filter = extractJqFilter();
+    const prs = JSON.stringify([
+      { headRefName: 'squad/cast-member-dev', number: 43, url: 'https://github.com/org/repo/pull/43' },
+    ]);
+    const result = runJqFilter(prs, filter);
+    expect(result).toBe('null');
+  });
+
+  it('Cast branch is selected and Cast Member branch is excluded when both are open', () => {
+    const filter = extractJqFilter();
+    const prs = JSON.stringify([
+      { headRefName: 'squad/cast-member-dev', number: 43, url: 'https://github.com/org/repo/pull/43' },
+      { headRefName: 'squad/cast-myrepo', number: 42, url: 'https://github.com/org/repo/pull/42' },
+    ]);
+    const result = runJqFilter(prs, filter);
+    expect(result).toContain('"headRefName": "squad/cast-myrepo"');
+    expect(result).not.toContain('squad/cast-member-dev');
   });
 });

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -632,3 +632,107 @@ describe('gh-aw: Plan Activate atomic task-call contract', () => {
     expect(content).toMatch(/idempotent via title match/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Test: Auto-Cast Pivot and resumable work (#1689)
+// ---------------------------------------------------------------------------
+
+describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
+  const content = readFileSync(SQUAD_WORKFLOW, 'utf8');
+  const ontologyPath = join(SHARED_DIR, 'planning-ontology.md');
+  const ontologyContent = readFileSync(ontologyPath, 'utf8');
+
+  it('Team Guard section exists and lists covered modes', () => {
+    expect(content).toMatch(/## Team Guard/);
+    expect(content).toMatch(/Applies to:.*Research/i);
+    expect(content).toMatch(/Applies to:.*Triage/i);
+    expect(content).toMatch(/Applies to:.*Plan/i);
+  });
+
+  it('Team Guard is exempt for Cast, Connect, Adopt, Status, Implement', () => {
+    expect(content).toMatch(/Exempt:.*Cast/i);
+    expect(content).toMatch(/Exempt:.*Connect/i);
+    expect(content).toMatch(/Exempt:.*Status/i);
+    expect(content).toMatch(/Exempt:.*Implement/i);
+  });
+
+  it('Team Guard uses a bash file check that emits TEAM_PRESENT or TEAM_ABSENT', () => {
+    expect(content).toMatch(/TEAM_PRESENT/);
+    expect(content).toMatch(/TEAM_ABSENT/);
+    expect(content).toMatch(/test -s .squad\/team\.md/);
+  });
+
+  it('Auto-Cast Pivot stops and does not run original mode when TEAM_ABSENT', () => {
+    expect(content).toMatch(/do not proceed with the original mode this run|do not run the original command this run/i);
+    expect(content).toMatch(/Stop\. Do not run (Cast|the original)/i);
+  });
+
+  it('squad-pending-intent-v1 marker is scanned before writing (write-once)', () => {
+    expect(content).toMatch(/squad-pending-intent-v1/);
+    // Must check for existing marker before posting
+    expect(content).toMatch(/Scan.*squad-pending-intent-v1|never write a second pending-intent/i);
+  });
+
+  it('squad-cast-opened-v1 marker is immutable (written once)', () => {
+    expect(content).toMatch(/squad-cast-opened-v1/);
+    expect(content).toMatch(/immutable.*never edited|never edited|immutable.*cast-opened/i);
+  });
+
+  it('first run completion copy does not fabricate or promise a PR number', () => {
+    // Must tell user to check PRs tab, not promise a specific PR number
+    expect(content).toMatch(/Pull Requests.*tab|check.*Pull Requests/i);
+    const castOpenedBlock = content.match(/squad-cast-opened-v1[\s\S]{0,800}/)?.[0] ?? '';
+    // Must NOT have a fabricated #{number} link in the cast-opened user copy
+    expect(castOpenedBlock).not.toMatch(/PR:.*#\d{1,6}/);
+  });
+
+  it('rerun path reads actual GitHub state via gh pr list before posting link', () => {
+    expect(content).toMatch(/gh pr list.*--head.*squad\/cast|gh pr list.*squad\/cast/i);
+    expect(content).toMatch(/open Cast PR.*found|cast PR.*found|Cast PR is found/i);
+  });
+
+  it('Cast PR dedup stops without opening a duplicate PR', () => {
+    expect(content).toMatch(/No duplicate PR opened|do not run Cast mode/i);
+  });
+
+  it('Cast PR body includes squad-cast-pr-v1 origin reference', () => {
+    expect(content).toMatch(/squad-cast-pr-v1.*origin-issue|origin-issue.*squad-cast-pr-v1/i);
+  });
+
+  it('normal-flow recovery never instructs user to run /squad cast separately', () => {
+    // The Auto-Cast section must explicitly forbid instructing the user to run /squad cast
+    expect(content).toMatch(/Never instruct.*\/squad cast|never.*\/squad cast separately/i);
+  });
+
+  it('partial activation N/M copy uses plan total not safe-output cap', () => {
+    expect(content).toMatch(/plan.*declared total|use the plan.*total.*not the safe-output cap/i);
+  });
+
+  it('partial activation post message includes rerun instruction', () => {
+    expect(content).toMatch(/N of M issues created.*rerun the identical|rerun the identical.*command to continue/i);
+  });
+
+  it('partial activation never surfaces safe-output cap as reason', () => {
+    expect(content).toMatch(/Never surface.*safe-output cap|never surface.*create-issue.*cap/i);
+  });
+
+  it('squad-pending-intent-v1 is registered in planning-ontology.md', () => {
+    expect(ontologyContent).toContain('<!-- squad-pending-intent-v1 -->');
+  });
+
+  it('squad-cast-opened-v1 is registered in planning-ontology.md', () => {
+    expect(ontologyContent).toContain('<!-- squad-cast-opened-v1 -->');
+  });
+
+  it('squad-cast-pr-v1 is registered in planning-ontology.md', () => {
+    expect(ontologyContent).toContain('<!-- squad-cast-pr-v1 -->');
+  });
+
+  it('safe-output caps (75 create-issue / 20 add-comment) are not conflated with plan limits', () => {
+    // The workflow frontmatter must declare max=75 for create-issue and max=20 for add-comment
+    const frontmatter = extractFrontmatter(SQUAD_WORKFLOW);
+    const safeOutputs = extractSafeOutputs(frontmatter);
+    expect((safeOutputs['create-issue'] as { max: number })?.max).toBe(75);
+    expect((safeOutputs['add-comment'] as { max: number })?.max).toBe(20);
+  });
+});

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -5,18 +5,23 @@
  * - safe-output configuration schema
  * - mode dispatch completeness
  * - shared component imports
- * - planning state machine marker consistency
+ * - planning state machine structured-artifact consistency
  */
 
-import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { afterAll, describe, it, expect } from 'vitest';
+import { cpSync, readFileSync, existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync, spawnSync } from 'node:child_process';
 import { minimatch } from 'minimatch';
 
 const WORKFLOWS_DIR = join(process.cwd(), 'workflows');
 const SQUAD_WORKFLOW = join(WORKFLOWS_DIR, 'squad.md');
 const SHARED_DIR = join(WORKFLOWS_DIR, 'shared');
+const TEST_WORKSPACES_DIR = join(process.cwd(), '.test-workspaces');
+
+afterAll(() => {
+  rmSync(TEST_WORKSPACES_DIR, { recursive: true, force: true });
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -77,6 +82,8 @@ function extractSafeOutputs(frontmatter: string): Record<string, Record<string, 
         const arrayMatch = value.match(/^\[(.+)\]$/);
         if (arrayMatch) {
           outputs[currentOutput][key] = arrayMatch[1].split(',').map(s => s.trim().replace(/"/g, ''));
+        } else if (value === 'true' || value === 'false') {
+          outputs[currentOutput][key] = value === 'true';
         } else if (!isNaN(Number(value))) {
           outputs[currentOutput][key] = Number(value);
         } else {
@@ -149,32 +156,43 @@ function extractModeTable(content: string): Array<{ command: string; mode: strin
   return rows;
 }
 
-/** Extract HTML comment markers from the planning ontology. */
-function extractOntologyMarkers(filePath: string): string[] {
-  const content = readFileSync(filePath, 'utf8');
-  const markers: string[] = [];
-  const markerRegex = /`(<!-- squad-[\w-]+ -->)`/g;
-  let match: RegExpExecArray | null;
-  while ((match = markerRegex.exec(content)) !== null) {
-    if (!markers.includes(match[1])) {
-      markers.push(match[1]);
-    }
-  }
-  return markers;
+interface SquadArtifactData {
+  squad_artifact: string;
+  schema_version: string;
+  origin_issue: number;
+  phases: number[];
 }
 
-/** Extract markers referenced in squad.md (both in code fences and inline). */
-function extractSquadMarkerReferences(content: string): string[] {
-  const markers: string[] = [];
-  const markerRegex = /`?(<!-- squad-[\w-]+ -->)`?/g;
-  let match: RegExpExecArray | null;
-  while ((match = markerRegex.exec(content)) !== null) {
-    const marker = match[0].replace(/`/g, '');
-    if (!markers.includes(marker)) {
-      markers.push(marker);
+/** Parse gh-aw's durable Structured data footer from a normalized body. */
+function extractStructuredData(content: string): SquadArtifactData[] {
+  return [...content.matchAll(/Structured data:\s*```json\s*([\s\S]*?)```/g)].map(match =>
+    JSON.parse(match[1]) as SquadArtifactData
+  );
+}
+
+/** Locate the newest compatible artifact exactly as downstream planning modes do. */
+function findLatestArtifact(
+  comments: string[],
+  artifactKind: string,
+  originIssue: number
+): { body: string; data: SquadArtifactData } | undefined {
+  for (const body of [...comments].reverse()) {
+    const data = extractStructuredData(body).find(
+      item =>
+        item.squad_artifact === artifactKind &&
+        item.schema_version === '1' &&
+        item.origin_issue === originIssue
+    );
+    if (data) {
+      return { body, data };
     }
   }
-  return markers;
+  return undefined;
+}
+
+function createTestWorkspace(prefix: string): string {
+  mkdirSync(TEST_WORKSPACES_DIR, { recursive: true });
+  return mkdtempSync(join(TEST_WORKSPACES_DIR, prefix));
 }
 
 // ---------------------------------------------------------------------------
@@ -191,6 +209,7 @@ describe('gh-aw: safe-output configuration', () => {
 
   it('each safe-output has a max value that is a positive integer ≤ 1000', () => {
     for (const [name, config] of Object.entries(safeOutputs)) {
+      if (name === 'data') continue;
       expect(config.max, `${name} should have a max field`).toBeDefined();
       const max = config.max as number;
       expect(max, `${name}.max should be > 0`).toBeGreaterThan(0);
@@ -233,6 +252,16 @@ describe('gh-aw: safe-output configuration', () => {
     expect(pr.labels, 'should have labels').toBeDefined();
     expect(pr.max, 'should have max').toBeDefined();
     expect(pr['allowed-base-branches'], 'should have allowed-base-branches').toBeDefined();
+    expect(pr['auto-close-issue'], 'Cast PR must not close the originating work issue').toBe(false);
+  });
+
+  it('defines the minimum schema-validated durable artifact envelope', () => {
+    expect(frontmatter).toMatch(/data:\n\s+type: object/);
+    expect(frontmatter).toMatch(/squad_artifact:\n\s+type: string/);
+    expect(frontmatter).toMatch(/schema_version:\n\s+type: string\n\s+enum: \["1"\]/);
+    expect(frontmatter).toMatch(/origin_issue:\n\s+type: integer\n\s+minimum: 1/);
+    expect(frontmatter).toMatch(/phases:\n\s+type: array\n\s+items:\n\s+type: integer\n\s+minimum: 1/);
+    expect(frontmatter).toMatch(/required:\n\s+- squad_artifact\n\s+- schema_version\n\s+- origin_issue\n\s+- phases/);
   });
 
   it('create-issue and add-comment outputs exist', () => {
@@ -374,84 +403,110 @@ describe('gh-aw: shared component imports', () => {
 // ---------------------------------------------------------------------------
 
 describe('gh-aw: planning state machine', () => {
-  const ontologyPath = join(SHARED_DIR, 'planning-ontology.md');
-  const ontologyContent = readFileSync(ontologyPath, 'utf8');
+  const ontologyContent = readFileSync(join(SHARED_DIR, 'planning-ontology.md'), 'utf8');
   const squadContent = readFileSync(SQUAD_WORKFLOW, 'utf8');
 
-  const ontologyMarkers = extractOntologyMarkers(ontologyPath);
-  const squadMarkers = extractSquadMarkerReferences(squadContent);
+  function registryArtifactKinds(): string[] {
+    const registry = ontologyContent.match(/## 4\. Structured Artifact Registry([\s\S]*?)(?=\n---|\n## \d)/);
+    if (!registry) throw new Error('Structured Artifact Registry section is missing');
+    return [...registry[1].matchAll(/^\| `([^`]+)` \|/gm)].map(match => match[1]);
+  }
 
-  it('ontology defines markers', () => {
-    expect(ontologyMarkers.length).toBeGreaterThan(0);
+  it('uses no Squad HTML comment as machine state', () => {
+    const unsupportedMarker = /<!-- squad-[\w-]+(?:-v\d+)? -->/;
+    expect(squadContent).not.toMatch(unsupportedMarker);
+    expect(ontologyContent).not.toMatch(unsupportedMarker);
   });
 
-  it('all markers follow naming convention: <!-- squad-{name}-v{N} -->', () => {
-    // Allow both versioned (squad-X-vN) and unversioned (squad-X) markers
-    const markerPattern = /^<!-- squad-[\w-]+(-(v\d+))? -->$/;
-    for (const marker of ontologyMarkers) {
-      expect(marker, `Marker "${marker}" should follow naming convention`).toMatch(markerPattern);
-    }
-  });
-
-  it('all markers referenced in squad.md are defined in planning-ontology.md', () => {
-    // Filter to only planning-related markers (skip markers that might be internal)
-    const planningMarkers = squadMarkers.filter(m =>
-      m.includes('squad-') && !m.includes('squad-plan-v1') && !m.includes('squad-plan-accepted')
-    );
-
-    for (const marker of planningMarkers) {
-      // Check if the marker is defined in the ontology (either in ontology table
-      // or in the broader ontology content)
-      const defined = ontologyContent.includes(marker);
-      expect(defined, `Marker "${marker}" referenced in squad.md should be defined in planning-ontology.md`).toBe(true);
-    }
-  });
-
-  it('state transition table defines produces/requires markers consistently', () => {
-    // Extract state transitions from the ontology
+  it('state transition table defines produced and required artifact kinds consistently', () => {
     const transitionBlock = ontologyContent.match(/```\n(idle[\s\S]*?)```/);
     expect(transitionBlock, 'Should have a state transition code block').not.toBeNull();
 
     const transitions = transitionBlock![1];
-    const producesMarkers = [...transitions.matchAll(/produces:\s*(<!-- [\w-]+ -->)/g)]
-      .map(m => m[1]);
-    const requiresMarkers = [...transitions.matchAll(/requires:\s*(<!-- [\w-]+ -->)/g)]
-      .map(m => m[1]);
+    const produced = [...transitions.matchAll(/produces:\s*squad_artifact=([\w-]+)/g)].map(match => match[1]);
+    const required = [...transitions.matchAll(/requires:\s*squad_artifact=([\w-]+)/g)].map(match => match[1]);
 
-    // Every required marker should be produced by some prior transition
-    // (except the first which requires "intent")
-    for (const required of requiresMarkers) {
-      if (required.includes('intent')) continue;
-      const isProduced = producesMarkers.includes(required);
-      expect(isProduced, `Required marker "${required}" should be produced by a prior state`).toBe(true);
+    for (const artifactKind of required) {
+      expect(
+        produced,
+        `Required artifact "${artifactKind}" should be produced by a lifecycle transition`
+      ).toContain(artifactKind);
     }
   });
 
-  it('Comment Marker Registry section covers all state-produced markers', () => {
-    // Extract markers from the "Comment Marker Registry" table
-    const registrySection = ontologyContent.match(/## 4\. Comment Marker Registry[\s\S]*?(?=\n---|\n## \d)/);
-    expect(registrySection, 'Should have a Comment Marker Registry section').not.toBeNull();
-
-    // Extract from state transitions
+  it('Structured Artifact Registry covers all state-produced artifacts', () => {
     const transitionBlock = ontologyContent.match(/```\n(idle[\s\S]*?)```/);
     const transitions = transitionBlock![1];
-    const producedMarkers = [...transitions.matchAll(/produces:\s*(<!-- [\w-]+ -->)/g)]
-      .map(m => m[1]);
+    const produced = [...transitions.matchAll(/produces:\s*squad_artifact=([\w-]+)/g)].map(match => match[1]);
+    const registry = registryArtifactKinds();
 
-    for (const marker of producedMarkers) {
-      expect(
-        registrySection![0].includes(marker),
-        `Produced marker "${marker}" should be listed in Comment Marker Registry`
-      ).toBe(true);
+    for (const artifactKind of produced) {
+      expect(registry, `Produced artifact "${artifactKind}" should be listed in the registry`).toContain(artifactKind);
     }
   });
 
-  it('ontology marker versions are consistent (all v1 in current spec)', () => {
-    const versionedMarkers = ontologyMarkers.filter(m => m.match(/v\d+/));
-    const versions = versionedMarkers.map(m => m.match(/v(\d+)/)![1]);
-    const uniqueVersions = [...new Set(versions)];
-    // Currently all should be v1
-    expect(uniqueVersions, 'All versioned markers should use the same version').toEqual(['1']);
+  it('workflow schema enumerates every registered artifact kind', () => {
+    for (const artifactKind of registryArtifactKinds()) {
+      expect(squadContent, `safe-outputs.data should allow "${artifactKind}"`).toMatch(
+        new RegExp(`^\\s+- ${artifactKind}$`, 'm')
+      );
+    }
+  });
+
+  it('Research fixture data supports downstream Triage discovery', () => {
+    const fixtures = join(process.cwd(), 'test-fixtures', 'planning', 'aspiregregator');
+    const researchBody = readFileSync(join(fixtures, 'research-output.md'), 'utf8');
+    const wrongOrigin = researchBody.replace('"origin_issue": 8', '"origin_issue": 999');
+    const discovered = findLatestArtifact(
+      ['No structured artifact here', wrongOrigin, researchBody],
+      'research',
+      8
+    );
+
+    expect(discovered?.data).toEqual({
+      squad_artifact: 'research',
+      schema_version: '1',
+      origin_issue: 8,
+      phases: [],
+    });
+    expect(discovered?.body).toContain('## Research Findings');
+  });
+
+  it('planning fixtures model normalized gh-aw bodies with durable JSON data', () => {
+    const fixtures = join(process.cwd(), 'test-fixtures', 'planning', 'aspiregregator');
+    const expected = new Map([
+      ['research-output.md', ['research']],
+      ['triage-output.md', ['triage']],
+      ['program-plan-output.md', ['program']],
+      ['implementation-plan-output.md', ['implementation']],
+      ['validation-output.md', ['validation']],
+      ['acceptance-outputs.md', ['scope-accepted', 'impl-accepted', 'activated']],
+      ['lifecycle-state.md', ['lifecycle-state']],
+    ]);
+
+    for (const [file, artifactKinds] of expected) {
+      const artifacts = extractStructuredData(readFileSync(join(fixtures, file), 'utf8'));
+      expect(artifacts.map(item => item.squad_artifact), file).toEqual(artifactKinds);
+      for (const artifact of artifacts) {
+        expect(artifact.schema_version, file).toBe('1');
+        expect(artifact.origin_issue, file).toBe(8);
+        expect(artifact.phases, file).toEqual([]);
+      }
+    }
+  });
+
+  it('phase-state artifacts retain accumulated phases in structured data', () => {
+    const body = [
+      '## Phase 2 Accepted',
+      '',
+      'Structured data:',
+      '```json',
+      '{"squad_artifact":"phases-accepted","schema_version":"1","origin_issue":8,"phases":[1,2]}',
+      '```',
+    ].join('\n');
+
+    expect(findLatestArtifact([body], 'phases-accepted', 8)?.data.phases).toEqual([1, 2]);
+    expect(squadContent).toContain('"phases":[{accumulated}]');
   });
 });
 
@@ -552,6 +607,38 @@ describe('gh-aw: prompt budget & planning import regression', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Test: gh-aw compilation retains durable state and Auto-Cast contracts
+// ---------------------------------------------------------------------------
+
+describe('gh-aw: compiled workflow contract', () => {
+  const ghAwAvailable = spawnSync('gh', ['aw', '--version'], { encoding: 'utf8' }).status === 0;
+
+  it.skipIf(!ghAwAvailable)('strict-compiles and preserves prompt/config behavior', () => {
+    const workspace = createTestWorkspace('gh-aw-compile-');
+    try {
+      execFileSync('git', ['init', '--quiet'], { cwd: workspace });
+      cpSync(WORKFLOWS_DIR, join(workspace, 'workflows'), { recursive: true });
+      execFileSync('gh', ['aw', 'compile', 'workflows/squad.md', '--strict'], {
+        cwd: workspace,
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+
+      const compiled = readFileSync(join(workspace, 'workflows', 'squad.lock.yml'), 'utf8');
+      expect(compiled).toContain('"auto_close_issue":false');
+      expect(compiled).toContain('"data_enabled":true');
+      expect(compiled).toContain('"required":["origin_issue","phases","schema_version","squad_artifact"]');
+      expect(compiled).toContain('"enum":["research","plan","plan-accepted"');
+      expect(compiled).toContain('{{#runtime-import shared/planning-ontology.md}}');
+      expect(compiled).toContain('{{#runtime-import squad.md}}');
+      expect(compiled).not.toMatch(/<!-- squad-[\w-]+(?:-v\d+)? -->/);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Test: Plan Activate hardening behaviors (forward-port #1683)
 // ---------------------------------------------------------------------------
 
@@ -640,8 +727,6 @@ describe('gh-aw: Plan Activate atomic task-call contract', () => {
 
 describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
   const content = readFileSync(SQUAD_WORKFLOW, 'utf8');
-  const ontologyPath = join(SHARED_DIR, 'planning-ontology.md');
-  const ontologyContent = readFileSync(ontologyPath, 'utf8');
 
   it('Team Guard section exists and lists covered modes', () => {
     expect(content).toMatch(/## Team Guard/);
@@ -685,21 +770,16 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
     expect(content).toMatch(/Stop\. Do not run (Cast|the original)/i);
   });
 
-  it('squad-pending-intent-v1 marker is scanned before writing (write-once)', () => {
-    expect(content).toMatch(/squad-pending-intent-v1/);
-    // Must check for existing marker before posting
-    expect(content).toMatch(/Scan.*squad-pending-intent-v1|never write a second pending-intent/i);
-  });
-
-  it('squad-cast-opened-v1 marker is immutable (written once)', () => {
-    expect(content).toMatch(/squad-cast-opened-v1/);
-    expect(content).toMatch(/immutable.*never edited|never edited|immutable.*cast-opened/i);
+  it('does not require unsupported Auto-Cast HTML markers', () => {
+    expect(content).not.toMatch(/squad-(pending-intent|cast-opened|cast-pr)-v1/);
+    expect(readFileSync(join(SHARED_DIR, 'planning-ontology.md'), 'utf8'))
+      .not.toMatch(/squad-(pending-intent|cast-opened|cast-pr)-v1/);
   });
 
   it('first run completion copy does not fabricate or promise a PR number', () => {
     // Must tell user to check PRs tab, not promise a specific PR number
     expect(content).toMatch(/Pull Requests.*tab|check.*Pull Requests/i);
-    const castOpenedBlock = content.match(/squad-cast-opened-v1[\s\S]{0,800}/)?.[0] ?? '';
+    const castOpenedBlock = content.match(/No roster \+ no open Cast PR[\s\S]{0,1200}/)?.[0] ?? '';
     // Must NOT have a fabricated #{number} link in the cast-opened user copy
     expect(castOpenedBlock).not.toMatch(/PR:.*#\d{1,6}/);
   });
@@ -717,11 +797,17 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
   });
 
   it('Cast PR dedup stops without opening a duplicate PR', () => {
+    expect(content).toMatch(/already opened a Cast PR[\s\S]*\*\*Cast PR:\*\* \{pr_url\}/i);
     expect(content).toMatch(/No duplicate PR opened|do not run Cast mode/i);
   });
 
-  it('Cast PR body includes squad-cast-pr-v1 origin reference', () => {
-    expect(content).toMatch(/squad-cast-pr-v1.*origin-issue|origin-issue.*squad-cast-pr-v1/i);
+  it('no open Cast PR always retries Cast, including after a closed or failed PR', () => {
+    expect(content).toMatch(/If no open Cast PR found.*Execute Cast Mode/s);
+    expect(content).toMatch(/closed or failed Cast PR is not durable team state/i);
+  });
+
+  it('Cast PR instructions forbid issue-closing keywords', () => {
+    expect(content).toMatch(/MUST NOT contain.*Fixes.*Closes.*Resolves/i);
   });
 
   it('normal-flow recovery never instructs user to run /squad cast separately', () => {
@@ -741,18 +827,6 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
     expect(content).toMatch(/Never surface.*safe-output cap|never surface.*create-issue.*cap/i);
   });
 
-  it('squad-pending-intent-v1 is registered in planning-ontology.md', () => {
-    expect(ontologyContent).toContain('<!-- squad-pending-intent-v1 -->');
-  });
-
-  it('squad-cast-opened-v1 is registered in planning-ontology.md', () => {
-    expect(ontologyContent).toContain('<!-- squad-cast-opened-v1 -->');
-  });
-
-  it('squad-cast-pr-v1 is registered in planning-ontology.md', () => {
-    expect(ontologyContent).toContain('<!-- squad-cast-pr-v1 -->');
-  });
-
   it('safe-output caps (75 create-issue / 20 add-comment) are not conflated with plan limits', () => {
     // The workflow frontmatter must declare max=75 for create-issue and max=20 for add-comment
     const frontmatter = extractFrontmatter(SQUAD_WORKFLOW);
@@ -766,7 +840,7 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
 // Test: Team Guard roster-row detection — git-committed state coverage (#1689 revision 3)
 //
 // These tests replicate the exact TG-1 shell command from workflows/squad.md against
-// a real temporary git repository. This validates the committed-HEAD contract: only a
+// a real project-local scratch git repository. This validates the committed-HEAD contract: only a
 // team.md that is committed to HEAD can produce TEAM_PRESENT. Local working-tree files
 // (e.g., from activation pre-steps like `squad init --preset default`) are invisible to
 // the guard, preventing false TEAM_PRESENT in fresh repos.
@@ -788,13 +862,11 @@ describe('gh-aw: Team Guard roster-row detection — committed-HEAD git repo cov
     ).trim();
   }
 
-  // Creates a temp git repo, runs the provided setup callback, then returns the dir.
+  // Creates a project-local scratch git repo, runs the setup callback, then returns the dir.
   // Caller must call cleanup() when done.
   function makeGitRepo(setup: (dir: string) => void): { dir: string; cleanup: () => void } {
-    const dir = execSync('mktemp -d', { encoding: 'utf8' }).trim();
-    execSync('git init', { cwd: dir, shell: '/bin/sh' });
-    execSync('git config user.email "test@squad.test"', { cwd: dir, shell: '/bin/sh' });
-    execSync('git config user.name "Squad Test"', { cwd: dir, shell: '/bin/sh' });
+    const dir = createTestWorkspace('team-guard-');
+    execFileSync('git', ['init', '--quiet'], { cwd: dir });
     setup(dir);
     return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
   }
@@ -803,8 +875,17 @@ describe('gh-aw: Team Guard roster-row detection — committed-HEAD git repo cov
     const fullPath = join(dir, relPath);
     mkdirSync(dirname(fullPath), { recursive: true });
     writeFileSync(fullPath, content);
-    execSync(`git add "${relPath}"`, { cwd: dir, shell: '/bin/sh' });
-    execSync('git commit -m "test"', { cwd: dir, shell: '/bin/sh' });
+    execFileSync('git', ['add', '--', relPath], { cwd: dir });
+    execFileSync('git', ['commit', '--quiet', '-m', 'test'], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'Squad Test',
+        GIT_AUTHOR_EMAIL: 'squad-test',
+        GIT_COMMITTER_NAME: 'Squad Test',
+        GIT_COMMITTER_EMAIL: 'squad-test',
+      },
+    });
   }
 
   function addWorkingTree(dir: string, relPath: string, content: string): void {
@@ -918,30 +999,18 @@ describe('gh-aw: Team Guard roster-row detection — committed-HEAD git repo cov
 });
 
 // ---------------------------------------------------------------------------
-// Test: Canonical marker fields — no raw user input in HTML attributes (#1689 revision)
+// Test: Auto-Cast prompt hygiene (#1689 revision)
 // ---------------------------------------------------------------------------
 
-describe('gh-aw: canonical marker fields and no raw input interpolation (#1689 revision)', () => {
+describe('gh-aw: Auto-Cast prompt hygiene (#1689 revision)', () => {
   const content = readFileSync(SQUAD_WORKFLOW, 'utf8');
-
-  it('pending-intent-v1 marker attributes must not contain raw {original_command} input', () => {
-    expect(content).not.toMatch(/pending-intent-v1[^>]*command="?\{original_command/);
-  });
-
-  it('pending-intent-v1 marker must use mode= canonical field', () => {
-    expect(content).toMatch(/pending-intent-v1[^>]*mode=/);
-  });
-
-  it('cast-pr-v1 marker must not contain raw {original_command} in origin-command attribute', () => {
-    expect(content).not.toMatch(/cast-pr-v1[^>]*origin-command="?\{original_command/);
-  });
-
-  it('cast-pr-v1 marker must use origin-mode= canonical field', () => {
-    expect(content).toMatch(/cast-pr-v1[^>]*origin-mode=/);
-  });
 
   it('{original_command} does not appear anywhere in workflow — only canonical command variables are used', () => {
     expect(content).not.toMatch(/\{original_command\}/);
+  });
+
+  it('contains no source-only assertion that Squad HTML comments survive gh-aw', () => {
+    expect(content).not.toMatch(/<!-- squad-[\w-]+(?:-v\d+)? -->/);
   });
 });
 
@@ -990,6 +1059,21 @@ describe('gh-aw: Cast PR dedup jq filter behavioral coverage (#1689 revision)', 
     ]);
     const result = runJqFilter(prs, filter);
     expect(result).toBe('null');
+  });
+
+  it('a closed Cast PR is absent from the open-PR scan, allowing additive retry', () => {
+    const filter = extractJqFilter();
+    const allPrs = [
+      {
+        headRefName: 'squad/cast-myrepo',
+        number: 41,
+        state: 'CLOSED',
+        url: 'https://github.com/org/repo/pull/41',
+      },
+    ];
+    const openPrs = allPrs.filter(pr => pr.state === 'OPEN');
+    expect(runJqFilter(JSON.stringify(openPrs), filter)).toBe('null');
+    expect(squadContent).toMatch(/If no open Cast PR found.*Execute Cast Mode/s);
   });
 
   it('Cast branch is selected and Cast Member branch is excluded when both are open', () => {

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { execSync } from 'node:child_process';
 import { minimatch } from 'minimatch';
 
 const WORKFLOWS_DIR = join(process.cwd(), 'workflows');
@@ -656,10 +657,14 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
     expect(content).toMatch(/Exempt:.*Implement/i);
   });
 
-  it('Team Guard uses a bash file check that emits TEAM_PRESENT or TEAM_ABSENT', () => {
+  it('Team Guard uses a roster-row detection check that emits TEAM_PRESENT or TEAM_ABSENT', () => {
     expect(content).toMatch(/TEAM_PRESENT/);
     expect(content).toMatch(/TEAM_ABSENT/);
-    expect(content).toMatch(/test -s .squad\/team\.md/);
+    // Must inspect ## Members section for real data rows — not just file size
+    expect(content).toMatch(/## Members/);
+    expect(content).toMatch(/awk.*## Members.*TEAM_PRESENT.*TEAM_ABSENT|TEAM_ABSENT.*awk.*## Members/s);
+    // Must NOT use the shallow `test -s` check that treats scaffold-only files as TEAM_PRESENT
+    expect(content).not.toMatch(/test -s \.squad\/team\.md/);
   });
 
   it('Auto-Cast Pivot stops and does not run original mode when TEAM_ABSENT', () => {
@@ -686,9 +691,14 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
     expect(castOpenedBlock).not.toMatch(/PR:.*#\d{1,6}/);
   });
 
-  it('rerun path reads actual GitHub state via gh pr list before posting link', () => {
-    expect(content).toMatch(/gh pr list.*--head.*squad\/cast|gh pr list.*squad\/cast/i);
+  it('rerun path reads actual GitHub state via gh pr list with headRefName + startsWith filter', () => {
+    // Must use headRefName field and startsWith to match squad/cast-{repo} patterns
+    expect(content).toMatch(/gh pr list/i);
+    expect(content).toMatch(/headRefName/);
+    expect(content).toMatch(/startswith\("squad\/cast-"\)/);
     expect(content).toMatch(/open Cast PR.*found|cast PR.*found|Cast PR is found/i);
+    // Exact --head matching truncates the branch name and never finds squad/cast-{repo}; must be forbidden
+    expect(content).not.toMatch(/--head "squad\/cast-"/);
   });
 
   it('Cast PR dedup stops without opening a duplicate PR', () => {
@@ -734,5 +744,67 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
     const safeOutputs = extractSafeOutputs(frontmatter);
     expect((safeOutputs['create-issue'] as { max: number })?.max).toBe(75);
     expect((safeOutputs['add-comment'] as { max: number })?.max).toBe(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: Team Guard roster-row detection — conceptual fixture coverage (#1689 revision)
+// ---------------------------------------------------------------------------
+
+describe('gh-aw: Team Guard roster-row detection logic (conceptual fixture coverage)', () => {
+  const TEAM_GUARD_FIXTURES = join(process.cwd(), 'test', 'fixtures', 'team-guard');
+
+  // Duplicate of the exact TG-1 shell snippet from workflows/squad.md (kept in sync).
+  // The snippet checks for a real member data row inside the ## Members section —
+  // neither the header row nor the separator row counts as TEAM_PRESENT.
+  function runRosterCheck(filePath: string): string {
+    return execSync(
+      `awk '/^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\\|/&&!/^\\|[-: |]*\\|$/&&!/\\| *Name *\\|/' '${filePath}' 2>/dev/null | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT`,
+      { shell: '/bin/sh', encoding: 'utf8' }
+    ).trim();
+  }
+
+  it('missing file → TEAM_ABSENT', () => {
+    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'nonexistent-fixture-file.md'))).toBe('TEAM_ABSENT');
+  });
+
+  it('empty file → TEAM_ABSENT', () => {
+    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'empty.md'))).toBe('TEAM_ABSENT');
+  });
+
+  it('scaffold/header-only (## Members with header + separator, no data rows) → TEAM_ABSENT', () => {
+    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'scaffold.md'))).toBe('TEAM_ABSENT');
+  });
+
+  it('one real member data row → TEAM_PRESENT', () => {
+    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'one-member.md'))).toBe('TEAM_PRESENT');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: Canonical marker fields — no raw user input in HTML attributes (#1689 revision)
+// ---------------------------------------------------------------------------
+
+describe('gh-aw: canonical marker fields and no raw input interpolation (#1689 revision)', () => {
+  const content = readFileSync(SQUAD_WORKFLOW, 'utf8');
+
+  it('pending-intent-v1 marker attributes must not contain raw {original_command} input', () => {
+    expect(content).not.toMatch(/pending-intent-v1[^>]*command="?\{original_command/);
+  });
+
+  it('pending-intent-v1 marker must use mode= canonical field', () => {
+    expect(content).toMatch(/pending-intent-v1[^>]*mode=/);
+  });
+
+  it('cast-pr-v1 marker must not contain raw {original_command} in origin-command attribute', () => {
+    expect(content).not.toMatch(/cast-pr-v1[^>]*origin-command="?\{original_command/);
+  });
+
+  it('cast-pr-v1 marker must use origin-mode= canonical field', () => {
+    expect(content).toMatch(/cast-pr-v1[^>]*origin-mode=/);
+  });
+
+  it('{original_command} does not appear anywhere in workflow — only canonical command variables are used', () => {
+    expect(content).not.toMatch(/\{original_command\}/);
   });
 });

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -9,8 +9,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
 import { execSync } from 'node:child_process';
 import { minimatch } from 'minimatch';
 
@@ -667,6 +667,19 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
     expect(content).not.toMatch(/test -s \.squad\/team\.md/);
   });
 
+  it('Team Guard TG-1 reads committed HEAD state via git show, not local filesystem', () => {
+    // Must use git show HEAD:.squad/team.md to read the committed blob, not a local file path
+    expect(content).toMatch(/git show HEAD:\.squad\/team\.md/);
+    // Must NOT read the local .squad/team.md file directly as an awk argument
+    expect(content).not.toMatch(/awk '[^']*' \.squad\/team\.md/);
+    expect(content).not.toMatch(/awk "[^"]*" \.squad\/team\.md/);
+  });
+
+  it('Team Guard description explains committed-HEAD vs local-activation distinction', () => {
+    expect(content).toMatch(/committed.*HEAD|HEAD.*committed/i);
+    expect(content).toMatch(/activation|local.*scaffold|scaffold.*local/i);
+  });
+
   it('Auto-Cast Pivot stops and does not run original mode when TEAM_ABSENT', () => {
     expect(content).toMatch(/do not proceed with the original mode this run|do not run the original command this run/i);
     expect(content).toMatch(/Stop\. Do not run (Cast|the original)/i);
@@ -750,43 +763,157 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Test: Team Guard roster-row detection — conceptual fixture coverage (#1689 revision)
+// Test: Team Guard roster-row detection — git-committed state coverage (#1689 revision 3)
+//
+// These tests replicate the exact TG-1 shell command from workflows/squad.md against
+// a real temporary git repository. This validates the committed-HEAD contract: only a
+// team.md that is committed to HEAD can produce TEAM_PRESENT. Local working-tree files
+// (e.g., from activation pre-steps like `squad init --preset default`) are invisible to
+// the guard, preventing false TEAM_PRESENT in fresh repos.
 // ---------------------------------------------------------------------------
 
-describe('gh-aw: Team Guard roster-row detection logic (conceptual fixture coverage)', () => {
-  const TEAM_GUARD_FIXTURES = join(process.cwd(), 'test', 'fixtures', 'team-guard');
+describe('gh-aw: Team Guard roster-row detection — committed-HEAD git repo coverage (#1689 revision 3)', () => {
+  // Content shared across test cases
+  const SCAFFOLD_CONTENT = `# Squad Team\n\n## Members\n| Name | Role | Charter path | Status |\n|------|------|--------------|--------|\n`;
+  const ONE_MEMBER_CONTENT = `# Squad Team\n\n## Members\n| Name | Role | Charter path | Status |\n|------|------|--------------|--------|\n| Eecom | Core Dev | .squad/agents/eecom/charter.md | active |\n`;
+  const ONE_MEMBER_CRLF_CONTENT = ONE_MEMBER_CONTENT.replace(/\n/g, '\r\n');
+  const SCAFFOLD_CRLF_CONTENT = SCAFFOLD_CONTENT.replace(/\n/g, '\r\n');
 
-  // Duplicate of the exact TG-1 shell snippet from workflows/squad.md (kept in sync).
-  // sub(/\r$/,"") normalizes CRLF so Windows-formatted team.md files are classified correctly.
-  function runRosterCheck(filePath: string): string {
+  // Runs the exact TG-1 command from squad.md in a given working directory.
+  // The command reads .squad/team.md from the committed HEAD via git show.
+  function runCommittedRosterCheck(cwd: string): string {
     return execSync(
-      `awk '{sub(/\\r$/,"")} /^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\\|/&&!/^\\|[-: |]*\\|$/&&!/\\| *Name *\\|/' '${filePath}' 2>/dev/null | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT`,
-      { shell: '/bin/sh', encoding: 'utf8' }
+      `git show HEAD:.squad/team.md 2>/dev/null | awk '{sub(/\\r$/,"")} /^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\\|/&&!/^\\|[-: |]*\\|$/&&!/\\| *Name *\\|/' | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT`,
+      { cwd, shell: '/bin/sh', encoding: 'utf8' }
     ).trim();
   }
 
-  it('missing file → TEAM_ABSENT', () => {
-    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'nonexistent-fixture-file.md'))).toBe('TEAM_ABSENT');
+  // Creates a temp git repo, runs the provided setup callback, then returns the dir.
+  // Caller must call cleanup() when done.
+  function makeGitRepo(setup: (dir: string) => void): { dir: string; cleanup: () => void } {
+    const dir = execSync('mktemp -d', { encoding: 'utf8' }).trim();
+    execSync('git init', { cwd: dir, shell: '/bin/sh' });
+    execSync('git config user.email "test@squad.test"', { cwd: dir, shell: '/bin/sh' });
+    execSync('git config user.name "Squad Test"', { cwd: dir, shell: '/bin/sh' });
+    setup(dir);
+    return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  }
+
+  function commitFile(dir: string, relPath: string, content: string): void {
+    const fullPath = join(dir, relPath);
+    mkdirSync(dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, content);
+    execSync(`git add "${relPath}"`, { cwd: dir, shell: '/bin/sh' });
+    execSync('git commit -m "test"', { cwd: dir, shell: '/bin/sh' });
+  }
+
+  function addWorkingTree(dir: string, relPath: string, content: string): void {
+    const fullPath = join(dir, relPath);
+    mkdirSync(dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, content);
+  }
+
+  // ── Case 1: no committed team.md but working-tree scaffold present ────────
+  it('no committed .squad/team.md but working-tree scaffold → TEAM_ABSENT', () => {
+    const { dir, cleanup } = makeGitRepo((d) => {
+      // Create an initial commit with an unrelated file so HEAD is valid
+      commitFile(d, 'README.md', '# Test\n');
+      // Add scaffold to working tree only — never committed
+      addWorkingTree(d, '.squad/team.md', SCAFFOLD_CONTENT);
+    });
+    try {
+      expect(runCommittedRosterCheck(dir)).toBe('TEAM_ABSENT');
+    } finally {
+      cleanup();
+    }
   });
 
-  it('empty file → TEAM_ABSENT', () => {
-    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'empty.md'))).toBe('TEAM_ABSENT');
+  // ── Case 2: committed empty team.md ──────────────────────────────────────
+  it('committed empty .squad/team.md → TEAM_ABSENT', () => {
+    const { dir, cleanup } = makeGitRepo((d) => {
+      commitFile(d, '.squad/team.md', '');
+    });
+    try {
+      expect(runCommittedRosterCheck(dir)).toBe('TEAM_ABSENT');
+    } finally {
+      cleanup();
+    }
   });
 
-  it('scaffold/header-only (## Members with header + separator, no data rows) → TEAM_ABSENT', () => {
-    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'scaffold.md'))).toBe('TEAM_ABSENT');
+  // ── Case 3: committed header-only scaffold ────────────────────────────────
+  it('committed header-only .squad/team.md (## Members + header + separator, no data rows) → TEAM_ABSENT', () => {
+    const { dir, cleanup } = makeGitRepo((d) => {
+      commitFile(d, '.squad/team.md', SCAFFOLD_CONTENT);
+    });
+    try {
+      expect(runCommittedRosterCheck(dir)).toBe('TEAM_ABSENT');
+    } finally {
+      cleanup();
+    }
   });
 
-  it('one real member data row → TEAM_PRESENT', () => {
-    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'one-member.md'))).toBe('TEAM_PRESENT');
+  // ── Case 4: committed real roster ────────────────────────────────────────
+  it('committed .squad/team.md with one real member row → TEAM_PRESENT', () => {
+    const { dir, cleanup } = makeGitRepo((d) => {
+      commitFile(d, '.squad/team.md', ONE_MEMBER_CONTENT);
+    });
+    try {
+      expect(runCommittedRosterCheck(dir)).toBe('TEAM_PRESENT');
+    } finally {
+      cleanup();
+    }
   });
 
-  it('CRLF scaffold/header-only (no data rows, Windows line endings) → TEAM_ABSENT', () => {
-    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'scaffold-crlf.md'))).toBe('TEAM_ABSENT');
+  // ── Case 5: working-tree real roster over absent committed path ──────────
+  it('working-tree real roster over absent committed .squad/team.md → TEAM_ABSENT', () => {
+    const { dir, cleanup } = makeGitRepo((d) => {
+      commitFile(d, 'README.md', '# Test\n');
+      // Full roster in working tree, but never committed
+      addWorkingTree(d, '.squad/team.md', ONE_MEMBER_CONTENT);
+    });
+    try {
+      expect(runCommittedRosterCheck(dir)).toBe('TEAM_ABSENT');
+    } finally {
+      cleanup();
+    }
   });
 
-  it('CRLF one real member data row (Windows line endings) → TEAM_PRESENT', () => {
-    expect(runRosterCheck(join(TEAM_GUARD_FIXTURES, 'one-member-crlf.md'))).toBe('TEAM_PRESENT');
+  // ── Case 6: committed real roster with dirty working-tree changes ─────────
+  it('committed real roster with dirty working-tree changes → TEAM_PRESENT (reads HEAD)', () => {
+    const { dir, cleanup } = makeGitRepo((d) => {
+      commitFile(d, '.squad/team.md', ONE_MEMBER_CONTENT);
+      // Overwrite with scaffold in working tree — guard must still read HEAD
+      addWorkingTree(d, '.squad/team.md', SCAFFOLD_CONTENT);
+    });
+    try {
+      expect(runCommittedRosterCheck(dir)).toBe('TEAM_PRESENT');
+    } finally {
+      cleanup();
+    }
+  });
+
+  // ── Case 7: committed CRLF scaffold → TEAM_ABSENT ────────────────────────
+  it('committed CRLF header-only .squad/team.md (Windows line endings) → TEAM_ABSENT', () => {
+    const { dir, cleanup } = makeGitRepo((d) => {
+      commitFile(d, '.squad/team.md', SCAFFOLD_CRLF_CONTENT);
+    });
+    try {
+      expect(runCommittedRosterCheck(dir)).toBe('TEAM_ABSENT');
+    } finally {
+      cleanup();
+    }
+  });
+
+  // ── Case 8: committed CRLF real roster → TEAM_PRESENT ────────────────────
+  it('committed CRLF .squad/team.md with one real member row (Windows line endings) → TEAM_PRESENT', () => {
+    const { dir, cleanup } = makeGitRepo((d) => {
+      commitFile(d, '.squad/team.md', ONE_MEMBER_CRLF_CONTENT);
+    });
+    try {
+      expect(runCommittedRosterCheck(dir)).toBe('TEAM_PRESENT');
+    } finally {
+      cleanup();
+    }
   });
 });
 

--- a/workflows/shared/planning-ontology.md
+++ b/workflows/shared/planning-ontology.md
@@ -296,6 +296,9 @@ The issue body IS the intent. No special format required, but structured intents
 
 | Marker | Artifact | Cardinality | Update Behavior |
 |--------|----------|-------------|-----------------|
+| `<!-- squad-pending-intent-v1 -->` | Auto-Cast: original issue + command | 1 per issue | Immutable once written; never written a second time |
+| `<!-- squad-cast-opened-v1 -->` | Auto-Cast: Cast was initiated | 1 per issue | Immutable once written |
+| `<!-- squad-cast-pr-v1 -->` | Cast PR body: origin issue + command reference | 1 per Cast PR | Immutable (in PR body, not issue comment) |
 | `<!-- squad-research-v1 -->` | Research findings | 1 per run (edit on re-run) | Replace body |
 | `<!-- squad-triage-v1 -->` | Triage disposition | 1 per run | Replace body |
 | `<!-- squad-program-v1 -->` | Program plan | 1 per run | Replace body |

--- a/workflows/shared/planning-ontology.md
+++ b/workflows/shared/planning-ontology.md
@@ -1,6 +1,6 @@
 # Planning Ontology & Artifact Schemas
 
-> **Version:** 1.0 · **Owner:** Procedures · **Status:** Active
+> **Version:** 2.0 · **Owner:** Procedures · **Status:** Active
 >
 > **Decision Ratifications:**
 > - `copilot-plan-workflow-ux.md` → **Ratified Option A + Option 3**: Explicit commands (`/squad plan accept`) under the `/squad` namespace; planning logic lives in `shared/` components imported by `squad.md`. This file IS the shared component.
@@ -10,18 +10,18 @@
 
 ## 1. Ontology Table
 
-| Concept | Purpose | GitHub Representation | Marker | Version |
-|---------|---------|----------------------|--------|---------|
+| Concept | Purpose | GitHub Representation | `squad_artifact` | Schema |
+|---------|---------|----------------------|------------------|--------|
 | **Intent** | Define what we're building and why | Root issue body | (issue body itself) | — |
-| **Research** | Gather evidence and context | Issue comment | `<!-- squad-research-v1 -->` | v1 |
-| **Triage** | Classify findings → work / decision / excluded | Issue comment | `<!-- squad-triage-v1 -->` | v1 |
-| **Program Plan** | Strategic decomposition into initiatives/epics | Issue comment | `<!-- squad-program-v1 -->` | v1 |
-| **Implementation Plan** | PR-sized tasks with deps and sizing | Issue comment | `<!-- squad-implementation-v1 -->` | v1 |
-| **Validation** | Verify postconditions before activation | Issue comment | `<!-- squad-validation-v1 -->` | v1 |
-| **Scope Acceptance** | Confirm program plan is approved | Issue comment | `<!-- squad-scope-accepted-v1 -->` | v1 |
-| **Impl Acceptance** | Confirm implementation plan is approved | Issue comment | `<!-- squad-impl-accepted-v1 -->` | v1 |
-| **Activation** | Create sub-issues and begin execution | Issue comment | `<!-- squad-activated-v1 -->` | v1 |
-| **Lifecycle State** | Running summary updated on each transition | Issue comment | `<!-- squad-lifecycle-state -->` | v1 |
+| **Research** | Gather evidence and context | Issue comment | `research` | 1 |
+| **Triage** | Classify findings → work / decision / excluded | Issue comment | `triage` | 1 |
+| **Program Plan** | Strategic decomposition into initiatives/epics | Issue comment | `program` | 1 |
+| **Implementation Plan** | PR-sized tasks with deps and sizing | Issue comment | `implementation` | 1 |
+| **Validation** | Verify postconditions before activation | Issue comment | `validation` | 1 |
+| **Scope Acceptance** | Confirm program plan is approved | Issue comment | `scope-accepted` | 1 |
+| **Impl Acceptance** | Confirm implementation plan is approved | Issue comment | `impl-accepted` | 1 |
+| **Activation** | Create sub-issues and begin execution | Issue comment | `activated` | 1 |
+| **Lifecycle State** | Running summary updated on each transition | Issue comment | `lifecycle-state` | 1 |
 
 ### Preconditions & Postconditions
 
@@ -44,53 +44,66 @@
 idle → researching
   triggered_by: /squad research
   requires: intent (issue body)
-  produces: <!-- squad-research-v1 -->
+  produces: squad_artifact=research
 
 researching → triaging
   triggered_by: /squad triage
-  requires: <!-- squad-research-v1 -->
-  produces: <!-- squad-triage-v1 -->
+  requires: squad_artifact=research
+  produces: squad_artifact=triage
 
 triaging → program_planning
   triggered_by: /squad plan program
-  requires: <!-- squad-triage-v1 -->
-  produces: <!-- squad-program-v1 -->
+  requires: squad_artifact=triage
+  produces: squad_artifact=program
 
 program_planning → implementation_planning
   triggered_by: /squad plan implementation
-  requires: <!-- squad-program-v1 -->
-  produces: <!-- squad-implementation-v1 -->
+  requires: squad_artifact=program
+  produces: squad_artifact=implementation
 
 implementation_planning → validating
   triggered_by: /squad plan validate
-  requires: <!-- squad-implementation-v1 -->
-  produces: <!-- squad-validation-v1 -->
+  requires: squad_artifact=implementation
+  produces: squad_artifact=validation
 
 validating → scope_accepted
   triggered_by: /squad plan accept scope
-  requires: <!-- squad-program-v1 -->
-  produces: <!-- squad-scope-accepted-v1 -->
+  requires: squad_artifact=program
+  produces: squad_artifact=scope-accepted
 
 scope_accepted → impl_accepted
   triggered_by: /squad plan accept implementation
-  requires: <!-- squad-validation-v1 --> (pass)
-  produces: <!-- squad-impl-accepted-v1 -->
+  requires: squad_artifact=validation with human-readable RESULT: PASS
+  produces: squad_artifact=impl-accepted
 
 impl_accepted → activated
   triggered_by: /squad plan activate
-  requires: <!-- squad-impl-accepted-v1 -->
-  produces: <!-- squad-activated-v1 -->
+  requires: squad_artifact=impl-accepted
+  produces: squad_artifact=activated
 ```
 
-**Idempotency rule:** Re-running any command updates the existing marker comment (edit, not duplicate). The lifecycle state comment is always updated on every transition. Idempotency applies to all planning-phase markers (research, triage, program plan, implementation plan, validation). Acceptance and activation markers are immutable once written — re-running these commands is a no-op if the marker already exists.
+**Idempotency rule:** Re-running any command updates the existing artifact comment (edit, not duplicate). The lifecycle state comment is always updated on every transition. Idempotency applies to research, triage, program plan, implementation plan, and validation artifacts. Acceptance and activation artifacts are immutable once written — re-running these commands is a no-op if matching structured data already exists.
 
-**Concurrency:** Concurrent acceptance commands are serialized by the workflow's concurrency group. Duplicate markers are harmless — subsequent phases find the first matching marker.
+**Concurrency:** Concurrent acceptance commands are serialized by the workflow's concurrency group. Duplicate artifacts are harmless — subsequent phases select the newest matching structured data.
 
 **Revision:** `/squad plan revise <feedback>` may be issued from any planning state (program_planning, implementation_planning, or validating). It revises the most recent plan artifact and resets validation if present.
 
 ---
 
 ## 3. Artifact Schemas
+
+Each artifact is a human-readable Markdown comment plus gh-aw safe-output `data`. The minimum envelope is:
+
+```json
+{
+  "squad_artifact": "{artifact_kind}",
+  "schema_version": "1",
+  "origin_issue": 123,
+  "phases": []
+}
+```
+
+gh-aw requires every declared schema property. Use `phases: []` for non-phase artifacts and the accumulated phase numbers for phase-state artifacts. gh-aw appends the validated envelope as a `Structured data:` fenced JSON block. HTML comments are unsupported for Squad state because gh-aw removes them from compiled prompts and sanitized bodies.
 
 ### 3.1 Intent (Root Issue Body)
 
@@ -114,7 +127,6 @@ The issue body IS the intent. No special format required, but structured intents
 ### 3.2 Research Findings
 
 ```markdown
-<!-- squad-research-v1 -->
 ## Research Findings
 
 ### Summary
@@ -142,7 +154,6 @@ The issue body IS the intent. No special format required, but structured intents
 ### 3.3 Triage Disposition
 
 ```markdown
-<!-- squad-triage-v1 -->
 ## Triage Disposition
 
 ### Work Items (→ planning)
@@ -169,7 +180,6 @@ The issue body IS the intent. No special format required, but structured intents
 ### 3.4 Program Plan
 
 ```markdown
-<!-- squad-program-v1 -->
 ## Program Plan
 
 ### Initiatives
@@ -201,7 +211,6 @@ The issue body IS the intent. No special format required, but structured intents
 ### 3.5 Implementation Plan
 
 ```markdown
-<!-- squad-implementation-v1 -->
 ## Implementation Plan
 
 ### Tasks
@@ -232,7 +241,6 @@ The issue body IS the intent. No special format required, but structured intents
 ### 3.6 Validation Result
 
 ```markdown
-<!-- squad-validation-v1 -->
 ## Plan Validation
 
 ### Result: ✅ PASS | ❌ FAIL
@@ -255,7 +263,6 @@ The issue body IS the intent. No special format required, but structured intents
 
 **Scope Acceptance:**
 ```markdown
-<!-- squad-scope-accepted-v1 -->
 ## Scope Accepted
 
 - **Program plan version:** <comment link>
@@ -266,7 +273,6 @@ The issue body IS the intent. No special format required, but structured intents
 
 **Implementation Acceptance:**
 ```markdown
-<!-- squad-impl-accepted-v1 -->
 ## Implementation Accepted
 
 - **Implementation plan version:** <comment link>
@@ -278,7 +284,6 @@ The issue body IS the intent. No special format required, but structured intents
 
 **Activation Record:**
 ```markdown
-<!-- squad-activated-v1 -->
 ## Execution Activated
 
 - **Issues created:** N
@@ -292,24 +297,28 @@ The issue body IS the intent. No special format required, but structured intents
 
 ---
 
-## 4. Comment Marker Registry
+## 4. Structured Artifact Registry
 
-| Marker | Artifact | Cardinality | Update Behavior |
-|--------|----------|-------------|-----------------|
-| `<!-- squad-pending-intent-v1 -->` | Auto-Cast: original issue + command | 1 per issue | Immutable once written; never written a second time |
-| `<!-- squad-cast-opened-v1 -->` | Auto-Cast: Cast was initiated | 1 per issue | Immutable once written |
-| `<!-- squad-cast-pr-v1 -->` | Cast PR body: origin issue + command reference | 1 per Cast PR | Immutable (in PR body, not issue comment) |
-| `<!-- squad-research-v1 -->` | Research findings | 1 per run (edit on re-run) | Replace body |
-| `<!-- squad-triage-v1 -->` | Triage disposition | 1 per run | Replace body |
-| `<!-- squad-program-v1 -->` | Program plan | 1 per run | Replace body |
-| `<!-- squad-implementation-v1 -->` | Implementation plan | 1 per run | Replace body |
-| `<!-- squad-validation-v1 -->` | Validation result | 1 per run | Replace body |
-| `<!-- squad-scope-accepted-v1 -->` | Scope acceptance | 1 total | Immutable once written |
-| `<!-- squad-impl-accepted-v1 -->` | Impl acceptance | 1 total | Immutable once written |
-| `<!-- squad-activated-v1 -->` | Activation record | 1 total | Immutable once written |
-| `<!-- squad-lifecycle-state -->` | Lifecycle summary | 1 total | Updated every transition |
+| `squad_artifact` | Artifact | `phases` Data | Cardinality | Update Behavior |
+|------------------|----------|---------------|-------------|-----------------|
+| `research` | Research findings | `[]` | 1 current per issue | Replace body |
+| `plan` | Fast-path plan | `[]` | 1 current per issue | Replace body |
+| `plan-accepted` | Fast-path full acceptance | `[]` | 1 total | Immutable |
+| `phases-accepted` | Fast-path accepted phase state | Accumulated accepted phases | 1 current per issue | Replace accumulated state |
+| `triage` | Triage disposition | `[]` | 1 current per issue | Replace body |
+| `program` | Program plan | `[]` | 1 current per issue | Replace body |
+| `implementation` | Implementation plan | `[]` | 1 current per issue | Replace body |
+| `validation` | Validation result | `[]`; body has `RESULT: PASS` or `FAIL` | 1 current per issue | Replace body |
+| `scope-accepted` | Scope acceptance | `[]` | 1 total | Immutable |
+| `impl-accepted` | Full implementation acceptance | `[]` | 1 total | Immutable |
+| `impl-phases-accepted` | Accepted implementation phase state | Accumulated accepted phases | 1 current per issue | Replace accumulated state |
+| `phases-activated` | Activated phase state | Accumulated activated phases | 1 current per issue | Replace accumulated state |
+| `activated` | Terminal activation record | All phases when phased; otherwise `[]` | 1 total | Immutable |
+| `lifecycle-state` | Lifecycle summary | `[]` | 1 current per issue | Updated every transition |
 
-**Version bump rule:** When schema changes are breaking, bump the version suffix (e.g., `v1` → `v2`). Old markers remain valid; new commands produce new versions.
+Every entry also requires `schema_version: "1"` and the triggering `origin_issue`.
+
+**Version bump rule:** When this data contract changes incompatibly, increment `schema_version`. Consumers may continue recognizing earlier structured schemas during a migration window.
 
 ---
 
@@ -318,7 +327,6 @@ The issue body IS the intent. No special format required, but structured intents
 This comment is created on first transition and updated on every subsequent transition:
 
 ```markdown
-<!-- squad-lifecycle-state -->
 ## Planning Lifecycle
 
 | Phase | Status | Artifact | Updated |
@@ -349,39 +357,41 @@ Status icons: `✅ Done` · `⏳ In Progress` · `⬚ Pending` · `❌ Failed` �
 
 The original `/squad plan` and `/squad plan accept` commands remain fully supported as **fast paths** that combine multiple lifecycle phases:
 
-| Legacy Command | Equivalent Phases | Marker Produced |
-|---------------|-------------------|-----------------|
-| `/squad plan` | program + implementation (combined) | `<!-- squad-plan-v1 -->` |
+| Legacy Command | Equivalent Phases | Artifact Data Produced |
+|---------------|-------------------|------------------------|
+| `/squad plan` | program + implementation (combined) | `squad_artifact=plan` |
 | `/squad plan accept` | scope + impl + activate (combined) | See note below |
-| `/squad plan revise` | revise (same as granular) | `<!-- squad-plan-v1 -->` |
-| `/squad research` | research (unchanged) | `<!-- squad-research-v1 -->` |
+| `/squad plan revise` | revise (same as granular) | Updates `squad_artifact=plan` |
+| `/squad research` | research (unchanged) | `squad_artifact=research` |
 
-> **`/squad plan accept` marker behavior:** When only a fast-path plan (`<!-- squad-plan-v1 -->`) exists, accept produces `<!-- squad-plan-accepted -->`. When granular artifacts exist (program plan + implementation plan), accept runs the granular accept/activate sequence, producing `<!-- squad-scope-accepted-v1 -->`, `<!-- squad-impl-accepted-v1 -->`, and `<!-- squad-activated-v1 -->` instead.
+> **`/squad plan accept` behavior:** When only a fast-path `plan` artifact exists, accept produces `plan-accepted` or `phases-accepted`. When granular artifacts exist, accept runs the granular accept/activate sequence, producing `scope-accepted`, `impl-accepted`, and `activated` artifacts instead.
 
 ### Coexistence Rules
 
-1. Fast-path markers (`squad-plan-v1`, `squad-plan-accepted`) and granular markers (`squad-program-v1`, `squad-implementation-v1`, etc.) are **independent namespaces** — they do not interfere.
+1. Fast-path artifact kinds (`plan`, `plan-accepted`, `phases-accepted`) and granular artifact kinds (`program`, `implementation`, etc.) are **independent namespaces** — they do not interfere.
 2. An issue may use EITHER the fast path OR the granular path, not both simultaneously.
-3. If a granular marker exists and a user runs `/squad plan` (fast path), the system warns that granular planning is in progress and asks for confirmation.
+3. If a granular artifact exists and a user runs `/squad plan` (fast path), the system warns that granular planning is in progress and asks for confirmation.
 4. The lifecycle state comment tracks whichever path is active.
+
+Legacy Squad HTML markers are not scanned. gh-aw removes HTML comments during prompt compilation and safe-output sanitization; durable state uses the structured data registry above.
 
 ---
 
 ## 7. Command Surface
 
-| Command | Mode | Phase | Output |
-|---------|------|-------|--------|
-| `/squad research` | Research | researching | `<!-- squad-research-v1 -->` |
-| `/squad triage` | Triage | triaging | `<!-- squad-triage-v1 -->` |
-| `/squad plan program` | Program Planning | program_planning | `<!-- squad-program-v1 -->` |
-| `/squad plan implementation` | Impl Planning | implementation_planning | `<!-- squad-implementation-v1 -->` |
-| `/squad plan validate` | Validation | validating | `<!-- squad-validation-v1 -->` |
-| `/squad plan accept scope` | Scope Acceptance | scope_accepted | `<!-- squad-scope-accepted-v1 -->` |
-| `/squad plan accept implementation` | Impl Acceptance | impl_accepted | `<!-- squad-impl-accepted-v1 -->` |
-| `/squad plan activate` | Activation | activated | `<!-- squad-activated-v1 -->` |
+| Command | Mode | Phase | `squad_artifact` Output |
+|---------|------|-------|-------------------------|
+| `/squad research` | Research | researching | `research` |
+| `/squad triage` | Triage | triaging | `triage` |
+| `/squad plan program` | Program Planning | program_planning | `program` |
+| `/squad plan implementation` | Impl Planning | implementation_planning | `implementation` |
+| `/squad plan validate` | Validation | validating | `validation` |
+| `/squad plan accept scope` | Scope Acceptance | scope_accepted | `scope-accepted` |
+| `/squad plan accept implementation` | Impl Acceptance | impl_accepted | `impl-accepted` or `impl-phases-accepted` |
+| `/squad plan activate` | Activation | activated | `activated` or `phases-activated` |
 | `/squad plan revise <feedback>` | Revision | (current phase) | Updates latest plan artifact |
-| `/squad plan` | Fast path (plan) | — | `<!-- squad-plan-v1 -->` |
-| `/squad plan accept` | Fast path (accept) | — | `<!-- squad-plan-accepted -->` |
+| `/squad plan` | Fast path (plan) | — | `plan` |
+| `/squad plan accept` | Fast path (accept) | — | `plan-accepted` or `phases-accepted` |
 
 ### Execution Model Support
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -116,6 +116,72 @@ The activation job ran `squad init --preset default` producing generic `.squad/`
 
 ---
 
+## Team Guard
+
+**Applies to:** Research, Triage, Plan, Plan Program, Plan Implementation, Plan Validate, Plan Revise, Triage Revise, Plan Accept, Plan Accept Scope, Plan Accept Implementation, Plan Activate.
+**Exempt:** Cast, Connect, Adopt, Cast Member, Retire, Status, Implement (these run their own pre-checks).
+
+### Step TG-1: Check Team Presence
+
+```bash
+test -s .squad/team.md && echo TEAM_PRESENT || echo TEAM_ABSENT
+```
+
+- `TEAM_PRESENT` → proceed to the original mode's section.
+- `TEAM_ABSENT` → execute **Auto-Cast Pivot** below; do not proceed with the original mode this run.
+
+### Auto-Cast Pivot
+
+**Universal response invariant:** current state · result · one primary next action · recovery on ⚠️/🔴.
+
+#### TG-2: Record Pending Intent (write-once)
+
+Scan ALL issue comments for `<!-- squad-pending-intent-v1 -->` as the first non-empty line.
+- Found → skip to TG-3 (never write a second pending-intent comment).
+- Not found → `add-comment` (immutable; never edited):
+  ```
+  <!-- squad-pending-intent-v1 issue={issue_number} command="{original_command}" -->
+  ```
+
+#### TG-3: Dedup Open Cast PR
+
+```bash
+gh pr list --head "squad/cast-" --state open --json number,url,title
+```
+
+**If an open Cast PR is found (rerun before merge):**
+- `add-comment`:
+  ```
+  🤖 Squad has already opened a Cast PR for this issue.
+
+  **Current state:** Cast PR open — your team is ready for review.
+  **Result:** No duplicate PR opened.
+  **Next action:** Merge the Cast PR, then return to this issue and rerun: `{original_command}`
+
+  **Cast PR:** {pr_url}
+  ```
+- Stop. Do not run Cast mode.
+
+**If no open Cast PR found (first run or Cast PR was merged/closed):**
+- Scan ALL issue comments for `<!-- squad-cast-opened-v1 -->` as the first non-empty line.
+- If `<!-- squad-cast-opened-v1 -->` found but no open PR → Cast PR may have been closed without merging. `add-comment` with recovery guidance: "The previous Cast PR appears to be closed. Rerun `{original_command}` to open a new one."  Stop.
+- If `<!-- squad-cast-opened-v1 -->` not found → **FIRST RUN**: execute Cast Mode Steps 0–6 using this issue as the casting brief. In the Cast PR body, include: `<!-- squad-cast-pr-v1 origin-issue={issue_number} origin-command="{original_command}" -->`. Then `add-comment` (immutable; never edited):
+  ```
+  <!-- squad-cast-opened-v1 -->
+  🤖 Squad is assembling your team.
+
+  **Current state:** No team detected — Squad auto-pivoted to Cast.
+  **Result:** A Cast PR has been opened. Check the **Pull Requests** tab to find and review it.
+  **Next action:** Merge the Cast PR, then return to this issue and rerun: `{original_command}`
+
+  ⚠️ The PR link is not available in this comment — find it in the **Pull Requests** tab.
+  ```
+- Stop. Do not run the original command this run.
+
+**Recovery (Cast step failure):** Report the exact error in plain language. Tell the user to rerun `{original_command}` on this issue to retry. Never instruct the user to run `/squad cast` separately.
+
+---
+
 #### Cast Mode
 
 Analyze repo, compose team, assign character names from a fictional universe, generate `.squad/` scaffolding, open PR.
@@ -755,7 +821,7 @@ Root → Epics → Tasks. Phase-specific: filter to matching phase heading.
 - Milestone: same as parent epic
 - Size: Project field if available, else body line
 
-**2d. Self-Validation:** Compare created/recognized task count vs expected. If created count is below expected: call `report_incomplete` immediately with `created={N}`, `expected={M}`, and the last verified issue number — never noop. Re-runs are idempotent via title match.
+**2d. Self-Validation:** Compare created/recognized task count vs expected (use the plan's declared total — not the safe-output cap). If created count is below expected: call `report_incomplete` immediately with `created={N}`, `expected={M}`, and the last verified issue number — never noop. Post: `N of M issues created so far — rerun the identical activation command to continue.` Re-runs are idempotent via title match. Never surface the `create-issue` or `add-comment` safe-output caps as the reason for a partial run.
 
 Labels must have descriptions and intentional colors.
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -35,10 +35,48 @@ tools:
     mode: gh-proxy
     toolsets: [default]
 safe-outputs:
+  data:
+    type: object
+    properties:
+      squad_artifact:
+        type: string
+        enum:
+          - research
+          - plan
+          - plan-accepted
+          - phases-accepted
+          - triage
+          - lifecycle-state
+          - program
+          - implementation
+          - validation
+          - scope-accepted
+          - impl-accepted
+          - impl-phases-accepted
+          - phases-activated
+          - activated
+      schema_version:
+        type: string
+        enum: ["1"]
+      origin_issue:
+        type: integer
+        minimum: 1
+      phases:
+        type: array
+        items:
+          type: integer
+          minimum: 1
+    required:
+      - squad_artifact
+      - schema_version
+      - origin_issue
+      - phases
+    additionalProperties: false
   create-pull-request:
     title-prefix: "[squad] "
     labels: [squad]
     max: 3
+    auto-close-issue: false
     allowed-base-branches:
       - "squad/*"
     allowed-files:
@@ -55,11 +93,27 @@ safe-outputs:
     max: 20
 ---
 
-## Comment Search Rules (all modes)
+## Planning Artifact Data Contract (all modes)
 
-1. **Paginate fully** — fetch ALL comments (paginate if >30). Markers may be beyond page 1.
-2. **Match FIRST LINE only** — marker must be the first non-empty line of the comment body.
-3. **Latest = newest** — if multiple comments share a marker, use the most recent.
+gh-aw removes HTML comments from prompts and sanitized output bodies. Never use HTML comments as Squad state markers.
+
+Every machine-readable planning comment MUST include safe-output `data` with:
+
+```json
+{
+  "squad_artifact": "{artifact_kind}",
+  "schema_version": "1",
+  "origin_issue": 123,
+  "phases": []
+}
+```
+
+Use the triggering issue number for `origin_issue`. Because gh-aw requires every declared schema property, emit `phases: []` for non-phase artifacts and the accumulated phase numbers for phase-state artifacts. Validation results remain in the human-readable body. gh-aw appends the validated envelope as a `Structured data:` fenced JSON block in the GitHub body.
+
+When locating artifacts:
+1. **Paginate fully** — fetch ALL comments (paginate if >30).
+2. **Parse structured data** — match exact `squad_artifact`, `schema_version: "1"`, and the current `origin_issue`.
+3. **Latest = newest** — if multiple comments match, use the most recent.
 
 # Squad — `/squad` Slash Command
 
@@ -145,16 +199,6 @@ The leading `sub(/\r$/,"")` normalizes CRLF line endings so Windows-formatted te
 
 **Universal response invariant:** current state · result · one primary next action · recovery on ⚠️/🔴.
 
-#### TG-2: Record Pending Intent (write-once)
-
-Scan ALL issue comments for `<!-- squad-pending-intent-v1 -->` as the first non-empty line.
-- Found → skip to TG-3 (never write a second pending-intent comment).
-- Not found → `add-comment` (immutable; never edited):
-  ```
-  <!-- squad-pending-intent-v1 issue={issue_number} mode={canonical_mode} -->
-  ```
-  (Include `phase={phase_n}` only when a phase was parsed. Never embed raw user input in marker attributes.)
-
 #### TG-3: Dedup Open Cast PR
 
 ```bash
@@ -174,12 +218,11 @@ gh pr list --state open --json number,url,headRefName --jq '[.[] | select(.headR
   ```
 - Stop. Do not run Cast mode.
 
-**If no open Cast PR found (first run or Cast PR was merged/closed):**
-- Scan ALL issue comments for `<!-- squad-cast-opened-v1 -->` as the first non-empty line.
-- If `<!-- squad-cast-opened-v1 -->` found but no open PR → Cast PR may have been closed without merging. `add-comment` with recovery guidance: "The previous Cast PR appears to be closed. Rerun `{canonical_command}` to open a new one."  Stop.
-- If `<!-- squad-cast-opened-v1 -->` not found → **FIRST RUN**: execute Cast Mode Steps 0–6 using this issue as the casting brief. In the Cast PR body, include: `<!-- squad-cast-pr-v1 origin-issue={issue_number} origin-mode={canonical_mode} -->`. Then `add-comment` (immutable; never edited):
+**If no open Cast PR found (first run, failed run, or a prior Cast PR was closed):**
+- Execute Cast Mode Steps 0–6 using this issue as the casting brief.
+- The Cast PR body may reference the originating issue and canonical command in plain language, but MUST NOT contain `Fixes`, `Closes`, or `Resolves` closing keywords for the originating work issue.
+- Then `add-comment`:
   ```
-  <!-- squad-cast-opened-v1 -->
   🤖 Squad is assembling your team.
 
   **Current state:** No team detected — Squad auto-pivoted to Cast.
@@ -188,6 +231,7 @@ gh pr list --state open --json number,url,headRefName --jq '[.[] | select(.headR
 
   ⚠️ The PR link is not available in this comment — find it in the **Pull Requests** tab.
   ```
+- A closed or failed Cast PR is not durable team state. A later rerun with no committed roster and no open Cast PR MUST attempt Cast again.
 - Stop. Do not run the original command this run.
 
 **Recovery (Cast step failure):** Report the exact error in plain language. Tell the user to rerun `{canonical_command}` on this issue to retry. Never instruct the user to run `/squad cast` separately.
@@ -384,7 +428,7 @@ Budget-aware breadth-first investigation: architecture mapping, technology audit
 
 ##### Step 3: Post Findings
 
-`add-comment` with marker `<!-- squad-research-v1 -->` as first line.
+`add-comment` with `data: {"squad_artifact":"research","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
 
 Structure: `## 🔬 Squad Research — {Title}` → Summary (2-3 sentences) → Current State → Gap Analysis → Risk & Complexity table (Area|Risk 🟢/🟡/🔴|Complexity S/M/L/XL|Notes) → Key Findings (with evidence) → Recommendations → Next Step (`/squad triage` or `/squad plan`).
 
@@ -392,7 +436,7 @@ Must be ≥200 chars of substantive findings. Tailor sections to scope.
 
 ##### Step 4: Verify Completion [MANDATORY]
 
-Confirm: marker posted, heading present, ≥200 chars substantive content, ≥1 recommendation. If ANY fails, go back and post now.
+Confirm: structured artifact data posted, heading present, ≥200 chars substantive content, ≥1 recommendation. If ANY fails, go back and post now.
 
 ---
 
@@ -407,7 +451,7 @@ Decompose issue into sub-issues as a comment. Does NOT create issues. Works on o
 ##### Step 1: Gather Context
 
 1. Read issue body (the epic/brief).
-2. Find latest `<!-- squad-research-v1 -->` comment. If found, use as primary context. If not, do lightweight repo analysis.
+2. Find latest `research` artifact comment for this issue. If found, use as primary context. If not, do lightweight repo analysis.
 3. Read `.squad/team.md` if exists for agent assignments.
 4. Text after `/squad plan` = planning guidance.
 
@@ -417,7 +461,7 @@ Break into discrete work items. **Minimum 3 items** unless genuinely atomic (exp
 
 ##### Step 3: Post Plan
 
-`add-comment` with marker `<!-- squad-plan-v1 -->` as first line.
+`add-comment` with `data: {"squad_artifact":"plan","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
 
 Structure: `## 📋 Squad Plan — {Title}` → reference line → Phase tables (# | Title | Owner | Size | Depends On) → Details per item (Scope, Acceptance criteria, Notes) → Dependency Graph → Execution Notes → Next Steps (`/squad plan accept`, `/squad plan accept phase 1`, `/squad plan revise`, `/squad plan`).
 
@@ -429,18 +473,18 @@ Do NOT create issues.
 
 `/squad plan accept` [phase {N}] — combines scope+impl+activation for simple workflows.
 
-**Behavior:** If granular artifacts exist (`<!-- squad-program-v1 -->` or `<!-- squad-implementation-v1 -->`), run Accept Scope → Accept Impl → Activate in sequence. If only `<!-- squad-plan-v1 -->` exists, use legacy behavior below.
+**Behavior:** If `program` or `implementation` artifacts exist, run Accept Scope → Accept Impl → Activate in sequence. If only a `plan` artifact exists, use legacy behavior below.
 
 **Acknowledge:** `🤖 Squad is creating the planned issues…`
 
 ##### Step 1: Find Plan
 
-Find latest `<!-- squad-plan-v1 -->` comment. If none: reply "No plan found. Run `/squad plan` first."
+Find latest `plan` artifact comment for this issue. If none: reply "No plan found. Run `/squad plan` first."
 
 ##### Step 1a: Phase Resolution
 
 1. Extract `requested_phase` from args (or null).
-2. Find `<!-- squad-phases-accepted: [...] -->` → `accepted_phases` (or []).
+2. Find the latest `phases-accepted` artifact and read its `phases` array → `accepted_phases` (or []).
 3. Validate: already-accepted → stop with next-available hint. Out-of-order → stop with sequential hint.
 4. Filter items: by phase if set, by unaccepted if prior phases exist, all if fresh.
 5. If no items remain after filter: stop.
@@ -466,9 +510,9 @@ Add `blockedBy` relationships via GitHub API. Graceful fallback to body-text ref
 
 ##### Step 4: Post Summary
 
-Marker varies:
-- Phase-specific: `<!-- squad-phases-accepted: [{accumulated}] -->` → Phase accepted table + remaining phases table
-- Full (no phases): `<!-- squad-plan-accepted -->` → All issues table
+Artifact data varies:
+- Phase-specific: `data: {"squad_artifact":"phases-accepted","schema_version":"1","origin_issue":{issue_number},"phases":[{accumulated}]}` → Phase accepted table + remaining phases table
+- Full (no phases): `data: {"squad_artifact":"plan-accepted","schema_version":"1","origin_issue":{issue_number},"phases":[]}` → All issues table
 
 ---
 
@@ -476,10 +520,10 @@ Marker varies:
 
 **Acknowledge:** `🤖 Squad is revising the plan…`
 
-1. Find `<!-- squad-plan-v1 -->`. If none: reply "No plan found."
+1. Find the latest `plan` artifact. If none: reply "No plan found."
 2. Read feedback after "revise".
 3. Apply feedback to plan.
-4. **EDIT the existing comment** (never post a new one with same marker).
+4. **EDIT the existing artifact comment** (never post a duplicate).
 5. Prepend revision note.
 
 ---
@@ -496,7 +540,7 @@ The planning ontology is imported — follow its schemas directly.
 
 ##### Step 1: Validate
 
-1. Find `<!-- squad-research-v1 -->`. If none: reply "Run `/squad research` first." Stop.
+1. Find the latest `research` artifact for this issue. If none: reply "Run `/squad research` first." Stop.
 2. Read root issue body (the Intent). If empty: reply "Issue body empty — add description." Stop.
 
 ##### Step 2: Classify
@@ -510,13 +554,13 @@ Default to `decision` when uncertain.
 
 ##### Step 3: Post Triage
 
-`add-comment` with marker `<!-- squad-triage-v1 -->` as first line.
+`add-comment` with `data: {"squad_artifact":"triage","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
 
 Structure: `## 🔍 Squad Triage — Dispositions` → Intent + reference lines → Work Items table (Finding|Scope Sketch|Effort|Rationale) → Decisions Needed table (Finding|Question|Impact|Blocks) → Excluded table (Finding|Reason) → Summary counts → Next step: `/squad plan program` or `/squad triage revise`.
 
 ##### Step 4: Update Lifecycle
 
-Find/create `<!-- squad-lifecycle-state -->` comment. Set Triage = `✅ Done`, state = Triaged, next = `/squad plan program`.
+Find/create the `lifecycle-state` artifact comment. Include `data: {"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":{issue_number},"phases":[]}`. Set Triage = `✅ Done`, state = Triaged, next = `/squad plan program`.
 
 ---
 
@@ -524,10 +568,10 @@ Find/create `<!-- squad-lifecycle-state -->` comment. Set Triage = `✅ Done`, s
 
 **Acknowledge:** `🤖 Squad is revising triage dispositions…`
 
-1. Find `<!-- squad-triage-v1 -->`. If none: reply "Run `/squad triage` first."
+1. Find the latest `triage` artifact. If none: reply "Run `/squad triage` first."
 2. Read feedback after "revise".
 3. Apply: reclassify, split, merge, adjust.
-4. **EDIT existing comment** (one marker per issue). Prepend revision note.
+4. **EDIT the existing artifact comment** (one current artifact per issue). Prepend revision note.
 5. Update lifecycle.
 
 ---
@@ -539,7 +583,7 @@ All planning modes resolve policy before executing.
 The planning policy schema is imported — follow it directly.
 
 Steps:
-1. Check issue body for `<!-- squad-policy: {name} -->` or `<!-- squad-setting: key=value -->`.
+1. Check issue body HTML-comment content for a line beginning `squad-policy:` or `squad-setting:`. Match the comment content, not the HTML delimiters.
 2. Check repo for `.squad/planning-policy.md` with YAML frontmatter.
 3. Match profile (`default`, `lean`, `enterprise`, `spike`, or custom).
 4. Fall back to defaults for unset values.
@@ -558,7 +602,7 @@ The planning ontology is imported — follow its schemas directly.
 
 ##### Step 1: Validate
 
-Find `<!-- squad-triage-v1 -->`. If none: reply "Run `/squad triage` first." Stop. Read root issue body.
+Find the latest `triage` artifact. If none: reply "Run `/squad triage` first." Stop. Read root issue body.
 
 ##### Step 2: Parse Triage
 
@@ -584,7 +628,7 @@ Not created yet — describes what activation will produce.
 
 ##### Step 5: Post Program Plan
 
-`add-comment` with marker `<!-- squad-program-v1 -->` as first line.
+`add-comment` with `data: {"squad_artifact":"program","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
 
 Structure: `## 📋 Squad Program Plan` → Intent + triage ref → Milestones table (Milestone|Outcome|Contains) → Initiatives & Epics (per initiative: outcome, epic table with Description|Stories|Milestone|Depends On, details per epic with Outcome/Stories/Acceptance criteria) → Unresolved Decisions table → Program Metadata → Dependency Graph → Next: `/squad plan accept scope` or `/squad plan program revise`.
 
@@ -600,8 +644,8 @@ Set Program Plan = `✅ Done`, state = Program Planned, next = `/squad plan acce
 
 Works on open/closed issues.
 
-1. Find `<!-- squad-program-v1 -->`. If none: reply "Run `/squad plan program` first."
-2. Check `<!-- squad-scope-accepted-v1 -->`. If scope accepted: require override flag or stop.
+1. Find the latest `program` artifact. If none: reply "Run `/squad plan program` first."
+2. Check for a `scope-accepted` artifact. If scope accepted: require override flag or stop.
 3. Read feedback after "revise".
 4. Apply revisions maintaining structural integrity (all Step 3 rules still apply, DAG preserved).
 5. **EDIT existing comment**. Prepend revision note.
@@ -621,7 +665,7 @@ The planning ontology is imported — follow its schemas directly.
 
 ##### Step 1: Validate
 
-Search in order: `<!-- squad-scope-accepted-v1 -->` (use as authoritative) → `<!-- squad-program-v1 -->` (draft) → `<!-- squad-plan-v1 -->` (fast-path). If none: reply "Run `/squad plan program` or `/squad plan` first." Stop.
+Search in order: `scope-accepted` artifact (use as authoritative) → `program` artifact (draft) → `plan` artifact (fast-path). If none: reply "Run `/squad plan program` or `/squad plan` first." Stop.
 
 ##### Step 2: Decompose Into Tasks
 
@@ -635,7 +679,7 @@ Check: sizes ≤ L, no cycles, traceability, coverage, agent validity. Fix befor
 
 ##### Step 4: Post Implementation Plan
 
-`add-comment` with marker `<!-- squad-implementation-v1 -->` as first line.
+`add-comment` with `data: {"squad_artifact":"implementation","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
 
 Structure: `## 🔧 Squad Implementation Plan` → Program ref → Phase tables (Title|Size|Depends On|Agent|Epic) → Details per task (Scope, Acceptance criteria, Dependencies, Rollout, Traces to) → Dependency Graph → Sizing Summary table → Validation Pre-check → Next: `/squad plan validate` or `/squad plan accept implementation`.
 
@@ -657,7 +701,7 @@ The planning ontology is imported — follow its schemas directly.
 
 ##### Step 1: Locate Artifacts
 
-Find: `<!-- squad-program-v1 -->`, `<!-- squad-implementation-v1 -->`, `<!-- squad-triage-v1 -->`. At minimum one of program/impl must exist or stop.
+Find the latest `program`, `implementation`, and `triage` artifacts. At minimum one of program/implementation must exist or stop.
 
 ##### Step 2: Run Checks
 
@@ -677,7 +721,7 @@ Severity: ❌ Critical (blocks acceptance): 1–6, 8. ⚠️ Warning: 7, 9, bord
 
 ##### Step 3: Post Result
 
-`add-comment` with marker `<!-- squad-validation-v1 -->` as first line.
+`add-comment` with `data: {"squad_artifact":"validation","schema_version":"1","origin_issue":{issue_number},"phases":[]}`. Keep `RESULT: PASS` or `RESULT: FAIL` in the human-readable body.
 
 Structure: `## ✅/❌ Squad Plan Validation — PASSED/FAILED` → Validated artifacts + timestamp → Results table (Check|Status|Details) → Issues Found (Critical ❌ then Warnings ⚠️ with fix instructions) → Summary (counts + verdict) → Next action.
 
@@ -701,8 +745,8 @@ Pass: suggest accept. Fail: suggest fix + re-validate.
 
 ##### Step 1: Validate
 
-1. Find `<!-- squad-program-v1 -->`. If none: reply "Run `/squad plan program` first." Stop.
-2. Check `<!-- squad-scope-accepted-v1 -->` already exists → reply already accepted, stop.
+1. Find the latest `program` artifact. If none: reply "Run `/squad plan program` first." Stop.
+2. Check whether a `scope-accepted` artifact already exists → reply already accepted, stop.
 
 ##### Step 2: Readiness
 
@@ -711,7 +755,7 @@ Pass: suggest accept. Fail: suggest fix + re-validate.
 
 ##### Step 3: Record
 
-`add-comment` with marker `<!-- squad-scope-accepted-v1 -->` as first line.
+`add-comment` with `data: {"squad_artifact":"scope-accepted","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
 
 Content: `## ✅ Scope Accepted` → program plan version link, accepted by, date, what was approved (initiative/epic counts, scope boundary), lock note.
 
@@ -729,28 +773,28 @@ Set Scope = `✅ Done`, next = `/squad plan implementation`.
 
 ##### Step 1: Validate
 
-**Precondition:** `<!-- squad-validation-v1 -->` with PASS status must exist.
+**Precondition:** a `validation` artifact whose human-readable body contains `RESULT: PASS` must exist.
 
-1. Find `<!-- squad-scope-accepted-v1 -->`. If none: reply "Accept scope first." Stop.
-2. Find `<!-- squad-implementation-v1 -->`. If none: reply "Run implementation first." Stop.
+1. Find a `scope-accepted` artifact. If none: reply "Accept scope first." Stop.
+2. Find the latest `implementation` artifact. If none: reply "Run implementation first." Stop.
 3. Find validation PASS. If none/FAIL: reply "Run validate first." Stop.
-4. Check `<!-- squad-impl-accepted-v1 -->`. If exists and no phase arg: reply already accepted, stop.
+4. Check for an `impl-accepted` artifact. If it exists and no phase arg: reply already accepted, stop.
 
 ##### Step 1a: Phase Resolution
 
-Same pattern as Plan Accept: extract `requested_phase`, find `<!-- squad-impl-phases-accepted: [...] -->` → `accepted_impl_phases`, validate order/duplication, scope acceptance to phase or remaining.
+Same pattern as Plan Accept: extract `requested_phase`, find the latest `impl-phases-accepted` artifact and read its `phases` array → `accepted_impl_phases`, validate order/duplication, scope acceptance to phase or remaining.
 
 ##### Step 2: Validate Integrity
 
 Run: size ≤ L, no cycles, traceability, coverage, agent validity (scoped to target items). On failure: list issues, stop.
 
-**Sizing source:** Use `<!-- squad-validation-v1 -->` Sizing Summary table as authoritative. Copy verbatim. Do NOT re-derive from plan text.
+**Sizing source:** Use the latest passed `validation` artifact's Sizing Summary table as authoritative. Copy verbatim. Do NOT re-derive from plan text.
 
 ##### Step 3: Record
 
-Marker varies:
-- Phase: `<!-- squad-impl-phases-accepted: [{accumulated}] -->` → `## ✅ Implementation Phase {N} Accepted` with phase sizing, remaining phases table
-- Full: `<!-- squad-impl-accepted-v1 -->` → `## ✅ Implementation Accepted` with total sizing (from validation), lock note
+Artifact data varies:
+- Phase: `data: {"squad_artifact":"impl-phases-accepted","schema_version":"1","origin_issue":{issue_number},"phases":[{accumulated}]}` → `## ✅ Implementation Phase {N} Accepted` with phase sizing, remaining phases table
+- Full: `data: {"squad_artifact":"impl-accepted","schema_version":"1","origin_issue":{issue_number},"phases":[]}` → `## ✅ Implementation Accepted` with total sizing (from validation), lock note
 
 Both include: impl plan link, scope acceptance link, accepted by, date, counts.
 
@@ -761,7 +805,7 @@ Phase: `🔄 Phase {N} of {total}`. Full: `✅ Done`, next = `/squad plan activa
 ##### Step 5: Auto-Activate (Phase-Specific Only)
 
 After phase acceptance, check if ready for automatic activation:
-1. All prior phases must be accepted AND activated (check `<!-- squad-phases-activated: [...] -->`).
+1. All prior phases must be accepted AND activated (check the latest `phases-activated` artifact's `phases` array).
 2. If Phase 1 or all prior activated: auto-activate using Plan Activate logic for this phase.
 3. If prior phases not activated: tell user to activate them first.
 4. Update lifecycle to reflect both acceptance and activation.
@@ -777,13 +821,13 @@ After phase acceptance, check if ready for automatic activation:
 ##### Step 1: Validate
 
 **Phase-specific:**
-1. Check `<!-- squad-impl-phases-accepted: [...] -->` contains requested phase. If not: stop.
-2. Check ordering: prior phase must be in `<!-- squad-phases-activated: [...] -->`. If not: stop.
+1. Check the latest `impl-phases-accepted` artifact's `phases` array contains requested phase. If not: stop.
+2. Check ordering: prior phase must be in the latest `phases-activated` artifact's `phases` array. If not: stop.
 3. Check not already activated.
 
 **No phase:**
-1. Find `<!-- squad-impl-accepted-v1 -->` or fully-accepted phases array. If none: stop.
-2. Check for re-activation (`<!-- squad-activated-v1 -->`): if exists, only create missing issues (idempotent).
+1. Find an `impl-accepted` artifact or fully accepted `impl-phases-accepted` state. If none: stop.
+2. Check for an `activated` artifact: if it exists, only create missing issues (idempotent).
 
 ##### Hallucination Guard
 
@@ -845,11 +889,11 @@ Add `blockedBy` via API for tasks and epics. Graceful fallback. Never fail activ
 
 **LAST action** — only after Steps 2+3 complete.
 
-Phase marker: `<!-- squad-phases-activated: [{accumulated}] -->` → `## ✅ Phase {N} Activated — {count} issues` + issue table + remaining phases table.
+Phase artifact: `data: {"squad_artifact":"phases-activated","schema_version":"1","origin_issue":{issue_number},"phases":[{accumulated}]}` → `## ✅ Phase {N} Activated — {count} issues` + issue table + remaining phases table.
 
-Full marker: `<!-- squad-activated-v1 -->` → `## ✅ Plan Activated — {epic_count} epics, {task_count} tasks` + hierarchy summary, created epics table, created tasks table, dependency order.
+Full artifact: `data: {"squad_artifact":"activated","schema_version":"1","origin_issue":{issue_number},"phases":[]}` → `## ✅ Plan Activated — {epic_count} epics, {task_count} tasks` + hierarchy summary, created epics table, created tasks table, dependency order.
 
-Terminal (last phase): include BOTH markers + "All Phases Activated" heading.
+Terminal (last phase): emit `data: {"squad_artifact":"activated","schema_version":"1","origin_issue":{issue_number},"phases":[{all_phases}]}` with an "All Phases Activated" heading.
 
 ##### Step 5: Update Lifecycle
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -124,10 +124,14 @@ The activation job ran `squad init --preset default` producing generic `.squad/`
 ### Step TG-1: Check Team Presence
 
 ```bash
-awk '{sub(/\r$/,"")} /^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\|/&&!/^\|[-: |]*\|$/&&!/\| *Name *\|/' .squad/team.md 2>/dev/null | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT
+git show HEAD:.squad/team.md 2>/dev/null | awk '{sub(/\r$/,"")} /^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\|/&&!/^\|[-: |]*\|$/&&!/\| *Name *\|/' | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT
 ```
 
-`TEAM_PRESENT` requires at least one Markdown table data row inside the `## Members` section — neither the header row (`| Name | Role | … |`) nor the separator row (`|---|---|`). A missing file, empty file, header-only scaffold, or zero-member table all yield `TEAM_ABSENT`. The leading `sub(/\r$/,"")` normalizes CRLF line endings so Windows-formatted team.md files are classified correctly.
+`TEAM_PRESENT` requires at least one Markdown table data row inside the `## Members` section of the **git-committed HEAD revision** of `.squad/team.md`. Neither the header row (`| Name | Role | … |`) nor the separator row (`|---|---|`) qualifies. A path absent from HEAD, an empty committed file, a header-only scaffold, or zero member rows all yield `TEAM_ABSENT`.
+
+**Why committed HEAD, not local files:** The activation pre-step (e.g., `squad init --preset default`) may restore a local `.squad/` scaffold before the agent job runs. Reading the local filesystem would return TEAM_PRESENT for that scaffold even though no team has been cast and committed. `git show HEAD:.squad/team.md` reads only what is in the repository's committed state — activation-restored local files are intentionally invisible to this guard. Local activation state is preserved for Cast generation (TG-3 onward); only the guard decision reads committed HEAD.
+
+The leading `sub(/\r$/,"")` normalizes CRLF line endings so Windows-formatted team.md files are classified correctly. If the repo has no commits yet, `git show HEAD:...` exits non-zero and the pipe produces no output → TEAM_ABSENT.
 
 - `TEAM_PRESENT` → proceed to the original mode's section.
 - `TEAM_ABSENT` → execute **Auto-Cast Pivot** below; do not proceed with the original mode this run.

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -124,10 +124,10 @@ The activation job ran `squad init --preset default` producing generic `.squad/`
 ### Step TG-1: Check Team Presence
 
 ```bash
-awk '/^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\|/&&!/^\|[-: |]*\|$/&&!/\| *Name *\|/' .squad/team.md 2>/dev/null | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT
+awk '{sub(/\r$/,"")} /^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\|/&&!/^\|[-: |]*\|$/&&!/\| *Name *\|/' .squad/team.md 2>/dev/null | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT
 ```
 
-`TEAM_PRESENT` requires at least one Markdown table data row inside the `## Members` section — neither the header row (`| Name | Role | … |`) nor the separator row (`|---|---|`). A missing file, empty file, header-only scaffold, or zero-member table all yield `TEAM_ABSENT`.
+`TEAM_PRESENT` requires at least one Markdown table data row inside the `## Members` section — neither the header row (`| Name | Role | … |`) nor the separator row (`|---|---|`). A missing file, empty file, header-only scaffold, or zero-member table all yield `TEAM_ABSENT`. The leading `sub(/\r$/,"")` normalizes CRLF line endings so Windows-formatted team.md files are classified correctly.
 
 - `TEAM_PRESENT` → proceed to the original mode's section.
 - `TEAM_ABSENT` → execute **Auto-Cast Pivot** below; do not proceed with the original mode this run.
@@ -154,7 +154,7 @@ Scan ALL issue comments for `<!-- squad-pending-intent-v1 -->` as the first non-
 #### TG-3: Dedup Open Cast PR
 
 ```bash
-gh pr list --state open --json number,url,headRefName --jq '[.[] | select(.headRefName | startswith("squad/cast-"))] | first'
+gh pr list --state open --json number,url,headRefName --jq '[.[] | select(.headRefName | (startswith("squad/cast-") and (startswith("squad/cast-member-") | not)))] | first'
 ```
 
 **If an open Cast PR is found (rerun before merge):**

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -124,13 +124,20 @@ The activation job ran `squad init --preset default` producing generic `.squad/`
 ### Step TG-1: Check Team Presence
 
 ```bash
-test -s .squad/team.md && echo TEAM_PRESENT || echo TEAM_ABSENT
+awk '/^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\|/&&!/^\|[-: |]*\|$/&&!/\| *Name *\|/' .squad/team.md 2>/dev/null | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT
 ```
+
+`TEAM_PRESENT` requires at least one Markdown table data row inside the `## Members` section — neither the header row (`| Name | Role | … |`) nor the separator row (`|---|---|`). A missing file, empty file, header-only scaffold, or zero-member table all yield `TEAM_ABSENT`.
 
 - `TEAM_PRESENT` → proceed to the original mode's section.
 - `TEAM_ABSENT` → execute **Auto-Cast Pivot** below; do not proceed with the original mode this run.
 
 ### Auto-Cast Pivot
+
+**Canonical command variables** (derived from Parse Command output — never from raw input):
+- `{canonical_mode}` — the parsed mode enum (e.g., `research`, `plan`, `plan-activate`)
+- `{canonical_command}` — reconstructed user-safe command: `/squad {canonical_mode}` with optional `phase {N}` suffix
+- `{phase_n}` — numeric phase if present; omit the field otherwise
 
 **Universal response invariant:** current state · result · one primary next action · recovery on ⚠️/🔴.
 
@@ -140,13 +147,14 @@ Scan ALL issue comments for `<!-- squad-pending-intent-v1 -->` as the first non-
 - Found → skip to TG-3 (never write a second pending-intent comment).
 - Not found → `add-comment` (immutable; never edited):
   ```
-  <!-- squad-pending-intent-v1 issue={issue_number} command="{original_command}" -->
+  <!-- squad-pending-intent-v1 issue={issue_number} mode={canonical_mode} -->
   ```
+  (Include `phase={phase_n}` only when a phase was parsed. Never embed raw user input in marker attributes.)
 
 #### TG-3: Dedup Open Cast PR
 
 ```bash
-gh pr list --head "squad/cast-" --state open --json number,url,title
+gh pr list --state open --json number,url,headRefName --jq '[.[] | select(.headRefName | startswith("squad/cast-"))] | first'
 ```
 
 **If an open Cast PR is found (rerun before merge):**
@@ -156,7 +164,7 @@ gh pr list --head "squad/cast-" --state open --json number,url,title
 
   **Current state:** Cast PR open — your team is ready for review.
   **Result:** No duplicate PR opened.
-  **Next action:** Merge the Cast PR, then return to this issue and rerun: `{original_command}`
+  **Next action:** Merge the Cast PR, then return to this issue and rerun: `{canonical_command}`
 
   **Cast PR:** {pr_url}
   ```
@@ -164,21 +172,21 @@ gh pr list --head "squad/cast-" --state open --json number,url,title
 
 **If no open Cast PR found (first run or Cast PR was merged/closed):**
 - Scan ALL issue comments for `<!-- squad-cast-opened-v1 -->` as the first non-empty line.
-- If `<!-- squad-cast-opened-v1 -->` found but no open PR → Cast PR may have been closed without merging. `add-comment` with recovery guidance: "The previous Cast PR appears to be closed. Rerun `{original_command}` to open a new one."  Stop.
-- If `<!-- squad-cast-opened-v1 -->` not found → **FIRST RUN**: execute Cast Mode Steps 0–6 using this issue as the casting brief. In the Cast PR body, include: `<!-- squad-cast-pr-v1 origin-issue={issue_number} origin-command="{original_command}" -->`. Then `add-comment` (immutable; never edited):
+- If `<!-- squad-cast-opened-v1 -->` found but no open PR → Cast PR may have been closed without merging. `add-comment` with recovery guidance: "The previous Cast PR appears to be closed. Rerun `{canonical_command}` to open a new one."  Stop.
+- If `<!-- squad-cast-opened-v1 -->` not found → **FIRST RUN**: execute Cast Mode Steps 0–6 using this issue as the casting brief. In the Cast PR body, include: `<!-- squad-cast-pr-v1 origin-issue={issue_number} origin-mode={canonical_mode} -->`. Then `add-comment` (immutable; never edited):
   ```
   <!-- squad-cast-opened-v1 -->
   🤖 Squad is assembling your team.
 
   **Current state:** No team detected — Squad auto-pivoted to Cast.
   **Result:** A Cast PR has been opened. Check the **Pull Requests** tab to find and review it.
-  **Next action:** Merge the Cast PR, then return to this issue and rerun: `{original_command}`
+  **Next action:** Merge the Cast PR, then return to this issue and rerun: `{canonical_command}`
 
   ⚠️ The PR link is not available in this comment — find it in the **Pull Requests** tab.
   ```
 - Stop. Do not run the original command this run.
 
-**Recovery (Cast step failure):** Report the exact error in plain language. Tell the user to rerun `{original_command}` on this issue to retry. Never instruct the user to run `/squad cast` separately.
+**Recovery (Cast step failure):** Report the exact error in plain language. Tell the user to rerun `{canonical_command}` on this issue to retry. Never instruct the user to run `/squad cast` separately.
 
 ---
 


### PR DESCRIPTION
Closes #1689

## Summary

Extends the Squad workflow so a user issuing any guarded command (Research, Triage, Plan, etc.) on an issue that has no team yet is automatically handled in a single, resumable journey — no separate `/squad cast` required.

---

## One-issue auto-Cast journey

**Without this change:** issuing `/squad research` on an issue with no `.squad/team.md` produced an unhelpful error. The user had to discover and separately run `/squad cast`, wait for the PR to merge, then re-issue the original command.

**With this change:** the workflow detects team absence via the new **Team Guard** and auto-pivots:

1. **Records intent (write-once):** Posts `<!-- squad-pending-intent-v1 issue={N} mode={canonical_mode} -->` — never duplicated across reruns.
2. **Deduplicates open Cast PRs:** Reads open PRs via `gh pr list --json headRefName` and `startswith("squad/cast-")` (excluding `squad/cast-member-*`). If a Cast PR is already open, it posts the PR link and stops — no duplicate.
3. **First run — runs Cast automatically:** Executes the full Cast mode (Steps 0–6) in the same workflow run. The Cast PR body carries `<!-- squad-cast-pr-v1 origin-issue={N} origin-mode={canonical_mode} -->` for traceability.
4. **Guides merge + rerun:** Notifies the user to merge the Cast PR then rerun `/squad {canonical_mode}` — always using the parsed canonical command, never raw user input.

### Same-run PR ID limitation

The Cast PR number is not available in the same run that opens it (a workflow constraint). The `squad-cast-opened-v1` comment honestly tells users to find it in the **Pull Requests** tab. This is the correct behavior; fabricating a number is explicitly forbidden.

---

## Roster detection (Team Guard TG-1)

`test -s .squad/team.md` was replaced with a portable awk roster-row check:

```bash
awk '{sub(/\r$/,"")} /^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\|/&&!/^\|[-: |]*\|$/&&!/\| *Name *\|/' .squad/team.md 2>/dev/null | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT
```

- Missing file, empty file, header-only scaffold, and zero-member table → `TEAM_ABSENT`
- One real data row → `TEAM_PRESENT`
- `sub(/\r$/,"")` normalizes CRLF line endings (Windows-formatted files no longer falsely report `TEAM_PRESENT`)

---

## Canonical commands (security hardening)

`{original_command}` (raw user input from the issue comment) is never embedded in HTML marker attributes. All marker fields contain only parsed, allowlisted values: issue integer, mode enum, optional numeric phase. User-facing retry copy uses `{canonical_command}` assembled from the parsed mode.

---

## N/M partial activation

Step 2d clarifies that the `N of M issues created` copy uses the plan's declared total — never the safe-output cap (75). Users are told to rerun the identical command to continue; the cap is never surfaced as a reason for stopping.

---

## Validation

| Check | Result |
|-------|--------|
| Tests | **77 pass** (62 pre-existing + 9 from revision 1 + 6 from revision 2) |
| Fixture coverage | missing / empty / scaffold / one-member / CRLF scaffold / CRLF one-member + jq Cast vs Cast-Member filter |
| `npm run build` | ✅ |
| `npm run lint` (tsc --noEmit) | ✅ |
| `gh aw compile --dir workflows/` | ✅ 1 succeeded, 0 warnings |
| Prompt size | **56.6 KB** / 100 KB ceiling |

> ⚠️ **E2E validation still required before merge.** The gh-aw runner behavior (slash command trigger, comment scanning, Cast step execution) cannot be fully exercised by structural tests. A live issue-comment test against the workflow is recommended.

---

## Review history

An initial revision was reviewed and one round of targeted structural findings were addressed (Team Guard roster semantics, PR dedup regex, marker injection hardening, CRLF safety, Cast-Member branch exclusion). All findings were resolved and re-reviewed before this PR was opened.