### PR TITLE
fix(sdk): refuse consult when info/exclude resolves outside the project

### DIFF
--- a/.changeset/lucky-moons-shake.md
+++ b/.changeset/lucky-moons-shake.md
@@ -1,0 +1,19 @@
+---
+'@bradygaster/squad-sdk': patch
+---
+
+Refuse consult mode when git's `info/exclude` resolves outside the project
+
+`setupConsultMode` hides `.squad/` by appending to git's `info/exclude`, but resolved that
+path with `git rev-parse --git-path info/exclude`, which answers for whichever repository
+*encloses* the directory. From a linked worktree, or from a directory that is not itself a
+repository root, the write landed on another checkout's exclude file — hiding `.squad/`
+across the main checkout and every sibling worktree. Because `info/exclude` is untracked
+and per-clone, nothing in the repo could undo it.
+
+`setupConsultMode` now verifies the exclude belongs to a repository rooted at
+`projectRoot` and refuses otherwise, pointing the caller at the main checkout. A new
+`isExcludeOwnedBy()` export performs that containment check.
+
+Writing to a worktree-local exclude is not an alternative: git keeps no per-worktree
+`info/exclude`, and a file placed at `.git/worktrees/<id>/info/exclude` is never read.

--- a/packages/squad-sdk/src/sharing/consult.ts
+++ b/packages/squad-sdk/src/sharing/consult.ts
@@ -320,7 +320,19 @@ export function getPersonalSquadRoot(): string {
 }
 
 /**
- * Resolve the git exclude path using git rev-parse (handles worktrees/submodules).
+ * Resolve the exclude file git actually reads for `cwd`.
+ *
+ * NOTE: this does not scope the answer to `cwd`. `git rev-parse` answers for whichever
+ * repository *encloses* `cwd`, and `info/exclude` is a shared path, so:
+ *
+ *   - from a linked worktree it returns the MAIN checkout's exclude (git keeps no
+ *     per-worktree exclude — a file written to `.git/worktrees/<id>/info/exclude` is
+ *     never read), and
+ *   - from a directory that is not itself a repo root it returns the exclude of some
+ *     ANCESTOR repository.
+ *
+ * In both cases a write here lands outside `cwd` and is invisible from it. Callers that
+ * intend to affect only `cwd` must check containment first — see `isExcludeOwnedBy`.
  *
  * @param cwd - Working directory inside the git repo
  * @throws Error if not a git repository
@@ -334,6 +346,30 @@ export function resolveGitExcludePath(cwd: string): string {
   } catch {
     throw new Error('Not a git repository. Consult mode requires git.');
   }
+}
+
+/**
+ * Whether the exclude file git reads for `projectRoot` belongs to a repository rooted
+ * AT `projectRoot`, rather than to a main checkout or an ancestor repository.
+ *
+ * Returns false for a linked worktree (common dir lives in the main checkout) and for a
+ * directory that merely sits inside some outer repository. Both are cases where writing
+ * to the exclude silently affects checkouts other than `projectRoot`.
+ */
+export function isExcludeOwnedBy(projectRoot: string): boolean {
+  let commonDir: string;
+  try {
+    const raw = execSync('git rev-parse --git-common-dir', {
+      cwd: projectRoot,
+      encoding: 'utf-8',
+    }).trim();
+    commonDir = path.resolve(projectRoot, raw);
+  } catch {
+    return false;
+  }
+
+  const rel = path.relative(path.resolve(projectRoot), commonDir);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
 }
 
 /**
@@ -364,7 +400,24 @@ export async function setupConsultMode(
     throw new Error('Not a git repository. Consult mode requires git.');
   }
 
-  // Resolve exclude path via git rev-parse (handles worktrees/submodules)
+  // Resolve exclude path via git rev-parse, then confirm it belongs to THIS project.
+  //
+  // Consult mode hides `.squad/` by appending to git's info/exclude. That file is shared
+  // per-repository, so if the resolved path belongs to a main checkout or an ancestor
+  // repo, the write hides `.squad/` in checkouts the caller never named — where it may be
+  // real, tracked state. info/exclude is untracked and per-clone, so nothing in the repo
+  // can undo it afterwards. Refuse instead of poisoning. (#1826, root cause of #1817)
+  if (!isExcludeOwnedBy(projectRoot)) {
+    throw new Error(
+      `Refusing to enable consult mode: ${projectRoot} is not the root of its own git repository.\n` +
+        `It is either a linked worktree or a directory inside an outer repository, so git's ` +
+        `info/exclude resolves outside it.\n` +
+        `Consult mode would hide .squad/ across the main checkout and every sibling worktree, ` +
+        `and info/exclude is untracked so the change could not be reverted from the repo.\n` +
+        `Run 'squad consult' from the main checkout instead.`,
+    );
+  }
+
   // Normalize to absolute path in case it's relative
   const gitExclude = (() => {
     const excludePath = resolveGitExcludePath(projectRoot);

--- a/test/sdk/consult.test.ts
+++ b/test/sdk/consult.test.ts
@@ -6,8 +6,9 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative, isAbsolute } from 'node:path';
 import { randomBytes } from 'node:crypto';
+import { execSync } from 'node:child_process';
 
 import {
   detectLicense,
@@ -420,8 +421,16 @@ describe('setupConsultMode', () => {
   const PERSONAL_SQUAD = join(SETUP_ROOT, 'personal-squad');
 
   beforeEach(() => {
-    // Create fake project with git
-    mkdirSync(join(PROJECT_ROOT, '.git', 'info'), { recursive: true });
+    // A REAL, isolated repo — not a hand-made `.git` directory.
+    //
+    // A fabricated `.git/` is not a valid repository, so `git rev-parse` walked out of the
+    // fixture and answered for the enclosing squad checkout. Every run of these tests then
+    // appended the consult block to the developer's own .git/info/exclude, hiding .squad/
+    // in their working clone. That is the poisoning in #1817/#1826 (240 B template + 73 B
+    // block = the 313 B observed there), and CI never showed it because CI clones are
+    // discarded. `git init` keeps the write inside the fixture. (#1826)
+    mkdirSync(PROJECT_ROOT, { recursive: true });
+    execSync('git init --quiet', { cwd: PROJECT_ROOT, stdio: 'ignore' });
     // Create fake personal squad
     mkdirSync(PERSONAL_SQUAD, { recursive: true });
   });
@@ -575,6 +584,58 @@ describe('setupConsultMode', () => {
 
     expect(result.dryRun).toBe(true);
     expect(existsSync(join(PROJECT_ROOT, '.squad'))).toBe(false);
+  });
+
+  // --- exclude containment (#1826, root cause of #1817) ---------------------
+  //
+  // info/exclude is shared per-repository and untracked. If the path git resolves
+  // belongs to a main checkout or an outer repo, the write hides .squad/ in checkouts
+  // the caller never named, and nothing in the repo can undo it.
+
+  it('writes the exclude inside the project, never to an enclosing repo', async () => {
+    const result = await setupConsultMode({
+      projectRoot: PROJECT_ROOT,
+      personalSquadRoot: PERSONAL_SQUAD,
+    });
+
+    const rel = relative(PROJECT_ROOT, result.gitExclude);
+    expect(
+      rel.startsWith('..') || isAbsolute(rel),
+      `consult wrote to ${result.gitExclude}, outside ${PROJECT_ROOT}. ` +
+        `That is a different repository's exclude file.`,
+    ).toBe(false);
+  });
+
+  it('refuses when the project is a directory inside an outer repository', async () => {
+    // A fabricated `.git/` — byte-for-byte the shape the old fixture created. It satisfies
+    // the "is there a .git here" check but is not a valid repository, so `git rev-parse`
+    // walks up and answers for the enclosing repo. This is the exact route by which this
+    // suite used to write into the developer's own checkout.
+    const nested = join(SETUP_ROOT, 'not-a-repo');
+    mkdirSync(join(nested, '.git', 'info'), { recursive: true });
+
+    await expect(
+      setupConsultMode({ projectRoot: nested, personalSquadRoot: PERSONAL_SQUAD }),
+    ).rejects.toThrow(/not the root of its own git repository/);
+  });
+
+  it('refuses from a linked worktree, whose exclude lives in the main checkout', async () => {
+    // git keeps no per-worktree info/exclude: a file written under
+    // .git/worktrees/<id>/info/exclude is never read. So there is no worktree-local
+    // place to put this, and the only safe action is to refuse.
+    execSync('git -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m init', {
+      cwd: PROJECT_ROOT,
+      stdio: 'ignore',
+    });
+    const linked = join(SETUP_ROOT, 'linked-wt');
+    execSync(`git worktree add --quiet --detach "${linked}"`, {
+      cwd: PROJECT_ROOT,
+      stdio: 'ignore',
+    });
+
+    await expect(
+      setupConsultMode({ projectRoot: linked, personalSquadRoot: PERSONAL_SQUAD }),
+    ).rejects.toThrow(/not the root of its own git repository/);
   });
 });
 


### PR DESCRIPTION
Closes #1826

## Summary

`setupConsultMode` hides `.squad/` by appending to git's `info/exclude`, but resolved that path with `git rev-parse --git-path info/exclude` — which answers for whichever repository **encloses** the directory, not one rooted at it. The "already squadified -> refuse" guard checked the **worktree-local** `.squad/`. The check was local; the write was global.

Two ways the write escapes:

- from a **linked worktree**, `info/exclude` resolves to the **main checkout**;
- from a directory that is **not itself a repo root**, it resolves to an **ancestor repository**.

Either way `.squad/` is hidden in checkouts the caller never named. Since `info/exclude` is untracked and per-clone, no repo-side change can repair it — which is why `.squad/e2e/` was invisible despite being absent from `.gitignore`, and why `git add -f` was needed for #1819-#1821.

## The route was not unprovable — this test suite was doing it

#1826 recorded the worktree route as *"unproven and now unprovable."* It turns out a **different** route was live in the repo, and it is reproducible on demand.

The fixture built a fabricated `.git/` directory:

```ts
mkdirSync(join(PROJECT_ROOT, '.git', 'info'), { recursive: true });
```

That satisfies the "is there a `.git` here" check but is **not a valid repository**, so `git rev-parse` walked out of the fixture and answered for the enclosing squad checkout. Every run of these tests appended the consult block to the developer's own `.git/info/exclude`.

Measured directly on my clone:

```
BEFORE: 240        # pristine git template
npx vitest run test/sdk/consult.test.ts -t "setupConsultMode"
Tests  11 passed | 41 skipped (52)
AFTER:  313        # +73 B consult block
```

**240 + 73 = 313** — byte-identical to the forensic math in #1826, which measured the live poisoned file at exactly 313 B. CI never surfaced it because CI clones are discarded, precisely as the issue predicted.

After this change, the same measurement holds steady across all five consult-adjacent suites (122 tests):

```
BEFORE: 241
AFTER:  241
```

## One of the issue's two suggested fixes is not available

#1826 offered: *"refuse ... **or** write to a worktree-local exclude."*

The second option does not work. Git keeps **no per-worktree `info/exclude`** — a file placed at `.git/worktrees/<id>/info/exclude` is simply never read. Verified directly:

```
git-dir:        C:/src/squad/.git/worktrees/bradygaster-shiny-chainsaw
git-common-dir: C:/src/squad/.git
--git-path:     C:/src/squad/.git/info/exclude     # <- the shared one

# planted ZZZ-probe-local.txt in the worktree-local info/exclude:
check-ignore result: ''                            # <- not honored
```

Taking that option would have produced a quieter bug: consult mode silently failing to hide `.squad/`, leaving it exposed to accidental commits. **Refusing is the only safe behaviour**, so that is what this implements.

## Change

- **`isExcludeOwnedBy(projectRoot)`** (new export) — verifies the git common dir is contained by `projectRoot`. One check covers all three cases: normal repo passes; linked worktree fails; nested-in-ancestor fails.
- **`setupConsultMode`** refuses before any mutation, with a message naming the cause and directing the caller to the main checkout.
- **`resolveGitExcludePath` docstring corrected.** It claimed to handle "worktrees/submodules" — the inverse of what it does. That claim is the proximate cause of this defect and is now documented as a hazard with an explicit pointer to the containment check.
- **Fixture is hermetic** — `git init` instead of a fabricated `.git/`.
- Three regression tests: exclude is written inside the project; refuse from a linked worktree; refuse from a fabricated-`.git` directory (the exact old-fixture shape).

## Validation

```
npx vitest run test/sdk/consult.test.ts test/cli/consult.test.ts \
  test/cross-package-exports.test.ts test/state/archival.test.ts \
  test/cli/nap-archival-safety.test.ts

Test Files  5 passed (5)
     Tests  122 passed (122)
```

`npm run build` passes. Changeset included (`patch`, squad-sdk).

## Follow-ups, not in this PR

- **`.squad/identity/prd-consult-mode.md:229`** advises *"Do not hard-code `resolve(cwd, '.git/info/exclude')`. In git worktrees..."* and prescribes `git rev-parse --git-path info/exclude`. That guidance is what produced this bug. It needs correcting, but it is identity/PRD material — flagging for **Scribe** rather than editing here.
- **`squad doctor` check** — suggestion (2) in #1826, to detect and repair clones already poisoned. This PR stops new poisonings; it cannot heal existing ones. Worth its own issue.
- Anyone who has run this suite has a poisoned clone. Repair is removing the `# Squad consult mode (local only)` block from `.git/info/exclude`.

Routing note: #1826 names **EECOM** for `consult.ts` with **CAPCOM/FIDO** for the doctor check. Handled here directly because it gates the E2E re-run this morning — **EECOM should review**.
