### PR TITLE
fix(dispatch): raise max to 2 and add schema static gate (#1772)

### DIFF
--- a/.squad/agents/eecom/history.md
+++ b/.squad/agents/eecom/history.md
@@ -1,5 +1,15 @@
 # Eecom history
 
+## 2026-08-20 — #1772 dispatch probe gate fix
+
+- Root cause confirmed: dispatch-workflow: max: 1 causes first-wins semantics; LLM empty probe consumes slot; real dispatch silently dropped.
+- Prior fix #1766 (prompt wording) confirmed insufficient via live run evidence.
+- Fix: raised max to 2 (squad-implement-worker.md) + extended check-workflow-input-interpolation.mjs with checkDispatchWorkflowSchemas() static gate.
+- Static gate validates JSON dispatch examples adjacent to dispatch_workflow references: requires non-empty workflow_name, non-empty inputs, inputs.issue_number.
+- Added 6 new tests in test/gh-aw-quality.test.ts; key structural test fails against max:1 state, passes after fix.
+- Build passes. Decision recorded at .squad/decisions/inbox/eecom-1772-dispatch-probe-gate.md.
+- Coordination needed: Procedures to add squad.md empty-command guard (separate PR).
+
 Summarized by Scribe on 2026-08-19T13:11:34.130-07:00 because this history exceeded 15KB.
 Full pre-summary history archived at `.squad/agents/eecom/history-archive-2026-08-19T13-11-34.130-07-00.md`.
 

--- a/scripts/check-workflow-input-interpolation.mjs
+++ b/scripts/check-workflow-input-interpolation.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // check-workflow-input-interpolation.mjs -- Catch prose-only workflow_dispatch input
-// references in agentic workflow prompt bodies.
+// references in agentic workflow prompt bodies, AND validate dispatch_workflow safe-output
+// JSON schemas to prevent the "empty probe destroys real dispatch" failure mode (#1772).
 //
 // An agentic workflow prompt is Markdown that gets rendered into the agent's context.
 // Writing `github.event.inputs.command` in backticks names the expression but never
@@ -22,6 +23,23 @@
 // interpolate it itself -- it cannot lean on `## Trigger Context` having resolved the
 // value into scope. Scanning skill bodies turns that from a convention into a
 // structural guarantee.
+//
+// DISPATCH SCHEMA GATE (#1772):
+// Workflow prompts that reference dispatch_workflow safe-output MAY include a JSON
+// example block showing the expected payload. When such a block is present, it must:
+//   (a) include a non-empty "workflow_name" key -- missing or empty causes gh-aw to
+//       run the wrong workflow or fail silently (confirmed in aspiregregator-squad-e2e
+//       run 32316227601).
+//   (b) include a non-empty "inputs" object -- top-level "command"/"issue_number" are
+//       silently dropped by gh-aw; they must be nested under "inputs".
+//   (c) if "inputs" is present, include "issue_number" -- dispatching without an issue
+//       number causes the receiving workflow to create a junk issue (confirmed in runs
+//       32324473906, 32394811753).
+//
+// This does not prevent an LLM from emitting an empty probe at runtime, but it does
+// prevent the authoring mistake of shipping a workflow with a structurally wrong schema
+// example. Combined with raising dispatch-workflow.max to >=2, the real dispatch gets a
+// second chance even when the LLM probes first.
 //
 // Exit 0 when clean, exit 1 with file:line details otherwise.
 // Uses only Node.js built-ins (fs, path, url).
@@ -147,11 +165,131 @@ function checkWorkflowDispatchActionDefaults(file, lines) {
   }
 }
 
+/**
+ * Check dispatch_workflow JSON schema examples in a workflow body for completeness.
+ *
+ * gh-aw processes dispatch_workflow safe-output entries in emission order and applies
+ * them up to the configured `max`. An empty or structurally incomplete entry emitted
+ * BEFORE the real one consumes the slot silently -- the real dispatch is discarded
+ * and the receiving workflow runs with no inputs (junk issue / wrong-skill failures).
+ *
+ * Rule: every JSON code block that appears adjacent to a `dispatch_workflow` or
+ * `dispatch-workflow` reference in the body must:
+ *   (a) include "workflow_name" with a non-empty value
+ *   (b) include "inputs" as a non-empty object (not top-level command/issue_number)
+ *   (c) if "inputs" is present, include "issue_number"
+ *
+ * Heuristic: a code block is "adjacent" if the preceding 20 lines contain
+ * `dispatch_workflow` or `dispatch-workflow`. This is intentionally liberal --
+ * false positives are far cheaper than missed malformed schemas.
+ *
+ * Blocks that are not valid JSON are skipped (other tooling owns JSON syntax).
+ */
+function checkDispatchWorkflowSchemas(file, lines, start) {
+  let i = start;
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Detect opening of a fenced JSON block
+    if (!/^```json\s*$/.test(line)) {
+      i++;
+      continue;
+    }
+
+    // Collect the block content
+    const blockStartLine = i;
+    i++;
+    const blockLines = [];
+    while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+      blockLines.push(lines[i]);
+      i++;
+    }
+    i++; // consume closing ```
+
+    // Is this block preceded by a dispatch_workflow reference?
+    const lookbackStart = Math.max(start, blockStartLine - 20);
+    const precedes = lines
+      .slice(lookbackStart, blockStartLine)
+      .some((l) => /dispatch[_-]workflow/i.test(l));
+    if (!precedes) continue;
+
+    let payload;
+    try {
+      payload = JSON.parse(blockLines.join('\n'));
+    } catch {
+      // Not valid JSON -- skip; JSON syntax errors are caught elsewhere.
+      continue;
+    }
+
+    if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) continue;
+
+    const relFile = relative(REPO_ROOT, file).replace(/\\/g, '/');
+    const blockLine = blockStartLine + 1;
+
+    // (a) workflow_name must be present and non-empty
+    if (!payload.workflow_name || typeof payload.workflow_name !== 'string' || payload.workflow_name.trim() === '') {
+      violations.push({
+        file: relFile,
+        line: blockLine,
+        ref: 'dispatch_workflow.workflow_name',
+        text: '```json (dispatch_workflow payload missing or empty workflow_name)',
+        kind: 'dispatch-schema-missing-workflow-name',
+      });
+    }
+
+    // (b) inputs must be present as a non-empty object (not top-level keys)
+    if (
+      !payload.inputs ||
+      typeof payload.inputs !== 'object' ||
+      Array.isArray(payload.inputs) ||
+      Object.keys(payload.inputs).length === 0
+    ) {
+      violations.push({
+        file: relFile,
+        line: blockLine,
+        ref: 'dispatch_workflow.inputs',
+        text: '```json (dispatch_workflow payload missing or empty inputs object)',
+        kind: 'dispatch-schema-missing-inputs',
+      });
+    } else {
+      // (c) inputs.issue_number must be present (may be a template placeholder)
+      if (!Object.prototype.hasOwnProperty.call(payload.inputs, 'issue_number')) {
+        violations.push({
+          file: relFile,
+          line: blockLine,
+          ref: 'dispatch_workflow.inputs.issue_number',
+          text: '```json (dispatch_workflow payload inputs missing issue_number)',
+          kind: 'dispatch-schema-missing-issue-number',
+        });
+      }
+    }
+
+    // Flag top-level command/issue_number as they are silently dropped by gh-aw
+    for (const key of ['command', 'issue_number']) {
+      if (Object.prototype.hasOwnProperty.call(payload, key)) {
+        violations.push({
+          file: relFile,
+          line: blockLine,
+          ref: `dispatch_workflow.${key} (top-level)`,
+          text: `\`\`\`json (dispatch_workflow payload has top-level "${key}" -- gh-aw ignores it; nest under inputs)`,
+          kind: 'dispatch-schema-top-level-input',
+        });
+      }
+    }
+  }
+}
+
 const violations = [];
 let scannedFiles = 0;
 
-for (const relDir of SCAN_DIRS) {
-  const dir = join(REPO_ROOT, relDir);
+// SQUAD_GATE_SCAN_OVERRIDE is set by tests to point at a fixture directory instead
+// of the real workflows tree. When set, only that directory is scanned.
+const SCAN_OVERRIDE = process.env.SQUAD_GATE_SCAN_OVERRIDE;
+const effectiveDirs = SCAN_OVERRIDE
+  ? [SCAN_OVERRIDE]
+  : SCAN_DIRS.map((d) => join(REPO_ROOT, d));
+
+for (const dir of effectiveDirs) {
   if (!existsSync(dir)) continue;
 
   for (const file of collectMarkdown(dir)) {
@@ -159,6 +297,7 @@ for (const relDir of SCAN_DIRS) {
     const lines = readFileSync(file, 'utf8').split(/\r?\n/);
     const start = bodyStartLine(lines);
     checkWorkflowDispatchActionDefaults(file, lines);
+    checkDispatchWorkflowSchemas(file, lines, start);
 
     for (let i = start; i < lines.length; i++) {
       const line = lines[i];
@@ -184,9 +323,22 @@ for (const relDir of SCAN_DIRS) {
 
 if (violations.length === 0) {
   console.log(
-    `Workflow input interpolation check passed: ${scannedFiles} prompt file(s) scanned, no bare github.event.inputs.* references.`,
+    `Workflow input interpolation check passed: ${scannedFiles} prompt file(s) scanned, no bare github.event.inputs.* references or malformed dispatch_workflow schemas.`,
   );
   process.exit(0);
+}
+
+const DISPATCH_KINDS = new Set([
+  'dispatch-schema-missing-workflow-name',
+  'dispatch-schema-missing-inputs',
+  'dispatch-schema-missing-issue-number',
+  'dispatch-schema-top-level-input',
+]);
+
+function kindLabel(kind) {
+  if (kind === 'destructive-default') return 'default';
+  if (DISPATCH_KINDS.has(kind)) return 'dispatch-schema';
+  return 'reference';
 }
 
 console.error(
@@ -196,11 +348,13 @@ console.error(
   'Bare prompt references name an expression without resolving it, so the agent receives the literal text',
 );
 console.error('instead of the dispatched value -- and silently no-ops.');
-console.error('Destructive action defaults let missing dispatch inputs silently run the wrong mode.\n');
+console.error('Destructive action defaults let missing dispatch inputs silently run the wrong mode.');
+console.error('Malformed dispatch_workflow schemas cause the receiving workflow to run with no inputs,');
+console.error('creating junk issues or running the wrong skill (confirmed: aspiregregator-squad-e2e runs 32324473906, 32316227601).\n');
 
 for (const { file, line, ref, text, kind } of violations) {
   console.error(`  ${file}:${line}`);
-  console.error(`    ${kind === 'destructive-default' ? 'default' : 'reference'}: ${ref}`);
+  console.error(`    ${kindLabel(kind)}: ${ref}`);
   console.error(`    line:      ${text}\n`);
 }
 
@@ -209,4 +363,8 @@ console.error('  - **Dispatched command:** `${{ github.event.inputs.command }}`'
 console.error('If the prompt genuinely needs to discuss the input rather than its value,');
 console.error('describe it without the literal `github.event.inputs.` prefix.');
 console.error('To fix destructive defaults: make the action input required, or use an inert default.');
+console.error('To fix dispatch_workflow schemas: ensure the JSON example includes:');
+console.error('  "workflow_name": "<name>",');
+console.error('  "inputs": { "issue_number": "...", ... }');
+console.error('Do not put command or issue_number at the top level -- gh-aw silently drops them.');
 process.exit(1);

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -1087,6 +1087,217 @@ describe('gh-aw: merge continuation dispatch contract', () => {
     expect(continuation).toMatch(/comment on the parent epic/i);
     expect(continuation).toMatch(/item_number[\s\S]*parent epic number/i);
   });
+
+  // -------------------------------------------------------------------------
+  // Structural gate: max >= 2 (#1772)
+  // -------------------------------------------------------------------------
+  // The `dispatch-workflow: max: 1` constraint means the FIRST safe-output entry
+  // wins and all later entries are silently discarded.  When the LLM emits an empty
+  // probe first, `max: 1` causes it to consume the only slot and the real dispatch
+  // never fires -- confirmed across three aspiregregator-squad-e2e runs
+  // (32324473906, 32394811753, 32316227601).
+  //
+  // Raising max to 2 gives the real dispatch a second slot even when the LLM
+  // probes first, breaking the silent-discard failure mode without requiring any
+  // change to gh-aw itself.
+  //
+  // This test FAILS against the pre-fix state (max: 1) and PASSES after the fix
+  // (max: 2).  It is the structural test that the wording-only approach (#1766)
+  // lacked: prompt text can be present and the live run still broken; this test
+  // directly asserts the frontmatter value that governs runtime behavior.
+  it('worker dispatch-workflow max is at least 2 to survive a probe + real dispatch', () => {
+    const safeOutputs = extractSafeOutputs(extractFrontmatter(SQUAD_IMPLEMENT_WORKER));
+    const dispatchWorkflow = safeOutputs['dispatch-workflow'];
+    expect(dispatchWorkflow, 'squad-implement-worker.md must declare dispatch-workflow safe-output').toBeDefined();
+    const max = dispatchWorkflow?.max as number | undefined;
+    expect(max, 'dispatch-workflow max must be >= 2 so a probe does not silently discard the real dispatch').toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: Dispatch workflow schema static gate (#1772)
+// ---------------------------------------------------------------------------
+// The static gate (scripts/check-workflow-input-interpolation.mjs) now validates
+// dispatch_workflow JSON examples in workflow prompts.  A malformed example --
+// missing `workflow_name`, missing `inputs`, or top-level `command`/`issue_number` --
+// causes gh-aw to run the wrong workflow or dispatch with no inputs.
+//
+// This suite:
+//   (a) verifies the gate passes against current workflow files
+//   (b) verifies the gate FAILS against a fixture with a malformed dispatch schema
+//       (the broken state that caused aspiregregator-squad-e2e failures)
+
+describe('gh-aw: dispatch_workflow schema static gate (#1772)', () => {
+  const scriptPath = join(process.cwd(), 'scripts', 'check-workflow-input-interpolation.mjs');
+  const fixturesDir = join(TEST_WORKSPACES_DIR, 'dispatch-schema-gate');
+
+  function runGate(scanDir: string): { exitCode: number; stderr: string; stdout: string } {
+    // The script resolves SCAN_DIRS relative to repo root via import.meta.url.
+    // We invoke it with a patched environment variable so the fixture directory is
+    // scanned instead of the real workflows directory.
+    const result = spawnSync(
+      process.execPath,
+      [scriptPath],
+      {
+        env: { ...process.env, SQUAD_GATE_SCAN_OVERRIDE: scanDir },
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      }
+    );
+    return {
+      exitCode: result.status ?? 1,
+      stderr: result.stderr ?? '',
+      stdout: result.stdout ?? '',
+    };
+  }
+
+  function writeFixture(name: string, content: string): string {
+    mkdirSync(fixturesDir, { recursive: true });
+    const path = join(fixturesDir, name);
+    writeFileSync(path, content, 'utf8');
+    return path;
+  }
+
+  it('passes against current workflow files (regression guard)', () => {
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: 'utf8',
+      cwd: process.cwd(),
+    });
+    expect(result.status, `Gate should exit 0; stderr: ${result.stderr}`).toBe(0);
+  });
+
+  it('fails when dispatch_workflow example is missing workflow_name', () => {
+    // This is failure shape (3) confirmed in run 32316227601: dispatch schema
+    // without workflow_name caused the squad workflow to run the wrong skill.
+    const fixture = writeFixture('missing-workflow-name.md', `---
+safe-outputs:
+  dispatch-workflow:
+    workflows: [squad]
+    max: 2
+---
+
+# Test Worker
+
+Dispatch workflow using the dispatch_workflow safe-output tool:
+
+\`\`\`json
+{
+  "inputs": {
+    "command": "implement",
+    "issue_number": "42"
+  }
+}
+\`\`\`
+`);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      env: { ...process.env, SQUAD_GATE_SCAN_OVERRIDE: fixturesDir },
+      encoding: 'utf8',
+      cwd: process.cwd(),
+    });
+    expect(result.status, 'Gate must exit 1 when dispatch_workflow JSON lacks workflow_name').toBe(1);
+    expect(result.stderr).toMatch(/dispatch-schema|workflow_name/i);
+    // Cleanup
+    rmSync(fixture);
+  });
+
+  it('fails when dispatch_workflow example has top-level command instead of inputs object', () => {
+    // This is failure shape (1) confirmed in runs 32324473906, 32394811753:
+    // top-level command/issue_number are silently dropped by gh-aw; the receiving
+    // workflow runs with no inputs and creates junk issues.
+    const fixture = writeFixture('top-level-inputs.md', `---
+safe-outputs:
+  dispatch-workflow:
+    workflows: [squad]
+    max: 2
+---
+
+# Test Worker
+
+Call dispatch_workflow to continue the relay:
+
+\`\`\`json
+{
+  "workflow_name": "squad",
+  "command": "implement",
+  "issue_number": "42"
+}
+\`\`\`
+`);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      env: { ...process.env, SQUAD_GATE_SCAN_OVERRIDE: fixturesDir },
+      encoding: 'utf8',
+      cwd: process.cwd(),
+    });
+    expect(result.status, 'Gate must exit 1 when dispatch_workflow JSON has top-level command').toBe(1);
+    expect(result.stderr).toMatch(/dispatch-schema|top-level/i);
+    rmSync(fixture);
+  });
+
+  it('fails when dispatch_workflow example is missing inputs.issue_number', () => {
+    const fixture = writeFixture('missing-issue-number.md', `---
+safe-outputs:
+  dispatch-workflow:
+    workflows: [squad]
+    max: 2
+---
+
+# Test Worker
+
+Use dispatch_workflow to queue the next wave:
+
+\`\`\`json
+{
+  "workflow_name": "squad",
+  "inputs": {
+    "command": "implement"
+  }
+}
+\`\`\`
+`);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      env: { ...process.env, SQUAD_GATE_SCAN_OVERRIDE: fixturesDir },
+      encoding: 'utf8',
+      cwd: process.cwd(),
+    });
+    expect(result.status, 'Gate must exit 1 when dispatch_workflow JSON inputs lacks issue_number').toBe(1);
+    expect(result.stderr).toMatch(/dispatch-schema|issue_number/i);
+    rmSync(fixture);
+  });
+
+  it('passes for a well-formed dispatch_workflow example', () => {
+    const fixture = writeFixture('valid-dispatch.md', `---
+safe-outputs:
+  dispatch-workflow:
+    workflows: [squad]
+    max: 2
+---
+
+# Test Worker
+
+Use dispatch_workflow to continue the relay:
+
+\`\`\`json
+{
+  "workflow_name": "squad",
+  "inputs": {
+    "command": "implement",
+    "issue_number": "{parent-epic-number}"
+  }
+}
+\`\`\`
+`);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      env: { ...process.env, SQUAD_GATE_SCAN_OVERRIDE: fixturesDir },
+      encoding: 'utf8',
+      cwd: process.cwd(),
+    });
+    expect(result.status, `Gate should exit 0 for valid schema; stderr: ${result.stderr}`).toBe(0);
+    rmSync(fixture);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/workflows/squad-implement-worker.md
+++ b/workflows/squad-implement-worker.md
@@ -201,7 +201,7 @@ safe-outputs:
     target: "*"
   dispatch-workflow:
     workflows: [squad]
-    max: 1
+    max: 2
     target-ref: ${{ github.event.repository.default_branch }}
 ---
 


### PR DESCRIPTION
## Problem

The merge-continuation relay silently fails. The implement worker emits an empty `dispatch_workflow` probe first, which consumes the only slot (`max: 1`). The real dispatch is silently discarded. Squad fires with no inputs and creates junk issues.

Confirmed three times in `bradygaster/aspiregregator-squad-e2e`:
- Run `32324473906` → Squad run `32324738114` → junk issue #12
- Run `32394811753` → Squad run `32395290857` → junk issue #14
- Run `32316227601` → wrong dispatch schema (no `inputs` wrapper, no `workflow_name`) → Squad ran wrong skill

Prior fix #1766 added prompt wording ("NEVER call dispatch_workflow with empty/placeholder arguments"). The wording was present in the live runs and the probe happened anyway. **Prompt text is not a reliable gate for LLM runtime behavior.**

## Fix

### 1. `workflows/squad-implement-worker.md` — raise `dispatch-workflow: max` from 1 to 2

With `max: 2`, the real dispatch gets a second slot even when the LLM probes first. The probe fires too (dispatching squad with no inputs), but the real dispatch now succeeds — the relay is no longer silently broken.

### 2. `scripts/check-workflow-input-interpolation.mjs` — dispatch schema static gate

Added `checkDispatchWorkflowSchemas()` that validates every JSON code block adjacent to a `dispatch_workflow` reference. Catches:
- Missing/empty `workflow_name` — confirmed failure shape in run `32316227601`
- Missing/empty `inputs` object — top-level `command`/`issue_number` are silently dropped by gh-aw
- `inputs` present but missing `issue_number`
- Top-level `command`/`issue_number` keys

The gate runs in CI at `.github/workflows/squad-workflow-lint.yml:146` on every PR that touches workflows.

## Tests Added (6 new)

| Test | Broken state | Fixed state |
|------|-------------|-------------|
| `worker dispatch-workflow max is at least 2` | ❌ FAILS (max:1) | ✅ passes |
| Gate fails: missing `workflow_name` | ❌ FAILS (gate would miss it) | ✅ gate catches it |
| Gate fails: top-level `command` instead of `inputs` | ❌ FAILS | ✅ catches |
| Gate fails: missing `inputs.issue_number` | ❌ FAILS | ✅ catches |
| Gate passes: well-formed schema | ✅ passes | ✅ passes |
| Gate passes: current workflow files | ✅ passes | ✅ passes |

**The `max >= 2` test is the key structural test that the wording-only approach (#1766) lacked**: prompt text can be present and the live run still broken; this test directly asserts the frontmatter value that governs runtime behavior. It fails against the old `max: 1` state and passes after the fix.

## What This Fix Does NOT Cover

The LLM probe behavior is not prevented — that requires gh-aw to validate dispatch payloads before counting them toward `max`. The fix reduces the blast radius and catches authoring mistakes.

## Coordination Required — squad.md empty-command guard

When `workflow_dispatch` fires with no `command` and no `issue_number` (from the probe), squad runs in an undefined mode and creates junk issues because both inputs are `required: false`. Procedures should add an explicit guard at the top of squad.md that detects empty `command`/`issue_number` on `workflow_dispatch`, logs a visible failure comment, and stops. This is a separate PR and should not block this fix.

Supersedes failed prompt-only approach in #1766.

Closes #1772