### PR TITLE
Certify roster set via emitting Team Guard Step TG-2 (Closes #1812)

### DIFF
--- a/.squad/decisions/inbox/procedures-1812-activate-roster-binding.md
+++ b/.squad/decisions/inbox/procedures-1812-activate-roster-binding.md
@@ -1,0 +1,146 @@
+### 2026-08-22: Roster provenance is certified by an emitting command (Team Guard Step TG-2), not by prose
+**Date:** 2026-08-22
+**Raised by:** Procedures
+**Status:** Decided
+**Issue:** #1812 (re-diagnoses #1784)
+
+#### Context
+
+`/squad plan activate` on fixture `aspiregregator-squad-e2e` (run `32471509974`) printed a
+provenance sentence claiming it read the roster from `.squad/team.md` `## Members` → `Name`
+column, and reported `lead, reviewer, devrel, security, docs`. The fixture's real cast is
+`Keaton, McManus, Fenster, Hockney, Kint`. The five reported names are exactly the
+`squad init --preset default` scaffold in
+`packages/squad-sdk/src/presets/builtin/default/preset.json`. Two defects:
+
+1. Activate bound against the hardcoded preset roster, not the repository's committed cast.
+2. It **claimed provenance it did not have** — a wrong answer wearing a citation.
+
+Downstream: at E4 the planner read `team.md` correctly and emitted the real names; activate
+compared them against the hardcoded list, matched none, and applied **no** `squad:{agent}`
+label. #1784's Condition 2 "passed" only because activate refused everything. **Refusal and
+correct binding are indistinguishable from the outside** — the through-line of this workstream.
+
+`workflows/squad.md` had already been hardened with bold, repeated prose instructing the agent
+to read `## Members` from *this repository's* `team.md`, take the `Name` column verbatim, and
+treat no other column as valid. That text was present; the defect happened anyway. A *declared*
+requirement is not an *enforced* one.
+
+#### Decision
+
+Add **Team Guard Step TG-2 — Certify the Roster Set**: a bash block modeled on the existing
+TG-1 line-444 `TEAM_PRESENT`/`TEAM_ABSENT` guard. It reads the **git-committed HEAD** revision
+of `.squad/team.md` (`git show HEAD:.squad/team.md` — working-tree preset scaffolds are
+invisible), finds the `Name` column of the `## Members` table **by header** (not by position),
+and emits one lowercased `ROSTER_MEMBER: {name}` per data row — or a single
+`ROSTER_UNREADABLE: {reason}` naming why (`absent from HEAD`, `no ## Members section`,
+`no Name column in ## Members table`, `## Members has no data rows`).
+
+Every downstream site that mints a `squad:{name}` label or binds an `Owner`/`Agent` value binds
+**only** to TG-2's stdout. Because the summary can only reproduce `ROSTER_MEMBER:` lines the
+command actually produced, **the provenance claim becomes true by construction**. On
+`ROSTER_UNREADABLE:` the binder halts with the named reason — never a provenance sentence for a
+read that did not happen, never a silent preset fallback.
+
+#### Why structural, not more prose
+
+The prose fix is the exact move that already failed here repeatedly, and is the anti-pattern
+this workstream is clearing. TG-2's stdout is an **observable artifact of the run** that a test
+can assert against; a prose directive's compliance cannot be observed. This is the same
+distinction as TG-1's `TEAM_PRESENT`/`TEAM_ABSENT` — a requirement vs. a rule. Modeling on
+PC-3 was explicitly rejected: PC-3's "exit non-zero on failure" is itself an unenforced prompt
+directive (accepted limitation, #1824). TG-2 sits in the Team Guard family because the problem
+**is** file provenance, not command-string normalization; modeling it on PC-* would have
+manufactured a parallel structure rather than reusing the right one.
+
+#### Why header-driven column detection, not `$2`
+
+An earlier draft extracted a fixed column position. That silently binds the wrong data if a repo
+authors `## Members` as `| Role | Name |` — it would emit the Role column, reproducing the exact
+#1812 anti-pattern with a *true-looking* provenance claim. TG-2 instead scans the header row for
+the cell whose trimmed text is `Name` and extracts that column; a table with no `Name` column
+yields `ROSTER_UNREADABLE: no Name column in ## Members table` rather than a confident wrong
+answer. (Mutation M2 proves this: pinning the column to position 2 reddens the header-order case,
+naming the leaked `ROSTER_MEMBER: lead` / `reviewer`.)
+
+#### Enforcement boundary — emission enforced, consumption directive (the good kind of unenforced)
+
+TG-2 makes **emission** shell-enforced and assertable: the new test extracts the block and runs
+it against real committed-HEAD git repos, proving the certified set is correct in isolation.
+**Consumption** — the model actually binding only to `ROSTER_MEMBER:` lines — remains a prompt
+directive. Nothing can compel the model to read its own emitted set. This is the *good* kind of
+unenforced: like RETRO's hop-1 contract, the limitation labels itself. The defect was never an
+unenforced directive; it was prose that read as a guarantee. This sentence stays in the record so
+the boundary is named, not silent.
+
+#### Postcondition `applied_labels ⊆ emitted_roster_members` is NOT reachable — named boundary
+
+A machine-checked postcondition (a shell step asserting every applied `squad:{name}` label is a
+subset of the emitted roster, failing loudly and naming the offending label) would close
+acceptance 2a's second half by machine rather than by reviewer. It is **not reachable** under
+gh-aw safe-outputs: the agent job runs read-only and writes `create-issue` requests to
+`/tmp/gh-aw/safeoutputs/outputs.jsonl`; a **separate executor job** (with `issues: write`) applies
+labels afterward. TG-2's stdout lives in the agent's bash sandbox and is not promotable to a
+cross-job artifact the executor consumes; the only agent→executor channel is the model-filled
+safe-output, which reintroduces the very model-memory trust the postcondition was meant to remove.
+So emission is assertable in-run; consumption cannot be asserted at label-application time in this
+architecture. Recorded as a boundary, not a silence — if safe-outputs later exposes the applied
+set to a same-job shell step, this postcondition becomes worth its bytes and closes 2a fully.
+
+#### CRLF / CR-strip could not be measured on this substrate — named boundary
+
+TG-2's extraction carries `{sub(/\r$/,"")}` to normalize CRLF-authored `team.md` on Linux
+runners. Mutation M8 (removing that strip) **could not be reddened** on the Windows git-bash test
+host: `git show HEAD:.squad/team.md` there emits LF (git-for-windows normalizes CR out before awk
+sees it, despite `core.autocrlf false`), and for regular GitHub tables the trailing pipe already
+quarantines any CR into a post-pipe field that is never read. Two empirical probes (with/without
+strip, on trailing-pipe and Name-last-no-trailing-pipe CRLF fixtures) produced identical clean
+output. The strip is **retained as defense-in-depth** (correct and load-bearing on Linux runners
+for irregular tables); its load-bearing behavior is **reasoned for Linux, not measured on
+Windows**. The dedicated CRLF test was rewritten to assert the end-to-end parse invariant (clean
+lowercased cast from a CRLF file) — which *is* reddenable (mutations M1/M4 flip it, naming the
+offending `ROSTER_MEMBER:` output) — and no longer claims to prove the strip in isolation.
+
+#### Prose removed — enumerated, each checked against `test/gh-aw-*`
+
+The verbose per-site roster prose was superseded by TG-2 emission + short binders that point at
+the certified set. Removed / compressed blocks: the plan `Owner/Agent binding rule` sub-steps
+(a–d) → one binder paragraph; the plan `Owner` re-check reminder → one pointer; the accept
+`squad:{owner}` minting paragraph → TG-2-bound sentence; the impl `Agent binding rule` working-
+notes paragraph → TG-2-bound sentence; the impl `Agent` re-check reminder → one pointer; the
+Check 10 four-step block → TG-2-bound restatement. Every test-pinned substring was verified to
+survive: `Owner/Agent binding rule` (plan), `Agent binding rule` + `appears verbatim in the
+`Name` column` (impl), `Name` column (all binders), the Check 10 `Never report a value as a
+valid roster name unless …` sentence, and the no-backticked-role-token invariant across all five
+skill blocks. All four existing gh-aw suites + the new one pass (172 passed / 13 skipped), which
+confirms no pinned assertion was dropped. No prose was removed that a `test/gh-aw-*` test asserts
+on.
+
+#### Caller enumeration (FIDO requirement)
+
+Every roster/owner/agent site across `workflows/` was enumerated:
+
+**Minting / binding — all bound to TG-2's certified set:**
+- `squad.md` accept `squad:{owner}` mint (§ "For each work item, create-issue")
+- `squad.md` activate Label Pre-flight gate `squad:{agent}` (runs TG-2, false-provenance
+  defenses, ≥1-label completeness rule) — governs the epic/task label declarations that follow it
+- `squad.md` plan `Owner/Agent binding rule`
+- `squad.md` impl `Agent binding rule` + its validation check
+- `squad.md` Check 10 roster validation
+
+**Pure consumers — NOT #1812 vectors (no independent roster derivation):**
+- `squad-implement-worker.md` "Route work to the member named by the `squad:{member}` label" —
+  consumes an already-certified label; reads `team.md` only for that member's charter/routing.
+- `shared/squad.md` `squad init` cast-preservation guard (#1657) — existence check via
+  `grep -q '^[|]'`, no name extraction for labels; aligned with the anti-preset-clobber intent.
+
+No second minting path shares the defect. No compiled `.lock.yml` artifacts are committed
+(gh-aw compiles at deploy time), so no regeneration is required.
+
+#### Risk
+
+Consumption remains model-trusted (see boundary above). If a future gh-aw version exposes the
+applied-label set to a same-job shell step, add the subset postcondition to machine-check
+acceptance 2a's second half. Until then, the ≥1-label completeness rule (activate must apply at
+least one `squad:{agent}` label, else fail) is the guard that keeps "refused everything" from
+masquerading as "bound correctly" — the failure mode that gave #1784 its false pass.

--- a/test/gh-aw-activate-roster-binding.test.ts
+++ b/test/gh-aw-activate-roster-binding.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Behavioral coverage for Team Guard Step TG-2 in `workflows/squad.md` (#1812).
+ *
+ * `/squad plan activate` minted `squad:{agent}` labels from the hardcoded
+ * `squad init --preset default` roster (lead, reviewer, devrel, security, docs)
+ * instead of this repository's real cast in `.squad/team.md`, and then printed a
+ * provenance sentence claiming it had read `team.md` when it had not. On the
+ * measured fixture (run 32471509974) the summary reported five preset names, none
+ * of which appears anywhere in the fixture's `team.md`. A wrong answer wearing a
+ * citation is worse than a wrong answer: refusal and correct binding are
+ * indistinguishable from the outside, which is how #1784 got a false pass.
+ *
+ * More prose telling the model to "really read the file" had already been tried
+ * repeatedly and failed. The fix is structural: TG-2 is a shell command whose
+ * stdout survives the run and can be asserted against. These tests do exactly
+ * that — they extract the bash block *declared* in the workflow and *execute* it
+ * against real committed git repositories. Nothing here re-reads prose to confirm
+ * prose. Every failure message names the offending input verbatim, because a
+ * status-only assertion passes a truncating parser (measured on #1832).
+ */
+
+import { describe, it, expect, afterAll } from 'vitest';
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SQUAD_WORKFLOW = join(process.cwd(), 'workflows', 'squad.md');
+const workflow = readFileSync(SQUAD_WORKFLOW, 'utf8');
+
+/**
+ * Resolve a POSIX shell. Checking only `/bin/sh` silently skips every behavioral
+ * case on Windows, and a check that never runs is indistinguishable from a check
+ * that always passes. Git ships a POSIX shell on Windows, so fall back to it.
+ */
+function resolvePosixShell(): string | null {
+  if (existsSync('/bin/sh')) return '/bin/sh';
+  if (process.platform !== 'win32') return null;
+  const roots = [
+    process.env['ProgramFiles'] ?? 'C:\\Program Files',
+    process.env['ProgramW6432'] ?? 'C:\\Program Files',
+    process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
+    join(process.env['LOCALAPPDATA'] ?? 'C:\\', 'Programs'),
+  ];
+  return roots.map(r => join(r, 'Git', 'bin', 'bash.exe')).find(existsSync) ?? null;
+}
+
+const POSIX_SHELL = resolvePosixShell();
+
+/** Pull the first fenced bash block that follows `heading`, dedented. */
+function bashBlockAfter(heading: string): string {
+  const at = workflow.indexOf(heading);
+  expect(at, `"${heading}" is missing from workflows/squad.md`).toBeGreaterThan(-1);
+
+  const rest = workflow.slice(at);
+  const fence = /^[ \t]*```bash[ \t]*\r?\n([\s\S]*?)^[ \t]*```/m.exec(rest);
+  expect(fence, `no fenced bash block follows "${heading}" in workflows/squad.md`).not.toBeNull();
+
+  return (fence?.[1] ?? '')
+    .split('\n')
+    .map(line => line.replace(/^[ \t]+/, ''))
+    .join('\n')
+    .trim();
+}
+
+const TG2_HEADING = '### Step TG-2: Certify the Roster Set';
+const TG2_BLOCK = bashBlockAfter(TG2_HEADING);
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+  for (const d of tempDirs) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+});
+
+/**
+ * Build a throwaway git repo. `committed` is written to `.squad/team.md` and
+ * committed to HEAD (null → team.md is absent from HEAD, but a HEAD still exists).
+ * `workingTree`, when given, overwrites the working-tree copy *without* committing
+ * it — this reproduces a preset scaffold sitting uncommitted next to a real
+ * committed roster, which is precisely the #1812 leak vector.
+ */
+function makeRepo(committed: string | null, workingTree?: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-aw-tg2-'));
+  tempDirs.push(dir);
+  execSync('git init', { cwd: dir, stdio: 'ignore' });
+  // Preserve CRLF bytes in the blob so the CRLF case actually exercises sub(/\r$/,"").
+  execSync('git config core.autocrlf false', { cwd: dir, stdio: 'ignore' });
+  execSync('git config user.email "t@t.com"', { cwd: dir, stdio: 'ignore' });
+  execSync('git config user.name "T"', { cwd: dir, stdio: 'ignore' });
+
+  if (committed === null) {
+    // HEAD must exist for `git show HEAD:...` to reach the "absent path" branch
+    // rather than erroring for lack of any commit.
+    writeFileSync(join(dir, 'README.md'), '# placeholder\n');
+    execSync('git add -f README.md', { cwd: dir, stdio: 'ignore' });
+    execSync('git commit -m init', { cwd: dir, stdio: 'ignore' });
+  } else {
+    mkdirSync(join(dir, '.squad'), { recursive: true });
+    writeFileSync(join(dir, '.squad', 'team.md'), committed);
+    execSync('git add -f .squad/team.md', { cwd: dir, stdio: 'ignore' });
+    execSync('git commit -m team', { cwd: dir, stdio: 'ignore' });
+  }
+
+  if (workingTree !== undefined) {
+    mkdirSync(join(dir, '.squad'), { recursive: true });
+    writeFileSync(join(dir, '.squad', 'team.md'), workingTree);
+  }
+  return dir;
+}
+
+/**
+ * Run the extracted TG-2 block in `cwd`. Trailing blank lines are trimmed but
+ * interior `\r` is deliberately preserved: erasing it here would hide a failure
+ * of the awk to strip a CRLF carriage return, which is exactly what the CRLF case
+ * must catch.
+ */
+function runTG2(cwd: string): string {
+  if (!POSIX_SHELL) throw new Error('no POSIX shell resolved');
+  return execFileSync(POSIX_SHELL, ['-c', TG2_BLOCK], { cwd, encoding: 'utf8' }).replace(/\n+$/, '');
+}
+
+const members = (out: string): string[] =>
+  out
+    .split('\n')
+    .filter(l => l.startsWith('ROSTER_MEMBER: '))
+    .map(l => l.slice('ROSTER_MEMBER: '.length));
+
+const unreadable = (out: string): string | null => {
+  const line = out.split('\n').find(l => l.startsWith('ROSTER_UNREADABLE: '));
+  return line ? line.slice('ROSTER_UNREADABLE: '.length) : null;
+};
+
+// A real cast roster (Name column first) — the shape #1784's fixture actually had.
+const CAST = [
+  '## Members',
+  '',
+  '| Name | Role |',
+  '|------|------|',
+  '| Keaton | Lead |',
+  '| McManus | Reviewer |',
+  '| Fenster | DevRel |',
+  '| Hockney | Security |',
+  '| Kint | Docs |',
+  '',
+].join('\n');
+
+// The exact preset scaffold that leaked in the measured defect.
+const PRESET = [
+  '## Members',
+  '',
+  '| Name | Role |',
+  '|------|------|',
+  '| lead | Lead |',
+  '| reviewer | Reviewer |',
+  '| devrel | DevRel |',
+  '| security | Security |',
+  '| docs | Docs |',
+  '',
+].join('\n');
+
+describe('gh-aw: Team Guard TG-2 roster certification (#1812)', () => {
+  // A skipped behavioral suite is a permanently-green gate. Fail loudly instead
+  // of quietly reporting a pass for assertions that never executed.
+  it('resolves a POSIX shell, so the behavioral cases below actually run', () => {
+    expect(
+      POSIX_SHELL,
+      'No POSIX shell found. The TG-2 cases below are behavioral — skipping them ' +
+        'would report a green suite for assertions that never ran. Install Git for ' +
+        'Windows (provides bash.exe) or run on a POSIX host.'
+    ).not.toBeNull();
+  });
+
+  // If the heading is renamed or the fenced block deleted, extraction would yield
+  // empty text and every execute-case below would vacuously pass. Guard that.
+  it('extracts a non-empty TG-2 block that emits the certified-roster vocabulary', () => {
+    expect(TG2_BLOCK.length, 'TG-2 bash block extracted empty from workflows/squad.md').toBeGreaterThan(0);
+    expect(TG2_BLOCK, 'TG-2 block must emit ROSTER_MEMBER: lines').toContain('ROSTER_MEMBER:');
+    expect(TG2_BLOCK, 'TG-2 block must emit ROSTER_UNREADABLE: on failure').toContain('ROSTER_UNREADABLE:');
+    // It must read the *committed* revision, not the working tree — the entire point.
+    expect(TG2_BLOCK, 'TG-2 must read the committed HEAD revision of team.md').toMatch(/git show HEAD:\.squad\/team\.md/);
+  });
+
+  it.skipIf(!POSIX_SHELL)('emits the committed cast verbatim (lowercased), not a preset', () => {
+    const out = runTG2(makeRepo(CAST));
+    expect(members(out), `expected the real cast from team.md; got:\n${out}`).toEqual([
+      'keaton',
+      'mcmanus',
+      'fenster',
+      'hockney',
+      'kint',
+    ]);
+    expect(unreadable(out), `unexpected ROSTER_UNREADABLE on a readable roster:\n${out}`).toBeNull();
+  });
+
+  it.skipIf(!POSIX_SHELL)('reads the Name column by header, not by position, when Role comes first', () => {
+    const roleFirst = [
+      '## Members',
+      '',
+      '| Role | Name |',
+      '|------|------|',
+      '| Lead | Keaton |',
+      '| Reviewer | McManus |',
+      '',
+    ].join('\n');
+    const out = runTG2(makeRepo(roleFirst));
+    expect(members(out), `expected names from the Name column; got:\n${out}`).toEqual(['keaton', 'mcmanus']);
+    // The bug this guards: extracting column 2 by position would emit the roles.
+    for (const role of ['lead', 'reviewer']) {
+      expect(members(out), `Role value "${role}" leaked as a roster member; got:\n${out}`).not.toContain(role);
+    }
+  });
+
+  it.skipIf(!POSIX_SHELL)('names the failure when the table has no Name column', () => {
+    const noName = [
+      '## Members',
+      '',
+      '| Handle | Role |',
+      '|--------|------|',
+      '| Keaton | Lead |',
+      '',
+    ].join('\n');
+    const out = runTG2(makeRepo(noName));
+    expect(members(out), `no member may be emitted without a Name column; got:\n${out}`).toEqual([]);
+    expect(unreadable(out), `expected a named "no Name column" reason; got:\n${out}`).toBe(
+      'no Name column in ## Members table'
+    );
+  });
+
+  it.skipIf(!POSIX_SHELL)('reads committed HEAD, so an uncommitted preset scaffold cannot leak', () => {
+    // The measured #1812 defect: a real cast is committed, but a preset team.md
+    // sits in the working tree. TG-2 must certify the committed cast only.
+    const out = runTG2(makeRepo(CAST, PRESET));
+    expect(members(out), `working-tree preset leaked past the committed HEAD read; got:\n${out}`).toEqual([
+      'keaton',
+      'mcmanus',
+      'fenster',
+      'hockney',
+      'kint',
+    ]);
+    for (const preset of ['lead', 'reviewer', 'devrel', 'security', 'docs']) {
+      expect(members(out), `preset name "${preset}" leaked into the certified roster; got:\n${out}`).not.toContain(
+        preset
+      );
+    }
+  });
+
+  it.skipIf(!POSIX_SHELL)('names the failure when team.md is absent from HEAD', () => {
+    const out = runTG2(makeRepo(null));
+    expect(members(out), `no roster may be emitted when team.md is absent; got:\n${out}`).toEqual([]);
+    expect(unreadable(out), `expected a named "absent from HEAD" reason; got:\n${out}`).toBe(
+      '.squad/team.md absent from HEAD'
+    );
+  });
+
+  it.skipIf(!POSIX_SHELL)('names the failure when there is no ## Members section', () => {
+    const noSection = ['# Squad', '', 'Some prose but no members table.', ''].join('\n');
+    const out = runTG2(makeRepo(noSection));
+    expect(members(out), `no roster may be emitted without a ## Members section; got:\n${out}`).toEqual([]);
+    expect(unreadable(out), `expected a named "no ## Members section" reason; got:\n${out}`).toBe(
+      'no ## Members section in .squad/team.md'
+    );
+  });
+
+  it.skipIf(!POSIX_SHELL)('names the failure when ## Members has header and separator but no data rows', () => {
+    const headerOnly = ['## Members', '', '| Name | Role |', '|------|------|', ''].join('\n');
+    const out = runTG2(makeRepo(headerOnly));
+    expect(members(out), `header/separator rows are not members; got:\n${out}`).toEqual([]);
+    expect(unreadable(out), `expected a named "no data rows" reason; got:\n${out}`).toBe(
+      '## Members has no data rows in .squad/team.md'
+    );
+  });
+
+  // CRLF-authored team.md is a real scenario (Windows editors). This asserts the
+  // whole pipeline — committed-HEAD read, section/header/row detection — yields the
+  // clean lowercased cast on CRLF input. It is reddenable: the lowercase mutation
+  // (drop tolower) and the working-tree mutation (cat vs git show) both flip it,
+  // naming the offending ROSTER_MEMBER output. Note: the awk's `sub(/\r$/,"")` could
+  // NOT be shown independently load-bearing on this substrate — for trailing-pipe
+  // GitHub tables the trailing pipe already quarantines the CR into a post-pipe
+  // field that is never read (measured). The strip is retained as defense-in-depth
+  // for irregular tables; this test does not claim to prove it.
+  it.skipIf(!POSIX_SHELL)('parses a CRLF-authored team.md into the clean lowercased cast', () => {
+    const crlf = [
+      '## Members',
+      '',
+      '| Name | Role |',
+      '|------|------|',
+      '| Keaton | Lead |',
+      '| McManus | Reviewer |',
+      '',
+    ].join('\r\n');
+    const out = runTG2(makeRepo(crlf));
+    expect(members(out), `expected the clean lowercased cast from a CRLF file; got:\n${out}`).toEqual([
+      'keaton',
+      'mcmanus',
+    ]);
+    expect(unreadable(out), `unexpected ROSTER_UNREADABLE on a readable CRLF roster:\n${out}`).toBeNull();
+  });
+});

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1114,7 +1114,7 @@ Rules: no task > max_task_size. DAG only. Every task traces to program item. Eve
 
 ##### Step 3: Validate Structure
 
-Check: sizes ≤ L, no cycles, traceability, coverage, agent validity (every `Agent` value appears verbatim in the `Name` column of the `## Members` table in `.squad/team.md`, or is `@copilot`). Fix before posting.
+Check: sizes ≤ L, no cycles, traceability, coverage, agent validity (every `Agent` value matches a Team Guard Step TG-2 `ROSTER_MEMBER:` line — appears verbatim in the `Name` column — or is `@copilot`). Fix before posting.
 
 ##### Step 4: Post Implementation Plan
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -446,12 +446,48 @@ git show HEAD:.squad/team.md 2>/dev/null | awk '{sub(/\r$/,"")} /^## Members/{f=
 
 `TEAM_PRESENT` requires at least one Markdown table data row inside the `## Members` section of the **git-committed HEAD revision** of `.squad/team.md`. Neither the header row (`| Name | Role | … |`) nor the separator row (`|---|---|`) qualifies. A path absent from HEAD, an empty committed file, a header-only scaffold, or zero member rows all yield `TEAM_ABSENT`.
 
-**Why committed HEAD, not local files:** The activation pre-step (e.g., `squad init --preset default`) may restore a local `.squad/` scaffold before the agent job runs. Reading the local filesystem would return TEAM_PRESENT for that scaffold even though no team has been cast and committed. `git show HEAD:.squad/team.md` reads only what is in the repository's committed state — activation-restored local files are intentionally invisible to this guard. Local activation state is preserved for Cast generation (TG-3 onward); only the guard decision reads committed HEAD.
+**Why committed HEAD, not local files:** an activation pre-step (e.g. `squad init --preset default`) can restore a local `.squad/` scaffold before the job runs; reading the local filesystem would return TEAM_PRESENT for that uncast scaffold. `git show HEAD:.squad/team.md` reads only committed state, so activation-restored local files are invisible to the guard.
 
-The leading `sub(/\r$/,"")` normalizes CRLF line endings so Windows-formatted team.md files are classified correctly. If the repo has no commits yet, `git show HEAD:...` exits non-zero and the pipe produces no output → TEAM_ABSENT.
+The leading `sub(/\r$/,"")` normalizes CRLF so Windows-formatted team.md classifies correctly. No commits → `git show` exits non-zero → TEAM_ABSENT.
 
 - `TEAM_PRESENT` → proceed to the original mode's section.
 - `TEAM_ABSENT` → execute **Auto-Cast Pivot** below; do not proceed with the original mode this run.
+
+### Step TG-2: Certify the Roster Set [MANDATORY when TEAM_PRESENT]
+
+Every step that mints a `squad:{name}` label or binds an `Owner`/`Agent` value binds **only** to this command's stdout. Run once.
+
+```bash
+TEAM_MD="$(git show HEAD:.squad/team.md 2>/dev/null)"
+if [ -z "$TEAM_MD" ]; then
+  echo "ROSTER_UNREADABLE: .squad/team.md absent from HEAD"
+elif ! printf '%s\n' "$TEAM_MD" | awk '{sub(/\r$/,"")} /^## Members/{f=1} END{exit !f}'; then
+  echo "ROSTER_UNREADABLE: no ## Members section in .squad/team.md"
+else
+  ROSTER="$(printf '%s\n' "$TEAM_MD" | awk -F'|' '
+    {sub(/\r$/,"")}
+    /^## Members/{f=1;next}
+    f&&/^#/{f=0}
+    f&&/^\|/{
+      if(col==0){for(i=1;i<=NF;i++){h=$i;gsub(/^[ \t]+|[ \t]+$/,"",h);if(h=="Name")col=i}next}
+      if($0 ~ /^\|[-: |]*\|$/)next
+      if(col==0)next
+      n=$col;gsub(/^[ \t]+|[ \t]+$/,"",n);if(n!="")print tolower(n)}
+    END{if(col==0)print "__NOCOL__"}')"
+  if printf '%s\n' "$ROSTER" | grep -q "__NOCOL__"; then
+    echo "ROSTER_UNREADABLE: no Name column in ## Members table"
+  elif [ -z "$ROSTER" ]; then
+    echo "ROSTER_UNREADABLE: ## Members has no data rows in .squad/team.md"
+  else
+    printf '%s\n' "$ROSTER" | awk '{print "ROSTER_MEMBER: " $0}'
+  fi
+fi
+```
+
+Reuses TG-1's committed-HEAD read (working-tree presets cannot leak); finds the `Name` column by header and emits one lowercased `ROSTER_MEMBER: {name}` per `## Members` data row, else a `ROSTER_UNREADABLE: {reason}`.
+
+- **`ROSTER_MEMBER:` lines** are the **certified roster set** — bind only to these, reproduce them verbatim as provenance; a name outside them (bar `@copilot`) must never become a `squad:{name}` label.
+- **`ROSTER_UNREADABLE:`** halts binding with its named reason — never a provenance sentence for a read that did not happen, never a preset fallback; treat as `TEAM_ABSENT`.
 
 ### Auto-Cast Pivot
 
@@ -825,27 +861,13 @@ Decompose issue into sub-issues as a comment. Does NOT create issues. Works on o
 
 1. Read issue body (the epic/brief).
 2. Find latest `research` artifact comment for this issue. If found, use as primary context. If not, do lightweight repo analysis.
-3. Read `.squad/team.md` if it exists. **Owner/Agent binding rule:**
-
-   a. Locate the `## Members` table in **this repository's** `.squad/team.md`.
-      Read its `Name` column and build the **allowed-owner set**: every `Name`
-      cell value copied verbatim, plus `@copilot`.
-   b. Before assigning any owner, write the allowed-owner set out explicitly in
-      your working notes, so the binding is grounded in the roster you actually
-      read rather than recalled. Use only values read from this repository's
-      `.squad/team.md` — never a name carried over from another roster, an
-      example, or a previous task.
-   c. Every `Owner` and `Agent` value you emit MUST be a member of the
-      allowed-owner set, character-for-character as it appears in the `Name`
-      column. The `Name` column is the sole source of these values; no other
-      column of `.squad/team.md` — the `Role` column included — supplies a valid
-      owner, in any casing.
-   d. Map each work item's domain to a member via `.squad/routing.md`, then
-      resolve that member to its exact `Name` cell value. If no cast member fits,
-      use `@copilot`.
-
-   This binding governs every `Owner`/`Agent` column and every `squad:{owner}`
-   label emitted downstream.
+3. Read `.squad/team.md` if it exists. **Owner/Agent binding rule:** permitted
+   `Owner`/`Agent` values are Team Guard Step TG-2's certified roster set — the
+   `Name` column of `## Members` in **this repository's** `.squad/team.md` — plus
+   `@copilot`. Map each item's domain to a member via `.squad/routing.md` and emit
+   that member's exact `Name` cell — never a recalled name, never another column
+   (the `Role` column included). If none fits, use `@copilot`. Governs every
+   `Owner`/`Agent` column and `squad:{owner}` label downstream.
 4. Text after `/squad plan` = planning guidance.
 
 ##### Step 2: Decompose
@@ -858,7 +880,7 @@ Break into discrete work items. **Minimum 3 items** unless genuinely atomic (exp
 
 Structure: `## 📋 Squad Plan — {Title}` → reference line → Phase tables (# | Title | Owner | Size | Depends On) → Details per item (Scope, Acceptance criteria, Notes) → Dependency Graph → Execution Notes → Next Steps (`/squad plan accept`, `/squad plan accept phase 1`, `/squad plan revise`, `/squad plan`).
 
-Every `Owner` cell MUST be a member of the allowed-owner set built in Step 1 — a verbatim value from the `Name` column of the `## Members` table in `.squad/team.md`, or `@copilot`. Re-check each `Owner` cell against that column before posting; a value that does not appear there is invalid and must be re-resolved.
+Re-check every `Owner` against the Step 1 permitted set before posting; a value absent from it is invalid and must be re-resolved.
 
 Do NOT create issues.
 
@@ -903,7 +925,7 @@ If plan has phases: Root → Phase issues → Task issues. Flat plan: tasks dire
 
 For each work item, `create-issue`:
 - Title: work item title
-- Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`), where `{owner}` is the work item's `Owner` value lowercased. Before minting each `squad:{owner}` label, confirm the `Owner` value appears verbatim in the `Name` column of the `## Members` table in `.squad/team.md`. The `Name` column is the only permitted source for this label — no other column of `.squad/team.md` supplies one. If the `Owner` value is not present in that column, do not mint the label: re-resolve the owner against the `Name` column, or fall back to `@copilot` and apply only the `squad` label.
+- Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`) where `{owner}` is the `Owner` lowercased. Mint `squad:{owner}` **only** when that value matches a `ROSTER_MEMBER:` line from Team Guard Step TG-2 — its stdout (the certified roster set, from the `Name` column of `## Members` in `.squad/team.md`) is the sole source; never re-read team.md or recall a name. Uncertified `Owner`: apply only `squad`, fall back to `@copilot`. On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster.
 - Body: scope, acceptance criteria, context (parent, phase, size, depends on, owner), notes, footer
 - Parent: phase issue (hierarchical) or root (flat)
 - Size: set Project field if available, else body `**Size:**` line
@@ -1086,7 +1108,7 @@ Search in order: `scope-accepted` artifact (use as authoritative) → `program` 
 
 Per task specify: Title, Scope (files/modules/APIs), Acceptance criteria, Size (XS <1h, S 1-3h, M 3-8h, L 1-2d; max per policy default L), Dependencies (task numbers), Agent, Rollout notes.
 
-**Agent binding rule:** before assigning any agent, read the `## Members` table in **this repository's** `.squad/team.md` and list its `Name` column values verbatim in your working notes. That list, plus `@copilot`, is the complete set of permitted `Agent` values — ground your assignments in the roster you just read rather than recalling one. Every `Agent` value MUST be one of those values, character-for-character. Resolve each task's domain to a member via `.squad/routing.md`, then emit that member's exact `Name` cell value. The `Name` column is the sole source of `Agent` values; no other column of `.squad/team.md` — the `Role` column included — supplies a valid one, in any casing. If no cast member fits, use `@copilot`.
+**Agent binding rule:** permitted `Agent` values are Team Guard Step TG-2's certified roster set (the `Name` column of `## Members` in **this repository's** `.squad/team.md`), plus `@copilot`. Resolve each task's domain via `.squad/routing.md` and emit that member's exact `Name` cell; no other column, the `Role` column included, supplies a valid `Agent`. If none fits, use `@copilot`.
 
 Rules: no task > max_task_size. DAG only. Every task traces to program item. Every epic has ≥1 task. Vertical slices. Group into phases by dependency order (Phase 1 = no deps).
 
@@ -1100,7 +1122,7 @@ Check: sizes ≤ L, no cycles, traceability, coverage, agent validity (every `Ag
 
 Structure: `## 🔧 Squad Implementation Plan` → Program ref → Phase tables (Title|Size|Depends On|Agent|Epic) → Details per task (Scope, Acceptance criteria, Dependencies, Rollout, Traces to) → Dependency Graph → Sizing Summary table → Validation Pre-check → Next: `/squad plan validate`.
 
-Every `Agent` cell MUST be a permitted value per the Agent binding rule (Step 2) — a verbatim value from the `Name` column of the `## Members` table in `.squad/team.md`, or `@copilot`. Re-check each `Agent` cell against that column before posting.
+Re-check every `Agent` against the Step 2 binding rule before posting.
 
 ##### Step 5: Update Lifecycle
 
@@ -1142,25 +1164,19 @@ Severity: ❌ Critical (blocks acceptance): 1–6, 8, 10. ⚠️ Warning: 7, 9, 
 
 ###### Check 10 — roster binding (the `Name` column is the sole source of truth)
 
-Run this check mechanically. Do not judge whether a value "looks like" a
-teammate, and do not accept a value because it seems plausible or was used
-earlier in the plan.
+Run mechanically; never accept a value because it "looks like" a teammate.
 
-1. Read the `## Members` table in **this repository's** `.squad/team.md`. Collect
-   its `Name` column cell values verbatim into the **roster set**. If
-   `.squad/team.md` is missing or its `## Members` table has no data rows, report
-   Check 10 as ❌ Critical and stop — a plan cannot bind owners without a roster.
-2. Quote the roster set in the validation output, so the reader can see exactly
-   which values were treated as valid.
-3. For every `Owner` cell in the program artifact and every `Agent` cell in the
-   implementation artifact: the value is valid **only** if it matches a roster-set
-   entry ignoring case, or is exactly `@copilot`. Every other value — including
-   any value drawn from a different column of `.squad/team.md`, such as the
-   `Role` column — is invalid.
-4. Every invalid value is a ❌ **Critical** finding, which makes the run
-   `RESULT: FAIL`. Report each one as: the artifact, the row, the offending
-   value, and the roster set it must be drawn from. Never report a value as a
-   valid roster name unless you found it in the `Name` column in step 1.
+1. The **roster set** is the certified output of Team Guard Step TG-2 — the
+   `ROSTER_MEMBER:` names from the `Name` column of `## Members`. If TG-2 emitted
+   `ROSTER_UNREADABLE:`, report Check 10 ❌ Critical and stop — no roster, no binding.
+2. Quote the roster set in the validation output.
+3. Every `Owner`/`Agent` cell is valid **only** if it matches a roster-set entry
+   ignoring case, or is exactly `@copilot`; any other value — including one from a
+   different column, such as the `Role` column — is invalid.
+4. Every invalid value is a ❌ **Critical** finding (`RESULT: FAIL`), reported with
+   artifact, row, offending value, and the roster set it must be drawn from.
+   Never report a value as a valid roster name unless TG-2 emitted it as a
+   `ROSTER_MEMBER:`.
 
 ##### Step 3: Post Result
 
@@ -1287,21 +1303,24 @@ Count expected issues before starting. If total > 50: recommend phased activatio
 
 **Roster binding gate — run this before any `create-issue` call.**
 
-1. Read the `## Members` table in **this repository's** `.squad/team.md` and
-   collect its `Name` column cell values verbatim into the **roster set**.
-2. List the roster set in the activation summary, so the labels applied can be
-   traced back to the roster that was actually read.
-3. For every `Agent` value in the implementation plan, confirm it matches a
-   roster-set entry ignoring case, or is exactly `@copilot`. The `Name` column is
-   the only permitted source; a value taken from any other column of
-   `.squad/team.md`, such as the `Role` column, does not qualify.
-4. A value that fails step 3 MUST NOT be turned into a `squad:{agent}` label.
-   Apply only the `squad` label for that issue and record the value in the
-   activation summary under a `Non-roster agent values` heading, naming the
-   roster set it should have been drawn from.
-
-`{agent}` in `squad:{agent}` is a roster-set value lowercased — never anything
-else.
+1. Run Team Guard Step TG-2; its `ROSTER_MEMBER:` lines are the **certified roster
+   set** — the only valid source for a `squad:{agent}` label this run. Do not re-read
+   team.md or recall a name.
+2. If TG-2 emitted a `ROSTER_UNREADABLE:` line, STOP: report that named reason in the
+   activation summary and mint no `squad:{agent}` label. Never print a roster-provenance
+   sentence for a read that did not happen, and never fall back to a preset or
+   remembered roster.
+3. Reproduce the certified `ROSTER_MEMBER:` lines verbatim in the summary as the
+   provenance of the labels applied — the summary may name only values TG-2 emitted.
+4. For every `Agent` value, mint `squad:{agent}` only when its lowercased form matches
+   a certified `ROSTER_MEMBER:` name, or the value is exactly `@copilot`.
+5. A value matching no certified name and not `@copilot` MUST NOT become a
+   `squad:{agent}` label: apply only `squad` for that issue and record the value under a
+   `Non-roster agent values` heading, naming the certified set it should come from.
+6. Completeness: when the plan names at least one roster `Agent`, at least one
+   `squad:{agent}` label MUST be applied across the created issues. Zero labels on a
+   plan with roster owners is a binding failure, not a pass — report it, don't proceed
+   silently.
 
 Then verify labels `squad` and each roster-bound `squad:{agent}` exist. If missing, record them in the activation summary as a prerequisite gap (label creation requires `issues: write` + `create-label` safe-output — not configured in this workflow). Continue activation — `create-issue` will apply any existing labels normally; unavailable labels are omitted and reported, not silently applied.
 


### PR DESCRIPTION
Closes #1812

Working as **Procedures** (Prompt Engineer).

## The defect (measured)

On fixture `aspiregregator-squad-e2e` (run `32471509974`), `plan activate` printed a provenance sentence claiming it read the roster from `.squad/team.md` `## Members` -> `Name` column, reporting `lead, reviewer, devrel, security, docs`. The fixture's real cast is `Keaton, McManus, Fenster, Hockney, Kint`. The five reported names are exactly the `squad init --preset default` scaffold. Two defects: (1) activate bound the hardcoded preset roster, not the committed cast; (2) it claimed a provenance it did not have. Downstream, activate matched the planner's real names against the hardcoded list, found none, and applied **no** `squad:{agent}` label — so #1784 Condition 2 "passed" only because activate refused everything. **Refusal and correct binding are indistinguishable from the outside.**

## The fix (structural, not prose)

Add **Team Guard Step TG-2 — Certify the Roster Set**, modeled on the existing TG-1 `TEAM_PRESENT`/`TEAM_ABSENT` guard. It:
- reads **committed HEAD** `.squad/team.md` (`git show HEAD:` — working-tree preset scaffolds are invisible),
- finds the `## Members` `Name` column **by header** (not position — a `| Role | Name |` table would otherwise leak the Role column with a true-looking citation),
- emits one lowercased `ROSTER_MEMBER: {name}` per data row, or a single `ROSTER_UNREADABLE: {reason}`.

Every minting/binding site (accept `squad:{owner}`, activate label pre-flight `squad:{agent}`, plan/impl binders, Check 10) binds **only** to TG-2's stdout. The summary can only reproduce names the command produced, so **provenance is true by construction**. `ROSTER_UNREADABLE:` halts binding with the named reason — never a preset fallback, never a provenance sentence for a read that did not happen.

Prose was chosen against deliberately: the file was already hardened with bold, repeated roster prose and the defect happened anyway. TG-2's stdout is an observable artifact a test can assert; a directive's compliance cannot be observed.

## What I measured

- **New test** `test/gh-aw-activate-roster-binding.test.ts` (10 tests) extracts the TG-2 bash block and runs it against real committed-HEAD git repos. All green. Full gh-aw family: **172 passed / 13 skipped** across 5 suites.
- **Mutation evidence** (each mutation applied, suite run, offending case confirmed red naming the input, then restored):
  - **M1** drop `tolower` -> lowercase cases red, naming `ROSTER_MEMBER: Keaton`.
  - **M2** pin column to position 2 -> header-order case red, naming leaked `ROSTER_MEMBER: lead`/`reviewer` (the exact #1812 anti-pattern).
  - **M3** drop `__NOCOL__` sentinel -> no-Name-column case red (misdiagnosed reason).
  - **M4** `git show HEAD:` -> `cat` -> preset-leak case red, naming the working-tree `ROSTER_MEMBER: lead/reviewer/devrel/security/docs`; also reddens the static `git show HEAD` guard.
  - **M5/M6/M7** replace absent / no-section / no-rows `ROSTER_UNREADABLE` with a spurious `ROSTER_MEMBER: ghost` -> each respective case red naming `ghost`.
- **Caller enumeration:** every `squad:{...}` and roster site across `workflows/` grepped. All minting/binding sites bind to TG-2. The two other roster consumers — `squad-implement-worker.md` (routes by an already-certified label) and `shared/squad.md` (#1657 `squad init` existence guard) — derive no roster and do not share the defect. No compiled `.lock.yml` artifacts are committed, so nothing needs regeneration.
- **Prose removal:** every compressed block checked against `test/gh-aw-*`; all pinned substrings survive (verified by the green plan-lifecycle + quality suites). No load-bearing prose dropped.

## What I could NOT measure (named boundaries)

- **CR-strip (M8):** removing the extraction's `sub(/\r$/,"")` **could not be reddened** on the Windows git-bash test host — `git show` emits LF there (CR normalized before awk), and a trailing pipe quarantines any CR into an unread field. The strip is retained as defense-in-depth (load-bearing on Linux runners for irregular tables); its behavior is reasoned for Linux, not measured on Windows. The CRLF test was rewritten to assert the end-to-end parse invariant (reddenable by M1/M4) rather than claim to prove the strip.
- **Machine-checked postcondition `applied_labels ⊆ emitted_roster_members`:** **not reachable** under gh-aw safe-outputs — labels are applied by a separate executor job, and TG-2's stdout is not promotable to a cross-job artifact. Emission is shell-enforced/assertable; consumption stays a prompt directive (the good kind of unenforced — it labels itself). The `≥1 label applied` completeness rule remains the guard that stops "refused everything" from masquerading as "bound correctly".

## Files

- `workflows/squad.md` — TG-2 block + rewired binders (net +80/-61; byte budget passes, 87B margin above floor).
- `test/gh-aw-activate-roster-binding.test.ts` — new suite (10 tests).
- `.squad/decisions/inbox/procedures-1812-activate-roster-binding.md` — decision record (Scribe merges).

No `packages/*/src/` touched — no changeset required.
