### PR TITLE
fix(ci): lint gh-aw generated workflows instead of skipping them

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -16,3 +16,41 @@ paths:
       # SC2086 (info: quoting/word-splitting) and SC2034+ (warning: unused variables),
       # as well as all actionlint-native checks.
       - "SC2129"
+
+  # ---------------------------------------------------------------------------
+  # gh-aw generated output (#1827)
+  #
+  # These files are DO-NOT-EDIT compiler output — editing them is pointless
+  # because the next compile clobbers the change. They were previously skipped
+  # wholesale by squad-workflow-lint.yml, which meant the artifact that actually
+  # runs received no lint at all. Skipping and suppressing look similar but are
+  # not: a skip hides every future error class, while the scoped ignores below
+  # hide exactly the classes that were measured and explained.
+  #
+  # Every exemption here was verified empirically against actionlint v1.7.12 —
+  # the version this CI pins, and the current latest release — by compiling the
+  # workflow sources and linting the emitted output, rather than assumed. Each
+  # reported error fell into one of the classes below; none was a genuine defect
+  # in the generated YAML. See the PR for #1827 for the measurements.
+  #
+  # Re-check these on every actionlint upgrade. An exemption that outlives the
+  # schema gap it documents silently narrows the gate.
+  # ---------------------------------------------------------------------------
+  "**/*.lock.yml":
+    ignore:
+      # `copilot-requests: write` is a real, current Actions permission scope,
+      # emitted by GitHub's own gh-aw toolchain. actionlint's permission-scope
+      # list has not caught up, so it reports the scope as unknown.
+      - 'unknown permission scope "copilot-requests"'
+      # `concurrency.queue: max` is a newer real Actions concurrency feature that
+      # is absent from actionlint's workflow schema.
+      - 'unexpected key "queue" for "concurrency" section'
+
+  "**/agentics-maintenance.yml":
+    ignore:
+      # A `workflow_dispatch` choice input whose first option is '' — the
+      # "no operation selected" entry, matching the input's own `default: ''`.
+      # GitHub accepts it; actionlint's syntax check rejects any empty string.
+      # Emitted by gh-aw's pkg/workflow/maintenance_workflow.go, so it cannot be
+      # fixed here. Scoped to this filename so the check still applies elsewhere.
+      - "string should not be empty"

--- a/.github/workflows/squad-workflow-lint.yml
+++ b/.github/workflows/squad-workflow-lint.yml
@@ -69,49 +69,25 @@ jobs:
 
       - name: Lint .github/workflows/*.yml
         run: |
-          # Why we skip machine-generated files:
+          # Every workflow here is linted, including DO-NOT-EDIT generated output
+          # (*.lock.yml from `gh aw compile`, agentics-maintenance.yml from gh-aw's
+          # code generators).
           #
-          # actionlint v1.7.12 is the current latest release and CANNOT be upgraded to fix
-          # these; the tool simply lags GitHub's evolving feature set.  Two known gaps:
+          # These files used to be skipped wholesale via a generated-header grep,
+          # because actionlint v1.7.12 — still the latest release, so this cannot be
+          # fixed by upgrading — reports errors against them for schema gaps rather
+          # than real defects. But skipping meant the artifact that actually runs got
+          # no lint at all, so a genuine defect in generated output was indistinguishable
+          # from the expected noise.
           #
-          #   • "copilot-requests: write" — a real, current GitHub Actions permission scope
-          #     used by GitHub's own gh-aw (Agentic Workflows) toolchain.
-          #   • "concurrency.queue: max" — a newer real Actions concurrency feature.
-          #
-          # The files that trigger these errors are DO-NOT-EDIT compiler output produced by
-          # gh-aw's `gh aw compile` toolchain (*.lock.yml files) or by gh-aw's own code
-          # generators (e.g. agentics-maintenance.yml).  They carry a header identifying them
-          # as generated and are validated upstream by gh-aw's own toolchain.  Editing them
-          # is NOT acceptable — they will be clobbered on the next compile/generate cycle.
-          #
-          # Detection strategy: skip any workflow whose first 5 lines contain "automatically
-          # generated" or "DO NOT EDIT".  This is header-based rather than filename-based so
-          # it automatically covers future gh-aw generated files without manual maintenance.
-          # Hand-authored workflows never carry such a header, so they always get linted.
+          # Those gaps are now suppressed by exact error message and scoped file path in
+          # .github/actionlint.yaml, so every other error class still fails this job.
+          # Each suppression was verified by compiling the sources and linting the emitted
+          # output against the pinned actionlint version (#1827); see that file for the
+          # rationale, and re-check the list whenever actionlint is upgraded.
 
-          echo "--- Linting .github/workflows/ (skipping DO-NOT-EDIT generated files) ---"
-          skipped=()
-          to_lint=()
-          for f in .github/workflows/*.yml; do
-            if head -5 "$f" | grep -qiE "(automatically generated|DO NOT EDIT)"; then
-              skipped+=("$f")
-            else
-              to_lint+=("$f")
-            fi
-          done
-
-          if [ ${#skipped[@]} -gt 0 ]; then
-            echo "⏭  Skipped (DO-NOT-EDIT generated files — validated by upstream toolchain):"
-            for f in "${skipped[@]}"; do echo "     $f"; done
-          fi
-
-          if [ ${#to_lint[@]} -gt 0 ]; then
-            echo "🔍 Linting ${#to_lint[@]} hand-authored workflow(s):"
-            for f in "${to_lint[@]}"; do echo "     $f"; done
-            actionlint "${to_lint[@]}"
-          else
-            echo "⚠️  No hand-authored workflows found to lint."
-          fi
+          echo "--- Linting .github/workflows/ ---"
+          actionlint .github/workflows/*.yml
 
       - name: Lint squad-cli template workflows
         run: |

--- a/test/actionlint-config.test.ts
+++ b/test/actionlint-config.test.ts
@@ -1,0 +1,118 @@
+/**
+ * actionlint configuration guard
+ *
+ * `.github/actionlint.yaml` suppresses specific actionlint errors. Every entry
+ * narrows the CI gate, so this suite freezes the list: adding a suppression
+ * requires editing this file too, which forces the reviewer to see it.
+ *
+ * Background (#1827). `.github/workflows/squad-workflow-lint.yml` used to skip
+ * any workflow whose header marked it DO-NOT-EDIT generated output. The reason
+ * was real — actionlint v1.7.12 (still the latest release, so this is not
+ * fixable by upgrading) reports errors against gh-aw's emitted YAML for schema
+ * gaps rather than genuine defects. But the cure removed the gate: the
+ * `*.lock.yml` file is the artifact that actually runs, and it was linted by
+ * nothing at all, so a real defect in generated output was indistinguishable
+ * from the expected noise.
+ *
+ * Measured against the pinned actionlint version by compiling the sources and
+ * linting the emitted output: 7 errors, every one falling into the three classes
+ * enumerated below, and none a genuine defect. Suppressing those by exact
+ * message and scoped path takes generated files from unlinted to linted with
+ * three known exemptions — the difference between hiding every future error
+ * class and hiding exactly the ones that were measured and explained.
+ *
+ * These exemptions describe *actionlint's* schema, not ours, so they expire
+ * when the tool catches up. Re-check them on every actionlint upgrade: an
+ * exemption that outlives the gap it documents silently narrows the gate.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+
+const CONFIG_PATH = join(process.cwd(), '.github', 'actionlint.yaml');
+const LINT_WORKFLOW_PATH = join(
+  process.cwd(),
+  '.github',
+  'workflows',
+  'squad-workflow-lint.yml',
+);
+
+/**
+ * The complete set of suppressions, keyed by the path glob they are scoped to.
+ * Adding an entry here is a deliberate act that widens what CI ignores.
+ */
+const EXPECTED_IGNORES: Record<string, string[]> = {
+  // Style-only shellcheck suggestion on the Actions multiline-output heredoc.
+  '**/*.yml': ['SC2129'],
+  // gh-aw compiler output: two real Actions features missing from actionlint's schema.
+  '**/*.lock.yml': [
+    'unknown permission scope "copilot-requests"',
+    'unexpected key "queue" for "concurrency" section',
+  ],
+  // gh-aw code-generator output: an intentional empty `choice` option.
+  '**/agentics-maintenance.yml': ['string should not be empty'],
+};
+
+interface ActionlintConfig {
+  paths?: Record<string, { ignore?: string[] }>;
+}
+
+function readConfig(): ActionlintConfig {
+  return parse(readFileSync(CONFIG_PATH, 'utf8')) as ActionlintConfig;
+}
+
+describe('actionlint config (#1827)', () => {
+  it('suppresses exactly the reviewed set of errors', () => {
+    const paths = readConfig().paths ?? {};
+
+    // Compared as whole objects so an unreviewed *path* is caught alongside an
+    // unreviewed *pattern* — a new glob is just as much a widening as a new entry.
+    const actual = Object.fromEntries(
+      Object.entries(paths).map(([glob, v]) => [glob, v?.ignore ?? []]),
+    );
+
+    expect(actual).toEqual(EXPECTED_IGNORES);
+  });
+
+  it('scopes generated-output suppressions to generated files', () => {
+    const paths = readConfig().paths ?? {};
+
+    // The two gh-aw exemptions describe compiler output. If either were widened to
+    // the repo-wide `**/*.yml` glob, a hand-authored workflow could carry a genuine
+    // permissions or concurrency error and still pass.
+    const repoWide = paths['**/*.yml']?.ignore ?? [];
+    for (const pattern of repoWide) {
+      expect(pattern).not.toMatch(/copilot-requests|concurrency|should not be empty/);
+    }
+  });
+
+  it('documents every suppression with a rationale comment', () => {
+    const raw = readFileSync(CONFIG_PATH, 'utf8');
+    const lines = raw.split(/\r?\n/);
+
+    // An undocumented suppression cannot be re-evaluated later, because nothing
+    // records what it was working around or when it should expire.
+    for (const patterns of Object.values(EXPECTED_IGNORES)) {
+      for (const pattern of patterns) {
+        const idx = lines.findIndex((l) => l.includes(pattern) && l.trimStart().startsWith('-'));
+        expect(idx, `no list entry found for: ${pattern}`).toBeGreaterThan(-1);
+        expect(
+          lines[idx - 1]?.trimStart().startsWith('#'),
+          `suppression is undocumented: ${pattern}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('does not reintroduce a wholesale skip of generated workflows', () => {
+    const workflow = readFileSync(LINT_WORKFLOW_PATH, 'utf8');
+
+    // The header-grep skip is what the scoped ignores replace. Restoring it would
+    // silently return the lock file to being linted by nothing, which is the exact
+    // condition #1827 was filed about.
+    expect(workflow).not.toMatch(/automatically generated\|DO NOT EDIT/i);
+    expect(workflow).toMatch(/actionlint \.github\/workflows\/\*\.yml/);
+  });
+});


### PR DESCRIPTION
Closes #1827

## What the measurement found

The issue asked me not to suppress all 6 errors without first determining which bucket each falls into. I did that, using the actionlint version CI pins (v1.7.12), by compiling the workflow sources and linting the emitted output.

**Every error is an actionlint schema gap. None is a genuine defect.**

| File | Error | Bucket |
|---|---|---|
| `squad.lock.yml` ×2, `squad-implement-worker.lock.yml` ×2 | `unknown permission scope "copilot-requests"` | actionlint behind — real, current Actions scope emitted by GitHub's own gh-aw toolchain |
| `squad.lock.yml` ×1, `squad-implement-worker.lock.yml` ×1 | `unexpected key "queue" for "concurrency"` | actionlint behind — real newer Actions concurrency feature |

That is where the issue's "6" comes from: **3 errors each across two lock files**, not 6 in one. The issue's follow-on premise — *"suppress the 2 known ones so the remaining 4 still gate"* — does not survive: there is no remaining 4. All six are the two known classes, so scoping the ignores leaves **zero** generated-output errors gating today. The value is entirely in what gates *tomorrow*.

## A third gap the issue didn't know about

`agentics-maintenance.yml` is also generated, and also skipped, and it carries a **7th error** nobody could see:

```
.github/workflows/agentics-maintenance.yml:49:13: string should not be empty [syntax-check]
```

It is the `''` entry in a `workflow_dispatch` choice input — the "no operation selected" option, matching the input's own `default: ''`. GitHub accepts it; actionlint rejects any empty string. Generated by gh-aw's `pkg/workflow/maintenance_workflow.go`, so it cannot be fixed here.

This is the clearest argument for the change: that file has been sitting in `.github/workflows/` accumulating unreviewed lint state, and the skip meant nobody would ever have known whether it was one benign error or ten real ones.

## The change

The skip and the scoped ignore look similar and are not. **A skip hides every future error class; a scoped ignore hides exactly the classes that were measured and explained.**

- **`.github/actionlint.yaml`** — three suppressions, each by exact message, each scoped to a path glob (`**/*.lock.yml`, `**/agentics-maintenance.yml`), each with a comment recording what it works around and that it expires when actionlint catches up.
- **`.github/workflows/squad-workflow-lint.yml`** — the 45-line header-grep skip becomes `actionlint .github/workflows/*.yml`. Generated files go from unlinted to linted-with-three-exemptions. Net −40 lines.
- **`test/actionlint-config.test.ts`** — freezes the suppression list so it cannot grow silently.

## Verification

`actionlint` over all **26** workflow files, generated included: **exit 0**.

Mutation-tested, because a suppression that hides more than it claims is worse than the skip it replaced:

| Mutation | Result |
|---|---|
| Bogus job key injected into a lock file | **2 errors** — `syntax-check` still live in generated files |
| A *different* unknown permission scope (`totally-fake-scope`) | **3 errors** — only the exact `copilot-requests` message is ignored |
| Empty choice option in a file that isn't `agentics-maintenance.yml` | **1 error** — the ignore is filename-scoped |

The guard suite was mutation-tested too — adding an ignore entry, widening a gh-aw pattern to the repo-wide glob, deleting a rationale comment, and reintroducing the header-grep skip each turn it red; all four recover green on restore.

Tests: 103 passed, 13 skipped, 0 failed.

## Not done here

The lock file is compiled in the *consumer's* repo — **no `.lock.yml` is committed to this one**. So this PR gates the emitted output only insofar as `agentics-maintenance.yml` represents it. Truly gating the lock file needs a CI step that runs `gh aw compile` and lints the result, and no job here installs the `gh aw` CLI today. I'll file that as a follow-up rather than bolt a new network dependency onto a fast lint job.

The optional companions in the issue — the `git add` line dropping `.github/aw/actions-lock.json`, and the three default-token scope gaps — are untouched and stay open on the issue.
