### PR TITLE
docs(e2e): repoint E1/E4 to the live fixture, preserve evidence records

### DIFF
--- a/.squad/e2e/E1-merge-continuation-relay.md
+++ b/.squad/e2e/E1-merge-continuation-relay.md
@@ -1,7 +1,7 @@
 # E1 — Merge-Continuation Relay: Evidence Record
 
 **Date:** 2026-08-21  
-**Fixture repo:** `bradygaster/aspiregregator-squad-e2e`  
+**Fixture repo (this run):** `bradygaster/aspiregregator-squad-e2e` — ⚠️ **retired.** Deleted 2026-08-24 along with every other test repo. The name is preserved here deliberately: this is an *evidence record*, and it must keep stating which repo actually produced the readings below. Re-runs target a different repo — see `$FIXTURE` in *PASS observation* below.  
 **Recorded by:** FIDO (Quality Owner)  
 **Session:** 70370e36-33b0-4786-bd72-4cf15518daa6
 
@@ -124,7 +124,7 @@ rule_d:
 
 **Cross-checks (completeness is not veracity).** Each of these must hold; otherwise the NOT VERIFIED verdict itself is invalid and the run scores **FAIL**:
 
-- `blocked_by_job_url` MUST target the fixture repo. Concretely: the URL path MUST contain `/<fixture-repo>/actions/runs/` where `<fixture-repo>` matches E1's fixture (as of 2026-08-21: `aspiregregator-squad-e2e`). A cancelled run from an unrelated repo satisfies the field type but does not support the claim.
+- `blocked_by_job_url` MUST target the fixture repo. Concretely: the URL path MUST contain `/<fixture-owner>/<fixture-repo>/actions/runs/`, where `<fixture-owner>/<fixture-repo>` is the `$FIXTURE` declared in *PASS observation* below (currently `octodemo/aspiregregator-squad-e2e`). A cancelled run from an unrelated repo satisfies the field type but does not support the claim. **Match on owner *and* name, not the bare name.** The repo name `aspiregregator-squad-e2e` was deliberately reused when the fixture moved orgs on 2026-08-24, so a name-only match cannot distinguish the current fixture from the retired one and would accept evidence from a repo that no longer exists.
 - `cancelled_at_utc` MUST fall within `[window_started_utc, window_ended_utc]`. A cancellation *before* the window opened wasn't blocking Rule D observation; a cancellation *after* the window closed didn't cause the NOT VERIFIED — the window already ended.
 - `blocked_by_step` MUST name a step visible on the linked run and MUST still be `in_progress` (not `completed`) at cancellation time. A step that had already returned before the run was cancelled didn't hang.
 
@@ -133,7 +133,9 @@ These cross-checks are the difference between "documented absence of signal" (th
 ### PASS observation (the mandatory extractions)
 
 ```powershell
-$FIXTURE = "bradygaster/aspiregregator-squad-e2e"
+$FIXTURE = "octodemo/aspiregregator-squad-e2e"   # re-run target (2026-08-24 onward). NOT the
+                                                 # repo named in this record's header — that one
+                                                 # was deleted. See the header note.
 $EPIC = <epic issue number>
 
 # The relay run's success timestamp — the start of the observation window.

--- a/.squad/e2e/E4-agent-binding-verification.md
+++ b/.squad/e2e/E4-agent-binding-verification.md
@@ -24,8 +24,13 @@
 
 ## ✅ Executed — 2026-08-21 · verdict PASS (n=1)
 
-Run against fixture `bradygaster/aspiregregator-squad-e2e`, seed issue **#22**,
+Run against fixture `bradygaster/aspiregregator-squad-e2e` (⚠️ **retired** — deleted 2026-08-24;
+name kept because this block records what actually ran), seed issue **#22**,
 `$E4_START` = `2026-08-21T09:18:32Z`. **8 gates, 8 green, zero interventions, ~55 min.**
+
+> ⚠️ **Every issue number, run ID, and roster name in this block belongs to the retired fixture.**
+> They are historical readings, not re-run inputs. A re-run must re-derive all of them against the
+> current `$FIXTURE` (Phase 0). Reusing them would score a new run against a deleted repo's evidence.
 
 | # | Condition | Result |
 |---|---|---|
@@ -247,8 +252,8 @@ never been executed as a formal gate. Re-run required.
 
 ### The two leaked tokens are NOT equal evidence
 
-This is the most important thing in this document. Verified against the fixture roster
-(`.squad/team.md` in `bradygaster/aspiregregator-squad-e2e`):
+This is the most important thing in this document. Verified against the roster of the **retired**
+fixture (`.squad/team.md` in `bradygaster/aspiregregator-squad-e2e`, deleted 2026-08-24):
 
 | Roster | Name | Role |
 |---|---|---|
@@ -259,6 +264,24 @@ This is the most important thing in this document. Verified against the fixture 
 | | Kint | DevOps / Platform Engineer |
 
 String check on that file: `DevRel` → **False**. `devrel` → **False**.
+
+> 🛑 **RE-DERIVE this table before any re-run — do not inherit it.**
+> The current fixture (`octodemo/aspiregregator-squad-e2e`) is a *bare application repo*: it has no
+> `.squad/` directory at all, so it has no roster until Squad is activated on it (Phase 0). Casting
+> generates names, so the new roster will **not** be Keaton/McManus/Fenster/Hockney/Kint.
+>
+> The dispositive/ambiguous split below is **derived from roster contents, not fixed vocabulary**.
+> The rule that survives is the *reasoning*, not the *tokens*:
+>
+> - A leaked token is **dispositive** when it appears nowhere in the fixture's roster (no Name, no
+>   Role, no charter) — its only possible source is the prohibition text, so the model copied it.
+> - A leaked token is **ambiguous** when the roster's own Role column contains that word, because
+>   role-column derivation and prohibition-copying then produce the same string.
+>
+> So: re-read the new `.squad/team.md`, re-run the string checks, and re-classify each token. If the
+> new cast happens to include a role containing "Lead", `squad:lead` stays ambiguous; if it does not,
+> `squad:lead` *becomes* dispositive. Scoring a new run against the retired fixture's classification
+> would assert a fact about a repo that no longer exists.
 
 - **`squad:devrel` is dispositive.** "DevRel" appears **nowhere** in the fixture — not as a
   Name, not as a Role, not in any charter. Its **only** possible source is the prohibition text
@@ -345,11 +368,39 @@ labels on the fixture; that is expected fixture state change, not an interventio
 > from refresh mistakes, not from the code under test.
 
 ```powershell
-$FIXTURE = "bradygaster/aspiregregator-squad-e2e"
+$FIXTURE = "octodemo/aspiregregator-squad-e2e"
 $SOURCE  = "bradygaster/squad"
 $EVIDENCE = Join-Path ([Environment]::GetFolderPath('Desktop')) "squad-e4-$(Get-Date -Format 'yyyyMMdd')"
 New-Item -ItemType Directory -Force -Path $EVIDENCE | Out-Null
 ```
+
+> **Why octodemo.** Actions minutes for the `bradygaster` org were near exhaustion, so E-scenario
+> runs bill to `octodemo` instead (owner decision, 2026-08-24). The pristine, **read-only** origin
+> is `bradygaster/Aspiregregator` — copy it, never run against it, never modify it.
+
+### 0-pre. Provision the fixture — required when it has no `.squad/`
+
+> 🛑 **0a–0d below assume Squad is already installed in the fixture.** They *refresh* an activated
+> fixture; they cannot create one. On 2026-08-24 every prior test repo was deleted, so the current
+> fixture was recreated from `bradygaster/Aspiregregator` and is a **bare application repo**.
+
+Assert the starting state before choosing a path — do not assume:
+
+```powershell
+gh api "repos/$FIXTURE/contents/.squad" --jq '.[].name' 2>$null
+$squadExit = $LASTEXITCODE
+# 0   -> activated; skip to 0a and refresh normally.
+# !=0 -> 404 / absent; Squad has never been activated here. Run activation FIRST.
+#        Do NOT interpret a 404 as "clean" and proceed: 0b would then report UNREADABLE
+#        for all four files, which is the correct failure but wastes a cycle diagnosing it.
+```
+
+Until activation runs, the fixture has **no roster**, so E4's dispositive/ambiguous
+classification has nothing to bind to. Re-derive it after activation
+(see *The two leaked tokens are NOT equal evidence*).
+
+Activation also requires repo secrets to be present, which are **not** copied from the origin
+and cannot be recovered from the deleted fixture — they must be re-supplied by the operator.
 
 ### 0a. The four trap doors
 

--- a/.squad/e2e/README.md
+++ b/.squad/e2e/README.md
@@ -47,7 +47,14 @@ The linter reads only fenced code blocks and skips comments, so a runbook may �
 
 ## Fixture
 
-All E-scenarios currently target `bradygaster/aspiregregator-squad-e2e`. Fixture-refresh procedure is embedded in E4's Phase 0. Do not point an E-scenario at a different fixture without first documenting why the existing fixture cannot express the scenario — a bent fixture proves less than an honest gap.
+All E-scenarios currently target `octodemo/aspiregregator-squad-e2e` (internal). Fixture-refresh procedure is embedded in E4's Phase 0. Do not point an E-scenario at a different fixture without first documenting why the existing fixture cannot express the scenario — a bent fixture proves less than an honest gap.
+
+**Fixture move, 2026-08-24 — the documented "why".** The previous fixture, `bradygaster/aspiregregator-squad-e2e`, was **deleted** along with every other test repo. The move was therefore forced, not preferential: the old fixture cannot express any scenario because it no longer exists. Two consequences that are easy to get wrong:
+
+- **The repo name was deliberately reused**, so a match on the bare name `aspiregregator-squad-e2e` no longer identifies the fixture uniquely. Evidence checks must match **owner and name** (E1's `blocked_by_job_url` cross-check was tightened for exactly this).
+- **The new fixture is a bare application repo.** It is a copy of `bradygaster/Aspiregregator` — the pristine, read-only origin, which must be copied and never run against or modified — and it has **no `.squad/` directory**, hence no roster, until Squad is activated on it. Every issue number, run ID, and roster name recorded in E1/E4 belongs to the retired fixture and must be **re-derived**, not find-and-replaced (see E4 Phase 0-pre).
+
+Runs bill to `octodemo` because the `bradygaster` org was near its Actions-minute limit.
 
 ## Related
 


### PR DESCRIPTION
Closes #1851.

## What changed

The E2E runbooks pointed at `bradygaster/aspiregregator-squad-e2e`, deleted 2026-08-24 with every other test repo. Re-run targets now point at `octodemo/aspiregregator-squad-e2e`, recreated from the pristine read-only origin `bradygaster/Aspiregregator`. Runs bill to `octodemo` because the `bradygaster` org was near its Actions-minute limit.

**Procedure moved; evidence did not.** `E1:4` and `E4:27` / `E4:256` state which repo produced the readings printed beside them. Rewriting them would falsify an evidence record, so they keep the retired name and are annotated as retired. Only `$FIXTURE` — the re-run input — was repointed.

## Three things a find-and-replace would have gotten wrong

**1. The repo name was reused across owners.** E1's `blocked_by_job_url` cross-check matched the bare name `aspiregregator-squad-e2e`. After the move that string no longer identifies the fixture — it matches the deleted repo equally well, so the check would accept evidence from a repo that does not exist. Tightened to match **owner and name**.

**2. E4's central criterion is derived, not fixed.** The dispositive/ambiguous split (`devrel` and `reviewer` dispositive, `lead` ambiguous) is not vocabulary — it is a function of the fixture's roster: a token is dispositive when it appears nowhere in the roster, ambiguous when the roster's own Role column contains it. Measured: the new fixture has **no `.squad/` directory at all** (`gh api repos/octodemo/aspiregregator-squad-e2e/contents/.squad` → 404, identical to the origin), so it has no roster, and casting will not reproduce Keaton/McManus/Fenster/Hockney/Kint. Added a re-derivation gate that states the *reasoning rule* so a re-run re-classifies instead of inheriting.

**3. Phase 0 cannot create a fixture, only refresh one.** It assumes `.github/workflows/squad.md` is already present. Added **Phase 0-pre**, which asserts activation state up front. Without it, 0b reports `UNREADABLE` on all four files — the correct failure, but only after a wasted diagnostic cycle.

## Verification

- `test/e2e-runbook-hygiene.test.ts` (the #1822 linter): **3/3 pass**.
- **Mutation-tested, not assumed.** Removing the `$LASTEXITCODE` pairing from the new Phase 0-pre block fails the linter at `E4:390` with the exact suppression diagnostic — so the new fenced block is genuinely covered, not vacuously passing.
- Audited every surviving `aspiregregator` reference. The 4 remaining `bradygaster/...` hits are all explicitly annotated as retired. The 4 hits in `test/gh-aw-quality.test.ts` are unaffected: `:520`/`:539` reference a **local** `test-fixtures/planning/aspiregregator/` directory, and `:1215`/`:1246` are comments citing historical run IDs.

## Remaining, and deliberately not in this PR

The fixture is repointed but **not yet runnable**. It still needs Squad activation (which generates `.squad/` and the roster) and repo secrets, which were not copied from the origin and cannot be recovered from the deleted fixture. That is operator work for the E2E run itself, not a documentation change — and Phase 0-pre now detects and states it rather than letting a run discover it late.
