### PR TITLE
fix(ci): wire gh aw compile as a real CI gate (#1732)

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -166,6 +166,14 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Install gh-aw extension
+        # Required so `gh aw --version` succeeds and the compile-gate test in
+        # test/gh-aw-quality.test.ts is NOT skipped. Without this step the test
+        # uses `it.skipIf(!ghAwAvailable)` and always skips — which is
+        # indistinguishable from having no gate at all. See #1732.
+        run: gh extension install github/gh-aw
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Build
         run: npm run build
       - name: Run tests

--- a/.squad/agents/fido/history.md
+++ b/.squad/agents/fido/history.md
@@ -3,6 +3,14 @@
 Summarized by Scribe on 2026-08-19T13:11:34.130-07:00 because this history exceeded 15KB.
 Full pre-summary history archived at `.squad/agents/fido/history-archive-2026-08-19T13-11-34.130-07-00.md`.
 
+## 2026-08-20 — #1732 compile gate shipped
+
+- **Defect confirmed:** `gh aw compile` was never a real CI gate. `test/gh-aw-quality.test.ts:978` uses `it.skipIf(!ghAwAvailable)` and `squad-ci.yml` never installed `gh-aw`, so the test always skipped in CI.
+- **Fix:** Added `gh extension install github/gh-aw` step to the `test` job in `.github/workflows/squad-ci.yml`, immediately before Build. Reason: the test lives in `npm test` — wiring it into `squad-workflow-lint.yml` (which never runs `npm test`) would accomplish nothing.
+- **Non-skippability verified locally:** (1) passing case: `gh aw compile --strict` on intact workflows exits 0; (2) break test: removed `squad-implement-worker.md` from temp workspace → compile exited 1 with "dispatch-workflow validation failed: workflow 'squad-implement-worker' not found" → gate fails as expected.
+- **Issue split noted:** Prompt-budget gate already shipped (test:637-669). String-assertion replacement too vague — both closed without implementing.
+- **Rule 5:** This gate fails if `gh aw compile --strict` exits non-zero — e.g., missing dispatch target, invalid frontmatter, or any `gh-aw` strict validation error.
+
 ## Condensed signals
 
 - Quality gate authority for all PRs. Test assertion arrays (EXPECTED_GUIDES, EXPECTED_FEATURES, EXPECTED_SCENARIOS, etc.) MUST stay in sync with files on disk. When reviewing PRs with CI failures, always check if dev branch has the same failures — don't block PRs for pre-existing issues. 3,931 tests passing, 149 test files, ~89s runtime.


### PR DESCRIPTION
## Summary

Fixes the silent-skip defect in the `gh aw compile` gate. Before this PR, the compile test at `test/gh-aw-quality.test.ts:978` used `it.skipIf(!ghAwAvailable)`, and the CI `test` job never installed the `gh-aw` extension — so `ghAwAvailable` was always `false` and the test **always skipped**. A gate that always skips is indistinguishable from no gate.

## The fix

Added `gh extension install github/gh-aw` to the `test` job in `.github/workflows/squad-ci.yml`, immediately before the Build step.

**Why `squad-ci.yml` (test job), not `squad-workflow-lint.yml`:**  
The compile assertion is a Vitest test that runs as part of `npm test`. `squad-workflow-lint.yml` runs actionlint/shellcheck and never invokes `npm test`. Installing the extension there would leave the test still skipping.

## Gate rule (Rule 5)

> **This gate fails if** `gh aw compile --strict` exits non-zero — e.g., a workflow references a missing dispatch target, has invalid frontmatter, or fails any `gh-aw` strict validation check.

## Non-skippability proof

Verified locally with `gh aw v0.86.2`:

1. **Extension installed → test runs (not skipped):** `gh aw --version` exits 0, so `ghAwAvailable = true` and `it.skipIf(false)` executes the test body.

2. **Break test → gate fails:** Created a temp workspace mirroring the test setup (git init + copy `workflows/` to `.github/workflows/`), then removed `squad-implement-worker.md`. Result:
   ```
   ✗ squad.md (1 error):
     dispatch-workflow validation failed: workflow 'squad-implement-worker' not found
   ✗ compilation failed
   Exit: 1
   ```
   The test would have failed. Reverted — intact compile exits 0.

## Issue split — three-way

Issue #1732 covers three concerns; this PR ships only one:

| Concern | Status |
|---------|--------|
| ✅ Compile gate | **This PR — SHIP** |
| ✅ Prompt-budget gate | Already shipped at `test/gh-aw-quality.test.ts:637-669` — **CLOSE, already done** |
| ❌ String-assertion replacement | Too vague to action as written — **CLOSE, skip** |

Closes #1732