### PR TITLE
fix(test): budget the delivered prompt, not authored source

### DIFF
--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -615,9 +615,28 @@ describe('gh-aw: prompt budget & planning import regression', () => {
   const imports = extractImports(frontmatter);
   const squadContent = readText(SQUAD_WORKFLOW);
 
-  // gh-aw enforces a hard 100 KB prompt ceiling (102 400 bytes)
-  const GH_AW_PROMPT_CEILING_KB = 100;
-  const GH_AW_PROMPT_CEILING_BYTES = GH_AW_PROMPT_CEILING_KB * 1024;
+  // There is no hard gh-aw prompt ceiling, and this block used to assert one (#1842).
+  //
+  // The 102 400 figure previously cited here as "gh-aw enforces a hard 100 KB prompt
+  // ceiling" is `defaultRepoMemoryMaxFileSize` in gh-aw's pkg/workflow/repo_memory.go —
+  // a cap on repo-MEMORY files, unrelated to prompts. gh-aw's own guidance
+  // (.github/aw/token-optimization.md) treats prompt size as a cost/quality concern
+  // ("strip redundant instructions"), never as a byte limit.
+  //
+  // It also measured the wrong quantity. What reaches the model is the AMBIENT prompt:
+  // gh-aw strips every inline `## skill:` block during the setup/interpolation step
+  // (.github/aw/skills.md), and ~2/3 of this workflow plus two entire imports are such
+  // blocks. Summing raw source therefore counted ~65 KB that never enters the initial
+  // request, while ignoring the boilerplate gh-aw injects (xpia.md, markdown.md,
+  // safe_outputs_*.md). Both sides of the comparison were wrong, which left the gate
+  // reporting ~26 bytes of headroom and failing correct changes on byte count alone.
+  //
+  // The real budget is asserted canonically in "gh-aw: inline skill extraction" →
+  // "keeps the ambient prompt under 40 KB". The check below is only a source-GROWTH
+  // regression guard: it keeps unbounded authoring growth visible without pretending
+  // authored bytes are delivered bytes.
+  const SOURCE_GROWTH_BUDGET_KB = 160;
+  const SOURCE_GROWTH_BUDGET_BYTES = SOURCE_GROWTH_BUDGET_KB * 1024;
 
   it('squad-planning-ontology.md is in the imports list', () => {
     expect(imports, 'shared/squad-planning-ontology.md must be imported').toContain('shared/squad-planning-ontology.md');
@@ -634,7 +653,7 @@ describe('gh-aw: prompt budget & planning import regression', () => {
     ).not.toMatch(/cat .github\/workflows\/shared\/[\w-]*planning-[\w-]+\.md/);
   });
 
-  it(`combined prompt (workflow + all imports) is under ${GH_AW_PROMPT_CEILING_KB} KB`, () => {
+  it(`combined source (workflow + all imports) stays under ${SOURCE_GROWTH_BUDGET_KB} KB`, () => {
     let totalBytes = Buffer.byteLength(squadContent, 'utf8');
 
     for (const importPath of imports) {
@@ -646,26 +665,14 @@ describe('gh-aw: prompt budget & planning import regression', () => {
     }
 
     const totalKB = (totalBytes / 1024).toFixed(1);
-    const headroomKB = ((GH_AW_PROMPT_CEILING_BYTES - totalBytes) / 1024).toFixed(1);
 
     expect(
       totalBytes,
-      `Combined prompt is ${totalKB} KB — exceeds the gh-aw ${GH_AW_PROMPT_CEILING_KB} KB ceiling. Headroom: ${headroomKB} KB.`
-    ).toBeLessThan(GH_AW_PROMPT_CEILING_BYTES);
-  });
-
-  it('reports combined bytes and headroom', () => {
-    let totalBytes = Buffer.byteLength(squadContent, 'utf8');
-    for (const importPath of imports) {
-      const fullPath = join(WORKFLOWS_DIR, importPath);
-      if (existsSync(fullPath)) totalBytes += Buffer.byteLength(readText(fullPath), 'utf8');
-    }
-    const headroomBytes = GH_AW_PROMPT_CEILING_BYTES - totalBytes;
-    // Informational — log bytes/headroom; fail only if headroom < 5 KB (regression guard)
-    expect(
-      headroomBytes,
-      `Headroom too low: ${(headroomBytes / 1024).toFixed(1)} KB remaining of ${GH_AW_PROMPT_CEILING_KB} KB ceiling`
-    ).toBeGreaterThan(5 * 1024);
+      `Combined authored source is ${totalKB} KB, over the ${SOURCE_GROWTH_BUDGET_KB} KB growth guard. ` +
+        `This is NOT a gh-aw limit — it flags unbounded growth of the workflow and its imports. ` +
+        `Check "keeps the ambient prompt under 40 KB" first: if ambient is healthy, the growth is ` +
+        `in inline skills (loaded on demand) and raising this guard is legitimate.`
+    ).toBeLessThan(SOURCE_GROWTH_BUDGET_BYTES);
   });
 });
 


### PR DESCRIPTION
Closes #1842

## The bug

The prompt-budget gate in `test/gh-aw-quality.test.ts` asserted a gh-aw prompt ceiling that **does not exist**, and measured a quantity gh-aw **never sends**. Both sides of the comparison were wrong, which left it reporting **~26 bytes of headroom** and failing correct changes on byte count alone.

### 1. The ceiling is misattributed

The comment claimed *"gh-aw enforces a hard 100 KB prompt ceiling (102 400 bytes)"*. Verified against gh-aw:

- `102400` is `defaultRepoMemoryMaxFileSize` in `github/gh-aw` → `pkg/workflow/repo_memory.go` — *"the default maximum file size in bytes (100KB)"* for **repo-memory files**. Unrelated to prompts.
- `.github/aw/workflow-constraints.md` never mentions a prompt ceiling.
- `.github/aw/token-optimization.md` treats prompt size purely as cost/quality (*"Strip redundant instructions, examples, and pleasantries from the prompt body"*), never as a byte limit.

### 2. It measured source, not the prompt

gh-aw strips every inline `` ## skill: `` block during the setup/interpolation step — per gh-aw `.github/aw/skills.md`:

> Extraction runs in the setup/interpolation step (not at compile time): gh-aw writes each block to engine-specific skill locations and **removes it from the main prompt body**.

Measured composition of what the gate was summing:

| | bytes |
|---|---:|
| What the test measured (raw source sum) | **97,254** |
| What actually enters initial context (ambient) | **31,855** |
| Extracted to on-demand skills | **65,398 (67%)** |

`shared/squad-planning-ontology.md` (16,420 B) and `shared/squad-planning-policy.md` (4,538 B) are **entirely** skill blocks — they start with `## skill:` on line 1 and are fully extracted. `workflows/squad.md` is 69,608 B of which only ~25,167 B is prompt body; 21 skill blocks begin at L540.

### 3. It ignored what gh-aw *does* inject

Compiling for real (`gh aw compile .github/workflows/squad.md --strict`, exit 0) shows `GH_AW_PROMPT_CONFIG` carrying ~17 prompt items, including eight gh-aw boilerplate files the test counts at zero: `xpia.md`, `temp_folder_prompt.md`, `markdown.md`, `safe_outputs_prompt.md`, `safe_outputs_create_pull_request.md`, `mcp_cli_tools_prompt.md`, `cli_proxy_with_safeoutputs_prompt.md`, `pr_context_prompt.md`. The lock also defers our four files via `{{#runtime-import}}` (`GH_AW_PROMPT_CONTENT_0005–0008`), confirming they are assembled at runtime rather than inlined at compile time.

## The fix

**The correct budget already existed in this file.** The `gh-aw: inline skill extraction` suite runs a faithful mirror of gh-aw's extractor (`extractInlineSkills`, itself modeled on `setup/js/extract_inline_skills.cjs`) and asserts `keeps the ambient prompt under 40 KB` against post-extraction ambient bytes. That is the real gate, and it passes at ~31.8 KB.

So this change does not add a second budget — it stops the redundant one from lying:

- Removed the fabricated `GH_AW_PROMPT_CEILING_KB` / `102400` constant and the false comment.
- Collapsed the two byte assertions into a single **source-growth guard** at 160 KB, explicitly documented as *not* a gh-aw limit, whose failure message points the reader at the ambient check first.
- Kept `readText()`'s CRLF normalization — it is why this math is platform-independent (`.gitattributes` pins `eol=lf` for many types but **not** `*.md`, so Windows worktrees would otherwise read +2,093 bytes).

## Impact

Real headroom is **~70 KB, not 26 bytes**. This unblocks #1801, #1780, #1730, #1757, and #1608, none of which needed to compact shell one-liners or delete rationale to buy bytes.

It also changes #1834: the shell-input security contract (`workflows/squad.md` L245–299, 2,695 B) can move into a `` ## skill: `` block rather than being deleted for budget reasons. #1834 is no longer a prerequisite for this issue.

## Validation

```
npx vitest run test/gh-aw-quality.test.ts
Tests  91 passed | 13 skipped (104)
```

The 13 skips are pre-existing and tracked in #1833 (`HAS_POSIX_SHELL` gating at L30 skips two `describe` blocks on Windows).

Test-only change — no `packages/*/src/` touched, so no changeset required.