### PR TITLE
docs: fix unrendered ::: asides across docs and blog

### DIFF
--- a/docs/src/content/blog/028-v090-whats-new.md
+++ b/docs/src/content/blog/028-v090-whats-new.md
@@ -42,9 +42,8 @@ Ralph's dispatcher reads these labels and routes the work to the machine in your
 - ML agents tagged `needs:gpu` route to GPU-equipped machines
 - Docker-based agents route to machines with Docker daemon running
 - Multi-region squads balance load based on capabilities
-:::note
-Capability Discovery works with Ralph's mesh routing. If you're not running Ralph, this is aspirational.
-:::
+
+> **Note:** Capability Discovery works with Ralph's mesh routing. If you're not running Ralph, this is aspirational.
 
 ---
 ### 3. Cooperative Rate Limiting — Predictive Circuit Breaker (#515)

--- a/docs/src/content/docs/guide/build-autonomous-agent.md
+++ b/docs/src/content/docs/guide/build-autonomous-agent.md
@@ -355,9 +355,7 @@ The autonomous-pipeline sample demonstrates three coordination patterns that age
 
 These patterns let agents coordinate without a central orchestrator. Each agent makes local decisions that accumulate into a shared knowledge base.
 
-:::note[`squad_route` requires `fanOutDepsGetter`]
-For `squad_route` to actually spawn agent sessions, the `ToolRegistry` must be constructed with a `fanOutDepsGetter` callback that provides fan-out dependencies (`sessionPool`, `modelClient`, `squadRoot`, `configGetter`). Without it, the tool returns an honest `fan-out-deps-unavailable` error instead of silently succeeding. See the [SDK reference](/reference/sdk/#toolregistry) for wiring details.
-:::
+> **`squad_route` requires `fanOutDepsGetter`:** For `squad_route` to actually spawn agent sessions, the `ToolRegistry` must be constructed with a `fanOutDepsGetter` callback that provides fan-out dependencies (`sessionPool`, `modelClient`, `squadRoot`, `configGetter`). Without it, the tool returns an honest `fan-out-deps-unavailable` error instead of silently succeeding. See the [SDK reference](/reference/sdk/#toolregistry) for wiring details.
 
 ---
 

--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -92,9 +92,7 @@ gh aw add \
 The single command installs the dedicated worker first, then the main workflow
 that dispatches it.
 
-:::note[Branch note]
-`@dev` pulls from the latest development branch where new modes and fixes land first. Stay on `@dev` to get improvements as they ship. Once gh-aw support reaches stable, you can switch to `@main` or drop the ref entirely for the default branch.
-:::
+> **Branch note:** `@dev` pulls from the latest development branch where new modes and fixes land first. Stay on `@dev` to get improvements as they ship. Once gh-aw support reaches stable, you can switch to `@main` or drop the ref entirely for the default branch.
 
 This registers the Squad workflow in your repository's agentic workflow
 configuration.
@@ -704,21 +702,17 @@ temporarily reduce the active count when no additional child is ready.
 `/squad implement` remains available as a manual recovery command if a run is
 cancelled or an external change requires the epic to be reevaluated.
 
-:::note[Repository setting]
-Pull-request delivery requires **Settings → Actions → General → Workflow
-permissions → Allow GitHub Actions to create and approve pull requests**.
-:::
+> **Repository setting:** Pull-request delivery requires **Settings → Actions →
+> General → Workflow permissions → Allow GitHub Actions to create and approve
+> pull requests**.
 
-:::note[Pull request CI]
-Pull requests created with the default `GITHUB_TOKEN` do not trigger other
-workflow runs. Set `GH_AW_CI_TRIGGER_TOKEN` to a suitable fine-grained PAT if
-implementation pull requests must start repository CI automatically.
-:::
+> **Pull request CI:** Pull requests created with the default `GITHUB_TOKEN` do
+> not trigger other workflow runs. Set `GH_AW_CI_TRIGGER_TOKEN` to a suitable
+> fine-grained PAT if implementation pull requests must start repository CI
+> automatically.
 
-:::note[Manual runs]
-From **Actions → Squad → Run workflow**, enter `implement` as the command and
-provide the target issue number.
-:::
+> **Manual runs:** From **Actions → Squad → Run workflow**, enter `implement` as
+> the command and provide the target issue number.
 
 ---
 

--- a/docs/src/content/docs/guide/personal-squad.md
+++ b/docs/src/content/docs/guide/personal-squad.md
@@ -2,9 +2,7 @@
 
 > ⚠️ **Experimental** — Squad is alpha software. APIs, commands, and behavior may change between releases.
 
-:::tip[Git helps protect your project state]
-We strongly recommend using git to version-control your project `.squad/` directory. Every session writes to it — decisions, logs, orchestration history. Agent charters, skills, and casting histories live in your personal squad directory (not committed to projects). Without version control, context window resets, crashes, or accidental deletions could be unrecoverable. If git isn't an option, regular manual backups to external storage or cloud sync can help protect your work.
-:::
+> **Tip — Git helps protect your project state:** We strongly recommend using git to version-control your project `.squad/` directory. Every session writes to it — decisions, logs, orchestration history. Agent charters, skills, and casting histories live in your personal squad directory (not committed to projects). Without version control, context window resets, crashes, or accidental deletions could be unrecoverable. If git isn't an option, regular manual backups to external storage or cloud sync can help protect your work.
 
 **Try this:**
 ```bash


### PR DESCRIPTION
## Why

Several docs pages were showing raw markdown directives to readers. On the gh-aw guide, the "Branch note" callout rendered as literal `:::note[Branch note] ... :::` text in the middle of the install instructions instead of as a styled callout.

## Root cause

The docs site is plain Astro, not Starlight. `docs/astro.config.mjs` registers only `remarkRewriteLinks` and `rehypePagefindAttrs`, with no `remark-directive` plugin. That means container directive syntax (`:::note[...]`, `:::tip[...]`) was never parsed by the markdown pipeline and passed straight through to the rendered page as plain text.

This is not a rendering regression so much as syntax that was never supported here. Six occurrences had crept in, presumably copied from Starlight-based docs.

## Fix

Converted every occurrence to the blockquote callout convention the site already uses in roughly 56 other places (`> **Label:** text`):

- `guide/gh-aw.md` - 4 callouts (Branch note, Repository setting, Pull request CI, Manual runs)
- `guide/build-autonomous-agent.md` - 1 callout
- `guide/personal-squad.md` - 1 tip
- `blog/028-v090-whats-new.md` - 1 note

No content was changed, only the callout wrapper syntax.

## Verification

Ran a full `npm run build` in `docs/`. The build succeeds and a scan of all 185 generated HTML pages finds zero remaining `:::` sequences.

## Note for reviewers

If we want directive syntax to work going forward, the alternative fix would be adding `remark-directive` plus a custom remark transform to `astro.config.mjs`. I went with matching the existing convention instead, since that is what the rest of the docs already do and it avoids introducing a second callout style.