### PR TITLE
chore(gh-aw): ignore downloaded workflow logs under .github/aw/logs

### DIFF
--- a/.github/aw/logs/.gitignore
+++ b/.github/aw/logs/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all downloaded workflow logs
+*
+
+# But keep the .gitignore file itself
+!.gitignore


### PR DESCRIPTION
## Summary

Adds `.github/aw/logs/.gitignore` to keep downloaded `gh aw logs` workflow run logs out of git tracking.

## Why

`gh aw logs` downloads workflow run logs into `.github/aw/logs/`. Without this ignore file, every future agentic-workflow triage session sees those downloads as untracked noise in `git status`, which risks:

- (a) someone blanket-staging them into a commit accidentally
- (b) obscuring real untracked work during review

This is exactly how the file itself got lost — it was created mid-triage in a throwaway worktree and was never staged. This PR lands it properly.

## What changed

- `.github/aw/logs/.gitignore` — ignores all files (`*`) except the `.gitignore` itself (`!.gitignore`)

## EOL / CI gate notes

- Blob is **LF** (verified via `git cat-file` hex inspection — no `0D` bytes)
- No parent `.gitignore` rule blocks this path (`git check-ignore -v` returned exit 1 — not ignored)
- No `.gitattributes` rule covers `.gitignore` files; the shebang-EOL CI check (`check-shebang-eol.mjs`) only targets files with shebangs, which this is not
- This is a `repo-health` chore — touches only `.github/`. No changeset needed.

## Scope

`repo-health` / chore — no `packages/*/src/` changes, no changeset required.