### PR TITLE
docs(e2e): PR #1819 review followup — fix false fail-open caveats, harden gate 3e (B), tighten E1 Rule D

### DIFF
--- a/.squad/e2e/E1-merge-continuation-relay.md
+++ b/.squad/e2e/E1-merge-continuation-relay.md
@@ -103,7 +103,7 @@ Rule D is now a formal gate on E1 (see next section). It is **not** getting its 
 **Rule D verdict — three possible outcomes:**
 
 - ✅ **PASS** — the epic issue is CLOSED within a stated observation window (default: 10 minutes after the last leaf's merge-continuation relay run reaches `success`). The closure is attributed to Squad (either commented by the coordinator or effected via a Squad-authored PR/dispatch), not a manual close.
-- ❌ **FAIL** — all leaves are CLOSED, the observation window has expired, the epic is still OPEN, and no `Squad —` workflow run in that window shows a closure attempt. This is a real Rule D defect: closure logic exists but did not fire, or fired against the wrong target.
+- ❌ **FAIL** — the epic is OPEN at window expiry. Full stop. Whether a closure was never attempted, fired against the wrong target, or fired and errored is *evidence recorded on the FAIL*, not a precondition for reaching it. A **late closure** (epic transitions to CLOSED after window expiry) is also a FAIL: the verdict is fixed at expiry and does not retroactively flip to PASS. Record the late-closure fact, run URL, and delay in the finding — the score is still FAIL because E1's whole point is that closure was supposed to be autonomous *and* on-time.
 - ⚠️ **NOT VERIFIED** — the observation was blocked by an infrastructure hang (`detection` on `Install ripgrep` is the known offender). Record the observation-blocking job's URL and step and the exact minute the run was cancelled. A NOT VERIFIED verdict is *not* a green: it is a documented absence of signal, and it does not close #1758.2 or any successor.
 
 ### The escape hatch (required text on any NOT VERIFIED result)
@@ -121,6 +121,14 @@ rule_d:
 ```
 
 **Do not omit any of these fields on a NOT VERIFIED.** An escape hatch that accepts blank fields becomes a way to score anything as NOT VERIFIED. If any of the required text is missing, treat the result as **FAIL** (blocked-observation is a claim; unsubstantiated blocked-observation is silence).
+
+**Cross-checks (completeness is not veracity).** Each of these must hold; otherwise the NOT VERIFIED verdict itself is invalid and the run scores **FAIL**:
+
+- `blocked_by_job_url` MUST target the fixture repo. Concretely: the URL path MUST contain `/<fixture-repo>/actions/runs/` where `<fixture-repo>` matches E1's fixture (as of 2026-08-21: `aspiregregator-squad-e2e`). A cancelled run from an unrelated repo satisfies the field type but does not support the claim.
+- `cancelled_at_utc` MUST fall within `[window_started_utc, window_ended_utc]`. A cancellation *before* the window opened wasn't blocking Rule D observation; a cancellation *after* the window closed didn't cause the NOT VERIFIED — the window already ended.
+- `blocked_by_step` MUST name a step visible on the linked run and MUST still be `in_progress` (not `completed`) at cancellation time. A step that had already returned before the run was cancelled didn't hang.
+
+These cross-checks are the difference between "documented absence of signal" (this hatch's whole point) and "any convenient cancelled run around the same time will do."
 
 ### PASS observation (the mandatory extractions)
 

--- a/.squad/e2e/E4-agent-binding-verification.md
+++ b/.squad/e2e/E4-agent-binding-verification.md
@@ -10,6 +10,7 @@
 |---|---|---|
 | 2026-08-21 (initial) | Executed, PASS at n=1, two qualifications recorded | see result below |
 | 2026-08-21 (post-run) | Phase 2 extended by one command (`plan activate`); new Phase 3e roster-provenance gate; contamination-table growth note; Condition 0 dual-role justification; `squad-e2e-runbook.md` citations replaced with self-contained text; scope-limitation section updated | #1811, #1812 — the n=1 PASS was structurally silent on the `plan activate` roster-read defect, and Condition 0's timing guarantee was undocumented |
+| 2026-08-21 (review followup) | Two caveats rewritten to correctly describe fail-closed routing (empty comment / anchor-mismatch → `A: FAIL` → INCONCLUSIVE for #1812, not "scores green"); gate 3e (B) hardened against `gh api` fetch failure and empty-set collapse (SetEquals(∅,∅) → True); Phase 3c roster fetch guarded the same way; verdict-interpretation table gained a `(A) PASS, (B) INCONCLUSIVE` row | PR #1819 review by Flight + Coordinator — the caveats overstated the risk, the code understated one |
 
 > ⚠️ **The n=1 PASS below scored the procedure that stopped at `plan implementation`.** The
 > amended procedure (Phase 2 now includes `plan activate`; Phase 3 now includes a
@@ -618,13 +619,23 @@ Every `squad:{x}` on a **newly created** issue must have `{x}` = a lowercased ro
 
 ```powershell
 $b = gh api "repos/$FIXTURE/contents/.squad/team.md" --jq '.content' 2>$null
-$roster = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b))
-Write-Host "roster contains 'DevRel' : $($roster.Contains('DevRel'))"   # expect False
-Write-Host "roster contains 'devrel' : $($roster.Contains('devrel'))"   # expect False
+if ([string]::IsNullOrWhiteSpace($b)) {
+    Write-Host "roster fetch: INCONCLUSIVE — gh api could not read $FIXTURE/.squad/team.md"
+} else {
+    $roster = $null
+    try { $roster = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b)) }
+    catch { Write-Host "roster fetch: INCONCLUSIVE — team.md base64 decode failed" }
+    if ($roster) {
+        Write-Host "roster contains 'DevRel' : $($roster.Contains('DevRel'))"   # expect False
+        Write-Host "roster contains 'devrel' : $($roster.Contains('devrel'))"   # expect False
+    }
+}
 ```
 
 If either reads `True`, the roster changed since 2026-08-21 and **the `devrel`-is-dispositive
-argument no longer holds** — re-derive the criterion before judging the run.
+argument no longer holds** — re-derive the criterion before judging the run. If the fetch
+prints INCONCLUSIVE, do not treat the two `False` values as absent: they were never read.
+Fix the fetch and re-check before scoring.
 
 ### 3d. Safe-outputs
 
@@ -675,24 +686,38 @@ if (-not $claim.Success) {
 
     # (B) set-equality.
     $b = gh api "repos/$FIXTURE/contents/.squad/team.md" --jq '.content' 2>$null
-    $roster = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b))
+    $roster = $null
+    if ([string]::IsNullOrWhiteSpace($b)) {
+        Write-Host "GATE 3e (B): INCONCLUSIVE — gh api could not read $FIXTURE/.squad/team.md (empty/null response); investigate before scoring #1812"
+    } else {
+        try { $roster = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b)) }
+        catch { Write-Host "GATE 3e (B): INCONCLUSIVE — team.md base64 decode failed ($($_.Exception.GetType().Name)); investigate before scoring #1812" }
+    }
 
-    # Extract the ## Members → Name column. Trim to that section only.
-    $members = [regex]::Match($roster, '(?ms)^##\s*Members\s*\r?\n(?<body>.*?)(?=^##|\z)').Groups['body'].Value
-    # Take the first non-header cell of each row; the Name column is convention position 1.
-    $realNames = [regex]::Matches($members, '(?m)^\|\s*([^|`\s][^|]*?)\s*\|') |
-                 ForEach-Object { $_.Groups[1].Value.Trim('` ').ToLower() } |
-                 Where-Object { $_ -notin @('name','---',':---',':---:','---:') }
+    if ($roster) {
+        # Extract the ## Members → Name column. Trim to that section only.
+        $members = [regex]::Match($roster, '(?ms)^##\s*Members\s*\r?\n(?<body>.*?)(?=^##|\z)').Groups['body'].Value
+        # Take the first non-header cell of each row; the Name column is convention position 1.
+        $realNames = [regex]::Matches($members, '(?m)^\|\s*([^|`\s][^|]*?)\s*\|') |
+                     ForEach-Object { $_.Groups[1].Value.Trim('` ').ToLower() } |
+                     Where-Object { $_ -notin @('name','---',':---',':---:','---:') }
 
-    $reportedRaw = $claim.Groups['set'].Value
-    $reportedNames = ($reportedRaw -split '[,`]') |
-                     ForEach-Object { $_.Trim('` ,').Trim().ToLower() } |
-                     Where-Object { $_.Length -gt 0 }
+        $reportedRaw = $claim.Groups['set'].Value
+        $reportedNames = ($reportedRaw -split '[,`]') |
+                         ForEach-Object { $_.Trim('` ,').Trim().ToLower() } |
+                         Where-Object { $_.Length -gt 0 }
 
-    $real = [System.Collections.Generic.HashSet[string]]::new([string[]]$realNames)
-    $reported = [System.Collections.Generic.HashSet[string]]::new([string[]]$reportedNames)
-    $eq = $real.SetEquals($reported)
-    Write-Host "GATE 3e (B): $(if ($eq) {'PASS'} else {'FAIL'}) — reported=[$($reportedNames -join ',')] real=[$($realNames -join ',')]"
+        # An empty set on either side is an infrastructure failure, not a verdict.
+        # SetEquals(∅, ∅) is True — do NOT let two failures cancel into a green.
+        if ($realNames.Count -eq 0 -or $reportedNames.Count -eq 0) {
+            Write-Host "GATE 3e (B): INCONCLUSIVE — parsed empty set (real=$($realNames.Count) reported=$($reportedNames.Count)); investigate before scoring #1812"
+        } else {
+            $real = [System.Collections.Generic.HashSet[string]]::new([string[]]$realNames)
+            $reported = [System.Collections.Generic.HashSet[string]]::new([string[]]$reportedNames)
+            $eq = $real.SetEquals($reported)
+            Write-Host "GATE 3e (B): $(if ($eq) {'PASS'} else {'FAIL'}) — reported=[$($reportedNames -join ',')] real=[$($realNames -join ',')]"
+        }
+    }
 }
 ```
 
@@ -704,16 +729,27 @@ if (-not $claim.Success) {
   claim is the strongest evidence: the activate step *cited* the fixture's `team.md` and
   produced a set that isn't in it. Do not accept an argument that the mismatch is cosmetic —
   cite this section back.
-- **(A) FAIL** → separate silent-success bug filed against Procedures. Do not proceed to score
-  this run for #1812 either way — you have no readable signal.
+- **(A) PASS, (B) INCONCLUSIVE** → infrastructure failure, not a verdict for #1812. The
+  fixture roster couldn't be read or parsed to a non-empty set, so there is nothing to
+  compare against. Do NOT score this run for #1812. Investigate the fetch/parse failure and
+  re-run once resolved.
+- **(A) FAIL** → separate silent-success bug filed against Procedures. Do not proceed to
+  score this run for #1812 either way — you have no readable signal.
 
 **Read this by eye too.** As with the `Agent` column, the automated set comparison is a
-double-check, not the judgement. A regex that "finds no mismatch" against an empty comment
-scores green. **Confirm the activate comment actually rendered a summary first.**
+double-check, not the judgement. If the activate comment failed to render at all, the (A)
+regex fails first, gate 3e prints `A: FAIL`, and the run scores **INCONCLUSIVE for #1812** —
+that is the correct routing (fail-closed), but it silently costs you the ability to
+distinguish "activate rendered a bad summary" from "activate didn't render a summary."
+**Confirm the activate comment actually rendered a summary first**, so the recorded A-FAIL
+captures the right defect and isn't mistaken for a #1812 signal.
 
 > ⚠️ **This gate assumes the activation summary's phrasing is stable.** The regex anchors on
 > `"Roster set read from"` and `"team.md"` and `"Name"`. If Procedures changes the phrasing,
-> update the anchor **before** re-running; a silently non-matching anchor scores green.
+> the (A) regex fails and gate 3e prints `A: FAIL` — the gate fails **closed** and the run
+> scores **INCONCLUSIVE for #1812** rather than falsely PASSing. That routing is correct, but
+> it costs a scored E4 run. **Update the anchors before re-running** so a Procedures rewording
+> doesn't silently burn a run.
 
 ---
 

--- a/.squad/e2e/E4-agent-binding-verification.md
+++ b/.squad/e2e/E4-agent-binding-verification.md
@@ -11,6 +11,7 @@
 | 2026-08-21 (initial) | Executed, PASS at n=1, two qualifications recorded | see result below |
 | 2026-08-21 (post-run) | Phase 2 extended by one command (`plan activate`); new Phase 3e roster-provenance gate; contamination-table growth note; Condition 0 dual-role justification; `squad-e2e-runbook.md` citations replaced with self-contained text; scope-limitation section updated | #1811, #1812 — the n=1 PASS was structurally silent on the `plan activate` roster-read defect, and Condition 0's timing guarantee was undocumented |
 | 2026-08-21 (review followup) | Two caveats rewritten to correctly describe fail-closed routing (empty comment / anchor-mismatch → `A: FAIL` → INCONCLUSIVE for #1812, not "scores green"); gate 3e (B) hardened against `gh api` fetch failure and empty-set collapse (SetEquals(∅,∅) → True); Phase 3c roster fetch guarded the same way; verdict-interpretation table gained a `(A) PASS, (B) INCONCLUSIVE` row | PR #1819 review by Flight + Coordinator — the caveats overstated the risk, the code understated one |
+| 2026-08-21 (review followup, 2nd pass) | Phase 0b fixture-freshness gate hardened: added third `UNREADABLE` state so double-`gh` failure no longer collapses into MATCH via `$null -eq $null`; Phase 0c post-condition updated to require both "all four MATCH" *and* "none UNREADABLE"; Phase 0d fix-presence check guarded (the `REM` sub-check inverts against an empty string — `.Contains(x)` returns False, which is the pass condition) | PR #1820 review by Coordinator — I claimed "exactly one 3c exposure and it's fixed" without enumerating; ten `2>$null` sites in file, the fixture-freshness gate was the higher-severity one I missed. Enumerated all ten before this pass |
 
 > ⚠️ **The n=1 PASS below scored the procedure that stopped at `plan implementation`.** The
 > amended procedure (Phase 2 now includes `plan activate`; Phase 3 now includes a
@@ -393,7 +394,15 @@ $pairs = @(
 foreach ($p in $pairs) {
     $s = gh api "repos/$SOURCE/contents/$($p.src)?ref=dev" --jq '.size' 2>$null
     $d = gh api "repos/$FIXTURE/contents/$($p.dst)"        --jq '.size' 2>$null
-    $state = if ($s -eq $d) { "MATCH" } else { "STALE" }
+    # UNREADABLE if either side didn't return a size. Do NOT collapse this into MATCH
+    # ($null -eq $null is $true — a double gh failure would print MATCH and green-light
+    # the whole run on an unverified fixture) and do NOT collapse into STALE either
+    # (STALE prescribes a refresh, which will not fix a broken credential and burns a
+    # cycle before anyone notices).
+    $state =
+      if ([string]::IsNullOrWhiteSpace($s) -or [string]::IsNullOrWhiteSpace($d)) { "UNREADABLE" }
+      elseif ($s -eq $d) { "MATCH" }
+      else               { "STALE" }
     Write-Host ("{0,-52} src={1,-7} fixture={2,-7} {3}" -f $p.dst, $s, $d, $state)
 }
 ```
@@ -407,7 +416,10 @@ foreach ($p in $pairs) {
 | `shared/squad-planning-ontology.md` | 16,839 | 16,420 | STALE |
 | `shared/squad-planning-policy.md` | 4,676 | 4,538 | STALE |
 
-All four were stale. Expect all four to read `MATCH` **after** a successful refresh.
+All four were stale. Expect all four to read `MATCH` **after** a successful refresh — and
+none to read `UNREADABLE`. `UNREADABLE` is a fetch failure, not a fixture problem: fix the
+credential or network before refreshing (a refresh does not repair a broken `gh` auth, and
+running one will burn a cycle before anyone notices the readings were never taken).
 
 ### 0c. Refresh both surfaces, then re-assert
 
@@ -415,9 +427,15 @@ Pull each source file from `dev` into the fixture, commit, then recompile the lo
 runtime-imports resolve against the refreshed copies.
 
 ```powershell
-# Re-run the 0b comparison loop. Required post-condition: all four report MATCH.
-# If any still reports STALE, the refresh did not take — stop and fix it.
-# Do NOT proceed on a STALE surface; every downstream result would be meaningless.
+# Re-run the 0b comparison loop. Required post-condition: all four report MATCH,
+# AND none report UNREADABLE. "All four MATCH" alone is NOT sufficient — the loop
+# must also assert the comparison was actually readable. A double gh failure prints
+# MATCH otherwise (both sides $null; $null -eq $null is $true).
+# If any reports STALE, the refresh did not take — stop and fix it.
+# If any reports UNREADABLE, the fetch never happened — fix the credential/network,
+# do NOT run the refresh (it will not help), then re-run this loop.
+# Do NOT proceed on a STALE or UNREADABLE surface; every downstream result would be
+# either meaningless (STALE) or unverified (UNREADABLE).
 ```
 
 ### 0d. Confirm the fix is actually present in the fixture
@@ -428,14 +446,24 @@ The byte comparison proves *currency*, not *content*. Assert the fix text direct
 # PowerShell gotcha: -like "*$key*" treats BACKTICKS as escape characters and yields
 # false negatives on prompt text (which is full of backticks). Use .Contains().
 $b = (gh api "repos/$FIXTURE/contents/.github/workflows/squad.md?ref=main" --jq '.content' 2>$null) -join '' -replace '\s',''
-$txt = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b))
-Write-Host "main squad.md length: $($txt.Length)"    # expect ~60,589 chars, NOT ~6.6 KB
-
-# #1789 REPLACED the old prohibition rather than appending to it, so assert BOTH directions.
-foreach ($k in 'Check 10','sole source of truth','Non-roster') {
-  Write-Host ("ADD {0,-24} {1}" -f $k, $txt.Contains($k))          # all must be True
+if ([string]::IsNullOrWhiteSpace($b)) {
+    Write-Host "0d fix-presence: INCONCLUSIVE — could not fetch $FIXTURE/.github/workflows/squad.md"
+} else {
+    $txt = $null
+    try { $txt = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b)) }
+    catch { Write-Host "0d fix-presence: INCONCLUSIVE — base64 decode failed ($($_.Exception.GetType().Name))" }
+    if ($txt) {
+        Write-Host "main squad.md length: $($txt.Length)"    # expect ~60,589 chars, NOT ~6.6 KB
+        # #1789 REPLACED the old prohibition rather than appending to it, so assert BOTH directions.
+        foreach ($k in 'Check 10','sole source of truth','Non-roster') {
+          Write-Host ("ADD {0,-24} {1}" -f $k, $txt.Contains($k))          # all must be True
+        }
+        # NB: the REM check inverts against an empty string — .Contains(x) returns False,
+        # and False is the pass condition. The IsNullOrWhiteSpace guard above prevents
+        # that path from ever being reached; do not remove it.
+        Write-Host ("REM {0,-24} {1}" -f 'never mint a role-derived', $txt.Contains('never mint a role-derived'))   # must be False
+    }
 }
-Write-Host ("REM {0,-24} {1}" -f 'never mint a role-derived', $txt.Contains('never mint a role-derived'))   # must be False
 ```
 
 > **Assert the removal, not only the addition.** A sync that appends without replacing leaves the


### PR DESCRIPTION
**Follow-up to #1819** — review by Flight (approved & merged, spec 7/7, zero procedural loss) surfaced four issues in the merged text. Coordinator independently re-derived all four against `dev` and authorized a single revision PR. Coordinator's post-push review of the first commit surfaced a fifth, higher-severity issue in code I had not amended and which I had claimed was clear without enumerating. Second commit fixes that. This PR now covers both passes.

Do not merge — route to Flight.

## Finding 1 — E4 fail-open caveats contradicted the code

Two blockquote / paragraph caveats in Phase 3e (`Read this by eye too.` and the anchor-stability `⚠️`) asserted that an empty comment or a non-matching anchor would "score green." They wouldn't: `if (-not $claim.Success) { "GATE 3e (A): FAIL" }` fires first in both cases and routes the run to **INCONCLUSIVE for #1812**. The gate fails **closed**, which is what the design wanted.

Left standing, the false caveats invite the next operator to distrust a genuine A-FAIL or to "fix" the code toward actual fail-open — either would harm the gate.

**Fix:** rewrote both caveats to describe the actual fail-closed → INCONCLUSIVE routing while preserving the operational rules (confirm the activate comment rendered; update anchors before re-running if Procedures rewords the summary).

## Finding 2 — E4 gate 3e (B) had a real fail-open corner

`$b = gh api ... 2>$null` swallowed fetch failures. If `$b` came back null the base64 decode threw `ArgumentNullException` (loud); if it came back empty string it produced an empty roster, `$realNames` parsed to zero elements, and `SetEquals(∅, ∅)` returned **True** — two silent failures cancelling into a **B: PASS**.

**Fix:** guarded `$b` with `IsNullOrWhiteSpace`, wrapped decode in `try/catch`, and refused to compare sets when either side parsed to Count 0. Any of those states now prints `GATE 3e (B): INCONCLUSIVE — <specific reason>`. Verdict-interpretation table gained an `(A) PASS, (B) INCONCLUSIVE → do not score this run for #1812` row.

The same `2>$null` pattern at Phase 3c's `devrel`-check roster fetch had the same exposure. Fixed there too.

## Finding 3 — E1 Rule D verdict partition had unclassified states

`FAIL` at L106 required *"no `Squad —` workflow run in that window shows a closure attempt."* The same bullet's prose named *"closure … fired against the wrong target"* as a defect. A wrong-target closure IS an attempt, so it satisfied the prose and violated the precondition. A closure that fired-and-errored matched no verdict; same for a closure at minute 12 against a 10-min window. Both could be argued into NOT VERIFIED.

**Fix (Flight's, which I agree with):** FAIL = "epic OPEN at window expiry. Full stop." Attempt evidence becomes detail *recorded on* the FAIL, not a precondition for it. Late closures are also FAIL by rule — the verdict is fixed at expiry and does not retroactively flip to PASS.

## Finding 4 — E1 escape hatch enforced completeness, not veracity

Required-fields rule (blank field ⇒ FAIL) closed "silence scores NOT VERIFIED." But nothing tied the cited job to the fixture, required the cancellation time to fall inside the observation window, or required the named step to have actually been in progress. A real-but-irrelevant cancelled run satisfied the escape hatch.

**Fix:** added a `Cross-checks (completeness is not veracity)` block. Each check fails FAIL. `blocked_by_job_url` must contain the fixture repo path; `cancelled_at_utc` must fall within `[window_started_utc, window_ended_utc]`; `blocked_by_step` must be `in_progress` at cancellation.

## Finding 5 (post-push, second commit) — Phase 0b fixture-freshness gate failed OPEN, and the audit that missed it

`$s = gh api ... 2>$null` and `$d = gh api ... 2>$null` at L394-395 run back-to-back under the same credentials. A single auth or network failure produces `$s=$null` and `$d=$null`, and `$null -eq $null` is `$true`, so all four pairs print **MATCH**. Since "all four MATCH" is the sole success criterion at Phase 0c and the failure signal is identical to the success signal, a total-fetch failure green-lit the whole scenario on an unverified fixture. This is higher severity than Finding 2 — it needs one root cause instead of a coincidence, and it authorizes the whole run rather than corrupting one gate.

The asymmetric case is already correct: one call succeeds, the other returns `$null`, `"57673" -eq $null` is false → **STALE** → fails closed. Only the both-fail case inverts.

**Fix:** added a third `UNREADABLE` state guarded by `IsNullOrWhiteSpace` on either side. Explicitly not MATCH (no false authorization) and explicitly not STALE (which would prescribe a refresh that won't fix a broken credential and would burn a cycle before anyone notices). Phase 0c post-condition text updated to require both "all four MATCH" **and** "none UNREADABLE."

Phase 0d (L430) had a related but smaller exposure: fetch failure produces `$txt = ""`; the three `ADD` sub-checks return `False` where `True` is required (operator catches), but the single `REM` sub-check returns `False` where `False` is the pass condition (silently passes one assertion of four). Length echo on L432 (`~60,589 chars, NOT ~6.6 KB`) is a real eyeball backstop, but the pattern was inconsistent with the guards elsewhere and one sub-check genuinely inverted. Guarded the fetch: prints `0d fix-presence: INCONCLUSIVE` on empty or on base64 decode failure, and the ADD/REM lines don't print at all if the roster is unreadable.

**Correction of a prior claim in this PR.** In my initial report on the first commit I wrote *"there was exactly one exposure and it's fixed."* That was a completeness claim over a set I hadn't enumerated. There are **ten** `2>$null` code sites in the file (an eleventh match is in the L14 amendment-log prose describing the fix, not a call site). On the second-pass audit at head `715093af`, guards now cover **four fail-open corners across five call sites** (L395–L396 are the two halves of one comparison; plus L448, L649, L716); the **five** listing/echo sites (L570, L574-prose, L588, L625, L703) are read by eye against no pass condition and are correctly left alone. Five guarded + five cleared = ten. That is what the audit should have said the first time.

## Verification

First commit (`cd0b2934`): 2 files, 72+/28−. Second commit (`715093af`): 1 file, 40+/12−.

Both files are already-tracked, so `git add -f` was not required. Staged with explicit paths, no `git add .`/`-A`/`-a`. Zero deletions across both commits. No CRLF-noise files touched.

Blob tree-verify after each commit — all present:

```
cd0b2934:
  OK  .squad/e2e/E1-merge-continuation-relay.md    10015 bytes
  OK  .squad/e2e/E4-agent-binding-verification.md  44264 bytes
715093af:
  OK  .squad/e2e/E4-agent-binding-verification.md  46770 bytes
```

`.git/info/exclude:9` still ignores `.squad/` — not touched here (Booster owns #1817).

E4 amendment log gained two rows in this PR: `(review followup)` for commit 1, `(review followup, 2nd pass)` for commit 2, explaining the sequence honestly.

## What this PR is NOT

- No new files.
- No fixture refresh, no re-run of E4 or E1. The n=1 E4 verdict for #1784 still stands until the amended procedure is executed against a refreshed fixture — separate decision.
- No changeset (`.squad/e2e/` doesn't match the drift regex at `squad-ci.yml:271`).
- No fix to #1817. No touch to `.git/info/exclude`.
- Not self-merged — route to Flight.

## Methodology notes (for the record)

**Line count.** Flight and Coordinator both measured E4 at "615 lines" with `Measure-Object -Line`, which silently drops blank lines; actual line count is 824. Byte-size comparison via `git cat-file -s` is what I'll rely on going forward.

**Completeness claims.** Twice in this session I reported thoroughness over a set I had not enumerated — the line count above, and the `2>$null` count in the first commit's writeup. Coordinator caught both. Correct pattern: enumerate first, then claim. Recorded here so the failure mode is visible to future readers rather than smoothed over.

Related:
- Post-merge of #1819 review comment: https://github.com/bradygaster/squad/pull/1819#issuecomment-5374934524
- #1811 (Condition 0 dual role) — closed in-doc by #1819; unchanged here.
- #1812 (`plan activate` hardcoded roster) — provenance gate hardened here.
- #1817 (`.git/info/exclude` trap) — not addressed; Booster owns.