### PR TITLE
fix(squad.md): stop seeding Owner/Agent binding with the tokens it forbids

### DIFF
--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -72,8 +72,43 @@ function isRoleStringLeak(ownerCell: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// #1759 — Owner/Agent columns must resolve to cast Names, never Role strings
+// #1759 / #1784 — Owner/Agent columns must resolve to cast Names, and the
+// binding sites must not seed the model with the tokens they forbid.
 // ---------------------------------------------------------------------------
+
+/**
+ * #1784: the binding rules used to enumerate their own counter-examples —
+ * `` never a Role string (`Lead`, `DevRel`) `` — and live run E3 showed the model
+ * emitting `lead`/`devrel` verbatim, including `devrel` for a roster that has no
+ * DevRel role. The concrete token is salient; the negation is not.
+ *
+ * A backticked code span is the most copyable form a token can take in the
+ * prompt, so the binding blocks must contain none that name a Role rather than a
+ * Name. Roles come from team.md's `Role` column, so this stays honest as the
+ * roster changes; the extra literals are the values E3 actually leaked.
+ */
+const FORBIDDEN_TOKENS = [
+  ...castRoles().map(r => r.toLowerCase()),
+  'devrel',
+  'reviewer',
+];
+
+/** Backticked code spans in `text`, lowercased. */
+function codeSpans(text: string): string[] {
+  return [...text.matchAll(/`([^`\n]+)`/g)].map(m => m[1].trim().toLowerCase());
+}
+
+/**
+ * Code spans in `text` that name a Role (or a known leaked value), in bare or
+ * `squad:`-prefixed form. These are the tokens #1784 proved get copied out.
+ */
+function leakedRoleTokens(text: string): string[] {
+  return codeSpans(text).filter(span => {
+    const bare = span.startsWith('squad:') ? span.slice('squad:'.length) : span;
+    if (NAMES_LC.has(bare)) return false; // a cast Name is a legitimate value
+    return FORBIDDEN_TOKENS.includes(bare);
+  });
+}
 
 describe('#1759: Owner/Agent bind to the cast Name column', () => {
   it('team.md exposes distinct Name and Role columns to bind against', () => {
@@ -114,23 +149,86 @@ describe('#1759: Owner/Agent bind to the cast Name column', () => {
     const block = skillBlock(squad, 'squad-plan');
     expect(block).toMatch(/Owner\/Agent binding rule/i);
     expect(block).toContain('`Name` column');
-    // Explicitly forbids the leaking values named in #1759.
-    expect(block).toMatch(/never a Role string/i);
-    expect(block).toMatch(/`lead`, `devrel`, `reviewer`/);
+    expect(block).toContain('@copilot');
   });
 
   it('squad-plan-accept mints squad:{owner} from the cast Name, not a role', () => {
     const block = skillBlock(squad, 'squad-plan-accept');
-    expect(block).toContain('cast **Name** lowercased');
-    expect(block).toContain('squad:flight');
-    expect(block).toMatch(/never mint a role-derived label such as `squad:lead`/);
+    expect(block).toContain('`Name` column');
+    expect(block).toContain('`squad:{owner}`');
   });
 
   it('squad-plan-implementation binds the Agent column to the cast Name', () => {
     const block = skillBlock(squad, 'squad-plan-implementation');
     expect(block).toMatch(/Agent binding rule/i);
     expect(block).toContain('`Name` column');
-    expect(block).toMatch(/agent validity \(every `Agent` resolves to a `Name` row/);
+    expect(block).toMatch(/appears verbatim in the `Name` column/);
+  });
+});
+
+describe('#1784: binding sites never name the tokens they forbid', () => {
+  it('the leak detector recognizes a prohibition that enumerates Role tokens', () => {
+    // The pre-fix text from workflows/squad.md:913 — this MUST be flagged, or
+    // the assertions below prove nothing.
+    const preFix =
+      'every `Agent` value MUST be a cast **Name** from the `Name` column of ' +
+      '`.squad/team.md`, never a Role string (`Lead`, `DevRel`) or lowercased ' +
+      'role (`lead`, `reviewer`).';
+    expect(leakedRoleTokens(preFix)).toEqual(
+      expect.arrayContaining(['lead', 'devrel', 'reviewer'])
+    );
+
+    // The pre-fix label text from workflows/squad.md:730.
+    const preFixLabel =
+      'never mint a role-derived label such as `squad:lead` or `squad:reviewer`.';
+    expect(leakedRoleTokens(preFixLabel)).toEqual(
+      expect.arrayContaining(['squad:lead', 'squad:reviewer'])
+    );
+
+    // A positive-only rule carries no forbidden token.
+    const postFix =
+      'Every `Agent` value MUST appear verbatim in the `Name` column of the ' +
+      '`## Members` table in `.squad/team.md`, or be `@copilot`.';
+    expect(leakedRoleTokens(postFix)).toEqual([]);
+  });
+
+  for (const skill of [
+    'squad-plan',
+    'squad-plan-accept',
+    'squad-plan-implementation',
+    'squad-plan-validate',
+    'squad-plan-activate',
+  ]) {
+    it(`${skill} states the binding positively, without naming a Role token`, () => {
+      expect(leakedRoleTokens(skillBlock(squad, skill))).toEqual([]);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #1784 — /squad plan validate must fail a non-roster Owner/Agent value
+// ---------------------------------------------------------------------------
+
+describe('#1784: squad-plan-validate treats the Name column as sole truth', () => {
+  const block = skillBlock(squad, 'squad-plan-validate');
+
+  it('declares a roster-binding check in the checks table', () => {
+    expect(block).toMatch(/Non-roster owner\/agent/i);
+  });
+
+  it('scores a non-roster value as Critical, not a warning', () => {
+    const severity = block.match(/^Severity:.*$/m)?.[0] ?? '';
+    // Check 10 is the roster check; it must sit on the Critical side.
+    expect(severity).toMatch(/Critical[^.]*\b10\b/);
+    expect(severity).not.toMatch(/Warning[^.]*\b10\b/);
+  });
+
+  it('binds the check to the Name column and forbids attesting validity otherwise', () => {
+    const check = block.match(/###### Check 10[\s\S]*?(?=\n##### )/)?.[0] ?? '';
+    expect(check).not.toEqual('');
+    expect(check).toContain('`Name` column');
+    expect(check).toMatch(/Critical/);
+    expect(check).toMatch(/Never report a value as a\s+valid roster name unless/);
   });
 });
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -661,15 +661,27 @@ Decompose issue into sub-issues as a comment. Does NOT create issues. Works on o
 
 1. Read issue body (the epic/brief).
 2. Find latest `research` artifact comment for this issue. If found, use as primary context. If not, do lightweight repo analysis.
-3. Read `.squad/team.md` if it exists. **Owner/Agent binding rule:** every
-   `Owner` and `Agent` value MUST be a cast **Name** taken verbatim from the
-   `## Members` table's `Name` column of `.squad/team.md` (e.g. `Flight`,
-   `Procedures`, `EECOM`) — never a Role string (`Lead`, `Prompt Engineer`,
-   `DevRel`) and never a lowercased role (`lead`, `devrel`, `reviewer`). Map each
-   work item's domain to an owner via `.squad/routing.md`, then resolve that
-   owner to its exact `Name`. If no cast member fits, use `@copilot`. This
-   binding governs every `Owner`/`Agent` column and every `squad:{owner}` label
-   emitted downstream.
+3. Read `.squad/team.md` if it exists. **Owner/Agent binding rule:**
+
+   a. Locate the `## Members` table in **this repository's** `.squad/team.md`.
+      Read its `Name` column and build the **allowed-owner set**: every `Name`
+      cell value copied verbatim, plus `@copilot`.
+   b. Before assigning any owner, write the allowed-owner set out explicitly in
+      your working notes, so the binding is grounded in the roster you actually
+      read rather than recalled. Use only values read from this repository's
+      `.squad/team.md` — never a name carried over from another roster, an
+      example, or a previous task.
+   c. Every `Owner` and `Agent` value you emit MUST be a member of the
+      allowed-owner set, character-for-character as it appears in the `Name`
+      column. The `Name` column is the sole source of these values; no other
+      column of `.squad/team.md` — the `Role` column included — supplies a valid
+      owner, in any casing.
+   d. Map each work item's domain to a member via `.squad/routing.md`, then
+      resolve that member to its exact `Name` cell value. If no cast member fits,
+      use `@copilot`.
+
+   This binding governs every `Owner`/`Agent` column and every `squad:{owner}`
+   label emitted downstream.
 4. Text after `/squad plan` = planning guidance.
 
 ##### Step 2: Decompose
@@ -682,7 +694,7 @@ Break into discrete work items. **Minimum 3 items** unless genuinely atomic (exp
 
 Structure: `## 📋 Squad Plan — {Title}` → reference line → Phase tables (# | Title | Owner | Size | Depends On) → Details per item (Scope, Acceptance criteria, Notes) → Dependency Graph → Execution Notes → Next Steps (`/squad plan accept`, `/squad plan accept phase 1`, `/squad plan revise`, `/squad plan`).
 
-The `Owner` column MUST be a cast **Name** per the Owner/Agent binding rule (Step 1) — a value from the `Name` column of `.squad/team.md`, never a Role string.
+Every `Owner` cell MUST be a member of the allowed-owner set built in Step 1 — a verbatim value from the `Name` column of the `## Members` table in `.squad/team.md`, or `@copilot`. Re-check each `Owner` cell against that column before posting; a value that does not appear there is invalid and must be re-resolved.
 
 Do NOT create issues.
 
@@ -727,7 +739,7 @@ If plan has phases: Root → Phase issues → Task issues. Flat plan: tasks dire
 
 For each work item, `create-issue`:
 - Title: work item title
-- Labels: `squad` (color `9B8FCC`), `squad:{owner}` (color `9B8FCC`), where `{owner}` is the work item's cast **Name** lowercased (e.g. Owner `Flight` → `squad:flight`). It MUST resolve to a `Name` row in `.squad/team.md`; never mint a role-derived label such as `squad:lead` or `squad:reviewer`.
+- Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`), where `{owner}` is the work item's `Owner` value lowercased. Before minting each `squad:{owner}` label, confirm the `Owner` value appears verbatim in the `Name` column of the `## Members` table in `.squad/team.md`. The `Name` column is the only permitted source for this label — no other column of `.squad/team.md` supplies one. If the `Owner` value is not present in that column, do not mint the label: re-resolve the owner against the `Name` column, or fall back to `@copilot` and apply only the `squad` label.
 - Body: scope, acceptance criteria, context (parent, phase, size, depends on, owner), notes, footer
 - Parent: phase issue (hierarchical) or root (flat)
 - Size: set Project field if available, else body `**Size:**` line
@@ -910,13 +922,13 @@ Search in order: `scope-accepted` artifact (use as authoritative) → `program` 
 
 Per task specify: Title, Scope (files/modules/APIs), Acceptance criteria, Size (XS <1h, S 1-3h, M 3-8h, L 1-2d; max per policy default L), Dependencies (task numbers), Agent, Rollout notes.
 
-**Agent binding rule:** every `Agent` value MUST be a cast **Name** from the `Name` column of `.squad/team.md` (resolved via `.squad/routing.md`), never a Role string (`Lead`, `DevRel`) or lowercased role (`lead`, `reviewer`). If no cast member fits, use `@copilot`.
+**Agent binding rule:** before assigning any agent, read the `## Members` table in **this repository's** `.squad/team.md` and list its `Name` column values verbatim in your working notes. That list, plus `@copilot`, is the complete set of permitted `Agent` values — ground your assignments in the roster you just read rather than recalling one. Every `Agent` value MUST be one of those values, character-for-character. Resolve each task's domain to a member via `.squad/routing.md`, then emit that member's exact `Name` cell value. The `Name` column is the sole source of `Agent` values; no other column of `.squad/team.md` — the `Role` column included — supplies a valid one, in any casing. If no cast member fits, use `@copilot`.
 
 Rules: no task > max_task_size. DAG only. Every task traces to program item. Every epic has ≥1 task. Vertical slices. Group into phases by dependency order (Phase 1 = no deps).
 
 ##### Step 3: Validate Structure
 
-Check: sizes ≤ L, no cycles, traceability, coverage, agent validity (every `Agent` resolves to a `Name` row in `.squad/team.md`, never a Role string). Fix before posting.
+Check: sizes ≤ L, no cycles, traceability, coverage, agent validity (every `Agent` value appears verbatim in the `Name` column of the `## Members` table in `.squad/team.md`, or is `@copilot`). Fix before posting.
 
 ##### Step 4: Post Implementation Plan
 
@@ -924,7 +936,7 @@ Check: sizes ≤ L, no cycles, traceability, coverage, agent validity (every `Ag
 
 Structure: `## 🔧 Squad Implementation Plan` → Program ref → Phase tables (Title|Size|Depends On|Agent|Epic) → Details per task (Scope, Acceptance criteria, Dependencies, Rollout, Traces to) → Dependency Graph → Sizing Summary table → Validation Pre-check → Next: `/squad plan validate`.
 
-The `Agent` column MUST be a cast **Name** per the Agent binding rule (Step 2) — a value from the `Name` column of `.squad/team.md`, never a Role string.
+Every `Agent` cell MUST be a permitted value per the Agent binding rule (Step 2) — a verbatim value from the `Name` column of the `## Members` table in `.squad/team.md`, or `@copilot`. Re-check each `Agent` cell against that column before posting.
 
 ##### Step 5: Update Lifecycle
 
@@ -960,8 +972,31 @@ Find the latest `program`, `implementation`, and `triage` artifacts. At minimum 
 | 7 | Incomplete metadata | Both | Missing sizes/agents/criteria |
 | 8 | Orphaned items | Both | Triage items not in program |
 | 9 | Milestone gaps | Program | Epics not in any milestone |
+| 10 | Non-roster owner/agent | Both | An `Owner`/`Agent` value is absent from the roster (see below) |
 
-Severity: ❌ Critical (blocks acceptance): 1–6, 8. ⚠️ Warning: 7, 9, borderline 5.
+Severity: ❌ Critical (blocks acceptance): 1–6, 8, 10. ⚠️ Warning: 7, 9, borderline 5.
+
+###### Check 10 — roster binding (the `Name` column is the sole source of truth)
+
+Run this check mechanically. Do not judge whether a value "looks like" a
+teammate, and do not accept a value because it seems plausible or was used
+earlier in the plan.
+
+1. Read the `## Members` table in **this repository's** `.squad/team.md`. Collect
+   its `Name` column cell values verbatim into the **roster set**. If
+   `.squad/team.md` is missing or its `## Members` table has no data rows, report
+   Check 10 as ❌ Critical and stop — a plan cannot bind owners without a roster.
+2. Quote the roster set in the validation output, so the reader can see exactly
+   which values were treated as valid.
+3. For every `Owner` cell in the program artifact and every `Agent` cell in the
+   implementation artifact: the value is valid **only** if it matches a roster-set
+   entry ignoring case, or is exactly `@copilot`. Every other value — including
+   any value drawn from a different column of `.squad/team.md`, such as the
+   `Role` column — is invalid.
+4. Every invalid value is a ❌ **Critical** finding, which makes the run
+   `RESULT: FAIL`. Report each one as: the artifact, the row, the offending
+   value, and the roster set it must be drawn from. Never report a value as a
+   valid roster name unless you found it in the `Name` column in step 1.
 
 ##### Step 3: Post Result
 
@@ -1086,7 +1121,25 @@ Count expected issues before starting. If total > 50: recommend phased activatio
 
 ##### Label Pre-flight
 
-Before the first `create-issue`, verify labels `squad` and any `squad:{agent}` exist. If missing, record them in the activation summary as a prerequisite gap (label creation requires `issues: write` + `create-label` safe-output — not configured in this workflow). Continue activation — `create-issue` will apply any existing labels normally; unavailable labels are omitted and reported, not silently applied.
+**Roster binding gate — run this before any `create-issue` call.**
+
+1. Read the `## Members` table in **this repository's** `.squad/team.md` and
+   collect its `Name` column cell values verbatim into the **roster set**.
+2. List the roster set in the activation summary, so the labels applied can be
+   traced back to the roster that was actually read.
+3. For every `Agent` value in the implementation plan, confirm it matches a
+   roster-set entry ignoring case, or is exactly `@copilot`. The `Name` column is
+   the only permitted source; a value taken from any other column of
+   `.squad/team.md`, such as the `Role` column, does not qualify.
+4. A value that fails step 3 MUST NOT be turned into a `squad:{agent}` label.
+   Apply only the `squad` label for that issue and record the value in the
+   activation summary under a `Non-roster agent values` heading, naming the
+   roster set it should have been drawn from.
+
+`{agent}` in `squad:{agent}` is a roster-set value lowercased — never anything
+else.
+
+Then verify labels `squad` and each roster-bound `squad:{agent}` exist. If missing, record them in the activation summary as a prerequisite gap (label creation requires `issues: write` + `create-label` safe-output — not configured in this workflow). Continue activation — `create-issue` will apply any existing labels normally; unavailable labels are omitted and reported, not silently applied.
 
 ##### Transient Failure Handling
 


### PR DESCRIPTION
Working as **Procedures** (Prompt Engineer).

Closes #1784.

## The finding

E3 ran the full long planning path against fixture `bradygaster/aspiregregator-squad-e2e` #16. Activate minted `squad:lead` x3 and `squad:devrel` x1.

We ruled out the innocent explanations. The fixture's `.github/workflows/squad.md` is 55,954 chars — byte-identical in length to `dev` — and contains every #1778 marker. The fixture has a valid `.squad/team.md` with a populated `## Members` table (Keaton, McManus, Fenster, Hockney, Kint).

**There is no DevRel role anywhere in that roster.** The model could not have derived `devrel` from `team.md`. It lifted both tokens verbatim out of the parenthetical that forbids them:

> never a Role string (`Lead`, `DevRel`) or lowercased role (`lead`, `reviewer`)

`squad.md:730` had the same shape — it spelled out `` `squad:lead` `` as the bad example, and `squad:lead` is exactly what shipped.

Naming the forbidden value concretely made it *more* likely to be emitted. The concrete token is salient; the negation is not.

## What changed

**Six binding sites in `workflows/squad.md`**, each rewritten as a positive requirement only — what the value MUST be, plus the `@copilot` fallback, with no enumerated counter-examples. Prohibition is now abstract ("no other column of `.squad/team.md` supplies a valid owner, in any casing").

| Site | Before | After |
|---|---|---|
| `squad-plan` Step 1 | ``Name`` verbatim ``(e.g. `Flight`, `Procedures`, `EECOM`)`` — ``never a Role string (`Lead`, `Prompt Engineer`, `DevRel`)`` and ``never a lowercased role (`lead`, `devrel`, `reviewer`)`` | 4-step procedure: build the allowed-owner set from the `Name` column, write it out, bind every value to it character-for-character, resolve via routing.md. No tokens named. |
| `squad-plan` Step 3 | "never a Role string" | "a verbatim value from the `Name` column … or `@copilot`. Re-check each cell before posting." |
| `squad-plan-accept` labels | ``never mint a role-derived label such as `squad:lead` or `squad:reviewer` `` | "confirm the `Owner` value appears verbatim in the `Name` column … if not present, do not mint the label" |
| `squad-plan-implementation` Step 2 | ``never a Role string (`Lead`, `DevRel`) or lowercased role (`lead`, `reviewer`)`` | "list the `Name` column values verbatim in your working notes … that list, plus `@copilot`, is the complete set of permitted values" |
| `squad-plan-implementation` Step 3 | "never a Role string" | "appears verbatim in the `Name` column … or is `@copilot`" |
| `squad-plan-implementation` Step 4 | "never a Role string" | "a verbatim value from the `Name` column … Re-check each cell before posting." |

Positive examples were genericized too. `` (e.g. `Flight`, `Procedures`, `EECOM`) `` and `` Owner `Flight` → `squad:flight` `` were this repo's names appearing in a prompt that runs against *other* repos' rosters — the same copy-the-salient-token mechanism, pointed at a different target.

**Grounding.** The plan and implementation rules now instruct the model to write out the roster it read *before* assigning, so the binding rests on data it just retrieved rather than on recall.

**`/squad plan validate` — Check 10.** The validator returned `RESULT: PASS`, 0 critical / 0 warnings, and explicitly attested that `lead`/`devrel` were "valid roster names." It now has a mechanical roster check with the `Name` column as sole source of truth: build the roster set, quote it in the output, flag every non-matching value as ❌ **Critical** (which forces `RESULT: FAIL`), and *"never report a value as a valid roster name unless you found it in the `Name` column."* A missing or empty roster is itself Critical.

**Activate pre-flight.** The skill that actually applies labels now gates on the roster set: a value that fails the check must not become a `squad:{agent}` label. That issue gets the bare `squad` label and the value is reported under a `Non-roster agent values` heading.

## Testing — read this part

#1778 shipped a "role-string-leak detector" that **passed while the system was broken.** It asserted the prompt text *contained* the rule. A prompt-text-presence test can never verify LLM compliance — the rule was present at 7 sites and was disobeyed at all of them. That is the #1766 failure mode.

Those assertions are deleted, not added to. In their place is the falsifiable inverse: **the binding blocks must contain no backticked code span that names a Role.** Backticked spans are the most copyable form a token takes in a prompt, and that is precisely the regression being fixed. The forbidden set is derived from `team.md`'s `Role` column rather than hardcoded, so it stays honest as the roster changes.

The detector is itself tested against the real pre-fix strings from lines 913 and 730, so a broken detector cannot silently pass.

**Falsifiability check — I restored the pre-fix `workflows/squad.md` and re-ran:**

```
× squad-plan-accept mints squad:{owner} from the cast Name, not a role
× squad-plan-implementation binds the Agent column to the cast Name
× squad-plan states the binding positively, without naming a Role token
× squad-plan-accept states the binding positively, without naming a Role token
× squad-plan-implementation states the binding positively, without naming a Role token
× declares a roster-binding check in the checks table
× scores a non-roster value as Critical, not a warning
× binds the check to the Name column and forbids attesting validity otherwise
  Tests  8 failed | 23 passed (31)
```

Post-fix: 31/31 pass.

## ⚠️ What I did NOT verify

**This fix is not live-verified.** No fixture run was performed. Everything above is static analysis of prompt text plus a compile check.

Concretely:
- I have **not** confirmed the model now emits cast Names. Only a fixture run through `/squad plan activate` and an inspection of the labels actually applied can show that. That is a **post-merge step** and it is the only evidence that closes this issue's success criteria.
- Check 10 and the activate gate are still **instructions to a model**, not code. They are strictly stronger than what was there — the validator previously had no roster check at all — but they can be disobeyed exactly as the binding rule was.
- Success criteria 1 and 2 in #1784 ("validated programmatically, not by prompt instruction") are **not met by this PR** and are deliberately out of scope. This is the low-risk half, shipped ahead of tomorrow's E2E series. The deterministic-enforcement rewrite is follow-up work.

## Verification performed

- `npx vitest run test/gh-aw-plan-lifecycle.test.ts` — 31/31 pass
- `gh aw compile --strict` gate (`gh-aw-quality.test.ts > strict-compiles and preserves prompt/config behavior`) — passes against the modified workflow
- `npm run build` — exit 0
- `npm test` — 9 files fail, all pre-existing. Confirmed by stashing both changed files and re-running the same 9 on a clean tree: identical failures (Windows path separators, CLI packaging smoke, scheduler timing, ESM patching).
- Staged diffstat: 2 files, +176/−25. Deletion check empty.
- No changeset — no `packages/*/src` changes.
