### PR TITLE
docs(readme): document gh-aw install surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,6 @@ If you use [GitHub Agentic Workflows](https://github.blog/changelog/2025-05-19-g
 gh aw add \
   bradygaster/squad/workflows/squad-implement-worker.md@dev \
   bradygaster/squad/workflows/squad.md@dev
-gh aw compile
 git add -- \
   .github/aw/ \
   .github/skills/ \
@@ -556,12 +555,12 @@ Review the complete generated diff before you commit:
 | Path | What gh-aw writes | Commit? |
 |------|-------------------|---------|
 | `.github/workflows/` | The Squad workflow sources, shared imports, compiled lock files, and `agentics-maintenance.yml` | Yes |
-| `.github/aw/actions-lock.json` | Pinned action versions and SHAs used by the compiled workflows | Yes |
-| `.github/skills/agentic-workflows/SKILL.md` | The agentic-workflows dispatcher skill | Yes |
+| `.github/aw/` | Supporting gh-aw state, including pinned action versions and SHAs | Yes |
+| `.github/skills/` | The agentic-workflows dispatcher skill | Yes |
 | `.gitattributes` | Marks compiled `.lock.yml` workflows as generated | Yes |
-| `.vscode/settings.json` | Enables GitHub Copilot for Markdown files in VS Code | Optional — commit only if you want to share this workspace setting |
+| `.vscode/` | Workspace settings that enable GitHub Copilot for Markdown files in VS Code | Optional — commit only if you want to share this workspace setting |
 
-`agentics-maintenance.yml` is a second installed workflow. Squad configures pull requests to expire after 14 days, so this workflow runs scheduled expiration cleanup and also exposes manual maintenance operations. To omit it, create `.github/workflows/aw.json` with `{"maintenance": false}` before compiling. gh-aw then warns that expiration is disabled and removes the maintenance workflow.
+`agentics-maintenance.yml` is a second installed workflow. Squad configures its created pull request safe output to expire after 14 days, so this workflow runs scheduled expiration cleanup and also exposes manual maintenance operations. To omit it, create `.github/workflows/aw.json` with `{"maintenance": false}` before installing. gh-aw then warns that expiration is disabled and removes the maintenance workflow.
 
 ### Slash commands
 

--- a/README.md
+++ b/README.md
@@ -533,12 +533,16 @@ If you use [GitHub Agentic Workflows](https://github.blog/changelog/2025-05-19-g
 
 ### Install
 
+<!-- cspell:ignore agentics -->
+
 ```bash
 gh aw add \
   bradygaster/squad/workflows/squad-implement-worker.md@dev \
   bradygaster/squad/workflows/squad.md@dev
 gh aw compile
 git add -- \
+  .github/aw/ \
+  .github/skills/ \
   .github/workflows/ \
   .gitattributes
 git commit -m "Add Squad workflow"
@@ -546,6 +550,18 @@ git push
 ```
 
 > `@dev` pulls the latest modes and fixes; switch to `@main` once gh-aw support is stable.
+
+Review the complete generated diff before you commit:
+
+| Path | What gh-aw writes | Commit? |
+|------|-------------------|---------|
+| `.github/workflows/` | The Squad workflow sources, shared imports, compiled lock files, and `agentics-maintenance.yml` | Yes |
+| `.github/aw/actions-lock.json` | Pinned action versions and SHAs used by the compiled workflows | Yes |
+| `.github/skills/agentic-workflows/SKILL.md` | The agentic-workflows dispatcher skill | Yes |
+| `.gitattributes` | Marks compiled `.lock.yml` workflows as generated | Yes |
+| `.vscode/settings.json` | Enables GitHub Copilot for Markdown files in VS Code | Optional — commit only if you want to share this workspace setting |
+
+`agentics-maintenance.yml` is a second installed workflow. Squad configures pull requests to expire after 14 days, so this workflow runs scheduled expiration cleanup and also exposes manual maintenance operations. To omit it, create `.github/workflows/aw.json` with `{"maintenance": false}` before compiling. gh-aw then warns that expiration is disabled and removes the maintenance workflow.
 
 ### Slash commands
 


### PR DESCRIPTION
## Summary

- document the complete file surface produced by the Squad gh-aw install
- identify the generated Agentic Maintenance workflow, its purpose, and the supported opt-out
- clarify that `.vscode/settings.json` is an optional shared workspace setting

Closes #1864

## Validation

- `npx --offline cspell@10.0.1 --no-progress README.md`
- `npx --offline markdownlint-cli2@0.23.2 README.md`
- `git diff --check`

## Caveats

- `npm test -- test/docs-links.test.ts` could not run because the required package proxy returned 404 for the locked `vitest-4.1.11.tgz`.
- A clean install produced every documented path, but the subsequent full compile currently reports the separately scoped missing `squad-review` workflow; this PR intentionally does not change that install flow.