### PR TITLE
fix(test): correct gh-aw compile test workspace layout for dispatch-workflow validation

### DIFF
--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -613,29 +613,49 @@ describe('gh-aw: prompt budget & planning import regression', () => {
 describe('gh-aw: compiled workflow contract', () => {
   const ghAwAvailable = spawnSync('gh', ['aw', '--version'], { encoding: 'utf8' }).status === 0;
 
+  // Explicit timeout: this test shells out to the real `gh aw compile` binary,
+  // which reliably finishes in ~2-3s in isolation but can exceed the 5s vitest
+  // default under full-suite parallel load/contention. Bumping this avoids
+  // spurious CI flakiness unrelated to the assertions themselves.
   it.skipIf(!ghAwAvailable)('strict-compiles and preserves prompt/config behavior', () => {
     const workspace = createTestWorkspace('gh-aw-compile-');
     try {
       execFileSync('git', ['init', '--quiet'], { cwd: workspace });
-      cpSync(WORKFLOWS_DIR, join(workspace, 'workflows'), { recursive: true });
-      execFileSync('gh', ['aw', 'compile', 'workflows/squad.md', '--strict'], {
+      // gh-aw's dispatch-workflow validation (added alongside #1682's
+      // safe-outputs.dispatch-workflow config) resolves its dispatch target against
+      // a `.github/workflows/` directory that it locates relative to the compiled
+      // file's path, assuming the standard `<repo-root>/.github/workflows/<file>.md`
+      // layout. This repo distributes the gh-aw *source* one level shallower, from a
+      // top-level `workflows/` directory (see docs/src/content/docs/guide/gh-aw.md),
+      // which downstream consumers install into their own `.github/workflows/` via
+      // `gh aw add owner/squad/workflows/squad-implement-worker.md@dev
+      // owner/squad/workflows/squad.md@dev` — landing both files side-by-side there.
+      // Mirror that real deployment layout in the ephemeral test workspace (instead
+      // of a bare `workflows/` copy) so the dispatch target `squad-implement-worker`
+      // resolves the same way it will for every real downstream install.
+      cpSync(WORKFLOWS_DIR, join(workspace, '.github', 'workflows'), { recursive: true });
+      execFileSync('gh', ['aw', 'compile', '.github/workflows/squad.md', '--strict'], {
         cwd: workspace,
         encoding: 'utf8',
         stdio: 'pipe',
       });
 
-      const compiled = readFileSync(join(workspace, 'workflows', 'squad.lock.yml'), 'utf8');
+      const compiled = readFileSync(join(workspace, '.github', 'workflows', 'squad.lock.yml'), 'utf8');
       expect(compiled).toContain('"auto_close_issue":false');
       expect(compiled).toContain('"data_enabled":true');
       expect(compiled).toContain('"required":["origin_issue","phases","schema_version","squad_artifact"]');
       expect(compiled).toContain('"enum":["research","plan","plan-accepted"');
-      expect(compiled).toContain('{{#runtime-import shared/planning-ontology.md}}');
-      expect(compiled).toContain('{{#runtime-import squad.md}}');
+      // gh-aw records runtime-import paths relative to the repo root (not the
+      // compiled file's own directory), so with the real `.github/workflows/`
+      // deployment layout these are prefixed accordingly — verified against an
+      // isolated compile outside this repo/worktree entirely.
+      expect(compiled).toContain('{{#runtime-import .github/workflows/shared/planning-ontology.md}}');
+      expect(compiled).toContain('{{#runtime-import .github/workflows/squad.md}}');
       expect(compiled).not.toMatch(/<!-- squad-[\w-]+(?:-v\d+)? -->/);
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`test/gh-aw-quality.test.ts` -> `gh-aw: compiled workflow contract` -> `strict-compiles and preserves prompt/config behavior` has kept `dev` red on vitest since **2026-08-12T23:39** (PR CI, not the `node --test` release gate, which does not run this file - see note below).

The test builds an ephemeral git workspace, copies this repo's `workflows/` into `<workspace>/workflows/`, then runs `gh aw compile workflows/squad.md --strict`.

#1682 added `safe-outputs.dispatch-workflow: { workflows: [squad-implement-worker] }` to `workflows/squad.md`. `gh aw compile --strict` (local version v0.85.4) validates that dispatch target against a `.github/workflows/` directory it computes relative to the compiled file, assuming the standard depth `<root>/.github/workflows/<file>.md`. This repo's real gh-aw source lives one level shallower, at `<root>/workflows/<file>.md`, so gh aw's computed root lands one directory too high - the *parent* of the actual workspace/repo root. It can never find `squad-implement-worker`, and `--strict` compilation fails:

```
dispatch-workflow: workflow 'squad-implement-worker' not found in <...>/.github/workflows
Checked for: squad-implement-worker.md, .lock.yml, .yml, .yaml
```

I reproduced this locally in a clean temp git repo containing only `workflows/`, and independently confirmed the off-by-one behavior against the real repo root as well. `squad-implement-worker.md` is present and committed on `dev` - this was never a missing-source problem, only a test-workspace-layout problem.

## What I changed (and why)

**Only `test/gh-aw-quality.test.ts`.** `workflows/squad.md`, `workflows/squad-implement-worker.md`, and #1682's `dispatch-workflow` feature surface are completely untouched - I did not revert, weaken, or touch the feature in any way.

In the compile test:
- Copy `workflows/` into `<workspace>/.github/workflows/` instead of `<workspace>/workflows/`.
- Compile `.github/workflows/squad.md` (was `workflows/squad.md`), and read the resulting lock file from the matching path.
- This mirrors exactly how real downstream consumers install and compile this repo's workflows per `docs/src/content/docs/guide/gh-aw.md`: `gh aw add owner/squad/workflows/squad-implement-worker.md@dev owner/squad/workflows/squad.md@dev` lands both `.md` files together in the consumer's own `.github/workflows/`, alongside `shared/*.md`, which is the layout `gh aw compile --strict`'s dispatch-workflow validation actually expects.
- I verified this placement in a fully isolated compile (outside this repo/worktree entirely): with `.github/workflows/` layout, `gh aw compile .github/workflows/squad.md --strict` succeeds (exit 0, 1 succeeded, 2 warnings, dispatch-workflow resolves).
- That same isolated compile also revealed a second, previously-passing assertion in this test needed updating: gh aw records `{{#runtime-import ...}}` placeholder paths relative to the repo root, not relative to the compiled file's directory. With this real layout the compiled output legitimately contains `{{#runtime-import .github/workflows/shared/planning-ontology.md}}` and `{{#runtime-import .github/workflows/squad.md}}` (previously asserted as the bare `shared/planning-ontology.md` / `squad.md`, which only held for the old, incorrect bare-`workflows/` test layout). Updated both literal assertions to match gh aw's genuine, verified behavior.
- Added a 20s explicit test timeout (`gh aw compile` subprocess reliably takes ~2-3s, but can exceed vitest's 5s default under full-suite parallel resource contention on some machines - observed this directly while re-running the full suite for verification; this is a low-risk hardening of the exact test being touched, not scope creep).

## Local verification

- `npx vitest run test/gh-aw-quality.test.ts -t "strict-compiles"`: **1 passed, 78 skipped.**
- Full `gh-aw-quality.test.ts` file: the only remaining failures (12) are pre-existing, unrelated, Windows-only `execSync(..., { shell: '/bin/sh' })` calls (Team Guard roster-row detection, Cast PR dedup jq filter) that ENOENT because `/bin/sh` doesn't exist on Windows. These are not caused by this change and were already confirmed (via the real failing CI run's logs) not to occur on Linux CI, where only this one dispatch-workflow test failed.
- Full `npx vitest run` (all ~272 test files, ~7500 tests) on this Windows dev machine: pre-existing, unrelated flakiness exists independent of this change (roughly 60-65 of 272 files fail even on a clean `dev` checkout, mostly Windows/`/bin/sh` and environment-specific issues) - I confirmed this is not a regression by diffing my change against a stashed/reverted state and re-running. My diff is a single, 26-line change to one test's workspace setup and two literal assertions; nothing else was touched.
- Note for reviewers: running the full suite also has a pre-existing side effect where some build/test step rewrites ~150 template files in the working tree with different line endings, and stamps a version comment into `.github/agents/squad.agent.md`. This is unrelated repo behavior (not part of my diff) - I reverted it every time it appeared and confirmed via `git diff --stat -w` that it is pure line-ending churn plus one unrelated version-stamp side effect, before committing.

## Note on why `dev` looked green on the release gate despite this

`squad-release.yml` runs `node --test test/*.test.cjs`, while PR CI runs vitest. `test/gh-aw-quality.test.ts` is a `.ts` file the release gate's glob never sees, so this red vitest test did not block `dev -> main` promotion (e.g. the v0.12.0 release-prep PR #1691 merged despite it). Worth knowing if `dev` looks green from the release workflow's perspective while PR CI disagrees.

## Confirming #1682 is untouched

- `git diff` for this PR touches only `test/gh-aw-quality.test.ts`.
- `workflows/squad.md`'s `dispatch-workflow`, `issue_number`/`aw_context` inputs, and `bots:` trigger are all present, unmodified, on this branch.
- `workflows/squad-implement-worker.md` is unmodified.

@bradygaster - flagging directly since you own #1682 and the dispatch-workflow feature; this PR only adjusts how the test verifies it compiles, it does not change the feature's behavior or configuration.