### PR TITLE
docs(changelog): reconcile 0.12.0 entry with final dev contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project will be documented in this file.
 - Docs: add Azure hosting guides (Dockerfile contract, ACA, AKS), a production security-hardening guide (threat model, prompt-injection defense, credential hygiene), a production-operations runbook (observability, state-backend selection, troubleshooting), and a Microsoft Agent Framework integration guide (#1574, #1575, #1578, #1579).
 - (cli) Add `gh aw init` tooling — skills, MCP config, and setup/maintenance workflows — for consuming gh-aw from a project (#1592).
 - (sdk) Expose `memory.*` tools (classify, write, search, promote, delete, audit) through the `squad_state` MCP server so agents can manage tiered memory directly.
+- (cli) Add a Squad implementation mode: `/squad implement` dispatches regular issues and ready epic tasks to an isolated implementation worker workflow, guarding dependency handling, duplicate-PR detection, concurrency, and PR file scope (#1682).
+- (cli) Ship an Auto-Cast pivot for gh-aw: when a repo has no team yet, workflows write a pending-intent marker, dedupe in-flight Cast PRs, and resume the original request once casting completes, so a single issue can guide resumable work end-to-end (#1690).
+- (sdk) Add `"max"` to `SquadReasoningEffort` and `VALID_REASONING_EFFORTS`, matching Copilot SDK 1.0.9's `ReasoningEffort = "max"` (#1693).
 
 ### Changed
 - (cli) Harden the Squad coordinator workflow prompt for gh-aw reliability: hard completion gates, atomic task-call contracts, configurable model selection, forward-ported safe-output hardening, and prompt-size compression (135KB → under the 100KB gh-aw limit) (#1669, #1678, #1680, #1683, #1685).
@@ -28,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - (cli) CI: pin GitHub Actions references to immutable commit SHAs across shipped workflow templates, and fail CI when unreleased changesets accumulate (#1475, #1481).
 - Docs: restructure navigation and do a voice pass across get-started, concepts, and issue-truth content; add the agentic-SDLC demo walkthrough (#1570-#1573).
 - Refresh dependencies across the workspace, including TypeScript, Vitest 4, Ink 7, `@github/copilot-sdk`, `@github/copilot`, and OpenTelemetry, plus routine security/patch bumps.
+- Bump `@hono/node-server` to 2.1.0 and the workspace's minor-patch dependency group (`@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint`, `eslint-plugin-n`, `@types/node`, `@github/copilot-sdk`, `ws`) (#1692, #1694).
 
 ### Fixed
 - (cli) Pin the CLI's `squad-sdk` dependency to the exact published version in `publish-cli` so installs can no longer resolve a stale SDK (#1638).


### PR DESCRIPTION
## What this reconciles

The `## [0.12.0] - 2026-08-12` CHANGELOG entry was authored before `dev` picked up 7 more commits ahead of the merge that shipped PR #1691. This PR brings the entry back in sync with the actual `dev` tip so release notes match what ships in v0.12.0. No version bumps — CHANGELOG.md only.

## Entries added

**### Added**
- `(cli)` Squad implementation mode — `/squad implement` dispatches regular issues and ready epic tasks to an isolated implementation worker workflow (#1682)
- `(cli)` Auto-Cast pivot for gh-aw — pending-intent marker, Cast PR dedup, and resumed original request once casting completes, so a single issue can guide resumable work (#1690)
- `(sdk)` Add `"max"` to `SquadReasoningEffort` / `VALID_REASONING_EFFORTS`, matching Copilot SDK 1.0.9's `ReasoningEffort = "max"` (#1693)

**### Changed**
- Summarized the `@hono/node-server` bump to 2.1.0 and the workspace minor-patch dependency group (`@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint`, `eslint-plugin-n`, `@types/node`, `@github/copilot-sdk`, `ws`) as a single line rather than listing every package (#1692, #1694)

## Omitted (deliberately, not user-facing)

- `fa18a51d` — chore: ignore gh-aw run artifacts and local MCP config (#1688). Pure `.gitignore` hygiene for local/CI-only paths (`/run-artifacts/`, `/.mcp.json`); no effect on shipped behavior.

## Verification

- `## [0.12.0] - 2026-08-12` header unchanged (exact string, date untouched) — required for `squad-release.yml`'s grep gate
- `## [Unreleased]` above it and `## [0.11.0] - 2026-06-29` below it both untouched
- `git diff --stat` against `dev`: `CHANGELOG.md | 4 ++++` — one file, four lines added, nothing else
- No package.json touched; versions remain at 0.12.0 as already merged in #1691

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
