### PR TITLE
Fail loudly instead of skipping when no POSIX shell resolves (#1833)

### DIFF
--- a/test/gh-aw-activate-roster-binding.test.ts
+++ b/test/gh-aw-activate-roster-binding.test.ts
@@ -21,31 +21,18 @@
 
 import { describe, it, expect, afterAll } from 'vitest';
 import { execFileSync, execSync } from 'node:child_process';
-import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { POSIX_SHELL, requirePosixShell } from './posix-shell';
 
 const SQUAD_WORKFLOW = join(process.cwd(), 'workflows', 'squad.md');
 const workflow = readFileSync(SQUAD_WORKFLOW, 'utf8');
 
 /**
- * Resolve a POSIX shell. Checking only `/bin/sh` silently skips every behavioral
- * case on Windows, and a check that never runs is indistinguishable from a check
- * that always passes. Git ships a POSIX shell on Windows, so fall back to it.
+ * POSIX-shell resolution lives in `./posix-shell` so the gh-aw suites share one
+ * implementation — this file used to carry a verbatim third copy (#1833).
  */
-function resolvePosixShell(): string | null {
-  if (existsSync('/bin/sh')) return '/bin/sh';
-  if (process.platform !== 'win32') return null;
-  const roots = [
-    process.env['ProgramFiles'] ?? 'C:\\Program Files',
-    process.env['ProgramW6432'] ?? 'C:\\Program Files',
-    process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
-    join(process.env['LOCALAPPDATA'] ?? 'C:\\', 'Programs'),
-  ];
-  return roots.map(r => join(r, 'Git', 'bin', 'bash.exe')).find(existsSync) ?? null;
-}
-
-const POSIX_SHELL = resolvePosixShell();
 
 /** Pull the first fenced bash block that follows `heading`, dedented. */
 function bashBlockAfter(heading: string): string {
@@ -121,8 +108,7 @@ function makeRepo(committed: string | null, workingTree?: string): string {
  * must catch.
  */
 function runTG2(cwd: string): string {
-  if (!POSIX_SHELL) throw new Error('no POSIX shell resolved');
-  return execFileSync(POSIX_SHELL, ['-c', TG2_BLOCK], { cwd, encoding: 'utf8' }).replace(/\n+$/, '');
+  return execFileSync(requirePosixShell(), ['-c', TG2_BLOCK], { cwd, encoding: 'utf8' }).replace(/\n+$/, '');
 }
 
 const members = (out: string): string[] =>
@@ -186,7 +172,7 @@ describe('gh-aw: Team Guard TG-2 roster certification (#1812)', () => {
     expect(TG2_BLOCK, 'TG-2 must read the committed HEAD revision of team.md').toMatch(/git show HEAD:\.squad\/team\.md/);
   });
 
-  it.skipIf(!POSIX_SHELL)('emits the committed cast verbatim (lowercased), not a preset', () => {
+  it('emits the committed cast verbatim (lowercased), not a preset', () => {
     const out = runTG2(makeRepo(CAST));
     expect(members(out), `expected the real cast from team.md; got:\n${out}`).toEqual([
       'keaton',
@@ -198,7 +184,7 @@ describe('gh-aw: Team Guard TG-2 roster certification (#1812)', () => {
     expect(unreadable(out), `unexpected ROSTER_UNREADABLE on a readable roster:\n${out}`).toBeNull();
   });
 
-  it.skipIf(!POSIX_SHELL)('reads the Name column by header, not by position, when Role comes first', () => {
+  it('reads the Name column by header, not by position, when Role comes first', () => {
     const roleFirst = [
       '## Members',
       '',
@@ -216,7 +202,7 @@ describe('gh-aw: Team Guard TG-2 roster certification (#1812)', () => {
     }
   });
 
-  it.skipIf(!POSIX_SHELL)('names the failure when the table has no Name column', () => {
+  it('names the failure when the table has no Name column', () => {
     const noName = [
       '## Members',
       '',
@@ -232,7 +218,7 @@ describe('gh-aw: Team Guard TG-2 roster certification (#1812)', () => {
     );
   });
 
-  it.skipIf(!POSIX_SHELL)('reads committed HEAD, so an uncommitted preset scaffold cannot leak', () => {
+  it('reads committed HEAD, so an uncommitted preset scaffold cannot leak', () => {
     // The measured #1812 defect: a real cast is committed, but a preset team.md
     // sits in the working tree. TG-2 must certify the committed cast only.
     const out = runTG2(makeRepo(CAST, PRESET));
@@ -250,7 +236,7 @@ describe('gh-aw: Team Guard TG-2 roster certification (#1812)', () => {
     }
   });
 
-  it.skipIf(!POSIX_SHELL)('names the failure when team.md is absent from HEAD', () => {
+  it('names the failure when team.md is absent from HEAD', () => {
     const out = runTG2(makeRepo(null));
     expect(members(out), `no roster may be emitted when team.md is absent; got:\n${out}`).toEqual([]);
     expect(unreadable(out), `expected a named "absent from HEAD" reason; got:\n${out}`).toBe(
@@ -258,7 +244,7 @@ describe('gh-aw: Team Guard TG-2 roster certification (#1812)', () => {
     );
   });
 
-  it.skipIf(!POSIX_SHELL)('names the failure when there is no ## Members section', () => {
+  it('names the failure when there is no ## Members section', () => {
     const noSection = ['# Squad', '', 'Some prose but no members table.', ''].join('\n');
     const out = runTG2(makeRepo(noSection));
     expect(members(out), `no roster may be emitted without a ## Members section; got:\n${out}`).toEqual([]);
@@ -267,7 +253,7 @@ describe('gh-aw: Team Guard TG-2 roster certification (#1812)', () => {
     );
   });
 
-  it.skipIf(!POSIX_SHELL)('names the failure when ## Members has header and separator but no data rows', () => {
+  it('names the failure when ## Members has header and separator but no data rows', () => {
     const headerOnly = ['## Members', '', '| Name | Role |', '|------|------|', ''].join('\n');
     const out = runTG2(makeRepo(headerOnly));
     expect(members(out), `header/separator rows are not members; got:\n${out}`).toEqual([]);
@@ -285,7 +271,7 @@ describe('gh-aw: Team Guard TG-2 roster certification (#1812)', () => {
   // GitHub tables the trailing pipe already quarantines the CR into a post-pipe
   // field that is never read (measured). The strip is retained as defense-in-depth
   // for irregular tables; this test does not claim to prove it.
-  it.skipIf(!POSIX_SHELL)('parses a CRLF-authored team.md into the clean lowercased cast', () => {
+  it('parses a CRLF-authored team.md into the clean lowercased cast', () => {
     const crlf = [
       '## Members',
       '',

--- a/test/gh-aw-command-parse.test.ts
+++ b/test/gh-aw-command-parse.test.ts
@@ -16,31 +16,18 @@
 
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { POSIX_SHELL } from './posix-shell';
 
 const SQUAD_WORKFLOW = join(process.cwd(), 'workflows', 'squad.md');
 const workflow = readFileSync(SQUAD_WORKFLOW, 'utf8');
 
 /**
- * Resolve a POSIX shell. Checking only `/bin/sh` (as the older gh-aw suites do)
- * silently skips every behavioral case on Windows, and a check that never runs is
- * indistinguishable from a check that always passes. Git ships a POSIX shell on
- * Windows, so fall back to it rather than skipping.
+ * POSIX-shell resolution lives in `./posix-shell` so the gh-aw suites share one
+ * implementation. It used to live here, and `gh-aw-quality.test.ts` grew its own
+ * `/bin/sh`-only variant that silently skipped 13 tests on Windows (#1833).
  */
-function resolvePosixShell(): string | null {
-  if (existsSync('/bin/sh')) return '/bin/sh';
-  if (process.platform !== 'win32') return null;
-  const roots = [
-    process.env['ProgramFiles'] ?? 'C:\\Program Files',
-    process.env['ProgramW6432'] ?? 'C:\\Program Files',
-    process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
-    join(process.env['LOCALAPPDATA'] ?? 'C:\\', 'Programs'),
-  ];
-  return roots.map(r => join(r, 'Git', 'bin', 'bash.exe')).find(existsSync) ?? null;
-}
-
-const POSIX_SHELL = resolvePosixShell();
 
 /** Pull the first fenced bash block that follows `heading`, dedented. */
 function bashBlockAfter(heading: string): string {

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -13,6 +13,7 @@ import { cpSync, readFileSync, existsSync, mkdirSync, mkdtempSync, writeFileSync
 import { join, dirname } from 'node:path';
 import { execFileSync, execSync, spawnSync } from 'node:child_process';
 import { minimatch } from 'minimatch';
+import { POSIX_SHELL, NO_POSIX_SHELL_MESSAGE, requirePosixShell } from './posix-shell';
 
 const WORKFLOWS_DIR = join(process.cwd(), 'workflows');
 const SQUAD_WORKFLOW = join(WORKFLOWS_DIR, 'squad.md');
@@ -21,13 +22,14 @@ const SHARED_DIR = join(WORKFLOWS_DIR, 'shared');
 const TEST_WORKSPACES_DIR = join(process.cwd(), '.test-workspaces');
 
 /**
- * Some suites execute the workflow's own `bash`/`jq` snippets through
- * `shell: '/bin/sh'` to prove the shipped one-liners behave as documented.
- * That shell does not exist on a stock Windows dev box, so gate those suites
- * instead of reporting spurious ENOENT failures. CI runs on Linux, where they
- * always execute.
+ * Some suites execute the workflow's own `bash`/`jq` snippets through a POSIX
+ * shell to prove the shipped one-liners behave as documented.
+ *
+ * These suites used to gate on `existsSync('/bin/sh')`, which is absent on a
+ * stock Windows dev box — so 13 tests (28 assertions) silently skipped while the
+ * suite still reported green (#1833). Git for Windows ships a POSIX shell, so
+ * resolve that instead of skipping, and fail loudly when none can be found.
  */
-const HAS_POSIX_SHELL = existsSync('/bin/sh');
 
 afterAll(() => {
   rmSync(TEST_WORKSPACES_DIR, { recursive: true, force: true });
@@ -1626,7 +1628,14 @@ describe('gh-aw: auto-cast pivot and resumable work (#1689)', () => {
 // the guard, preventing false TEAM_PRESENT in fresh repos.
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!HAS_POSIX_SHELL)('gh-aw: Team Guard roster-row detection — committed-HEAD git repo coverage (#1689 revision 3)', () => {
+describe('gh-aw: Team Guard roster-row detection — committed-HEAD git repo coverage (#1689 revision 3)', () => {
+  // A skipped behavioral suite is a permanently-green gate (#1833). Fail loudly
+  // instead of quietly reporting a pass for assertions that never executed.
+  it('resolves a POSIX shell, so the behavioral cases below actually run', () => {
+    expect(POSIX_SHELL, NO_POSIX_SHELL_MESSAGE).not.toBeNull();
+  });
+
+
   // Content shared across test cases
   const SCAFFOLD_CONTENT = `# Squad Team\n\n## Members\n| Name | Role | Charter path | Status |\n|------|------|--------------|--------|\n`;
   const ONE_MEMBER_CONTENT = `# Squad Team\n\n## Members\n| Name | Role | Charter path | Status |\n|------|------|--------------|--------|\n| Eecom | Core Dev | .squad/agents/eecom/charter.md | active |\n`;
@@ -1638,7 +1647,7 @@ describe.skipIf(!HAS_POSIX_SHELL)('gh-aw: Team Guard roster-row detection — co
   function runCommittedRosterCheck(cwd: string): string {
     return execSync(
       `git show HEAD:.squad/team.md 2>/dev/null | awk '{sub(/\\r$/,"")} /^## Members/{f=1;next} f&&/^#/{f=0} f&&/^\\|/&&!/^\\|[-: |]*\\|$/&&!/\\| *Name *\\|/' | grep -q . && echo TEAM_PRESENT || echo TEAM_ABSENT`,
-      { cwd, shell: '/bin/sh', encoding: 'utf8' }
+      { cwd, shell: requirePosixShell(), encoding: 'utf8' }
     ).trim();
   }
 
@@ -1798,7 +1807,13 @@ describe('gh-aw: Auto-Cast prompt hygiene (#1689 revision)', () => {
 // Test: Cast PR dedup jq filter — behavioral coverage (#1689 revision)
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!HAS_POSIX_SHELL)('gh-aw: Cast PR dedup jq filter behavioral coverage (#1689 revision)', () => {
+describe('gh-aw: Cast PR dedup jq filter behavioral coverage (#1689 revision)', () => {
+  // See #1833 — this suite skipped silently on Windows and still reported green.
+  it('resolves a POSIX shell, so the behavioral cases below actually run', () => {
+    expect(POSIX_SHELL, NO_POSIX_SHELL_MESSAGE).not.toBeNull();
+  });
+
+
   const squadContent = readText(SQUAD_WORKFLOW);
 
   // Extract the exact --jq expression from squad.md so this test stays in sync.
@@ -1811,7 +1826,7 @@ describe.skipIf(!HAS_POSIX_SHELL)('gh-aw: Cast PR dedup jq filter behavioral cov
   function runJqFilter(jsonInput: string, filter: string): string {
     return execSync(
       `echo '${jsonInput.replace(/'/g, "'\\''")}' | jq -r '${filter}'`,
-      { shell: '/bin/sh', encoding: 'utf8' }
+      { shell: requirePosixShell(), encoding: 'utf8' }
     ).trim();
   }
 

--- a/test/posix-shell.ts
+++ b/test/posix-shell.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared POSIX-shell resolution for the gh-aw behavioral suites.
+ *
+ * Several gh-aw suites execute the workflow's own `bash`/`jq` one-liners to prove
+ * the shipped snippets behave as documented. Those suites used to gate themselves
+ * on `existsSync('/bin/sh')`, which is absent on a stock Windows dev box — so they
+ * skipped, and the suite still reported green. A check that never runs is
+ * indistinguishable from a check that always passes.
+ *
+ * Git for Windows ships a POSIX shell, so resolve that instead of skipping. When
+ * no shell can be resolved at all, callers must fail loudly rather than skip:
+ * see `requirePosixShell()`.
+ *
+ * This lives in one place on purpose. It previously existed only inside
+ * `gh-aw-command-parse.test.ts`; a second copy pasted into another suite is how
+ * this class of bug spreads.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function resolvePosixShell(): string | null {
+  if (existsSync('/bin/sh')) return '/bin/sh';
+  if (process.platform !== 'win32') return null;
+  const roots = [
+    process.env['ProgramFiles'] ?? 'C:\\Program Files',
+    process.env['ProgramW6432'] ?? 'C:\\Program Files',
+    process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)',
+    join(process.env['LOCALAPPDATA'] ?? 'C:\\', 'Programs'),
+  ];
+  return roots.map(r => join(r, 'Git', 'bin', 'bash.exe')).find(existsSync) ?? null;
+}
+
+export const POSIX_SHELL = resolvePosixShell();
+
+/**
+ * Names the missing dependency explicitly. Per #1832's finding, a status-only
+ * assertion passes clean against a generic-diagnostic mutation, so the diagnostic
+ * text is part of the contract and is asserted on.
+ */
+export const NO_POSIX_SHELL_MESSAGE =
+  'No POSIX shell found. These cases are behavioral — skipping them would report a ' +
+  'green suite for assertions that never ran. Install Git for Windows (provides ' +
+  'bash.exe) or run on a POSIX host.';
+
+/** Resolve a POSIX shell or throw naming the missing dependency. Never skips. */
+export function requirePosixShell(): string {
+  if (!POSIX_SHELL) throw new Error(NO_POSIX_SHELL_MESSAGE);
+  return POSIX_SHELL;
+}


### PR DESCRIPTION
Closes #1833.

## The defect, measured

`test/gh-aw-quality.test.ts` gated two `describe` blocks on `existsSync('/bin/sh')`, absent on a stock Windows dev box.

| | Tests | Skipped |
|---|---|---|
| **Before** | 96 passed | **13 skipped** (109) |
| **After** | **111 passed** | **0** (111) |

The 13 hidden tests now execute — and **pass** — on Windows. `jq` and `awk` resolve through Git Bash, so no previously-hidden product defect surfaced.

## The fix

The correct shape already existed in `gh-aw-command-parse.test.ts` (from #1832). Rather than copy it a third time — the issue's explicit warning — it moves to **`test/posix-shell.ts`** and all three gh-aw suites import it.

The audit for acceptance criterion 4 found the propagation had already happened: `gh-aw-activate-roster-binding.test.ts` carried a **verbatim third copy** plus 8 more `it.skipIf(!POSIX_SHELL)` cases. Those are folded in here — deduping two copies while leaving the third would have left the vector intact.

- Every `skipIf`-on-shell-probe removed: **2 describes + 8 its**.
- Absence throws via `requirePosixShell()` and is asserted by a named guard test.

## Proven capable of failing

Forcing `resolvePosixShell()` to return `null`:

```
AssertionError: No POSIX shell found. These cases are behavioral — skipping them
would report a green suite for assertions that never ran. Install Git for
Windows (provides bash.exe) or run on a POSIX host.
```

Red from both the guard assertion *and* every behavioral case. Per #1832's finding that a status-only check passes a generic-diagnostic mutation, the diagnostic text names the missing dependency explicitly.

## Verification

- `gh-aw-quality` + `gh-aw-command-parse` + `gh-aw-activate-roster-binding`: **157 passed, 0 skipped**
- `npx eslint` on all four files: clean
- No `skipIf` on a shell probe remains in any gh-aw suite

## Remaining `skipIf`, deliberately untouched

`gh-aw-quality.test.ts:1094` — `it.skipIf(!ghAwAvailable)` for the `gh aw compile` gate. Same defect class, but it is **#1834's subject** and needs a CI job that installs `gh aw`; the finding is recorded on that issue. The other two (`aspire-integration`, `docs-build`) gate on non-gh-aw build prerequisites and carry explicit skip reasons.