### PR TITLE
docs: document .local-backup customization backups in squad upgrade

### DIFF
--- a/docs/src/content/docs/features/self-upgrade.md
+++ b/docs/src/content/docs/features/self-upgrade.md
@@ -121,6 +121,32 @@ squad upgrade --self --skip-repo-upgrade
 
 *(This flag may not exist yet — just showing the pattern. For now, self-upgrade always runs repo upgrade.)*
 
+### Your Customizations Are Backed Up
+
+`squad upgrade` overwrites Squad-owned files with the latest templates. Before it overwrites a file you've edited locally, it saves your version alongside it as `<file>.local-backup` and prints a warning.
+
+This covers `.github/agents/squad.agent.md` and the Squad-managed workflow files in `.github/workflows/`.
+
+```text
+⚠  squad.agent.md has local customizations — backed up to squad.agent.md.local-backup
+   To restore: copy squad.agent.md.local-backup → squad.agent.md
+⚠  squad-ci.yml has local customizations — backed up to squad-ci.yml.local-backup
+```
+
+To restore your version, copy the backup back over the refreshed file:
+
+```bash
+cp .github/agents/squad.agent.md.local-backup .github/agents/squad.agent.md
+```
+
+Three things worth knowing:
+
+- **Version stamps don't count as customizations.** The `<!-- squad-cli vX.Y.Z -->` line in `squad.agent.md` changes on every release, so it's stripped before comparing. A file that differs only by its version stamp is refreshed silently, with no backup.
+- **Only the most recent backup is kept.** Backups are written to a fixed path, so re-customizing a file and upgrading again overwrites the previous `.local-backup`. Move anything you want to keep somewhere safe before your next upgrade.
+- **Backups aren't gitignored.** They show up as untracked files in `git status`. Delete them once you've merged back what you need.
+
+`squad upgrade --dry-run` previews the upgrade and will tell you if `squad.agent.md` would be backed up. It stops short of the workflow files, so it won't flag customized workflows — check those yourself before upgrading if you've edited them.
+
 ---
 
 ## Permission Errors

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -39,7 +39,7 @@ squad init
 | `squad start [--tunnel] [--port N] [--command cmd]` | Start Copilot with remote phone access via PTY and WebSocket | No |
 | `squad status` | Show which squad is active and why | Yes |
 | `squad doctor` | Validate squad setup integrity and diagnose issues (alias: `heartbeat`) | Yes |
-| `squad upgrade` | Upgrade Squad-owned files to latest version | Yes |
+| `squad upgrade` | Upgrade Squad-owned files to latest version; locally customized files are saved as `<file>.local-backup` | Yes |
 | `squad upgrade --state-backend <type>` | Migrate state backend (`orphan`, `two-layer`); installs git hooks automatically | Yes |
 | `squad upgrade --migrate-directory` | Rename legacy `.ai-team/` directory to `.squad/` | Yes |
 | `squad triage` | Auto-triage issues and assign to team (primary name; `watch` is an alias) | Yes |


### PR DESCRIPTION
## Why

Follow-up from this morning's PR triage sweep. I audited the 16 merged PRs for doc drift; most were clean, but one real gap surfaced.

`squad upgrade` backs up locally customized Squad-owned files to `<file>.local-backup` before overwriting them — and **#1709** (merged this morning) extended that behavior to workflow files. That behavior was only ever recorded in `.squad/decisions.md`. It appeared nowhere in user-facing docs, so a user who customized `squad.agent.md` or a Squad-managed workflow would see their file silently replaced and have no documented way to know a backup existed.

## What changed

**`docs/src/content/docs/features/self-upgrade.md`** — new *Your Customizations Are Backed Up* subsection under *Auto-Refresh Repo Templates*:

- Which files are covered — `.github/agents/squad.agent.md` and the Squad-managed workflows
- Sample warning output and how to restore from a backup
- Version stamps are stripped before comparison, so a version-line-only diff isn't treated as a customization (`upgrade.ts:250-253`)
- Only the most recent backup is kept — the path is fixed, so re-customizing and upgrading again overwrites it (`upgrade.ts:261`, `:473`)
- Backups aren't gitignored, so they linger as untracked files
- `--dry-run` previews the `squad.agent.md` backup only — it returns at `upgrade.ts:1137`, before `writeWorkflowFile` runs, so customized workflows are **not** flagged

**`docs/src/content/docs/reference/cli.md`** — one-line cross-reference on the `squad upgrade` row for discoverability.

## Verification

Every claim was traced to source rather than inferred:

| Claim | Source |
|---|---|
| `--dry-run` is a real flag | `cli-entry.ts:413` |
| Version stamp stripped before compare | `upgrade.ts:250-253` |
| Agent backup prints restore instructions | `upgrade.ts:262-263` |
| Workflow backup warns only, no restore line | `upgrade.ts:474` |
| Dry-run returns before workflow files | `upgrade.ts:1137` |
| `.local-backup` not in `.gitignore` | `git grep` — no match |

I initially wrote that `--dry-run` shows *all* files that would be backed up, then found the early return at `:1137` and corrected it. The doc now says what the code actually does.

## Follow-up worth considering (not in this PR)

`*.local-backup` isn't in `.gitignore`, and `ensureGitignore()` in `upgrade.ts` doesn't add it. Since backups land in `.github/workflows/`, a careless `git add -A` would commit them. Adding the entry is a one-liner in product source — it needs a changeset and is out of scope for a docs PR, so I've documented the sharp edge instead. Happy to open a separate issue if you want it fixed.

## Notes

- Docs-only — no changeset required (`changelog-gate` only applies to `packages/*/src/`)
- Also leaves the pre-existing stale parenthetical at line 122 about `--skip-repo-upgrade` untouched — out of scope, but flagging it since it admits the flag may not exist