### PR TITLE
fix(workflows): interpolate dispatch inputs so merge continuation resolves the epic

### DIFF
--- a/.github/workflows/squad-workflow-lint.yml
+++ b/.github/workflows/squad-workflow-lint.yml
@@ -18,6 +18,7 @@ on:
       - '.squad-templates/workflows/**'
       - 'templates/workflows/**'
       - 'workflows/**'
+      - 'scripts/check-workflow-input-interpolation.mjs'
   push:
     branches: [dev, main]
     paths:
@@ -27,6 +28,7 @@ on:
       - '.squad-templates/workflows/**'
       - 'templates/workflows/**'
       - 'workflows/**'
+      - 'scripts/check-workflow-input-interpolation.mjs'
 
 permissions:
   contents: read
@@ -135,3 +137,10 @@ jobs:
         run: |
           echo "--- Linting templates/workflows/ (root mirror) ---"
           actionlint templates/workflows/*.yml
+
+      # actionlint only reads YAML. Agentic workflow prompts are Markdown, where a
+      # `github.event.inputs.x` reference written as prose is silently inert: the
+      # dispatched value never reaches the agent, the run still reports success, and
+      # the workflow no-ops with no visible signal. See #1740.
+      - name: Check agentic prompt input interpolation
+        run: node scripts/check-workflow-input-interpolation.mjs

--- a/scripts/check-workflow-input-interpolation.mjs
+++ b/scripts/check-workflow-input-interpolation.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// check-workflow-input-interpolation.mjs -- Catch prose-only workflow_dispatch input
+// references in agentic workflow prompt bodies.
+//
+// An agentic workflow prompt is Markdown that gets rendered into the agent's context.
+// Writing `github.event.inputs.command` in backticks names the expression but never
+// resolves it, so the agent sees a literal string instead of the dispatched value.
+// The workflow then looks healthy from the Actions tab -- run-name and `if:` guards
+// interpolate correctly in frontmatter -- while the agent silently no-ops for want of
+// a value that was delivered but never rendered.
+//
+// Rule: inside a prompt body, every `github.event.inputs.*` reference must appear
+// within a `${{ ... }}` interpolation. Two deliberate exemptions:
+//
+//   * Frontmatter -- `run-name`, `if`, `concurrency` and friends are evaluated by
+//     Actions itself, not by the agent.
+//   * Other `github.event.*` paths (notably `comment.body` and `issue.body`) -- these
+//     carry untrusted user text. gh-aw supplies them to the agent through sanitized
+//     trigger context; interpolating them straight into the prompt would be a
+//     prompt-injection vector, so bare prose references are correct there.
+//
+// Exit 0 when clean, exit 1 with file:line details otherwise.
+// Uses only Node.js built-ins (fs, path).
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+
+const SCAN_DIRS = [
+  'workflows',
+  '.squad-templates/workflows',
+  'templates/workflows',
+  'packages/squad-cli/templates/workflows',
+  'packages/squad-sdk/templates/workflows',
+];
+
+const INPUT_REF = /github\.event\.inputs\.[A-Za-z0-9_]+/g;
+const INTERPOLATION = /\$\{\{[^}]*\}\}/g;
+
+/** Collect .md files from a directory tree, skipping nothing -- these trees are small. */
+function collectMarkdown(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...collectMarkdown(full));
+    } else if (entry.name.endsWith('.md')) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+/**
+ * Return the 0-based line index where the prompt body starts.
+ * A leading `---` fence opens YAML frontmatter; the body begins after its closing fence.
+ * Without frontmatter the whole file is body.
+ */
+function bodyStartLine(lines) {
+  if (lines[0]?.trim() !== '---') return 0;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') return i + 1;
+  }
+  return 0;
+}
+
+const violations = [];
+let scannedFiles = 0;
+
+for (const relDir of SCAN_DIRS) {
+  const dir = join(REPO_ROOT, relDir);
+  if (!existsSync(dir)) continue;
+
+  for (const file of collectMarkdown(dir)) {
+    scannedFiles++;
+    const lines = readFileSync(file, 'utf8').split(/\r?\n/);
+    const start = bodyStartLine(lines);
+
+    for (let i = start; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line.includes('github.event.inputs.')) continue;
+
+      // Blank out every interpolation, then see if any reference survives outside one.
+      const masked = line.replace(INTERPOLATION, (match) => ' '.repeat(match.length));
+      const bare = masked.match(INPUT_REF);
+      if (!bare) continue;
+
+      for (const ref of bare) {
+        violations.push({
+          file: relative(REPO_ROOT, file).replace(/\\/g, '/'),
+          line: i + 1,
+          ref,
+          text: line.trim(),
+        });
+      }
+    }
+  }
+}
+
+if (violations.length === 0) {
+  console.log(
+    `Workflow input interpolation check passed: ${scannedFiles} prompt file(s) scanned, no bare github.event.inputs.* references.`,
+  );
+  process.exit(0);
+}
+
+console.error(
+  `Workflow input interpolation check FAILED: ${violations.length} bare github.event.inputs.* reference(s) in prompt bodies.\n`,
+);
+console.error(
+  'These name an expression without resolving it, so the agent receives the literal text',
+);
+console.error('instead of the dispatched value -- and silently no-ops.\n');
+
+for (const { file, line, ref, text } of violations) {
+  console.error(`  ${file}:${line}`);
+  console.error(`    reference: ${ref}`);
+  console.error(`    line:      ${text}\n`);
+}
+
+console.error('To fix: wrap the reference in an interpolation, e.g.');
+console.error('  - **Dispatched command:** `${{ github.event.inputs.command }}`');
+console.error('If the prompt genuinely needs to discuss the input rather than its value,');
+console.error('describe it without the literal `github.event.inputs.` prefix.');
+process.exit(1);

--- a/scripts/check-workflow-input-interpolation.mjs
+++ b/scripts/check-workflow-input-interpolation.mjs
@@ -24,7 +24,7 @@
 // structural guarantee.
 //
 // Exit 0 when clean, exit 1 with file:line details otherwise.
-// Uses only Node.js built-ins (fs, path).
+// Uses only Node.js built-ins (fs, path, url).
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { resolve, join, dirname, relative } from 'node:path';

--- a/scripts/check-workflow-input-interpolation.mjs
+++ b/scripts/check-workflow-input-interpolation.mjs
@@ -14,10 +14,14 @@
 //
 //   * Frontmatter -- `run-name`, `if`, `concurrency` and friends are evaluated by
 //     Actions itself, not by the agent.
-//   * Other `github.event.*` paths (notably `comment.body` and `issue.body`) -- these
-//     carry untrusted user text. gh-aw supplies them to the agent through sanitized
-//     trigger context; interpolating them straight into the prompt would be a
-//     prompt-injection vector, so bare prose references are correct there.
+//   * Other `github.event.*` paths -- see the INPUT_REF comment below.
+//
+// This scans whole files, including `## skill:` blocks, and that matters: mode
+// playbooks are now extracted into inline skills and restored in isolation, with no
+// guarantee about what precedes them. A skill body that needs a dispatch input must
+// interpolate it itself -- it cannot lean on `## Trigger Context` having resolved the
+// value into scope. Scanning skill bodies turns that from a convention into a
+// structural guarantee.
 //
 // Exit 0 when clean, exit 1 with file:line details otherwise.
 // Uses only Node.js built-ins (fs, path).
@@ -37,6 +41,13 @@ const SCAN_DIRS = [
   'packages/squad-sdk/templates/workflows',
 ];
 
+// Scoped to `inputs.*` deliberately. Do NOT widen this to all `github.event.*`:
+// `comment.body` and `issue.body` are attacker-controlled. gh-aw delivers them to the
+// agent through sanitized trigger context, so interpolating them here would splice
+// untrusted text straight into the prompt ahead of the sanitizer -- a prompt-injection
+// vector. A bare prose reference to those paths is CORRECT and must not be "fixed".
+// An earlier draft of this check flagged them; the gate was right and the tempting fix
+// was wrong.
 const INPUT_REF = /github\.event\.inputs\.[A-Za-z0-9_]+/g;
 const INTERPOLATION = /\$\{\{[^}]*\}\}/g;
 

--- a/workflows/squad-implement-worker.md
+++ b/workflows/squad-implement-worker.md
@@ -142,7 +142,8 @@ For a merged pull request:
    `squad/implement-{issue-number}-` head branch.
 2. Read the child issue and resolve its parent epic using the native parent
    relationship, falling back to its `Parent: #N` body line.
-3. If no parent epic exists, emit `noop` and stop.
+3. If no parent epic exists, comment on the merged pull request saying its issue
+   is standalone and that no further work was queued, then stop.
 4. Call the workflow-specific `squad` safe-output tool exactly once:
 
 ```json
@@ -154,6 +155,18 @@ For a merged pull request:
 
 Never call the generic `dispatch_workflow` tool. Never edit files or create a
 pull request in this mode. Stop after the `squad` workflow is dispatched.
+
+**Always leave a visible next step.** Every merge continuation ends with a
+comment — never a silent exit. Cover both terminal cases:
+
+- Parent epic resolved → name the epic and state that its next children were
+  queued.
+- No parent epic → state that the pull request's issue is standalone and that
+  nothing further was queued.
+
+Never emit `noop` for a merge continuation. `noop` is not reported as a comment,
+so it strands a merged pull request with no signal about what happens next — the
+exact failure this procedure exists to prevent.
 
 The remaining instructions apply only to `workflow_dispatch`.
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -132,14 +132,32 @@ When locating artifacts:
 
 ## Trigger Context
 
-Read slash command from: `github.event.comment.body` (issue/PR comment), `github.event.issue.body` (issue body), or `github.event.inputs.command` (workflow_dispatch, default: `cast`).
+The dispatch inputs for this run are interpolated below. Treat a non-empty value
+as authoritative; an empty value means this run was not started by a workflow
+dispatch.
 
-- **Issue body:** `github.event.issue.body` — the full issue description
-- **Issue comment:** `github.event.comment.body` — the full comment text
-- **PR review comment:** `github.event.comment.body` — the full comment text
-- **Workflow dispatch:** `github.event.inputs.command` — manual input (default: `cast`)
-- **Manual issue target:** `github.event.inputs.issue_number` — issue number for
-  `/squad implement` runs started from the Actions tab
+- **Dispatched command:** `${{ github.event.inputs.command }}`
+- **Dispatched issue number:** `${{ github.event.inputs.issue_number }}`
+
+Resolve the slash command in this order:
+
+1. **Dispatched command** (above) — when non-empty, this run is a workflow
+   dispatch. Use this value as the command and skip the remaining sources.
+2. **Issue comment / PR review comment:** `github.event.comment.body` — the full
+   comment text.
+3. **Issue body:** `github.event.issue.body` — the full issue description.
+4. Otherwise default to `cast`.
+
+Resolve the target issue in this order:
+
+1. **Dispatched issue number** (above) — when non-empty, this is the target
+   issue, including for merge-driven epic continuations.
+2. The triggering issue or pull request number from the event payload.
+
+**Never emit `noop` when the dispatched command is non-empty.** A workflow
+dispatch is always actionable: run the named mode against the dispatched issue
+number. If the dispatched command is non-empty but the dispatched issue number
+is empty, post a comment naming the missing input rather than exiting silently.
 
 The activation job already ran `squad init --preset default`, which produced a
 generic 5-agent team (lead, reviewer, devrel, security, docs) in `.squad/`. Cast
@@ -483,10 +501,10 @@ to this mode so it can automatically refill the parent epic's available slots.
 
 ##### Step 1: Validate and Gather Context
 
-1. Resolve the target issue number from `github.event.inputs.issue_number` for a
-   workflow dispatch, otherwise from the triggering issue. If invoked from a
-   pull request review comment, explain that `/squad implement` must be run from
-   the target issue.
+1. Resolve the target issue number using the Trigger Context resolution order:
+   the interpolated dispatched issue number when non-empty, otherwise the
+   triggering issue. If invoked from a pull request review comment, explain that
+   `/squad implement` must be run from the target issue.
 2. Read the target issue title, body, labels, state, and relevant comments.
 3. Find open child issues using native GitHub sub-issue relationships. Also
    include open issues whose body contains a
@@ -531,6 +549,18 @@ Post a comment on the epic listing the dispatched children, blocked children,
 children with existing implementation pull requests, and any ready children
 deferred because all three slots are occupied. If no child is ready or no slot
 is available, post the status summary and do not dispatch a workflow.
+
+**Always leave a visible next step.** Every Implement run against an epic ends
+with a comment on that epic — never a silent exit. Cover each terminal case:
+
+- Children dispatched → name them and state how many children remain open.
+- All remaining children blocked → name the blocking dependencies.
+- All three slots occupied → name the in-flight pull requests.
+- No open children left → state that the epic's implementation is complete.
+
+Never emit `noop` for an Implement run. `noop` is not reported as a comment, so
+it strands the epic with no signal about what to do next — the exact failure
+this procedure exists to prevent.
 
 After each implementation pull request merges, this workflow runs again and
 fills newly available slots. Continue until the epic has no open children.


### PR DESCRIPTION
Closes #1740

## What broke

The PR-merged → continue-implementation chain already existed and fired correctly end-to-end — it just died on the last hop, silently.

```
PR github/gh-aw#53527 merged
  → squad-implement-worker run 32082398976 ✅ (merge trigger fired)
  → dispatched squad with {"command":"implement","issue_number":"53498"} ✅
  → squad run 32082667356 ✅ … emitted noop:
     "no comment body, issue number, or workflow_dispatch input was provided"
```

`53498` appears nowhere in that run's agent log.

## Root cause

`workflows/squad.md` only *described* its `workflow_dispatch` inputs in prose — backtick-quoted expression names, never `${{ }}` interpolations. The values were delivered to Actions but never rendered into the agent's context.

The frontmatter `run-name` *does* interpolate, which is why the Actions tab showed a healthy `Squad — implement` run while the agent saw nothing.

**This was drift, not a novel mistake.** `workflows/squad-implement-worker.md` already had it right — 7/7 `github.event.inputs.*` references interpolated (5/5 in the prompt body, plus `run-name` and `concurrency`). Two files that should have followed the same rule diverged, and only one of them was correct. The worker is the reference implementation.

Compounding it: `noop` is configured `report-as-issue: false`, so the failed continuation posted zero comments. The epic went quiet with no next step — exactly what surfaced on [github/gh-aw#53498](https://github.com/github/gh-aw/issues/53498).

## How the interpolation actually works — please read before extending this pattern

It is tempting to assume GitHub Actions interpolates the prompt. **It does not**, and the real mechanism constrains what is safe to add here.

The compiled `squad.lock.yml` contains **zero prompt text**. The body is pulled in at runtime:

```
GH_AW_PROMPT_CONTENT_0008: "{{#runtime-import .github/workflows/squad.md}}"
```

The file is read off disk inside the job, so Actions never sees its `${{ }}`. Instead gh-aw's own `runtime_import.cjs` resolves them — and it does not neutralize what it dislikes, it **throws**:

```
ERR_VALIDATION: File .github/workflows/squad.md contains unauthorized
GitHub Actions expressions
```

Here is the part worth knowing: `github.event.inputs.command` is **not** in that module's `ALLOWED_EXPRESSIONS` list. It is accepted anyway, via `isSafeExpression()`'s property-path check, and then resolved through `context.payload.inputs` (populated for `workflow_dispatch`).

So interpolating a dispatch input in a prompt body is safe because of a *code path*, not because of the allow-list — reading the list alone would suggest this change hard-fails the workflow. It was verified by executing `isSafeExpression()` against the real module, and by running the whole 150 KB file through `processExpressions()` without a throw.

**Practical consequence:** anyone extending this pattern to a different expression should execute `isSafeExpression()` against it first. A wrong guess fails the run at runtime, not at compile time.

## Changes

**1. Interpolate, don't describe** (`workflows/squad.md`)
Trigger Context now emits real values for the dispatched command and issue number, with an explicit resolution order for each and a rule against no-oping a non-empty dispatch.

**2. Always leave a visible next step** (`workflows/squad.md`)
Every Implement run against an epic must end with a comment on that epic, covering all four terminal cases: children dispatched, all blocked, all slots occupied, or implementation complete. `noop` is explicitly banned for Implement runs.

**3. Lint guard** (`scripts/check-workflow-input-interpolation.mjs` + CI step)
Fails on bare `github.event.inputs.*` references in agentic prompt bodies. This bug class is invisible to `actionlint` (which only reads YAML) and invisible at runtime (the run reports success), so it recurs silently without a gate.

Measured against `dev` before this fix, the gate finds **4 bare references, all in `workflows/squad.md`** (L135, L140, L141, L486) — and **zero** in `squad-implement-worker.md`, which quantifies the drift above.

**4. Same rule for the worker's merge continuation** (`workflows/squad-implement-worker.md`)
Added after a live end-to-end run showed change 2 fixed only half the problem.

The worker's post-merge path still emitted `noop` when a merged pull request's issue had no parent epic — and `noop` is not reported as a comment, so a merged PR ended with no signal about what happens next. That is the *same* defect as #53498, one hop further down the chain: change 2 covers the router's epic runs, this covers the worker's per-PR runs.

Observed live: merging a Squad implementation pull request produced a green worker run whose log read `report-as-issue is disabled, skipping no-op message posting`. Nothing was posted anywhere a human would look. The worker already declares `add-comment` with `target: "*"` — it had the capability all along and simply wasn't required to use it. Both terminal cases now end in a comment: epic resolved and children queued, or issue is standalone and nothing further queued.

The head-branch guard case needs no rule — it's a workflow-level `if:`, so the agent never runs at all for non-Squad merges. Verified live when a merged `squad/cast-*` PR correctly produced a skipped run.

## Two scoping decisions worth reviewing

**Scoped to `inputs.*`, not all `github.event.*`.** An earlier draft flagged everything and immediately caught `comment.body` and `issue.body`. Those must stay un-interpolated: they carry attacker-controlled text that gh-aw delivers through sanitized trigger context, so interpolating them would splice untrusted input into the prompt *ahead of* the sanitizer. There, a bare prose reference is the correct form. The gate was working; the tempting fix was wrong. That reasoning is now a comment directly above the filter so the next reader isn't tempted to "fix" it.

**Scans whole files, including `## skill:` blocks.** This is load-bearing after #1739. One of the four bare references on `dev` (L486) sits *inside* the `squad-implement` skill block — a gate that only walked ambient prose would have missed a live instance of the exact bug on day one.

It also enforces something the skill refactor made structural: skill bodies are restored in isolation with no guarantee about what precedes them, so a skill needing a dispatch input must interpolate it *itself* rather than assume `## Trigger Context` already resolved it into scope. The gate turns that from a convention into a checked property.

## Validation

**Reproduced the failure and the fix offline, against production gh-aw code.** Downloaded `github/gh-aw-actions` at the exact SHA the lock file pins (`6aab9e5b5c91c615506061f09bedd81a23babe3c`, v0.86.2) and ran its real `runtime_import.cjs` over the full `squad.md` body with a simulated `workflow_dispatch` payload of `{command: "implement", issue_number: "53498"}`:

| | `dev` (pre-fix) | this branch |
|---|---|---|
| `53498` reaches the prompt | **no** | **yes** |
| rendered line | `` `github.event.inputs.issue_number` `` | `` `53498` `` |

The pre-fix column is run `32082667356`'s `noop`, reproduced deterministically without dispatching anything.

Also verified:

- `gh aw compile --strict` against a scratch checkout: 2 workflows, 2 succeeded. The compiler lifts both inputs into `GH_AW_GITHUB_EVENT_INPUTS_*` env vars across all three prompt steps.
- Whole-file `processExpressions()` run does **not** throw — no unauthorized expression anywhere in the merged file.
- Rebased onto `39f7a2f` (#1739, mode playbooks → inline skills). Clean rebase, but placement was verified by listing H2 boundaries rather than trusting the diff: both implement hunks land at **L504 / L553**, inside `## skill: \`squad-implement\`` (spans **489–569**). Git will reattach a hunk across a skill boundary and still rebase cleanly.
- No `##` headings added inside a skill block — edits are bold lead-ins and bullets, so nothing implicitly closes it.
- `test/gh-aw-quality.test.ts`: **79 passed, 13 skipped** — including `discards no content during extraction`, `loses no bytes overall`, ambient-prompt-under-40 KB, and the strict-compile contract test.
- Guard passes on the rebased tree (5 prompt files scanned, clean). Negative test with the original prose line reproduced → correctly failed at `github.event.inputs.command`, while ignoring the interpolated frontmatter in the same fixture.
- No `packages/*/src/` changes, so no changeset required.

**Live end-to-end run** (`bradygaster/aspiregregator-squad-test`, a real .NET/Aspire/Orleans repo) exercised change 1 in production rather than in simulation:

- `/squad implement` on an issue produced the visible router status comment — *"Dispatched the implementation worker for this issue (#2)"* — which is precisely the behavior this PR adds. Pre-fix, that run would have no-op'd silently.
- The worker then produced a real modernization pull request, green on ubuntu / windows / macOS, and merging it fired the continuation trigger correctly.
- That merge is what exposed the gap now closed by change 4.

## Note on ordering

Once this lands, gh-aw needs its `squad.md` refreshed from this source before pelikhan's epic will resume — the fix has to reach the consumer repo to unblock #53498.

