### PR TITLE
fix(workflows): quote squad-cast skill description so its frontmatter parses

### DIFF
--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -658,9 +658,58 @@ const SKILL_START_RE = /^##[ \t]+skill:[ \t]+`([a-z][a-z0-9_-]*)`[ \t]*$/gm;
 
 interface ExtractionResult {
   ambient: string;
-  skills: { name: string; bytes: number }[];
+  skills: { name: string; bytes: number; body: string }[];
   discardedBytes: number;
   markerBytes: number;
+}
+
+/**
+ * Report why a skill's frontmatter would fail to parse as YAML, or null if it is fine.
+ *
+ * gh-aw's extractor (setup/js/extract_inline_skills.cjs) filters skill frontmatter
+ * LINE BY LINE and never parses it, so a malformed `description:` is written to
+ * .github/skills/<name>/SKILL.md verbatim and surfaces only when the agent tries to
+ * load that skill. `gh aw compile --strict` does not catch it either: at compile time
+ * a skill block is still ordinary markdown. This check closes that gap.
+ *
+ * Deliberately hand-rolled rather than delegating to a YAML library: this repo has no
+ * YAML parser in its dependency tree (frontmatter elsewhere is validated by actionlint,
+ * which only reads real workflow YAML), and a lint this narrow does not justify adding
+ * one. It targets the plain-scalar hazards that actually bite in a one-line description.
+ */
+function findFrontmatterScalarError(body: string): { key: string; value: string; reason: string } | null {
+  if (!body.startsWith('\n---\n') && !body.startsWith('---\n')) return null;
+  const opened = body.slice(body.indexOf('---\n') + 4);
+  const closeIdx = opened.indexOf('\n---');
+  if (closeIdx === -1) return null;
+
+  for (const line of opened.slice(0, closeIdx).split('\n')) {
+    const m = /^([A-Za-z_][A-Za-z0-9_-]*):[ \t]+(.*)$/.exec(line);
+    if (!m) continue;
+    const [, key, raw] = m;
+    const value = raw.trim();
+    if (!value) continue;
+
+    // A quoted scalar escapes every hazard below.
+    const quoted =
+      (value.startsWith('"') && value.endsWith('"') && value.length > 1) ||
+      (value.startsWith("'") && value.endsWith("'") && value.length > 1);
+    if (quoted) continue;
+
+    // Block scalars (`|`, `>`) carry their value on following lines.
+    if (/^[|>][-+0-9]*$/.test(value)) continue;
+
+    if (/:\s/.test(value)) {
+      return { key, value, reason: 'unquoted value contains ": " and parses as a nested mapping' };
+    }
+    if (/\s#/.test(value)) {
+      return { key, value, reason: 'unquoted value contains " #" and would be truncated as a comment' };
+    }
+    if (/^[[{&*!%@`]/.test(value)) {
+      return { key, value, reason: `unquoted value starts with the YAML indicator "${value[0]}"` };
+    }
+  }
+  return null;
 }
 
 /** Mirror of gh-aw's inline-skill extraction, including its discard behaviour. */
@@ -678,7 +727,7 @@ function extractInlineSkills(content: string): ExtractionResult {
   let cursor = 0;
   let discardedBytes = 0;
   let markerBytes = 0;
-  const skills: { name: string; bytes: number }[] = [];
+  const skills: { name: string; bytes: number; body: string }[] = [];
 
   for (const start of starts) {
     const startIdx = start.index!;
@@ -695,7 +744,11 @@ function extractInlineSkills(content: string): ExtractionResult {
 
     if (endMarker) {
       const bodyEnd = bodyStart + endMarker.index;
-      skills.push({ name: start[1], bytes: Buffer.byteLength(content.slice(bodyStart, bodyEnd), 'utf8') });
+      skills.push({
+        name: start[1],
+        bytes: Buffer.byteLength(content.slice(bodyStart, bodyEnd), 'utf8'),
+        body: content.slice(bodyStart, bodyEnd),
+      });
       markerBytes += Buffer.byteLength(endMarker[0], 'utf8');
       cursor = bodyEnd + endMarker[0].length;
       continue;
@@ -704,7 +757,11 @@ function extractInlineSkills(content: string): ExtractionResult {
     // Implicit close: next H2 after the start marker, else EOF.
     const nextH2 = h2Positions.find(p => p > startIdx);
     const bodyEnd = nextH2 ?? content.length;
-    skills.push({ name: start[1], bytes: Buffer.byteLength(content.slice(bodyStart, bodyEnd), 'utf8') });
+    skills.push({
+      name: start[1],
+      bytes: Buffer.byteLength(content.slice(bodyStart, bodyEnd), 'utf8'),
+      body: content.slice(bodyStart, bodyEnd),
+    });
 
     // Everything from here to the next start marker is dropped on the floor.
     const nextStart = starts.find(s => s.index! > startIdx)?.index ?? content.length;
@@ -787,6 +844,20 @@ describe('gh-aw: inline skill extraction', () => {
       `Ambient prompt is ${(ambientBytes / 1024).toFixed(1)} KB. Mode playbooks and planning ` +
         `reference material belong in inline skills, not the always-loaded prompt.`
     ).toBeLessThan(AMBIENT_BUDGET_BYTES);
+  });
+
+  it('gives every skill parseable YAML frontmatter', () => {
+    const offenders = result.skills
+      .map(s => ({ name: s.name, err: findFrontmatterScalarError(s.body) }))
+      .filter((s): s is { name: string; err: NonNullable<ReturnType<typeof findFrontmatterScalarError>> } => s.err !== null);
+
+    expect(
+      offenders.map(o => `${o.name}: ${o.err.key} — ${o.err.reason}\n    ${o.err.value}`).join('\n  '),
+      'Skill frontmatter must be valid YAML. Nothing upstream catches this: the extractor ' +
+        'filters frontmatter line-by-line without parsing it, and `gh aw compile --strict` ' +
+        'sees skill blocks as plain markdown. A broken value reaches the agent as a skill ' +
+        'that cannot load. Quote the value.'
+    ).toBe('');
   });
 
   it('gives every dispatchable mode a skill to load', () => {

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -699,13 +699,26 @@ function findFrontmatterScalarError(body: string): { key: string; value: string;
     // Block scalars (`|`, `>`) carry their value on following lines.
     if (/^[|>][-+0-9]*$/.test(value)) continue;
 
+    // `[` and `{` open YAML flow collections, which are valid unquoted and parse
+    // fine -- `[a, b]` and `{a: b}` are not errors. Only an unterminated one is.
+    // Checked before the ": " rule below so a flow mapping is not mistaken for a
+    // nested mapping.
+    if (/^[[{]/.test(value)) {
+      const opens = (value.match(/[[{]/g) ?? []).length;
+      const closes = (value.match(/[\]}]/g) ?? []).length;
+      if (opens !== closes) {
+        return { key, value, reason: 'unquoted value opens a YAML flow collection that is never closed' };
+      }
+      continue;
+    }
+
     if (/:\s/.test(value)) {
       return { key, value, reason: 'unquoted value contains ": " and parses as a nested mapping' };
     }
     if (/\s#/.test(value)) {
       return { key, value, reason: 'unquoted value contains " #" and would be truncated as a comment' };
     }
-    if (/^[[{&*!%@`]/.test(value)) {
+    if (/^[&*!%@`]/.test(value)) {
       return { key, value, reason: `unquoted value starts with the YAML indicator "${value[0]}"` };
     }
   }
@@ -858,6 +871,32 @@ describe('gh-aw: inline skill extraction', () => {
         'sees skill blocks as plain markdown. A broken value reaches the agent as a skill ' +
         'that cannot load. Quote the value.'
     ).toBe('');
+  });
+
+  it('flags real frontmatter scalar hazards without flagging valid YAML', () => {
+    const wrap = (line: string) => `\n---\n${line}\nname: x\n---\nbody`;
+
+    // Valid unquoted plain scalars and flow collections must not be flagged.
+    for (const ok of [
+      'description: Cast a squad',
+      'description: "Cast a squad: from a repo"',
+      "description: 'already quoted'",
+      'allowed: [read, write]',
+      'options: {mode: fast}',
+      'description: |',
+    ]) {
+      expect(findFrontmatterScalarError(wrap(ok)), `false positive on: ${ok}`).toBeNull();
+    }
+
+    // Genuine hazards must still be caught.
+    for (const bad of [
+      'description: Cast a squad: from a repo',
+      'description: Cast a squad #1',
+      'description: &anchor',
+      'allowed: [read, write',
+    ]) {
+      expect(findFrontmatterScalarError(wrap(bad)), `missed hazard in: ${bad}`).not.toBeNull();
+    }
   });
 
   it('gives every dispatchable mode a skill to load', () => {

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -295,7 +295,7 @@ gh pr list --state open --json number,url,headRefName --jq '[.[] | select(.headR
 
 ## skill: `squad-cast`
 ---
-description: Cast a Squad team: analyze the repo, compose agents, assign character names, scaffold .squad/, open the Cast PR.
+description: "Cast a Squad team: analyze the repo, compose agents, assign character names, scaffold .squad/, open the Cast PR."
 ---
 
 Analyze repo, compose team, assign character names from a fictional universe, generate `.squad/` scaffolding, open PR.


### PR DESCRIPTION
Follow-up to #1739.

## The defect

`workflows/squad.md` — the `squad-cast` inline skill's frontmatter is not valid YAML:

```yaml
description: Cast a Squad team: analyze the repo, compose agents, …
```

The unquoted `: ` parses as a nested mapping inside a compact mapping. It is 1 of 21 skill blocks; the other 20 are fine.

## Why every existing gate missed it

I traced each layer rather than assuming:

| Layer | Result | Why |
|---|---|---|
| `gh aw compile --strict` | ✅ passes | at compile time a `## skill:` block is still ordinary markdown, not YAML |
| gh-aw runtime extractor | ✅ no warning | `extract_inline_skills.cjs` filters frontmatter **line by line** and never parses it |
| `test/gh-aw-quality.test.ts` | ✅ 79 passed | modelled byte *conservation*, never frontmatter *validity* |

So the malformed value is written to `.github/skills/squad-cast/SKILL.md` verbatim, with no signal anywhere in the chain. Verified by running gh-aw's actual extractor (pinned SHA `6aab9e5`, v0.86.2) over the assembled prompt and checking all 21 emitted frontmatter blocks — `squad-cast` is the only one that fails.

## Severity, stated honestly

I proved the YAML is **invalid**. I did **not** prove Copilot's skill loader rejects it — that runtime isn't reachable from here. So this is "defect with unknown blast radius," not "cast is definitely down."

What raises the stakes: `cast` is the onboarding entry point, and #1739 also added *"If the parsed mode's skill cannot be loaded, report the failure in plain language and stop. Never improvise a mode playbook from memory."* — a load failure is a hard stop by design, with no fallback.

## This is a deviation, not a style choice

Every other `SKILL.md` in the repo whose `description` contains a colon quotes the value — `ci-validation-gates`, `git-workflow`, `coordinator-source-of-truth`. `squad-cast` is the lone exception.

## Changes

**1. Quote the description** (`workflows/squad.md`) — one line.

**2. Class-level assertion** (`test/gh-aw-quality.test.ts`) — `gives every skill parseable YAML frontmatter`, covering the plain-scalar hazards that bite in a one-line description: unquoted `: `, unquoted ` #` (silently truncates as a comment), and leading YAML indicators. Quoted values and block scalars pass through.

Hand-rolled rather than importing a YAML parser: this repo has **no YAML library in its dependency tree** (frontmatter elsewhere is validated by actionlint, which only reads real workflow YAML). Adding a dependency for a lint this narrow isn't worth it, and relying on a hoisted transitive `yaml` would break mysteriously the day it stops being hoisted.

## Validation

- **Negative test first:** reverted the quoting so the tree matched `dev` byte-for-byte (`git diff` empty), ran the new assertion → **failed**, naming the skill and reason:
  ```
  squad-cast: description — unquoted value contains ": " and parses as a nested mapping
  ```
  Restored the fix → passes. A test that only passes proves nothing.
- Full `test/gh-aw-quality.test.ts`: **80 passed, 13 skipped** (was 79/13 — the +1 is this assertion). No regressions.
- `eslint test/gh-aw-quality.test.ts` clean.
- No `packages/*/src/` changes, so no changeset required.

## Deliberately not included

While investigating I hit a false positive worth recording: my first extractor run reported "no frontmatter" for **all 21** skills, because this worktree materializes `squad.md` as CRLF and the extractor guards on `content.startsWith("---\n")`.

That is **local only** — `git ls-files --eol` confirms `i/lf w/crlf`, so the index is LF and CI sees LF. `.gitattributes` pins LF for `*.yml`, `*.sh`, and `Dockerfile*` but not `*.md`.

Pinning `*.md text eol=lf` would be reasonable hygiene, but it renormalizes **61 files** (53 CRLF + 8 mixed in the index) and would bury a one-line fix under line-ending churn. Left for a separate PR.
