### PR TITLE
fix(sdk): support command paths containing spaces in scheduler script tasks (#1794)

### DIFF
--- a/.changeset/scheduler-quoted-task-ref.md
+++ b/.changeset/scheduler-quoted-task-ref.md
@@ -1,5 +1,5 @@
 ---
-'@bradygaster/squad-sdk': patch
+'@bradygaster/squad-sdk': minor
 ---
 
 Fix scheduler script tasks failing on the default Windows Node install path

--- a/.changeset/scheduler-quoted-task-ref.md
+++ b/.changeset/scheduler-quoted-task-ref.md
@@ -1,0 +1,32 @@
+---
+'@bradygaster/squad-sdk': patch
+---
+
+Fix scheduler script tasks failing on the default Windows Node install path
+
+`LocalPollingProvider` split `task.ref` on whitespace with no quote handling,
+so a command path containing a space was truncated at the first space. On
+Windows that breaks the *default* install location — `C:\Program Files\nodejs\node.exe`
+became `C:\Program`, and the task failed with `ENOENT`. This affected any user
+who did not install Node somewhere unusual, not an exotic edge case.
+
+Script task refs are now parsed with quote awareness, and an unquoted command
+path is resolved by widening across spaces (longest match first) the same way
+Windows `CreateProcess` does. A ref whose first token already resolves is used
+unchanged, so existing configurations — including bare PATH commands like
+`node` — keep their exact previous behaviour. Quote characters appearing
+mid-token, as in `node -e console.log('hi')`, are still passed through to the
+child verbatim rather than being stripped.
+
+`TaskConfig.argv?: string[]` is added as the unambiguous form: when present,
+`ref` is used verbatim as the executable and is never parsed. Prefer it for any
+command path containing spaces.
+
+Spawn failures are also no longer silent. `execFile` reports them with a
+*string* code (`ENOENT`, `EACCES`) and no stdout or stderr, which previously
+fell through every branch and produced `code: undefined, stderr: ''`. `TaskResult`
+gains `spawnError?: string` for that code, and the error message now names the
+ref that could not be spawned.
+
+`shell: false` is retained, so the injection-safety property of the existing
+implementation is unchanged.

--- a/packages/squad-sdk/src/runtime/scheduler.ts
+++ b/packages/squad-sdk/src/runtime/scheduler.ts
@@ -12,6 +12,7 @@
  */
 
 import path from 'node:path';
+import { existsSync } from 'node:fs';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { FSStorageProvider } from '../storage/fs-storage-provider.js';
@@ -86,6 +87,15 @@ export interface TaskConfig {
   type: 'workflow' | 'script' | 'copilot' | 'webhook';
   ref: string;
   args?: Record<string, string>;
+  /**
+   * Explicit argument vector for `script` tasks (#1794).
+   *
+   * When present, `ref` is used verbatim as the executable path and is never
+   * parsed. This is the unambiguous form and should be preferred for any
+   * command path that contains spaces — e.g. the default Windows Node install
+   * at `C:\Program Files\nodejs\node.exe`.
+   */
+  argv?: string[];
 }
 
 export interface RetryConfig {
@@ -117,6 +127,13 @@ export interface TaskResult {
   stderr?: string;
   /** Process exit code if known (rejection-only). */
   code?: number;
+  /**
+   * Non-numeric failure code from the OS when the child could not be spawned
+   * at all — e.g. `ENOENT` for a missing executable (#1794). Distinct from
+   * `code`, which is the child's own exit status and only exists if the child
+   * actually ran.
+   */
+  spawnError?: string;
   /** Signal that terminated the process if known (rejection-only). */
   signal?: string;
   /** True iff the process was killed because it exceeded the timeout. */
@@ -397,6 +414,96 @@ function cronFieldMatches(field: string, value: number): boolean {
  * can cause issues even without shell interpretation.
  * The structural protection comes from execFileSync (shell: false).
  */
+/**
+ * Split a script `task.ref` into argv, honouring single and double quotes.
+ *
+ * Quotes only *group* when they open at a token boundary. A quote character
+ * appearing mid-token is a literal, so refs like
+ * `node -e console.log('hi')` keep passing the inner quotes straight through
+ * to the child exactly as they did when this function split on whitespace.
+ *
+ * Backslash is NOT an escape character: Windows paths are full of them
+ * (`C:\Program Files\nodejs\node.exe`) and treating them as escapes would
+ * mangle the modal case this exists to support (#1794).
+ *
+ * Returns whether the first token was quoted, because that removes all
+ * ambiguity about where the command ends and the arguments begin.
+ */
+export function tokenizeTaskRef(ref: string): { tokens: string[]; firstQuoted: boolean } {
+  const tokens: string[] = [];
+  let current = '';
+  let hasCurrent = false;
+  let quote: '"' | "'" | null = null;
+  let firstQuoted = false;
+
+  for (const ch of ref.trim()) {
+    if (quote !== null) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if ((ch === '"' || ch === "'") && !hasCurrent) {
+      // Opening quote at a token boundary — this one groups.
+      if (tokens.length === 0) firstQuoted = true;
+      quote = ch;
+      hasCurrent = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (hasCurrent) {
+        tokens.push(current);
+        current = '';
+        hasCurrent = false;
+      }
+      continue;
+    }
+    // Includes quote characters encountered mid-token: literal.
+    current += ch;
+    hasCurrent = true;
+  }
+
+  if (quote !== null) {
+    throw new ScheduleValidationError(`Task ref has an unterminated ${quote} quote`);
+  }
+  if (hasCurrent) tokens.push(current);
+
+  return { tokens, firstQuoted };
+}
+
+/**
+ * Decide which leading tokens form the executable path.
+ *
+ * A quoted first token is authoritative. Otherwise the plain first token is
+ * tried first, so every previously-working ref keeps its exact behaviour
+ * (including bare names resolved via PATH, which are not files on disk).
+ * Only when that fails do we widen across spaces, longest match first —
+ * mirroring how Windows CreateProcess resolves an unquoted path such as
+ * `C:\Program Files\nodejs\node.exe` (#1794).
+ */
+export function resolveScriptCommand(
+  tokens: string[],
+  firstQuoted: boolean,
+  exists: (p: string) => boolean = existsSync,
+): { command: string; args: string[] } {
+  const first = tokens[0] ?? '';
+  if (firstQuoted || tokens.length === 1) {
+    return { command: first, args: tokens.slice(1) };
+  }
+  if (exists(first)) {
+    return { command: first, args: tokens.slice(1) };
+  }
+  for (let i = tokens.length; i >= 2; i--) {
+    const candidate = tokens.slice(0, i).join(' ');
+    if (exists(candidate)) {
+      return { command: candidate, args: tokens.slice(i) };
+    }
+  }
+  return { command: first, args: tokens.slice(1) };
+}
+
 export function validateTaskRef(ref: string): void {
   if (!ref || ref.trim().length === 0) {
     throw new ScheduleValidationError('Task ref must be a non-empty string');
@@ -487,9 +594,18 @@ export class LocalPollingProvider implements ScheduleProvider {
         // loop and OpenTelemetry exporters.
         try {
           validateTaskRef(entry.task.ref);
-          const argv = entry.task.ref.trim().split(/\s+/);
-          const command = argv[0]!;
-          const args = argv.slice(1);
+          // An explicit argv is unambiguous: `ref` is the executable, verbatim.
+          // Otherwise parse the ref with quote awareness and resolve a command
+          // path that may contain spaces (#1794).
+          let command: string;
+          let args: string[];
+          if (entry.task.argv) {
+            command = entry.task.ref.trim();
+            args = entry.task.argv;
+          } else {
+            const { tokens, firstQuoted } = tokenizeTaskRef(entry.task.ref);
+            ({ command, args } = resolveScriptCommand(tokens, firstQuoted));
+          }
           const { stdout } = await execFileAsync(command, args, {
             encoding: 'utf8',
             timeout: SCRIPT_DEFAULT_TIMEOUT_MS,
@@ -514,6 +630,14 @@ export class LocalPollingProvider implements ScheduleProvider {
           if (e.stdout !== undefined) result.output = e.stdout.toString().trim();
           if (e.stderr !== undefined) result.stderr = e.stderr.toString().trim();
           if (typeof e.code === 'number') result.code = e.code;
+          // A spawn failure (ENOENT/EACCES/...) carries a *string* code and no
+          // stdout/stderr at all — the child never ran. Previously this fell
+          // through every branch and produced `code: undefined, stderr: ''`,
+          // telling an operator nothing about what failed to spawn (#1794).
+          if (typeof e.code === 'string') {
+            result.spawnError = e.code;
+            result.error = `${e.code}: failed to spawn '${entry.task.ref}' — ${e.message}`;
+          }
           if (e.signal) result.signal = e.signal;
           // execFile sets `killed=true` AND `signal='SIGTERM'` when the
           // configured `timeout` fires. Either flag is sufficient evidence.

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -15,6 +15,8 @@ import {
   GitHubActionsProvider,
   ScheduleValidationError,
   validateTaskRef,
+  tokenizeTaskRef,
+  resolveScriptCommand,
 } from '../packages/squad-sdk/src/runtime/scheduler.js';
 import type {
   ScheduleManifest,
@@ -521,6 +523,157 @@ describe('Scheduler: LocalPollingProvider', () => {
       for (const t of ticks) {
         expect(t).toBeLessThan(75);
       }
+    });
+  });
+});
+
+// ============================================================================
+// #1794 — task refs whose command path contains a space
+// ============================================================================
+//
+// `C:\Program Files\nodejs\node.exe` is the DEFAULT Windows Node install
+// location, so this is the modal Windows configuration, not an edge case.
+// The provider split `task.ref` on whitespace with no quote handling, so the
+// command became `C:\Program` and the spawn failed with ENOENT.
+//
+// Every test here uses a path containing a space by construction. A test using
+// a space-free path passes identically before and after the fix and proves
+// nothing — that is the vacuity trap in this particular bug.
+
+describe('Scheduler: LocalPollingProvider — command paths containing spaces (#1794)', () => {
+  let sandbox: string;
+  let spacedNode: string;
+
+  beforeAll(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'squad-sched-space-'));
+    // Mirror the real-world shape: a directory named like "Program Files".
+    const nodeDir = path.join(sandbox, 'Program Files', 'nodejs');
+    fs.mkdirSync(nodeDir, { recursive: true });
+    spacedNode = path.join(nodeDir, path.basename(process.execPath));
+    fs.copyFileSync(process.execPath, spacedNode);
+  });
+
+  afterAll(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('the fixture path really does contain a space (guards against a vacuous test)', () => {
+    expect(spacedNode).toContain(' ');
+    expect(fs.existsSync(spacedNode)).toBe(true);
+  });
+
+  it('executes an unquoted command path containing a space', async () => {
+    const provider = new LocalPollingProvider();
+    const entry = validEntry({
+      task: { type: 'script', ref: `${spacedNode} -e console.log('unquoted-ok')` },
+    });
+    const result = await provider.execute(entry);
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('unquoted-ok');
+  });
+
+  it('executes a double-quoted command path containing a space', async () => {
+    const provider = new LocalPollingProvider();
+    const entry = validEntry({
+      task: { type: 'script', ref: `"${spacedNode}" -e console.log('quoted-ok')` },
+    });
+    const result = await provider.execute(entry);
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('quoted-ok');
+  });
+
+  it('passes a quoted ARGUMENT containing a space through as one argv entry', async () => {
+    const provider = new LocalPollingProvider();
+    const entry = validEntry({
+      task: {
+        type: 'script',
+        ref: `"${spacedNode}" -e console.log(process.argv[1]) "hello there world"`,
+      },
+    });
+    const result = await provider.execute(entry);
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('hello there world');
+  });
+
+  it('executes via explicit argv with no parsing at all', async () => {
+    const provider = new LocalPollingProvider();
+    const entry = validEntry({
+      task: {
+        type: 'script',
+        ref: spacedNode,
+        argv: ['-e', `console.log('argv-ok')`],
+      },
+    });
+    const result = await provider.execute(entry);
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('argv-ok');
+  });
+
+  it('names the command and surfaces ENOENT when the executable does not exist', async () => {
+    const provider = new LocalPollingProvider();
+    const missing = path.join(sandbox, 'Program Files', 'nowhere', 'ghost.exe');
+    const entry = validEntry({
+      task: { type: 'script', ref: `${missing} --version` },
+    });
+    const result = await provider.execute(entry);
+    expect(result.success).toBe(false);
+    // Pre-fix this returned code: undefined and stderr: '' — a spawn failure
+    // that told an operator nothing about what failed to spawn.
+    expect(result.spawnError).toBe('ENOENT');
+    expect(result.error).toContain('ghost.exe');
+  });
+});
+
+describe('tokenizeTaskRef / resolveScriptCommand (#1794)', () => {
+  it('keeps a quoted path with spaces as a single token', () => {
+    const { tokens, firstQuoted } = tokenizeTaskRef(`"C:\\Program Files\\nodejs\\node.exe" -v`);
+    expect(firstQuoted).toBe(true);
+    expect(tokens).toEqual(['C:\\Program Files\\nodejs\\node.exe', '-v']);
+  });
+
+  it('does NOT treat backslashes as escapes', () => {
+    const { tokens } = tokenizeTaskRef(`C:\\Program\\nodejs\\node.exe -v`);
+    expect(tokens[0]).toBe('C:\\Program\\nodejs\\node.exe');
+  });
+
+  it('treats a quote appearing mid-token as a literal character', () => {
+    // Backward compatibility: refs like `node -e console.log('hi')` must keep
+    // passing the inner quotes through untouched. Stripping them turns the
+    // string literal into an identifier and the child throws ReferenceError.
+    const { tokens } = tokenizeTaskRef(`node -e console.log('hi')`);
+    expect(tokens).toEqual(['node', '-e', `console.log('hi')`]);
+  });
+
+  it('groups a quoted argument containing spaces into one token', () => {
+    const { tokens } = tokenizeTaskRef(`node script.js "two words"`);
+    expect(tokens).toEqual(['node', 'script.js', 'two words']);
+  });
+
+  it('rejects an unterminated quote rather than silently mis-splitting', () => {
+    expect(() => tokenizeTaskRef(`node "unterminated`)).toThrow(ScheduleValidationError);
+  });
+
+  it('prefers the plain first token when it exists, leaving old refs untouched', () => {
+    const exists = (p: string) => p === '/usr/bin/node';
+    expect(resolveScriptCommand(['/usr/bin/node', '-v'], false, exists)).toEqual({
+      command: '/usr/bin/node',
+      args: ['-v'],
+    });
+  });
+
+  it('widens across spaces to find an unquoted command path that exists', () => {
+    const full = 'C:\\Program Files\\nodejs\\node.exe';
+    const exists = (p: string) => p === full;
+    expect(
+      resolveScriptCommand(['C:\\Program', 'Files\\nodejs\\node.exe', '-v'], false, exists),
+    ).toEqual({ command: full, args: ['-v'] });
+  });
+
+  it('falls back to the first token for bare PATH commands that are not files', () => {
+    const exists = () => false;
+    expect(resolveScriptCommand(['node', '-v'], false, exists)).toEqual({
+      command: 'node',
+      args: ['-v'],
     });
   });
 });


### PR DESCRIPTION
Closes #1794.

## The defect

`LocalPollingProvider.execute` split `task.ref` on whitespace with no quote handling:

```ts
const argv = entry.task.ref.trim().split(/\s+/);
const command = argv[0]!;
```

On Windows the default Node install is `C:\Program Files\nodejs\node.exe`, so `command` became `C:\Program` and every script task failed with `ENOENT`. **This is the modal Windows configuration**, not an exotic edge case — it breaks for anyone who did not install Node somewhere unusual.

It was also documented in the test suite *as a constraint rather than a bug*. Two existing tests carry the comment:

```ts
// Space-free script — the scheduler tokenizes `task.ref` by whitespace.
```

Same shape as #1796: correctly observed, worked around, never fixed.

## Red, reproducing the actual modal failure

`process.execPath` on the test machine is literally `C:\Program Files\nodejs\node.exe`. A **full suite run on unmodified `dev`** fails four pre-existing scheduler tests for exactly this reason:

```
FAIL  test/scheduler.test.ts > Scheduler: LocalPollingProvider > should execute script tasks
FAIL  test/scheduler.test.ts > ... > rich error capture on script failure > captures the exit code on a non-zero exit
FAIL  test/scheduler.test.ts > ... > rich error capture on script failure > captures stderr written by the child
FAIL  test/scheduler.test.ts > ... > rich error capture on script failure > does not block the event loop while a script runs
```

All four pass after this change. This PR removes `test/scheduler.test.ts` from the Windows failing set entirely (#1797 baseline: 9 files → 8).

The new tests build their fixture at `<tmp>/Program Files/nodejs/node.exe` from a real copy of the running Node binary, so the red is the actual spawn failure and not a synthetic string with a space in it. Pre-fix:

```
FAIL > ... (#1794) > executes an unquoted command path containing a space
  AssertionError: expected false to be true
FAIL > ... (#1794) > executes a double-quoted command path containing a space
  AssertionError: expected false to be true
FAIL > ... (#1794) > passes a quoted ARGUMENT containing a space through as one argv entry
  AssertionError: expected false to be true
FAIL > ... (#1794) > executes via explicit argv with no parsing at all
  AssertionError: expected false to be true
FAIL > ... (#1794) > names the command and surfaces ENOENT when the executable does not exist
  AssertionError: expected undefined to be 'ENOENT'

Tests  5 failed | 1 passed | 67 skipped (73)
```

The 1 pass is deliberate: `the fixture path really does contain a space (guards against a vacuous test)`. A space-free fixture passes identically before and after and proves nothing, so the suite asserts it cannot silently become vacuous.

## The fix

- **Quote-aware tokenizer.** Backslash is *not* an escape — Windows paths are full of them.
- **Unquoted path resolution.** If the first token already resolves on disk it is used unchanged, so every previously-working ref keeps its exact behaviour, including bare PATH commands like `node` which are not files at all. Only when that fails do we widen across spaces, longest match first — the same way Windows `CreateProcess` resolves an unquoted path.
- **`TaskConfig.argv?: string[]`** as the unambiguous form: `ref` is the executable verbatim, never parsed.
- **`TaskResult.spawnError?: string`.** `execFile` reports spawn failures with a *string* code (`ENOENT`, `EACCES`) and no stdout/stderr, which fell through every branch and produced `code: undefined, stderr: ''`. That is the silent-success class again — a failure that reports nothing. The message now names the ref.
- `shell: false` retained, so the injection-safety property is unchanged.

## A backward-compat trap this nearly shipped

Naive shell-style tokenizing strips the inner quotes from `node -e console.log('hi')`, turning the string literal into an identifier so the child dies with `ReferenceError`. **I found this because the existing suite went red, not by reading it** — my first tokenizer broke `should execute script tasks` and two others.

Quotes now group only when they open at a token boundary; a quote mid-token is a literal. Pinned directly:

```ts
it('treats a quote appearing mid-token as a literal character', () => {
  const { tokens } = tokenizeTaskRef(`node -e console.log('hi')`);
  expect(tokens).toEqual(['node', '-e', `console.log('hi')`]);
});
```

## Verification

| Check | Result |
|---|---|
| `test/scheduler.test.ts` post-fix | **81 passed** |
| Negative control (change stashed, full suite) | 4 scheduler tests fail |
| Isolation of the two suites that differed between full runs | 340 passed — flakes, not caused by this change (see below) |
| `npm run build` | exit 0 |
| `git diff --cached --stat` | 3 files, +313 / -4 |
| `git diff --cached --diff-filter=D --name-only` | empty |
| Changeset | `.changeset/scheduler-quoted-task-ref.md` (patch, `@bradygaster/squad-sdk`) |

## ⚠️ Finding that affects tomorrow's baseline, not this PR

Running the full suite three times produced **three different failing sets**: 9 files (the #1797 baseline), 8 (with this change), 7 (control, change stashed). `template-sync`, `consumer-imports`, `promote-insider-tag` and `patch-esm-imports` move in and out between runs. All pass in isolation.

So **the Windows failure count is not stable run-to-run**, which weakens the single-number rule in #1797. `template-sync`'s instability is specifically the #1796 race — fixed in #1798, unfixed on this branch. Reported separately; flagging here so the count change from this PR (9 → 8) is not read as the whole story.
