### PR TITLE
fix(gh-aw): bump activation CLI pin 0.11.0 → 0.12.0 (new-repo readiness)

### DIFF
--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -142,7 +142,7 @@ Set a repository variable to control which Squad CLI version the workflow uses:
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `SQUAD_CLI_VERSION` | Squad CLI version to install during activation | `0.11.0` |
+| `SQUAD_CLI_VERSION` | Squad CLI version to install during activation | `0.12.0` |
 
 Set it in **Settings → Secrets and variables → Actions → Variables**.
 

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -45,7 +45,7 @@
 #
 # Optional custom Squad CLI version:
 #   vars.SQUAD_CLI_VERSION
-#   Default is 0.11.0.
+#   Default is 0.12.0.
 #
 # Optional model override:
 #   vars.SQUAD_MODEL
@@ -78,7 +78,7 @@ jobs:
 
       - name: Initialize Squad team
         env:
-          SQUAD_CLI_VERSION: ${{ vars.SQUAD_CLI_VERSION || '0.11.0' }}
+          SQUAD_CLI_VERSION: ${{ vars.SQUAD_CLI_VERSION || '0.12.0' }}
           GH_TOKEN: ${{ steps.squad-app-token.outputs.token || secrets.SQUAD_GITHUB_TOKEN || github.token }}
         run: |
           # Preserve committed cast state: if .squad/team.md already exists with
@@ -87,7 +87,7 @@ jobs:
             echo "✓ Existing squad team detected with roster entries — skipping init."
           else
             echo "No existing squad team found — running squad init."
-            npx --yes "@bradygaster/squad-cli@${SQUAD_CLI_VERSION:-0.11.0}" init --preset default --state-backend local
+            npx --yes "@bradygaster/squad-cli@${SQUAD_CLI_VERSION:-0.12.0}" init --preset default --state-backend local
           fi
 
       - name: Upload Squad state artifact


### PR DESCRIPTION
## Summary

The Squad bootstrap in `workflows/shared/squad.md` pins the CLI version the activation job installs. The default fell two minor versions behind the npm registry, and the drift lands precisely on the population targeted by the upcoming new-repo E2E wave.

## Verified state before the bump

| Source | Version |
|---|---|
| activation default pin (`workflows/shared/squad.md` × 2, `docs/…/gh-aw.md` × 1) | `0.11.0` |
| `npm view '@bradygaster/squad-cli' dist-tags`.latest | `0.12.0` |
| `npm view '@bradygaster/squad-cli' dist-tags`.insider | `0.12.0` |
| in-repo `packages/squad-cli/package.json` | `0.13.0` (**unpublished** — `npm view @0.13.0` returns E404) |

An existing repo with `vars.SQUAD_CLI_VERSION` set is unaffected. A brand-new repo has no variable, falls through the `|| '0.11.0'` fallback in both the `env:` block and the `npx --yes …@${SQUAD_CLI_VERSION:-0.11.0}` one-liner, and lands on the two-minor-old CLI.

## Why `0.12.0` and not `0.13.0`

`0.13.0` is the version bump waiting on unmerged changesets (`.changeset/scheduler-quoted-task-ref.md`, `scribe-archival-integrity.md`, `max-reasoning-effort.md`, plus `README.md`). It is not on npm. Pinning there would take activation from stale to hard-broken — `npx --yes "@bradygaster/squad-cli@0.13.0"` returns E404 today, verified against the live registry.

## Why still a fixed pin, not a floating `latest` tag

Reproducibility over freshness, deliberately. The activation bootstrap runs in the unrestricted-network job and hands state off to the sandboxed agent job; a bad point release landing in the middle of that hop is a failure class that's hard to debug from an agent-side artifact. A fixed pin preserves the property that the same `@dev` commit produces the same activation. Consumers keep `vars.SQUAD_CLI_VERSION` as an opt-in override for freshness.

If we later want floating, it should be a separate deliberate decision, not fallout from this fix.

## Files changed

- `workflows/shared/squad.md` — 3 occurrences (comment on line 48, `env:` default on line 81, `npx` fallback on line 90). All bumped.
- `docs/src/content/docs/guide/gh-aw.md` — 1 occurrence (variable table on line 145).
- `git diff --cached --stat`: 2 files changed, 4 insertions(+), 4 deletions(-). No deletions.

## Changeset

**Not required.** The changelog gate regex at `.github/workflows/squad-ci.yml:271` matches:

```
^packages/squad-(sdk|cli)/src/|^packages/squad-(sdk|cli)/templates/|^\.squad-templates/|^templates/|^\.squad/agents/.+/charter\.md$
```

Neither `workflows/shared/` nor `docs/` matches. Rely on the live check to confirm; if the gate flags this I'll add one, but I don't expect it to.

## Out of scope, noted for later

- `docs/src/content/docs/features/standalone-install.md` still cites `v0.11.0` in curl-install examples, Actions defaults, and an MCP config sample (5 hits). That is the standalone/tarball distribution channel — a different concern from the gh-aw activation pin. Called out in the assessment; not touching it here to keep this PR surgical.
- Everything else from the new-repo readiness gap list (PR #1709 merge, `gh aw compile`+actionlint CI gate, `sync-squad-labels.yml` v7/v4 consistency, #1593, #1502, #1730, #1731) is parked pending Coordinator sequencing.

## Follow-up

Task 2 in the same coordinator request is empirical cold-start verification on a throwaway repo. That's a separate deliverable — findings will be reported after this PR is open. Naming will make disposability obvious.

## Verification checklist

- [x] npm dist-tags queried against live registry (`latest: 0.12.0`)
- [x] `npm view '@bradygaster/squad-cli@0.13.0'` verified as E404
- [x] Grepped all `.md`/`.mdx`/`.yml`/`.yaml`/`.ts`/`.js`/`.mjs`/`.cjs`/`.tsx`/`.jsx` for `SQUAD_CLI_VERSION` — only the 4 in-scope hits found
- [x] `git diff --cached --diff-filter=D --name-only` empty
- [x] `git status --short` shows only the two intended files
- [x] Known CRLF-noise files not touched (`docs/pagefind.yml`, `samples/storage-provider-azure/scripts/*.sh`, `packages/squad-cli/src/remote-ui/app.js`)

**Do not self-merge.** Requesting a reviewer per Coordinator direction.