### PR TITLE
docs: correct SQUAD_GITHUB_TOKEN framing; distinguish Squad from gh-aw runtime requirements

### DIFF
--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -48,17 +48,12 @@ git add -- \
 git commit -m "ci: add Squad agentic workflow"
 git push
 
-# 6. (Recommended) Verify your token configuration before continuing
-gh api repos/{owner}/{repo}/actions/secrets --jq '.secrets[].name' | grep SQUAD_GITHUB
-
-# 7. Open an issue and type /squad cast — done!
+# 6. Open an issue and type /squad cast — done!
 ```
 
 After pushing, open an issue in your repo and write `/squad cast` in the body or
 a comment. Squad analyzes your codebase, composes a team of specialist agents,
 and opens a PR with the result.
-
-If your first run fails at the bootstrap step (missing `/usr/local/bin/copilot`), set `SQUAD_GITHUB_TOKEN` before retrying. See [Configure SQUAD_GITHUB_TOKEN](#configure-squad_github_token) for minimum required permissions.
 
 ---
 
@@ -158,43 +153,6 @@ normally create `.github/aw/logs/.gitignore`; if it is missing, add:
 
 Once pushed, the `/squad` slash command is live on your repo.
 
-### Pre-flight token check
-
-Before running your first `/squad` command, verify that the workflow's token has
-enough permission to complete the Copilot runtime bootstrap step. The bootstrap
-runs in the activation job and invokes the Squad CLI via `npx`. If it fails with
-a message such as `missing /usr/local/bin/copilot`, the cause is almost always
-an insufficient token.
-
-**Quick check — run this in any terminal authenticated to your repo:**
-
-```bash
-gh api repos/{owner}/{repo}/actions/secrets --jq '.secrets[].name' | grep SQUAD_GITHUB
-```
-
-If `SQUAD_GITHUB_TOKEN` appears in the output, the secret is set and the
-bootstrap will use it. If the command returns nothing, the workflow falls back to
-the built-in `github.token`.
-
-**When `github.token` is sufficient:**
-
-- The repo is personal (not an organization repo).
-- Copilot is enabled for the repository.
-- The first `/squad` run succeeds end-to-end.
-
-**When `SQUAD_GITHUB_TOKEN` is required:**
-
-- The run fails with `missing /usr/local/bin/copilot` or `Resource not accessible by integration`.
-- The repository is in an organization with restricted default workflow permissions.
-- You see the bootstrap step pass but the agent step fail with a Copilot permission error.
-
-In these cases, set `SQUAD_GITHUB_TOKEN` before running `/squad` for the first time.
-See [Configure SQUAD_GITHUB_TOKEN](#configure-squad_github_token) below.
-
-:::caution[Set the token before your first /squad run]
-A run that fails at the bootstrap step does not retry automatically. Set `SQUAD_GITHUB_TOKEN` **before** posting `/squad cast`, then trigger a new run.
-:::
-
 ### Optional: pin a CLI version
 
 Set a repository variable to control which Squad CLI version the workflow uses:
@@ -219,36 +177,14 @@ or elevated permissions, configure a GitHub App:
 The workflow mints an installation token from these credentials at activation
 time.
 
-### Configure SQUAD_GITHUB_TOKEN
+### Optional: PAT fallback
 
-If `github.token` is insufficient for your setup (see [Pre-flight token check](#pre-flight-token-check)
-above), set a Personal Access Token. Use a **fine-grained PAT** with the minimum
-required permissions — avoid classic PATs with broad scopes.
-
-**Minimum permissions for a fine-grained PAT:**
-
-| Permission | Access |
-|-----------|--------|
-| **Contents** | Read |
-| **Issues** | Read and write |
-| **Pull requests** | Read and write |
-| **Workflows** | Read and write |
-| **Metadata** | Read (always required) |
-
-Create the PAT at **GitHub → Settings → Developer settings → Personal access
-tokens → Fine-grained tokens**. Scope it to the target repository only.
-
-Then add it as a repository secret:
-
-```bash
-gh secret set SQUAD_GITHUB_TOKEN --body "<your-pat>" --repo {owner}/{repo}
-```
-
-Or via **Settings → Secrets and variables → Actions → Secrets → New repository secret**.
+If you don't want to use a GitHub App but need more than the default token, set
+a Personal Access Token:
 
 | Setting | Type | Purpose |
 |---------|------|---------|
-| `SQUAD_GITHUB_TOKEN` | Secret | PAT used when `github.token` is insufficient |
+| `SQUAD_GITHUB_TOKEN` | Secret | Fallback PAT when no GitHub App is configured |
 
 **Auth precedence:** GitHub App token → `SQUAD_GITHUB_TOKEN` → `github.token`.
 

--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -48,12 +48,17 @@ git add -- \
 git commit -m "ci: add Squad agentic workflow"
 git push
 
-# 6. Open an issue and type /squad cast — done!
+# 6. (Recommended) Verify your token configuration before continuing
+gh api repos/{owner}/{repo}/actions/secrets --jq '.secrets[].name' | grep SQUAD_GITHUB
+
+# 7. Open an issue and type /squad cast — done!
 ```
 
 After pushing, open an issue in your repo and write `/squad cast` in the body or
 a comment. Squad analyzes your codebase, composes a team of specialist agents,
 and opens a PR with the result.
+
+If your first run fails at the bootstrap step (missing `/usr/local/bin/copilot`), set `SQUAD_GITHUB_TOKEN` before retrying. See [Configure SQUAD_GITHUB_TOKEN](#configure-squad_github_token) for minimum required permissions.
 
 ---
 
@@ -153,6 +158,43 @@ normally create `.github/aw/logs/.gitignore`; if it is missing, add:
 
 Once pushed, the `/squad` slash command is live on your repo.
 
+### Pre-flight token check
+
+Before running your first `/squad` command, verify that the workflow's token has
+enough permission to complete the Copilot runtime bootstrap step. The bootstrap
+runs in the activation job and invokes the Squad CLI via `npx`. If it fails with
+a message such as `missing /usr/local/bin/copilot`, the cause is almost always
+an insufficient token.
+
+**Quick check — run this in any terminal authenticated to your repo:**
+
+```bash
+gh api repos/{owner}/{repo}/actions/secrets --jq '.secrets[].name' | grep SQUAD_GITHUB
+```
+
+If `SQUAD_GITHUB_TOKEN` appears in the output, the secret is set and the
+bootstrap will use it. If the command returns nothing, the workflow falls back to
+the built-in `github.token`.
+
+**When `github.token` is sufficient:**
+
+- The repo is personal (not an organization repo).
+- Copilot is enabled for the repository.
+- The first `/squad` run succeeds end-to-end.
+
+**When `SQUAD_GITHUB_TOKEN` is required:**
+
+- The run fails with `missing /usr/local/bin/copilot` or `Resource not accessible by integration`.
+- The repository is in an organization with restricted default workflow permissions.
+- You see the bootstrap step pass but the agent step fail with a Copilot permission error.
+
+In these cases, set `SQUAD_GITHUB_TOKEN` before running `/squad` for the first time.
+See [Configure SQUAD_GITHUB_TOKEN](#configure-squad_github_token) below.
+
+:::caution[Set the token before your first /squad run]
+A run that fails at the bootstrap step does not retry automatically. Set `SQUAD_GITHUB_TOKEN` **before** posting `/squad cast`, then trigger a new run.
+:::
+
 ### Optional: pin a CLI version
 
 Set a repository variable to control which Squad CLI version the workflow uses:
@@ -177,14 +219,36 @@ or elevated permissions, configure a GitHub App:
 The workflow mints an installation token from these credentials at activation
 time.
 
-### Optional: PAT fallback
+### Configure SQUAD_GITHUB_TOKEN
 
-If you don't want to use a GitHub App but need more than the default token, set
-a Personal Access Token:
+If `github.token` is insufficient for your setup (see [Pre-flight token check](#pre-flight-token-check)
+above), set a Personal Access Token. Use a **fine-grained PAT** with the minimum
+required permissions — avoid classic PATs with broad scopes.
+
+**Minimum permissions for a fine-grained PAT:**
+
+| Permission | Access |
+|-----------|--------|
+| **Contents** | Read |
+| **Issues** | Read and write |
+| **Pull requests** | Read and write |
+| **Workflows** | Read and write |
+| **Metadata** | Read (always required) |
+
+Create the PAT at **GitHub → Settings → Developer settings → Personal access
+tokens → Fine-grained tokens**. Scope it to the target repository only.
+
+Then add it as a repository secret:
+
+```bash
+gh secret set SQUAD_GITHUB_TOKEN --body "<your-pat>" --repo {owner}/{repo}
+```
+
+Or via **Settings → Secrets and variables → Actions → Secrets → New repository secret**.
 
 | Setting | Type | Purpose |
 |---------|------|---------|
-| `SQUAD_GITHUB_TOKEN` | Secret | Fallback PAT when no GitHub App is configured |
+| `SQUAD_GITHUB_TOKEN` | Secret | PAT used when `github.token` is insufficient |
 
 **Auth precedence:** GitHub App token → `SQUAD_GITHUB_TOKEN` → `github.token`.
 

--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -61,7 +61,7 @@ and opens a PR with the result.
 
 | Requirement | Details |
 |-------------|---------|
-| GitHub repo with Copilot | Copilot must be enabled for the repository |
+| GitHub repo with Copilot | Copilot must be enabled **and configured for use in GitHub Actions** for the repository. gh-aw uses `copilot-requests: write` to install and invoke the Copilot runtime in the activation job — if Copilot is not enabled for Actions, the run fails before Squad starts. Enable it under **Settings → Copilot → Copilot in GitHub Actions**. |
 | `gh` CLI | [Install the GitHub CLI](https://cli.github.com/) and authenticate with `gh auth login` |
 | `gh aw` extension | `gh extension install github/gh-aw` |
 
@@ -179,14 +179,15 @@ time.
 
 ### Optional: PAT fallback
 
-If you don't want to use a GitHub App but need more than the default token, set
-a Personal Access Token:
+Squad CLI's `init` step runs in the activation job and uses `github.token` by default. If your use case requires elevated access for Squad CLI operations (for example, initializing against a private registry or cross-repo reads), you can supply a Personal Access Token:
 
 | Setting | Type | Purpose |
 |---------|------|---------|
-| `SQUAD_GITHUB_TOKEN` | Secret | Fallback PAT when no GitHub App is configured |
+| `SQUAD_GITHUB_TOKEN` | Secret | PAT for Squad CLI `init` — not used by gh-aw's Copilot runtime |
 
 **Auth precedence:** GitHub App token → `SQUAD_GITHUB_TOKEN` → `github.token`.
+
+This token is **not** what gh-aw uses to invoke Copilot. The Copilot runtime bootstrap is a gh-aw platform concern driven by `copilot-requests: write` and requires Copilot to be enabled for Actions — see [Prerequisites](#prerequisites).
 
 ---
 
@@ -873,6 +874,7 @@ gh aw compile
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
+| `missing /usr/local/bin/copilot` in activation log | Copilot is not enabled for GitHub Actions in this repository — a gh-aw platform requirement, not a Squad requirement | Enable **Copilot in GitHub Actions** under **Settings → Copilot**. `SQUAD_GITHUB_TOKEN` does not fix this error. |
 | "Nothing to cast from" comment | Both repo and issue are empty | Add a README or write a casting brief in the issue body |
 | Cast produces a generic team | Issue body was empty, repo was analyzed alone | Write a detailed casting brief (see [example](#example-writing-a-casting-brief)) |
 | "Could not access" error on Connect/Adopt | Source repo is private or doesn't exist | Verify the source repo is accessible and contains a `.squad/` directory |


### PR DESCRIPTION
Working as PAO (DevRel)

Closes #1703

## Investigation finding

The demo failure (`missing /usr/local/bin/copilot`) is a **gh-aw platform requirement**, not a Squad token requirement.

- The Copilot binary is installed by gh-aw's runtime based on `engine: id: copilot` and `copilot-requests: write` — Squad does not control this step.
- `SQUAD_GITHUB_TOKEN` is used only by Squad CLI's `init` step inside the activation job (`workflows/shared/squad.md` line 82). It has no effect on whether gh-aw can bootstrap the Copilot binary.
- The demo repo adding `SQUAD_GITHUB_TOKEN` and then succeeding is likely correlation, not causation — the actual requirement was Copilot being enabled for GitHub Actions.

## Changes

**File:** `docs/src/content/docs/guide/gh-aw.md` (+6/-4 lines)

1. **Prerequisites table**: Expanded the Copilot row to specify that Copilot must be enabled *for GitHub Actions* (Settings → Copilot → Copilot in GitHub Actions), and that this is a gh-aw platform requirement. `SQUAD_GITHUB_TOKEN` has nothing to do with it.

2. **Optional: PAT fallback section**: Clarified that `SQUAD_GITHUB_TOKEN` is used only by Squad CLI `init` in the activation job — not by gh-aw's Copilot runtime. Added an explicit note that this token does not affect the Copilot binary installation.

3. **Troubleshooting table**: Added a row for the specific `missing /usr/local/bin/copilot` error, pointing to Copilot-for-Actions not being enabled, and explicitly stating `SQUAD_GITHUB_TOKEN` does not fix it.

`SQUAD_GITHUB_TOKEN` remains accurately documented as optional throughout.

## Validation

```
✓ test/docs-build.test.ts (22 tests | 16 skipped) 109ms
```