### PR TITLE
fix(gh-aw): scan the first non-empty line in PC-0, not record 1 (#1835)

### DIFF
--- a/test/gh-aw-command-parse.test.ts
+++ b/test/gh-aw-command-parse.test.ts
@@ -197,6 +197,49 @@ describe('gh-aw: /squad command parsing (#1824)', () => {
       expect(normalize('')).not.toBe('NO_COMMAND');
     });
 
+    // #1835: PC-0 anchored on NR==1, so a value whose first character is a
+    // newline put an EMPTY string on the scanned record and a structurally
+    // valid command halted silently. Silent-loss-of-a-valid-command is the
+    // defect class #1824 and #1832 exist to close, so it is closed here too.
+    describe('leading blank lines are skipped, not read as an empty command (#1835)', () => {
+      const leading: Array<{ input: string; expected: string }> = [
+        { input: '\nimplement', expected: 'implement' },
+        { input: '\n\n\ncast', expected: 'cast' },
+        { input: '\n  connect org/repo  ', expected: 'connect org/repo' },
+        { input: '\n/squad status', expected: 'status' },
+      ];
+
+      it.each(leading)('dispatching $input reaches its mode', ({ input, expected }) => {
+        expect(
+          normalize(input),
+          `PC-0 must skip leading blank lines and normalize ${JSON.stringify(input)} ` +
+            `to "/squad ${expected}". Scanning only record 1 reads the leading newline ` +
+            'as an empty command and emits EMPTY_DISPATCH, halting a valid dispatch ' +
+            'silently via the activation guard.'
+        ).toBe(`/squad ${expected}`);
+
+        expect(
+          parseDispatch(input),
+          `The full dispatch path (PC-0 then PC-1) must resolve ${JSON.stringify(input)} ` +
+            `to ${JSON.stringify(expected)}.`
+        ).toBe(expected);
+      });
+
+      it.each(['', '   ', '\n', '\n\n', ' \n \t \n '])(
+        'genuinely empty input %j still yields EMPTY_DISPATCH',
+        blank => {
+          // The fix must not overshoot: whitespace-only input carries no command,
+          // so it must still reach the silent activation-guard halt rather than
+          // being normalized into a bogus "/squad " with an empty argument.
+          expect(
+            normalize(blank),
+            `${JSON.stringify(blank)} carries no command, so PC-0 must still yield ` +
+              'EMPTY_DISPATCH for the silent activation-guard halt (PR #1777).'
+          ).toBe('EMPTY_DISPATCH');
+        }
+      );
+    });
+
     it('PC-1 is NOT loosened — a bare token still fails on the comment path', () => {
       // The tempting wrong fix is to teach PC-1 to accept bare words. That reopens
       // #1824: prose merely containing "cast" would silently mint a team. The

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -312,12 +312,12 @@ command** to `SQUAD_DISPATCH_COMMAND` per hop 1 and run exactly this. Its output
 is the `SQUAD_TRIGGER_BODY` PC-1 consumes:
 
 ```bash
-printf '%s\n' "$SQUAD_DISPATCH_COMMAND" | awk 'NR==1{sub(/\r$/,""); sub(/^[[:space:]]+/,""); sub(/[[:space:]]+$/,""); if($0==""){print "EMPTY_DISPATCH"; exit} if($0 ~ /^\/squad([[:space:]]|$)/) print; else print "/squad " $0}'
+printf '%s\n' "$SQUAD_DISPATCH_COMMAND" | awk '{sub(/\r$/,"");sub(/^[[:space:]]+/,"");sub(/[[:space:]]+$/,"");if($0=="")next;f=1;if($0~/^\/squad([[:space:]]|$)/)print;else print "/squad " $0;exit}END{if(!f)print "EMPTY_DISPATCH"}'
 ```
 
 Normalization is idempotent: `implement` and `/squad implement` both yield
 `/squad implement`, so typing the slash prefix into the dispatch box is not
-penalized.
+penalized. It scans the first non-empty line (#1835).
 
 `EMPTY_DISPATCH` means the activation guard above should already have halted the
 run. Halt with that guard's `::warning::`; never route it to PC-3, which posts a


### PR DESCRIPTION
Closes #1835

## What

PC-0 normalized the dispatched command with an `awk` program gated on `NR==1`. A value whose first character is a newline puts an **empty string** on that record, so:

```
PC0($'\nimplement')  →  EMPTY_DISPATCH
```

`EMPTY_DISPATCH` routes to the activation guard, which halts with a `::warning::` and **no comment** by design (PR #1777, junk issues #12/#14). A structurally valid `implement` dispatch therefore halted **silently** instead of running — the same silent-loss-of-a-valid-command class that #1824 and #1832 exist to close.

## Fix

Scan the **first non-empty line** rather than record 1: skip blank records, take the first one carrying content, and fall through to `EMPTY_DISPATCH` via `END` only when every record was empty or whitespace-only. Genuinely empty input still reaches the silent activation-guard halt, so #1777 stays closed.

PC-1 is untouched. The asymmetry is deliberate — on the comment path a missing `/squad` token *is* the error condition, and loosening it would reopen #1824.

## Acceptance (from the issue)

| # | Criterion | Status |
|---|---|---|
| 1 | `PC0($'\nimplement')` yields `/squad implement` | ✅ |
| 2 | `PC0('')` and `PC0('   ')` still yield `EMPTY_DISPATCH` | ✅ |
| 3 | Reverting the fix turns the new test red, failure text names the input | ✅ |
| 4 | Existing PC-0 cases green, PC-1 cases untouched | ✅ |

## Mutation proof

Reverting the `awk` to `NR==1` turns four new cases red, each naming the offending input:

```
× dispatching '\nimplement' reaches its mode
× dispatching '\n\n\ncast' reaches its mode
× dispatching '\n  connect org/repo  ' reaches its mode
× dispatching '\n/squad status' reaches its mode

AssertionError: PC-0 must skip leading blank lines and normalize "\nimplement"
to "/squad implement". Scanning only record 1 reads the leading newline as an
empty command and emits EMPTY_DISPATCH, halting a valid dispatch silently via
the activation guard.: expected 'EMPTY_DISPATCH' to be '/squad implement'
```

A status-only assertion would pass a truncating parser; these name the input, per the standing bar. Whitespace-only cases (`''`, `'   '`, `'\n'`, `'\n\n'`, `' \n \t \n '`) pin `EMPTY_DISPATCH` so the fix cannot overshoot.

Tests: **27 → 36** in `gh-aw-command-parse`. `gh-aw-quality` stays green.

## ⚠️ Reviewer note — prompt budget is nearly exhausted

The `awk` one-liner is written **without inter-statement spaces deliberately**, and the explanatory paragraph I first wrote was removed. Both overran `gh-aw-quality`'s `reports combined bytes and headroom` gate.

`workflows/squad.md` on `dev` sits **~37 bytes** above the 5 KB floor of the 100 KB prompt ceiling. This PR leaves **~65 bytes**. Readable spacing in that one line cost ~18 bytes; a five-line prose note cost ~430.

**The next change to `workflows/squad.md` will fail CI on byte count regardless of its merit.** That needs its own issue — I did not file one as part of this PR.

## Scope

`workflows/squad.md` + `test/gh-aw-command-parse.test.ts`. No `packages/*/src/` changes, so no changeset required.