### PR TITLE
chore: bump dev to 0.13.0 for next cycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bradygaster/squad",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -8461,7 +8461,7 @@
     },
     "packages/squad-cli": {
       "name": "@bradygaster/squad-cli",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8502,12 +8502,11 @@
     },
     "packages/squad-sdk": {
       "name": "@bradygaster/squad-sdk",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.9",
-        "vscode-jsonrpc": "^9.0.1",
-        "ws": "8.21.3"
+        "vscode-jsonrpc": "^9.0.1"
       },
       "devDependencies": {
         "@types/node": "^26.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

v0.12.0 shipped successfully today: main is at 0.12.0, tag 0.12.0 exists, the GitHub Release is published, and both @bradygaster/squad-cli and @bradygaster/squad-sdk are live on npm at 0.12.0 (latest + insider promoted).

This PR stages dev for the next cycle by bumping the base version from 