### PR TITLE
docs: add release ancestry preflight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8461,7 +8461,7 @@
     },
     "packages/squad-cli": {
       "name": "@bradygaster/squad-cli",
-      "version": "0.13.0",
+      "version": "0.13.0-build.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8502,7 +8502,7 @@
     },
     "packages/squad-sdk": {
       "name": "@bradygaster/squad-sdk",
-      "version": "0.13.0",
+      "version": "0.13.0-build.1",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.13.0",
+  "version": "0.13.0-build.1",
   "private": true,
   "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.13.0",
+  "version": "0.13.0-build.1",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {

--- a/packages/squad-cli/templates/skills/release-process/SKILL.md
+++ b/packages/squad-cli/templates/skills/release-process/SKILL.md
@@ -34,6 +34,18 @@ Squad publishes two npm packages: `@bradygaster/squad-sdk` and `@bradygaster/squ
 
 ## Rules (Non-Negotiable)
 
+### 0. Verify `dev` and `main` Share Ancestry BEFORE Starting Any Release-Prep Work
+
+> Source: 2026-08-13 orphaned-history incident, PR #1699. `dev`'s history was silently reset on 2026-07-13 (a dependabot bump became a brand-new root commit with zero shared history with `main`). Nothing in normal release-prep work (version bump, CHANGELOG entry, changeset consolidation, CI) surfaces this — `dev` builds and tests green the whole time because none of it touches `main`'s history. The break is invisible until the very last step: opening the `dev` → `main` promotion PR, which GitHub then reports as flatly unmergeable, with `git merge-tree` refusing outright and no reviewable diff.
+
+**Before touching version numbers or the CHANGELOG, run:**
+
+```bash
+git merge-base upstream/dev upstream/main
+```
+
+If this returns a commit SHA (exit 0), proceed normally. **If it returns nothing (exit 1), STOP.** The promotion PR will be unmergeable no matter how clean `dev`'s own release content is — fix ancestry first via a separate `chore: restore shared ancestry` PR (merge `main` into `dev` with `--allow-unrelated-histories`; do not rebase if `dev` has a `non_fast_forward` ruleset, since rebase requires a force-push and rewrites every commit under every open PR). See `.squad/decisions/inbox/data-restore-dev-main-ancestry.md` for the full worked example and the diff-based verification technique used to prove a dev-wins conflict resolution was safe.
+
 ### 1. Coordinator Does NOT Publish
 
 The coordinator routes work and manages agents. It does NOT run `npm publish`, trigger release workflows, or make release decisions. Brady owns the release trigger. If an agent or the coordinator is asked to publish, escalate to Brady.
@@ -132,6 +144,7 @@ Set this environment variable in all CI build steps to prevent the build script 
 | GITHUB_TOKEN can't trigger downstream workflows (v0.9.4) | squad-npm-publish.yml never fires | Manual `gh workflow run` or use PAT/GitHub App token (see below) |
 | Lockfile integrity check rejects workspace packages (v0.9.4) | False failures in squad-npm-publish.yml | Only validate packages resolved from npm registry (`startsWith('https://')`) (PR #1044) |
 | `prebuild` version bump breaks workspace linking (v0.9.4) | Local builds fail after bump-build.mjs runs | `git checkout -- package.json packages/*/package.json` then fresh install |
+| `dev` and `main` silently drift to unrelated histories (2026-08-13) | `dev` → `main` promotion PR is flatly unmergeable, no reviewable diff | Run `git merge-base upstream/dev upstream/main` BEFORE starting release-prep; see Rule 0 above |
 
 ## v0.9.4 Incident Learnings
 

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.13.0",
+  "version": "0.13.0-build.1",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/squad-sdk/templates/skills/release-process/SKILL.md
+++ b/packages/squad-sdk/templates/skills/release-process/SKILL.md
@@ -34,6 +34,18 @@ Squad publishes two npm packages: `@bradygaster/squad-sdk` and `@bradygaster/squ
 
 ## Rules (Non-Negotiable)
 
+### 0. Verify `dev` and `main` Share Ancestry BEFORE Starting Any Release-Prep Work
+
+> Source: 2026-08-13 orphaned-history incident, PR #1699. `dev`'s history was silently reset on 2026-07-13 (a dependabot bump became a brand-new root commit with zero shared history with `main`). Nothing in normal release-prep work (version bump, CHANGELOG entry, changeset consolidation, CI) surfaces this — `dev` builds and tests green the whole time because none of it touches `main`'s history. The break is invisible until the very last step: opening the `dev` → `main` promotion PR, which GitHub then reports as flatly unmergeable, with `git merge-tree` refusing outright and no reviewable diff.
+
+**Before touching version numbers or the CHANGELOG, run:**
+
+```bash
+git merge-base upstream/dev upstream/main
+```
+
+If this returns a commit SHA (exit 0), proceed normally. **If it returns nothing (exit 1), STOP.** The promotion PR will be unmergeable no matter how clean `dev`'s own release content is — fix ancestry first via a separate `chore: restore shared ancestry` PR (merge `main` into `dev` with `--allow-unrelated-histories`; do not rebase if `dev` has a `non_fast_forward` ruleset, since rebase requires a force-push and rewrites every commit under every open PR). See `.squad/decisions/inbox/data-restore-dev-main-ancestry.md` for the full worked example and the diff-based verification technique used to prove a dev-wins conflict resolution was safe.
+
 ### 1. Coordinator Does NOT Publish
 
 The coordinator routes work and manages agents. It does NOT run `npm publish`, trigger release workflows, or make release decisions. Brady owns the release trigger. If an agent or the coordinator is asked to publish, escalate to Brady.
@@ -132,6 +144,7 @@ Set this environment variable in all CI build steps to prevent the build script 
 | GITHUB_TOKEN can't trigger downstream workflows (v0.9.4) | squad-npm-publish.yml never fires | Manual `gh workflow run` or use PAT/GitHub App token (see below) |
 | Lockfile integrity check rejects workspace packages (v0.9.4) | False failures in squad-npm-publish.yml | Only validate packages resolved from npm registry (`startsWith('https://')`) (PR #1044) |
 | `prebuild` version bump breaks workspace linking (v0.9.4) | Local builds fail after bump-build.mjs runs | `git checkout -- package.json packages/*/package.json` then fresh install |
+| `dev` and `main` silently drift to unrelated histories (2026-08-13) | `dev` → `main` promotion PR is flatly unmergeable, no reviewable diff | Run `git merge-base upstream/dev upstream/main` BEFORE starting release-prep; see Rule 0 above |
 
 ## v0.9.4 Incident Learnings
 


### PR DESCRIPTION
### What

Adds a mandatory `dev`/`main` shared-ancestry preflight to the bundled release-process guidance and synchronizes the workspace packages to development build version `0.13.0-build.1`.

### Why

A silently reset `dev` history can leave normal release preparation green while making the final `dev` to `main` promotion PR unmergeable. Release preparation should detect this condition before version or changelog work begins.

### How

The release-process skill now requires `git merge-base upstream/dev upstream/main` before release preparation, explains how to stop and recover when no merge base exists, and records the failure mode in the incident table. The template change is mirrored across both the CLI- and SDK-bundled copies.

---

### ⚠️ Quick Check
- [x] If SDK/CLI source files changed: completed the applicable Changeset step below (`npx changeset add` / `.changeset/*.md`, direct `CHANGELOG.md` entry for maintainers, or `skip-changelog` label for no user-facing changes) (N/A: no SDK/CLI source files changed)

### PR Readiness Checklist

> The PR readiness bot will validate these automatically after push.
> Check each item before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for full details.

#### Branch & Commit
- [x] Branch created from `dev` (not `main`)
- [x] Branch is up to date with `dev` (`git fetch upstream && git rebase upstream/dev`)
- [x] Verified diff contains only intended changes (`git diff --cached --stat`)
- [x] PR is **not** in draft mode (mark ready when checks pass)
- [x] Commit history is clean (squash fixups before review)

#### Build & Test
- [x] `npm run build` passes
- [ ] `npm test` passes (all tests green)
- [x] `npm run lint` passes (type check clean)
- [x] `npm run lint:eslint` passes
- [x] For migration PRs (>20 files): include test output summary in PR description (N/A: 6 files)

#### Changeset
- [x] Changeset added via `npx changeset add` (if `packages/squad-sdk/src/` or `packages/squad-cli/src/` changed) (N/A: no source files changed)
- [x] Or direct `CHANGELOG.md` entry (maintainers only — write-protected for external contributors) (N/A)
- [x] Or `skip-changelog` label applied (if no user-facing changes) (N/A)

#### Docs
<!-- "N/A" only if truly no user-facing change. -->
- [x] README section updated (if new feature/module) (N/A: release-process documentation only)
- [x] Docs feature page (if new user-facing capability) (N/A)

#### Exports
<!-- For SDK changes only. "N/A" if no new modules. -->
- [x] package.json subpath exports updated (if new module) (N/A)

---

### Breaking Changes

None.

### Waivers

Waived: `npm test` green requirement. The Windows run completed with 7,068 passing tests and 113 failures across 36 files, dominated by existing timeout, path-separator, and temporary-directory failures unrelated to the six documentation/version files changed here. FIDO approval requested before merge.