### PR TITLE
fix(gh-aw): fail loudly when /squad parses no command (#1824)

### DIFF
--- a/test/gh-aw-command-parse.test.ts
+++ b/test/gh-aw-command-parse.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Behavioral coverage for the `/squad` command parser in `workflows/squad.md` (#1824).
+ *
+ * `/squad cast` silently no-opped with a green check whenever the command did not
+ * start the issue body. Success and no-op were indistinguishable, on the first-run
+ * path for every new user.
+ *
+ * These tests compare two independent sources: the shell commands *declared* in the
+ * Parse Command section of `workflows/squad.md` are extracted from the markdown and
+ * then *executed* against real issue bodies. Nothing here re-reads prose to confirm
+ * prose. A test asserting only "a command at position 0 parses" would guard the one
+ * case that was never broken, so the load-bearing assertions below are the inverse:
+ * a body that yields no mode must produce an explicit sentinel and a diagnostic that
+ * names the offending text verbatim.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SQUAD_WORKFLOW = join(process.cwd(), 'workflows', 'squad.md');
+const workflow = readFileSync(SQUAD_WORKFLOW, 'utf8');
+
+/**
+ * Resolve a POSIX shell. Checking only `/bin/sh` (as the older gh-aw suites do)
+ * silently skips every behavioral case on Windows, and a check that never runs is
+ * indistinguishable from a check that always passes. Git ships a POSIX shell on
+ * Windows, so fall back to it rather than skipping.
+ */
+function resolvePosixShell(): string | null {
+  if (existsSync('/bin/sh')) return '/bin/sh';
+  if (process.platform !== 'win32') return null;
+  const roots = [
+    process.env['ProgramFiles'] ?? 'C:\\Program Files',
+    process.env['ProgramW6432'] ?? 'C:\\Program Files',
+    process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
+    join(process.env['LOCALAPPDATA'] ?? 'C:\\', 'Programs'),
+  ];
+  return roots.map(r => join(r, 'Git', 'bin', 'bash.exe')).find(existsSync) ?? null;
+}
+
+const POSIX_SHELL = resolvePosixShell();
+
+/** Pull the first fenced bash block that follows `heading`, dedented. */
+function bashBlockAfter(heading: string): string {
+  const at = workflow.indexOf(heading);
+  expect(at, `"${heading}" is missing from workflows/squad.md`).toBeGreaterThan(-1);
+
+  const rest = workflow.slice(at);
+  const fence = /^[ \t]*```bash[ \t]*\r?\n([\s\S]*?)^[ \t]*```/m.exec(rest);
+  expect(fence, `no fenced bash block follows "${heading}" in workflows/squad.md`).not.toBeNull();
+
+  return (fence?.[1] ?? '')
+    .split('\n')
+    .map(line => line.replace(/^[ \t]+/, ''))
+    .join('\n')
+    .trim();
+}
+
+const PC1_HEADING = '### Step PC-1: Extract the command argument';
+const PC3_HEADING = '### Step PC-3: No recognized command';
+
+/** Run a command extracted from the workflow with the issue body in the env. */
+function runDeclared(command: string, body: string): string {
+  if (!POSIX_SHELL) throw new Error('no POSIX shell resolved');
+  return execFileSync(POSIX_SHELL, ['-c', command], {
+    encoding: 'utf8',
+    env: { ...process.env, SQUAD_TRIGGER_BODY: body },
+  }).replace(/\r/g, '').replace(/\n+$/, '');
+}
+
+const parse = (body: string) => runDeclared(bashBlockAfter(PC1_HEADING), body);
+const diagnose = (body: string) => runDeclared(bashBlockAfter(PC3_HEADING), body);
+
+describe('gh-aw: /squad command parsing (#1824)', () => {
+  // A skipped behavioral suite is a permanently-green gate. Fail loudly instead of
+  // quietly reporting a pass for assertions that never executed.
+  it('resolves a POSIX shell, so the behavioral cases below actually run', () => {
+    expect(
+      POSIX_SHELL,
+      'No POSIX shell found. The parser cases below are behavioral — skipping them ' +
+        'would report a green suite for assertions that never ran. Install Git for ' +
+        'Windows (provides bash.exe) or run on a POSIX host.'
+    ).not.toBeNull();
+  });
+
+  describe('Step PC-1 — the command is found anywhere in the body', () => {
+    const cases: Array<{ name: string; body: string; expected: string }> = [
+      // The regression that was never broken — kept only as a floor.
+      { name: 'command at position 0', body: '/squad cast', expected: 'cast' },
+      // #1824 proper: the natural shape of a first-run issue.
+      {
+        name: 'prose, blank line, then the command',
+        body: 'Hi team! Excited to try this out.\n\n/squad cast',
+        expected: 'cast',
+      },
+      { name: 'leading blank line', body: '\n/squad cast', expected: 'cast' },
+      // Mutation-hardening: the three cases above all survive a *line*-anchored scan
+      // (`/^\/squad/`), because awk anchors per record. Only a command that is not the
+      // first token on its line distinguishes a body-wide scan from a line-anchored one,
+      // so these two cases carry that weight. Do not delete them as redundant.
+      {
+        name: 'command indented under prose (not line-anchored)',
+        body: 'Setting Squad up on this repo.\n\n    /squad cast',
+        expected: 'cast',
+      },
+      {
+        name: 'command mid-sentence',
+        body: 'When you get a chance please run /squad plan accept implementation phase 2 today',
+        expected: 'plan accept implementation phase 2 today',
+      },
+      { name: 'CRLF body', body: 'Hello\r\n\r\n/squad cast\r\n', expected: 'cast' },
+      { name: 'bare /squad after prose', body: 'context first\n\n/squad', expected: '' },
+      // The no-op cases — these are the ones that matter.
+      { name: 'no command anywhere', body: 'We should improve the docs.', expected: 'NO_COMMAND' },
+      { name: 'empty body', body: '', expected: 'NO_COMMAND' },
+    ];
+
+    it.each(cases)('$name', ({ body, expected }) => {
+      expect(parse(body)).toBe(expected);
+    });
+  });
+
+  describe('a run that matched no command must be loud, not silent', () => {
+    it('an invocation that looks real but does not parse yields NO_COMMAND and a diagnostic naming it', () => {
+      // Wrong case: unmistakably an attempted invocation, not a parseable one.
+      const body = 'Hello team\n\n/Squad cast\n';
+
+      expect(
+        parse(body),
+        'A body with no parseable command must produce the NO_COMMAND sentinel so the ' +
+          'router can fail. Anything else lets the run proceed and finish green.'
+      ).toBe('NO_COMMAND');
+
+      const diagnostic = diagnose(body);
+
+      // Mutation guard: a generic "unrecognized command" message passes a status-only
+      // assertion while telling the user nothing. Require the offending text itself.
+      expect(
+        diagnostic,
+        'The failure diagnostic must quote the text it actually saw. A message that ' +
+          'omits the offending input leaves the user with the same non-signal #1824 ' +
+          'was filed about.'
+      ).toContain('/Squad cast');
+      expect(diagnostic, 'the diagnostic must locate the text it saw').toMatch(/^3:/m);
+      expect(diagnostic).not.toBe('NO_SQUAD_TEXT_IN_BODY');
+    });
+
+    it('a glued invocation is reported verbatim rather than ignored', () => {
+      const body = 'Please /squadcast the team';
+      expect(parse(body)).toBe('NO_COMMAND');
+      expect(diagnose(body)).toContain('/squadcast');
+    });
+
+    it('a body with no /squad text still reports an explicit sentinel, never silence', () => {
+      const body = 'We should improve the docs.';
+      expect(parse(body)).toBe('NO_COMMAND');
+      expect(diagnose(body)).toBe('NO_SQUAD_TEXT_IN_BODY');
+    });
+  });
+
+  describe('Step PC-2 routes NO_COMMAND to failure, not to cast', () => {
+    const pc2 = workflow.slice(
+      workflow.indexOf('### Step PC-2:'),
+      workflow.indexOf(PC3_HEADING)
+    );
+
+    it('sends NO_COMMAND to PC-3 and forbids the cast fallback', () => {
+      expect(pc2, 'PC-2 must be present').not.toBe('');
+      const noCommandRule = pc2.slice(pc2.indexOf('NO_COMMAND'));
+      expect(noCommandRule).toContain('Step PC-3');
+      expect(
+        /do \*\*not\*\* fall back to `cast`/i.test(noCommandRule),
+        'PC-2 must explicitly forbid defaulting to cast when no command parsed — that ' +
+          'fallback is what made a typo indistinguishable from a real cast.'
+      ).toBe(true);
+    });
+
+    it('PC-3 fails the run instead of reporting success', () => {
+      const pc3 = workflow.slice(workflow.indexOf(PC3_HEADING));
+      expect(pc3).toContain('::error::');
+      expect(pc3, 'PC-3 must fail the run').toMatch(/exit non-zero/i);
+      expect(pc3, 'PC-3 must not fall back to noop, which reports no comment').toMatch(
+        /Never call `noop`/i
+      );
+    });
+  });
+});

--- a/test/gh-aw-command-parse.test.ts
+++ b/test/gh-aw-command-parse.test.ts
@@ -58,20 +58,25 @@ function bashBlockAfter(heading: string): string {
     .trim();
 }
 
+const PC0_HEADING = '### Step PC-0: Normalize a dispatched command';
 const PC1_HEADING = '### Step PC-1: Extract the command argument';
 const PC3_HEADING = '### Step PC-3: No recognized command';
 
-/** Run a command extracted from the workflow with the issue body in the env. */
-function runDeclared(command: string, body: string): string {
+/** Run a command extracted from the workflow with a value in the environment. */
+function runDeclared(command: string, value: string, varName = 'SQUAD_TRIGGER_BODY'): string {
   if (!POSIX_SHELL) throw new Error('no POSIX shell resolved');
   return execFileSync(POSIX_SHELL, ['-c', command], {
     encoding: 'utf8',
-    env: { ...process.env, SQUAD_TRIGGER_BODY: body },
+    env: { ...process.env, [varName]: value },
   }).replace(/\r/g, '').replace(/\n+$/, '');
 }
 
 const parse = (body: string) => runDeclared(bashBlockAfter(PC1_HEADING), body);
 const diagnose = (body: string) => runDeclared(bashBlockAfter(PC3_HEADING), body);
+const normalize = (command: string) =>
+  runDeclared(bashBlockAfter(PC0_HEADING), command, 'SQUAD_DISPATCH_COMMAND');
+/** The dispatch path exactly as the workflow runs it: PC-0, then PC-1. */
+const parseDispatch = (command: string) => parse(normalize(command));
 
 describe('gh-aw: /squad command parsing (#1824)', () => {
   // A skipped behavioral suite is a permanently-green gate. Fail loudly instead of
@@ -112,13 +117,99 @@ describe('gh-aw: /squad command parsing (#1824)', () => {
       },
       { name: 'CRLF body', body: 'Hello\r\n\r\n/squad cast\r\n', expected: 'cast' },
       { name: 'bare /squad after prose', body: 'context first\n\n/squad', expected: '' },
+      // Two tokens on one line. A greedy `sub(/^.*\/squad/,"")` strips through the
+      // LAST token and resolves these to `status` / `implement` — a different mode
+      // than the user asked for, silently. First-token-wins is the declared
+      // contract, so extraction stays anchored to match()'s RSTART/RLENGTH.
+      // Both positions are kept: `(^|[[:space:]])` matches empty at position 0 and
+      // a real space mid-line, so RLENGTH differs by one between them.
+      {
+        name: 'two commands on one line, first mid-line — the first wins',
+        body: 'Please /squad cast, then /squad status',
+        expected: 'cast, then /squad status',
+      },
+      {
+        name: 'two commands on one line, first at position 0 — the first wins',
+        body: '/squad research and later /squad implement',
+        expected: 'research and later /squad implement',
+      },
       // The no-op cases — these are the ones that matter.
       { name: 'no command anywhere', body: 'We should improve the docs.', expected: 'NO_COMMAND' },
       { name: 'empty body', body: '', expected: 'NO_COMMAND' },
     ];
 
     it.each(cases)('$name', ({ body, expected }) => {
-      expect(parse(body)).toBe(expected);
+      // Name the offending input in the failure message. A bare `toBe` reports the
+      // values but not which fixture produced them, and a diagnostic that omits the
+      // input is the same non-signal #1824 was filed about.
+      expect(
+        parse(body),
+        `PC-1 must extract ${JSON.stringify(expected)} from ${JSON.stringify(body)}.`
+      ).toBe(expected);
+    });
+  });
+
+  describe('the workflow_dispatch relay path carries a bare command (PC-0)', () => {
+    // The absent assertion that let a working path break. `workflow_dispatch`
+    // delivers a BARE token: squad-implement-worker.md dispatches
+    // {"command": "implement"}, and squad.md's own input schema documents
+    // `cast`, `implement`, `connect org/repo`. None carry a `/squad` prefix, so
+    // PC-1 alone returns NO_COMMAND and PC-3 hard-fails a run that worked before.
+    const dispatched = [
+      'implement', // squad-implement-worker.md relay, and the schema's examples
+      'research',
+      'cast',
+      'status',
+      'connect org/repo',
+      'plan accept implementation phase 2',
+    ];
+
+    it.each(dispatched)('dispatching %j reaches its mode instead of failing the run', cmd => {
+      expect(
+        parseDispatch(cmd),
+        `A workflow_dispatch of ${JSON.stringify(cmd)} must resolve to that command. ` +
+          'Both manual dispatch and the squad-implement-worker relay send a bare ' +
+          'token; NO_COMMAND here routes a structurally valid run into PC-3 and ' +
+          'hard-fails it — a regression on the autonomous relay.'
+      ).toBe(cmd);
+    });
+
+    it('normalization is idempotent for a human-typed slash prefix', () => {
+      // Someone typing `/squad implement` into the Actions dispatch box must not
+      // be punished with a doubled prefix that then matches no mode.
+      expect(normalize('/squad implement')).toBe('/squad implement');
+      expect(parseDispatch('/squad implement')).toBe('implement');
+    });
+
+    it('trims whitespace around the dispatched input', () => {
+      expect(parseDispatch('  implement  ')).toBe('implement');
+    });
+
+    it('an empty dispatch halts via the activation guard, never via PC-3', () => {
+      // PR #1777 / junk issues #12 and #14: the empty activation probe must stay
+      // silent and side-effect free. Routing it to PC-3 would post a comment and
+      // fail the run — the exact side effect the activation guard exists to stop.
+      expect(
+        normalize(''),
+        'An empty dispatch must yield EMPTY_DISPATCH so it routes to the activation ' +
+          'guard halt, not to PC-3.'
+      ).toBe('EMPTY_DISPATCH');
+      expect(normalize('')).not.toBe('NO_COMMAND');
+    });
+
+    it('PC-1 is NOT loosened — a bare token still fails on the comment path', () => {
+      // The tempting wrong fix is to teach PC-1 to accept bare words. That reopens
+      // #1824: prose merely containing "cast" would silently mint a team. The
+      // asymmetry is deliberate — dispatch is schema-guaranteed a command, a
+      // comment is not, so absence stays an error there.
+      for (const bare of ['implement', 'cast', 'please cast the team']) {
+        expect(
+          parse(bare),
+          `PC-1 must still reject ${JSON.stringify(bare)}, which carries no /squad ` +
+            'token. Loosening PC-1 instead of normalizing in PC-0 reopens #1824 on ' +
+            'the issue-body and comment paths.'
+        ).toBe('NO_COMMAND');
+      }
     });
   });
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -230,14 +230,61 @@ Repository owners must configure Copilot setup steps separately when needed.
 
 ## Parse Command
 
-1. Read trigger body from event payload.
-2. Strip `/squad` prefix, trim whitespace.
-3. Match **longest-prefix-first**:
+**The command may appear anywhere in the body — not only at the start.** A body
+that opens with a greeting, a sentence of context, or a blank line and *then*
+carries the command is the normal shape of a first-run issue. Never assume the
+body begins with `/squad`, and never decide by eye whether a command is present.
+
+### Step PC-1: Extract the command argument [MANDATORY]
+
+Assign the resolved trigger body (the dispatched command, comment body, or issue
+body chosen above) to `SQUAD_TRIGGER_BODY`, then run exactly this:
+
+```bash
+printf '%s\n' "$SQUAD_TRIGGER_BODY" | awk '{sub(/\r$/,"")} !f && /(^|[[:space:]])\/squad([[:space:]]|$)/ {f=1; sub(/^.*\/squad/,""); sub(/^[[:space:]]+/,""); sub(/[[:space:]]+$/,""); print} END{if(!f) print "NO_COMMAND"}'
+```
+
+It scans **every** line, takes the first `/squad` token wherever it sits, and
+prints the argument text that followed it. Empty output means a bare `/squad`.
+Exactly `NO_COMMAND` means no `/squad` token exists anywhere in the body.
+
+### Step PC-2: Route on the extracted text
+
+1. `NO_COMMAND` → go to **Step PC-3**. Do **not** fall back to `cast`, do not
+   enter a skill, do not finish the run reporting success.
+2. Empty → mode is `cast` (bare `/squad`).
+3. Otherwise match **longest-prefix-first**:
    - `plan accept implementation` (3), `plan accept scope` (3), `plan program revise` (3)
    - `plan implementation` (2), `plan program` (2), `plan activate` (2), `plan validate` (2), `plan accept` (2), `plan revise` (2), `triage revise` (2)
    - `cast-member` (1), `plan` (1), `cast`, `connect`, `adopt`, `retire`, `status`, `research`, `triage`, `implement`
-4. Default to `cast` if empty.
+4. No prefix matches → go to **Step PC-3**.
 5. **Phase selector:** If remaining args contain `phase {N}`, extract N.
+
+### Step PC-3: No recognized command [MANDATORY — a no-op run must never report success]
+
+Reaching this step means the run matched no mode: it cast nothing, planned
+nothing, changed nothing. Reporting success here is the #1824 defect — a green
+check and a real cast were indistinguishable, so a first-run user got an empty
+team and no signal that anything had gone wrong.
+
+1. Show the text actually present in the body:
+
+   ```bash
+   printf '%s\n' "$SQUAD_TRIGGER_BODY" | tr -d '\r' | grep -n -i -m 3 -F -- '/squad' || echo 'NO_SQUAD_TEXT_IN_BODY'
+   ```
+
+2. Emit `echo "::error::Squad parsed no recognized command. Text seen: <verbatim
+   output of the command above>"`. Quote the observed text — never a generic
+   "unrecognized command" message with the offending input omitted.
+3. Post one comment on the triggering issue reproducing that same text verbatim
+   and listing the valid commands from the Modes table.
+4. **Fail the run** — exit non-zero. Never call `noop`, never post a success
+   summary, never let the run finish green.
+
+Deliberate widening: this scan also matches `/squad` inside a quoted line or a
+fenced block. Excluding those would reintroduce a silent-skip path, which is the
+exact bug class this step exists to eliminate. Parsing them and surfacing the
+result is preferred over ignoring them without a trace.
 
 ## Execute Mode
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -173,13 +173,18 @@ Resolve the slash command in this order:
 1. **Dispatched command** (above) — when the event name is
    `workflow_dispatch`, this input must be present for the run to proceed. If it
    is empty, the activation guard above has already halted the run; never reach
-   this step with an empty dispatched command. When it is non-empty, use this
-   value as the command and skip the remaining sources.
+   this step with an empty dispatched command. When it is non-empty, it is the
+   trigger source; skip the remaining sources.
 2. **Issue comment / PR review comment:** `github.event.comment.body` — the full
    comment text.
 3. **Issue body:** `github.event.issue.body` — the full issue description.
 4. Otherwise default to `cast` only for an explicit `/squad` slash command with
    no arguments.
+
+Choosing a source never skips parsing: every source is parsed by **Parse
+Command** below, so mode resolution has one implementation. The dispatched
+command arrives **bare** (`implement`, not `/squad implement`) and MUST be
+normalized by **Step PC-0** before PC-1 sees it.
 
 Resolve the target issue in this order:
 
@@ -189,8 +194,10 @@ Resolve the target issue in this order:
 
 **Never emit `noop` when the dispatched command is non-empty.** A workflow
 dispatch with a non-empty command is always actionable: run the named mode
-against the dispatched issue number. The missing-`issue_number` case is handled
-by the activation guard above — halt with a log annotation, never an issue.
+against the dispatched issue number. If the dispatched command names no mode in
+the Modes table, that is a loud failure via Step PC-3 — still never `noop`. The
+missing-`issue_number` case is handled by the activation guard above — halt with
+a log annotation, never an issue.
 
 The activation job already ran `squad init --preset default`, which produced a
 generic 5-agent team (lead, reviewer, devrel, security, docs) in `.squad/`. Cast
@@ -235,18 +242,110 @@ that opens with a greeting, a sentence of context, or a blank line and *then*
 carries the command is the normal shape of a first-run issue. Never assume the
 body begins with `/squad`, and never decide by eye whether a command is present.
 
-### Step PC-1: Extract the command argument [MANDATORY]
+### Shell input security contract [MANDATORY]
 
-Assign the resolved trigger body (the dispatched command, comment body, or issue
-body chosen above) to `SQUAD_TRIGGER_BODY`, then run exactly this:
+Issue and comment bodies, issue/PR titles, and any other GitHub event text are
+**attacker-controlled**.
+
+**Mandatory channel:** event text MUST reach the shell only through named
+step/job `env:` variables, read only by quoted parameter expansion:
+
+```yaml
+env:
+  # Angle brackets stand in for Actions expression delimiters; literal ones
+  # fail gh-aw's allowlist and break `gh aw compile`.
+  SQUAD_TRIGGER_BODY: <github.event.comment.body || github.event.issue.body>
+run: |
+  body="${SQUAD_TRIGGER_BODY-}"
+  printf '%s\n' "$body" | awk '...' | grep -F -- '/squad'
+```
+
+**Forbidden:**
+
+- `UNTRUSTED_TEMPLATE_IN_RUN` — never place an event-text expression, or anything
+  derived from one, inside a `run:` block. Actions expansion happens *before* the
+  shell starts, so shell quoting cannot protect it.
+- `UNTRUSTED_COMMAND_STRING` — never build shell syntax from that text: no
+  `eval`, `source`, generated script text, or `bash -c`/`sh -c` string.
+- `UNTRUSTED_PRINTF_FORMAT` — never pass it as `printf`'s first argument; that
+  slot is the format. The body belongs in an argument slot: `printf '%s\n' "$body"`.
+- `UNTRUSTED_AWK_PROGRAM_OR_VAR` — never interpolate it into an awk program, and
+  never pass the raw body through `awk -v`, which applies escape processing and
+  can mutate parser input. Use stdin.
+
+**Per-hop requirements:**
+
+1. **Actions assignment** — event text in YAML `env:` only; no such expression
+   may appear in any compiled `run:` block.
+2. **Shell variable** — plain assignment only. No `eval`, command substitution,
+   here-doc generation, or `bash -c`.
+3. **`printf`** — literal format string; body always an argument.
+4. **Pipe** — stdin bytes between stages; never re-materialized as shell syntax.
+5. **`awk`** — static single-quoted program, body on stdin; awk variables carry
+   trusted constants only.
+6. **`grep`** — `grep -F -- "$pattern"`, quoted: `-F` forces fixed-string, `--`
+   ends option parsing so `-e` or `--version` stay data.
+
+**Verification requirement:** the gate must inspect **compiled** gh-aw output,
+not just this markdown, and fail when a compiled `run:` block carries event
+expressions, or when parser code passes a body variable as a `printf` format,
+into `eval`/`bash -c`, or into an awk program/`awk -v`. A gate that cannot turn
+red on a fixture whose `run:` prints a raw issue-body expression is not valid.
+
+That gate is **not implemented**; it is tracked in #1834. This contract is
+normative today but reviewed by hand, not enforced by CI. The steps below
+satisfy hops 2–6 as written; hop 1 is unverifiable here, since this repository
+ships no compiled gh-aw output.
+
+### Step PC-0: Normalize a dispatched command [MANDATORY on `workflow_dispatch`]
+
+`workflow_dispatch` delivers a **bare** command — its input schema documents
+`cast`, `implement`, `connect org/repo`, never `/squad implement`. PC-1 scans for
+a literal `/squad` token, so a bare token yields `NO_COMMAND` and routes a valid
+manual or relayed run into the PC-3 failure path. Normalize here rather than
+loosening PC-1: on the comment and issue-body paths a missing token *is* the
+error condition and must keep failing loudly (#1824). Only dispatch is
+structurally guaranteed a command, so only it is normalized.
+
+When `github.event_name` is `workflow_dispatch`, assign the **Dispatched
+command** to `SQUAD_DISPATCH_COMMAND` per hop 1 and run exactly this. Its output
+is the `SQUAD_TRIGGER_BODY` PC-1 consumes:
 
 ```bash
-printf '%s\n' "$SQUAD_TRIGGER_BODY" | awk '{sub(/\r$/,"")} !f && /(^|[[:space:]])\/squad([[:space:]]|$)/ {f=1; sub(/^.*\/squad/,""); sub(/^[[:space:]]+/,""); sub(/[[:space:]]+$/,""); print} END{if(!f) print "NO_COMMAND"}'
+printf '%s\n' "$SQUAD_DISPATCH_COMMAND" | awk 'NR==1{sub(/\r$/,""); sub(/^[[:space:]]+/,""); sub(/[[:space:]]+$/,""); if($0==""){print "EMPTY_DISPATCH"; exit} if($0 ~ /^\/squad([[:space:]]|$)/) print; else print "/squad " $0}'
+```
+
+Normalization is idempotent: `implement` and `/squad implement` both yield
+`/squad implement`, so typing the slash prefix into the dispatch box is not
+penalized.
+
+`EMPTY_DISPATCH` means the activation guard above should already have halted the
+run. Halt with that guard's `::warning::`; never route it to PC-3, which posts a
+comment and fails the run. An empty activation probe must stay silent and
+side-effect free (PR #1777; junk issues #12 and #14).
+
+On the comment and issue-body paths there is no PC-0: assign the raw body
+directly to `SQUAD_TRIGGER_BODY`.
+
+### Step PC-1: Extract the command argument [MANDATORY]
+
+Assign the trigger body chosen above — PC-0's output on `workflow_dispatch`, the
+raw comment or issue body otherwise — to `SQUAD_TRIGGER_BODY` per hop 1, then
+run exactly this:
+
+```bash
+printf '%s\n' "$SQUAD_TRIGGER_BODY" | awk '{sub(/\r$/,"")} !f && match($0, /(^|[[:space:]])\/squad([[:space:]]|$)/) {f=1; rest=substr($0, RSTART+RLENGTH); sub(/^[[:space:]]+/,"",rest); sub(/[[:space:]]+$/,"",rest); print rest} END{if(!f) print "NO_COMMAND"}'
 ```
 
 It scans **every** line, takes the first `/squad` token wherever it sits, and
 prints the argument text that followed it. Empty output means a bare `/squad`.
 Exactly `NO_COMMAND` means no `/squad` token exists anywhere in the body.
+
+`match()`/`substr()` extract the remainder of the **first** token. Greedy
+`sub(/^.*\/squad/,"")` strips through the *last* token on the line, so
+`/squad cast, then /squad status` resolves to `status` — a different mode than
+requested. First-token-wins is the contract; keep extraction anchored to
+`RSTART`/`RLENGTH`.
 
 ### Step PC-2: Route on the extracted text
 
@@ -285,6 +384,17 @@ Deliberate widening: this scan also matches `/squad` inside a quoted line or a
 fenced block. Excluding those would reintroduce a silent-skip path, which is the
 exact bug class this step exists to eliminate. Parsing them and surfacing the
 result is preferred over ignoring them without a trace.
+
+**Known limitation — step 4 is an instruction, not an enforced exit code.** This
+file is an LLM prompt, so "fail the run" is a directive the runtime agent is
+asked to obey, not a branch CI can execute. `test/gh-aw-command-parse.test.ts`
+proves the *declared* commands emit `NO_COMMAND` and a diagnostic quoting the
+offending text; it cannot prove the agent then exits non-zero. That gap is
+inherent to gh-aw, not an oversight — two independent reviews have flagged it.
+Steps 1–3 are load-bearing precisely because their output is observable: an
+`::error::` annotation and an issue comment survive whatever exit status the
+agent chooses. Do not drop them in favor of step 4, and do not call step 4 a
+guarantee.
 
 ## Execute Mode
 


### PR DESCRIPTION
Working as **Procedures (Prompt Architecture)**.

Closes #1824.

## The defect

`## Parse Command` in `workflows/squad.md` said *"Strip `/squad` prefix, trim whitespace"* — a position-0 assumption — and had **no failure branch at all**. Step 4, *"Default to `cast` if empty"*, was the silent-success path. There was no state in which the router could report "I did not understand this," so a run that cast nothing and a run that worked were byte-identical to the user.

## The fix

Priority follows the issue's own framing: **(2) fail loudly** is the deliverable, **(1) parse anywhere** is today's instance.

- **PC-1** scans the whole body for the first `/squad` token and prints either the argument text or the `NO_COMMAND` sentinel.
- **PC-2** routes `NO_COMMAND` to PC-3 and *explicitly forbids* falling back to `cast`.
- **PC-3** (mandatory) greps the body, emits `::error::` with the offending text **quoted verbatim**, comments on the issue, and **exits non-zero**. Never `noop`, never a success summary.

## How this is verified

The parser is an LLM prompt, not code, so there is no function to unit-test. The parse is instead declared as concrete shell commands *in the markdown*, and `test/gh-aw-command-parse.test.ts` **extracts those exact commands and executes them** against real issue bodies. The declared contract and its observed behavior are independent sources — neither re-reads the other. This follows the existing TG-1 precedent in `test/gh-aw-quality.test.ts`.

A test asserting "a command at position 0 parses" would guard the one case that was never broken. The load-bearing assertion is the inverse: **a body that yields no mode must produce an explicit sentinel and a diagnostic naming the offending text.**

### Proved it can fail

| State | Result |
|---|---|
| Pre-fix `workflows/squad.md` | **14 of 15 red** |
| Fix applied | **15 of 15 green** |

Honest caveat: that red is **structural** (`"### Step PC-1 ..." is missing`), not behavioral. It proves coupling to the new contract, not sensitivity to a subtly-wrong parser. A behavioral pre-fix red is not constructible — there was no prior implementation to run, only prose. **The mutations below are what actually tested sensitivity, and one of them found a real hole.**

### Mutation 1 — reintroduce position-0 anchoring

Changed only the awk regex inside the *fixed* file; headings and prose untouched.

**Only 1 of 14 assertions caught it.** The headline case — *prose, blank line, then the command*, the literal #1824 scenario — **passed under the reintroduced bug.**

Cause: `^` in awk anchors per **record**, not per body. `printf` feeds awk line-by-line, so a line-anchored parser still handles a command sitting on its own line after prose. That case cannot distinguish the two parsers.

Added two cases whose only job is to carry that weight — an **indented** command and a **mid-sentence** command, both invisible to a line-anchored scan. Re-running the mutation then produced **2 failures naming the specific input**. They look redundant next to the blank-line case; there is a comment in the test saying they are not.

### Mutation 2 — generic diagnostic (the #1793 shape)

Replaced PC-3's grep with `echo 'unrecognized command'`. Every status-shaped signal stayed intact: `::error::` still present, PC-2 still forbids the fallback, the run still fails. **A status-only assertion passes this clean** — exactly how a truncating parser slipped through on #1793.

Caught by **3 assertions**, because they require the diagnostic to *contain the offending text*, not merely to exist:

```
→ expected 'unrecognized command' to contain '/Squad cast'
→ expected 'unrecognized command' to contain '/squadcast'
→ expected 'unrecognized command' to be 'NO_SQUAD_TEXT_IN_BODY'
```

### The gate cannot silently skip

`HAS_POSIX_SHELL = existsSync('/bin/sh')` is false on Windows, which silently skips **102** behavioral assertions in `gh-aw-quality.test.ts` — a permanently-green gate. This suite resolves Git Bash instead, and **hard-asserts that a shell was found**, so a suite that could not run reports red rather than green.

## Deliberate non-actions

- **The scan matches `/squad` inside quoted lines and fenced blocks.** Excluding them reintroduces a silent-skip path — the exact bug class PC-3 exists to remove. gh-aw's `slash_command` trigger has already decided this is a squad command before the prompt sees the body. Documented in-file.
- **The 102 `/bin/sh` skips were not fixed.** Real, and worth its own issue; out of scope here and would blow `Diff Size Guard`.
- **#1812 not touched.** Verified separate: it is a hardcoded roster inside `plan activate`, downstream of routing. No shared code path with `Parse Command`.

## Checks

- Targeted gh-aw suites: **150 passed** — ambient budget still under 40 KB, byte conservation and skill extraction intact.
- `npm run build` passes. Build churn (two `SKILL.md` templates) was reverted, not committed; `SKIP_BUILD_BUMP=1` suppressed the version bumps.
- Full suite: 11 failures, **all pre-existing**. Verified by stashing this branch's changes — 5 reproduce on clean `dev`; the other 6 pass when run in a smaller batch (15s/9s/5s durations in the full run mark them as parallel-load timeouts).
- No changeset: `workflows/` and `test/` do not match `SDK_CLI_PATH_REGEX`.
