### PR TITLE
feat(sdk): add "max" to SquadReasoningEffort — unblocks Dependabot PR #1671

### DIFF
--- a/.changeset/max-reasoning-effort.md
+++ b/.changeset/max-reasoning-effort.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-sdk': patch
+---
+
+Add `"max"` as a valid `SquadReasoningEffort` level to match the Copilot SDK 1.0.9 addition of `ReasoningEffort = "max"`. Unblocks Dependabot PR #1671.

--- a/packages/squad-sdk/src/adapter/types.ts
+++ b/packages/squad-sdk/src/adapter/types.ts
@@ -766,7 +766,7 @@ export interface SquadInfiniteSessionConfig {
  * re-declaring the union inline. The runtime list lives in config/models.ts as
  * `VALID_REASONING_EFFORTS` (kept in sync via `satisfies`).
  */
-export type SquadReasoningEffort = "low" | "medium" | "high" | "xhigh";
+export type SquadReasoningEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 /**
  * Valid context tiers (context-window sizes) for models that support them.

--- a/packages/squad-sdk/src/config/models.ts
+++ b/packages/squad-sdk/src/config/models.ts
@@ -817,7 +817,7 @@ export function writeAgentModelOverrides(
  * Canonical runtime list — import this instead of duplicating. The `satisfies`
  * clause keeps it in lock-step with the canonical {@link SquadReasoningEffort} type.
  */
-export const VALID_REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh'] as const satisfies readonly SquadReasoningEffort[];
+export const VALID_REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'] as const satisfies readonly SquadReasoningEffort[];
 /** Canonical reasoning-effort union (alias of {@link SquadReasoningEffort}). */
 export type ValidReasoningEffort = SquadReasoningEffort;
 const VALID_REASONING_EFFORTS_WITH_AUTO: readonly string[] = [...VALID_REASONING_EFFORTS, 'auto'];

--- a/test/model-preference.test.ts
+++ b/test/model-preference.test.ts
@@ -463,6 +463,13 @@ describe('writeReasoningEffort', () => {
     const raw = JSON.parse(readFileSync(join(squadDir, 'config.json'), 'utf-8'));
     expect(raw).not.toHaveProperty('defaultReasoningEffort');
   });
+
+  it('accepts max as a valid effort level', () => {
+    writeReasoningEffort(squadDir, 'max');
+    const raw = JSON.parse(readFileSync(join(squadDir, 'config.json'), 'utf-8'));
+    expect(raw.defaultReasoningEffort).toBe('max');
+    expect(readReasoningEffort(squadDir)).toBe('max');
+  });
 });
 
 // ============================================================================
@@ -641,6 +648,16 @@ describe('clampReasoningEffort', () => {
   it('treats max and xhigh as equivalent', () => {
     // xhigh requested, model supports max
     expect(clampReasoningEffort('xhigh', ['low', 'medium', 'high', 'max'])).toBe('xhigh');
+    // max requested, model supports xhigh
+    expect(clampReasoningEffort('max', ['low', 'medium', 'high', 'xhigh'])).toBe('xhigh');
+  });
+
+  it('passes through max when model directly supports max', () => {
+    expect(clampReasoningEffort('max', ['low', 'medium', 'high', 'max'])).toBe('max');
+  });
+
+  it('clamps max to xhigh for models that use that name at the top tier', () => {
+    expect(clampReasoningEffort('max', ['low', 'medium', 'high', 'xhigh'])).toBe('xhigh');
   });
 
   it('returns undefined for unrecognized effort value', () => {


### PR DESCRIPTION
## Summary

Adds `"max"` as a valid value for `SquadReasoningEffort`, unblocking Dependabot PR #1671 (`deps: bump the minor-patch group with 4 updates`).

**Root cause:** Copilot SDK 1.0.9 added `ReasoningEffort = "max"`. Squad's `SquadReasoningEffort` type was `"low" | "medium" | "high" | "xhigh"` — missing `"max"`, causing a type incompatibility when the updated SDK is consumed.

## Changes

- `packages/squad-sdk/src/adapter/types.ts`: added `"max"` to the `SquadReasoningEffort` union
- `packages/squad-sdk/src/config/models.ts`: added `"max"` to `VALID_REASONING_EFFORTS` const (the `satisfies` clause keeps type and runtime list in lock-step automatically)
- `test/model-preference.test.ts`: 3 new tests covering `"max"` as a first-class effort value
- `.changeset/max-reasoning-effort.md`: patch changeset for `@bradygaster/squad-sdk`

The clamping infrastructure (`EFFORT_RANK`, `clampReasoningEffort`) already treated `max` and `xhigh` as rank-equivalent — no changes needed there.

**Backwards compatible:** existing callers using `low/medium/high/xhigh` are unaffected.

## Validation

```
✓ npm run build — passes (both squad-sdk and squad-cli)
✓ vitest run test/model-preference.test.ts — 104/104 tests pass (101 existing + 3 new)
```

## Relationship to Dependabot PR

This PR does **not** close Dependabot PR #1671 (Dependabot manages its own branch). Once this is merged to `dev`, the `@github/copilot-sdk` bump in #1671 will be compatible with Squad's type system.

Working as **CAPCOM** (SDK Expert)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>