### PR TITLE
feat: add squad health readiness checks

### DIFF
--- a/.changeset/1605-squad-health.md
+++ b/.changeset/1605-squad-health.md
@@ -1,5 +1,5 @@
 ---
-"@bradygaster/squad-cli": patch
+"@bradygaster/squad-cli": minor
 "@bradygaster/squad-sdk": patch
 ---
 

--- a/.changeset/1605-squad-health.md
+++ b/.changeset/1605-squad-health.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+Add `squad health` readiness diagnostics and fail-fast shared workflow integration.

--- a/.squad-templates/routing.md
+++ b/.squad-templates/routing.md
@@ -6,14 +6,9 @@ How to decide who handles what.
 
 | Work Type | Route To | Examples |
 |-----------|----------|----------|
-| {domain 1} | {Name} | {example tasks} |
-| {domain 2} | {Name} | {example tasks} |
-| {domain 3} | {Name} | {example tasks} |
-| Code review | {Name} | Review PRs, check quality, suggest improvements |
-| Testing | {Name} | Write tests, find edge cases, verify fixes |
-| Scope & priorities | {Name} | What to build next, trade-offs, decisions |
-| Session logging | Scribe | Automatic — never needs routing |
-| RAI review | Rai | Content safety, bias checks, credential detection, ethical review |
+
+Preset installation adds concrete routes for the configured team. Add or edit rows
+here only when their agent names also exist in the casting registry.
 
 ## Issue Routing
 

--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -151,7 +151,7 @@ Set a repository variable to control which Squad CLI version the workflow uses:
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `SQUAD_CLI_VERSION` | Squad CLI version to install during activation | `0.12.0` |
+| `SQUAD_CLI_VERSION` | Squad CLI version to install during activation | `0.14.0` |
 
 Set it in **Settings → Secrets and variables → Actions → Variables**.
 

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -990,7 +990,8 @@ async function main(): Promise<void> {
   if (cmd === 'health') {
     const { runHealthCommand } = await import('./cli/commands/health.js');
     const exitCode = await runHealthCommand(getSquadStartDir(), args.slice(1));
-    process.exit(exitCode);
+    process.exitCode = exitCode;
+    return;
   }
 
   if (cmd === 'consult') {
@@ -1171,5 +1172,4 @@ main().catch(err => {
   }
   process.exit(1);
 });
-
 

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -233,6 +233,8 @@ async function main(): Promise<void> {
     console.log(`             Diagnostics: --log-level info|debug or --verbose`);
     console.log(`  ${BOLD}state-mcp${RESET}  MCP bridge exposing Squad runtime state tools`);
     console.log(`  ${BOLD}doctor${RESET}     Validate squad setup (check files, config, health)`);
+    console.log(`  ${BOLD}health${RESET}     Validate team state for CI (team, registry, routing, backend, env)`);
+    console.log(`             Flags: --json (structured output for CI)`);
     console.log(`  ${BOLD}consult${RESET}    Enter consult mode with your personal squad`);
     console.log(`             Flags: --status, --check`);
     console.log(`  ${BOLD}extract${RESET}    Extract learnings from consult mode session`);
@@ -985,6 +987,12 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (cmd === 'health') {
+    const { runHealthCommand } = await import('./cli/commands/health.js');
+    const exitCode = await runHealthCommand(getSquadStartDir(), args.slice(1));
+    process.exit(exitCode);
+  }
+
   if (cmd === 'consult') {
     const { runConsult } = await import('./cli/commands/consult.js');
     await runConsult(getSquadStartDir(), args.slice(1));
@@ -1163,6 +1171,5 @@ main().catch(err => {
   }
   process.exit(1);
 });
-
 
 

--- a/packages/squad-cli/src/cli/commands/health.ts
+++ b/packages/squad-cli/src/cli/commands/health.ts
@@ -1,0 +1,640 @@
+/**
+ * `squad health` readiness checks for CI and agent dispatch.
+ *
+ * @module cli/commands/health
+ */
+
+import path from 'node:path';
+import {
+  FSStorageProvider,
+  resolveStateBackend,
+  verifyStateBackend,
+  type StateBackend,
+  type StateBackendType,
+} from '@bradygaster/squad-sdk';
+import { parseCharterMarkdown } from '@bradygaster/squad-sdk/agents';
+import {
+  parseRoutingRulesMarkdown,
+  parseTeamMarkdown,
+} from '@bradygaster/squad-sdk/parsers';
+import { effectiveSquadDir } from '../core/effective-squad-dir.js';
+
+const storage = new FSStorageProvider();
+
+export const HEALTH_SCHEMA = 'squad-health/v1' as const;
+
+export type HealthCheckStatus = 'pass' | 'fail' | 'skip';
+export type HealthCheckId =
+  | 'team'
+  | 'registry-charters'
+  | 'routing'
+  | 'state-backend'
+  | 'env-vars';
+
+export interface HealthCheckItem {
+  id: HealthCheckId;
+  status: HealthCheckStatus;
+  message: string;
+  diagnostics?: string[];
+}
+
+export interface HealthReport {
+  schema: typeof HEALTH_SCHEMA;
+  status: 'pass' | 'fail';
+  checks: HealthCheckItem[];
+}
+
+interface CastingRegistry {
+  agents: Record<string, unknown>;
+}
+
+function pass(id: HealthCheckId, message: string): HealthCheckItem {
+  return { id, status: 'pass', message };
+}
+
+function fail(
+  id: HealthCheckId,
+  message: string,
+  diagnostics?: string[],
+): HealthCheckItem {
+  return diagnostics && diagnostics.length > 0
+    ? { id, status: 'fail', message, diagnostics }
+    : { id, status: 'fail', message };
+}
+
+function skip(id: HealthCheckId, message: string): HealthCheckItem {
+  return { id, status: 'skip', message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readRequiredFile(filePath: string, displayPath: string): string {
+  if (!storage.existsSync(filePath)) {
+    throw new Error(`${displayPath} not found`);
+  }
+  let content: string | undefined;
+  try {
+    content = storage.readSync(filePath);
+  } catch (error) {
+    throw new Error(`${displayPath} could not be read (${errorKind(error)})`);
+  }
+  if (!content?.trim()) {
+    throw new Error(`${displayPath} is empty`);
+  }
+  return content;
+}
+
+function parseJsonObject(content: string, displayPath: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content) as unknown;
+  } catch {
+    throw new Error(`${displayPath} contains invalid JSON`);
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(`${displayPath} root must be a JSON object`);
+  }
+  return parsed;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'unknown error';
+}
+
+function errorKind(error: unknown): string {
+  if (isRecord(error) && typeof error.code === 'string') {
+    return error.code;
+  }
+  return error instanceof Error ? error.name : 'Error';
+}
+
+function normalizeAgentRef(value: string): string {
+  const link = value.match(/^\[([^\]]+)\]\([^)]+\)$/);
+  return (link?.[1] ?? value)
+    .replace(/[`*_~]/g, '')
+    .replace(/[^\x20-\x7e]/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+function readRegistry(squadDir: string): CastingRegistry {
+  const displayPath = 'casting/registry.json';
+  const registryPath = path.join(squadDir, 'casting', 'registry.json');
+  const parsed = parseJsonObject(
+    readRequiredFile(registryPath, displayPath),
+    displayPath,
+  );
+  if (!isRecord(parsed.agents)) {
+    throw new Error(`${displayPath} must contain an agents object`);
+  }
+  if (Object.keys(parsed.agents).length === 0) {
+    throw new Error(`${displayPath} must contain at least one agent`);
+  }
+  return { agents: parsed.agents };
+}
+
+function checkTeam(squadDir: string): HealthCheckItem {
+  try {
+    const content = readRequiredFile(
+      path.join(squadDir, 'team.md'),
+      '.squad/team.md',
+    );
+    const parsed = parseTeamMarkdown(content);
+    if (parsed.agents.length === 0) {
+      return fail(
+        'team',
+        'team.md has no parseable members',
+        parsed.warnings.length > 0 ? [...parsed.warnings].sort() : undefined,
+      );
+    }
+
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const agent of parsed.agents) {
+      const key = normalizeAgentRef(agent.name);
+      if (!key) {
+        return fail('team', 'team.md contains a member with an empty name');
+      }
+      if (seen.has(key)) duplicates.add(agent.name);
+      seen.add(key);
+    }
+    if (duplicates.size > 0) {
+      return fail(
+        'team',
+        'team.md has duplicate member names',
+        [...duplicates].sort().map((name) => `duplicate: ${name}`),
+      );
+    }
+
+    return pass('team', `team.md is valid (${parsed.agents.length} members)`);
+  } catch (error) {
+    return fail('team', errorMessage(error));
+  }
+}
+
+function checkRegistryAndCharters(squadDir: string): HealthCheckItem {
+  let registry: CastingRegistry;
+  try {
+    registry = readRegistry(squadDir);
+  } catch (error) {
+    return fail('registry-charters', errorMessage(error));
+  }
+
+  const diagnostics: string[] = [];
+  const normalizedIds = new Map<string, string>();
+  const persistentNames = new Map<string, string>();
+  const agentIds = Object.keys(registry.agents).sort((a, b) =>
+    a.localeCompare(b),
+  );
+
+  for (const agentId of agentIds) {
+    const normalizedId = normalizeAgentRef(agentId);
+    if (
+      normalizedId !== agentId ||
+      !/^[a-z0-9][a-z0-9-]*$/.test(agentId)
+    ) {
+      diagnostics.push(
+        `${agentId}: registry key must be a lowercase kebab-case agent id`,
+      );
+      continue;
+    }
+
+    const duplicateId = normalizedIds.get(normalizedId);
+    if (duplicateId) {
+      diagnostics.push(`${agentId}: duplicates registry agent ${duplicateId}`);
+      continue;
+    }
+    normalizedIds.set(normalizedId, agentId);
+
+    const entry = registry.agents[agentId];
+    if (!isRecord(entry)) {
+      diagnostics.push(`${agentId}: registry entry must be an object`);
+      continue;
+    }
+    if (
+      typeof entry.persistent_name !== 'string' ||
+      !entry.persistent_name.trim()
+    ) {
+      diagnostics.push(`${agentId}: registry entry is missing persistent_name`);
+      continue;
+    }
+    if (typeof entry.status !== 'string' || !entry.status.trim()) {
+      diagnostics.push(`${agentId}: registry entry is missing status`);
+      continue;
+    }
+    if (!['active', 'inactive', 'retired'].includes(entry.status)) {
+      diagnostics.push(`${agentId}: registry entry has invalid status`);
+      continue;
+    }
+
+    const persistentName = normalizeAgentRef(entry.persistent_name);
+    const duplicateName = persistentNames.get(persistentName);
+    if (duplicateName) {
+      diagnostics.push(
+        `${agentId}: persistent_name duplicates registry agent ${duplicateName}`,
+      );
+      continue;
+    }
+    persistentNames.set(persistentName, agentId);
+
+    const charterDirectory =
+      entry.status === 'retired'
+        ? path.join('agents', '_alumni', agentId)
+        : path.join('agents', agentId);
+    const displayPath = path.join(charterDirectory, 'charter.md');
+    try {
+      const charter = parseCharterMarkdown(
+        readRequiredFile(path.join(squadDir, displayPath), displayPath),
+      );
+      if (!charter.identity.name || !charter.identity.role) {
+        diagnostics.push(
+          `${agentId}: charter must declare identity name and role`,
+        );
+      } else if (
+        normalizeAgentRef(charter.identity.name) !== persistentName
+      ) {
+        diagnostics.push(
+          `${agentId}: charter identity does not match persistent_name`,
+        );
+      }
+    } catch (error) {
+      diagnostics.push(`${agentId}: ${errorMessage(error)}`);
+    }
+  }
+
+  if (diagnostics.length > 0) {
+    return fail(
+      'registry-charters',
+      `${diagnostics.length} registry or charter validation failure${diagnostics.length === 1 ? '' : 's'}`,
+      diagnostics.sort((a, b) => a.localeCompare(b)),
+    );
+  }
+
+  return pass(
+    'registry-charters',
+    `${agentIds.length} registry agent${agentIds.length === 1 ? '' : 's'} have valid charters`,
+  );
+}
+
+function loadRegistryKeys(squadDir: string): Set<string> {
+  const registry = readRegistry(squadDir);
+  const keys = new Set<string>();
+  for (const [agentId, entry] of Object.entries(registry.agents)) {
+    if (!isRecord(entry)) {
+      throw new Error(`registry entry ${agentId} must be an object`);
+    }
+    keys.add(normalizeAgentRef(agentId));
+  }
+  return keys;
+}
+
+function checkRouting(squadDir: string): HealthCheckItem {
+  try {
+    const content = readRequiredFile(
+      path.join(squadDir, 'routing.md'),
+      '.squad/routing.md',
+    );
+    const parsed = parseRoutingRulesMarkdown(content);
+    if (parsed.rules.length === 0) {
+      return fail(
+        'routing',
+        'routing.md has no parseable routing rules',
+        parsed.warnings.length > 0 ? [...parsed.warnings].sort() : undefined,
+      );
+    }
+
+    let registryKeys: Set<string>;
+    try {
+      registryKeys = loadRegistryKeys(squadDir);
+    } catch {
+      return fail(
+        'routing',
+        'routing references cannot be validated because the casting registry is invalid',
+      );
+    }
+
+    const unresolved = new Set<string>();
+    const referenced = new Set<string>();
+    const workTypes = new Set<string>();
+    const duplicates = new Set<string>();
+
+    for (const rule of parsed.rules) {
+      const workType = rule.workType.trim().toLowerCase();
+      if (workTypes.has(workType)) duplicates.add(rule.workType);
+      workTypes.add(workType);
+
+    }
+
+    const agentReferences =
+      parsed.agentReferences ??
+      parsed.rules.flatMap((rule) => rule.agents);
+    for (const agent of agentReferences) {
+      const key = normalizeAgentRef(agent);
+      if (!key || !registryKeys.has(key)) {
+        unresolved.add(agent);
+      } else {
+        referenced.add(key);
+      }
+    }
+
+    const diagnostics = [
+      ...[...duplicates]
+        .sort((a, b) => a.localeCompare(b))
+        .map((workType) => `duplicate work type: ${workType}`),
+      ...[...unresolved]
+        .sort((a, b) => a.localeCompare(b))
+        .map((agent) => `unknown agent: ${agent}`),
+    ];
+    if (diagnostics.length > 0) {
+      return fail(
+        'routing',
+        'routing.md contains invalid or unresolved references',
+        diagnostics,
+      );
+    }
+
+    return pass(
+      'routing',
+      `routing.md has ${parsed.rules.length} rules referencing ${referenced.size} known agents`,
+    );
+  } catch (error) {
+    return fail('routing', errorMessage(error));
+  }
+}
+
+function canonicalBackendType(value: string): StateBackendType | null {
+  switch (value.trim().toLowerCase()) {
+    case 'local':
+    case 'worktree':
+      return 'local';
+    case 'orphan':
+      return 'orphan';
+    case 'two-layer':
+    case 'git-notes':
+      return 'two-layer';
+    case 'external':
+    case 'external-stub':
+      return 'external-stub';
+    default:
+      return null;
+  }
+}
+
+function backendMatches(
+  backend: StateBackend,
+  configured: StateBackendType,
+): boolean {
+  if (configured === 'local') return backend.name === 'local';
+  return backend.name === configured;
+}
+
+function captureResolverOutput<T>(operation: () => T): T {
+  const originalWarn = console.warn;
+  const originalLog = console.log;
+  console.warn = () => undefined;
+  console.log = () => undefined;
+  try {
+    return operation();
+  } finally {
+    console.warn = originalWarn;
+    console.log = originalLog;
+  }
+}
+
+function checkStateBackend(
+  localSquadDir: string,
+  repoRoot: string,
+): HealthCheckItem {
+  const configPath = path.join(localSquadDir, 'config.json');
+  if (!storage.existsSync(configPath)) {
+    return skip(
+      'state-backend',
+      'No state backend is configured; local state files are in use',
+    );
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    config = parseJsonObject(
+      readRequiredFile(configPath, '.squad/config.json'),
+      '.squad/config.json',
+    );
+  } catch (error) {
+    return fail('state-backend', errorMessage(error));
+  }
+
+  if (config.stateBackend === undefined || config.stateBackend === null) {
+    return skip(
+      'state-backend',
+      'No state backend is configured; local state files are in use',
+    );
+  }
+  if (
+    typeof config.stateBackend !== 'string' ||
+    !config.stateBackend.trim()
+  ) {
+    return fail(
+      'state-backend',
+      'stateBackend must be a non-empty string when configured',
+    );
+  }
+
+  const configured = canonicalBackendType(config.stateBackend);
+  if (!configured) {
+    return fail(
+      'state-backend',
+      'Unknown configured state backend',
+    );
+  }
+
+  try {
+    const backend = captureResolverOutput(() =>
+      resolveStateBackend(localSquadDir, repoRoot, configured),
+    );
+    if (!backendMatches(backend, configured)) {
+      return fail(
+        'state-backend',
+        `Configured ${configured} state backend could not be initialized`,
+        [`resolved backend: ${backend.name}`],
+      );
+    }
+
+    const verification = verifyStateBackend(backend);
+    if (!verification.ok) {
+      return fail(
+        'state-backend',
+        `Configured ${configured} state backend is unreachable`,
+        ['backend verification failed'],
+      );
+    }
+
+    return pass(
+      'state-backend',
+      `Configured ${configured} state backend is reachable`,
+    );
+  } catch (error) {
+    return fail(
+      'state-backend',
+      `Configured ${configured} state backend check failed`,
+      [`error: ${errorKind(error)}`],
+    );
+  }
+}
+
+const ENV_CONFIG_PATHS = [
+  '.mcp.json',
+  path.join('.copilot', 'mcp-config.json'),
+  path.join('.vscode', 'mcp.json'),
+] as const;
+const ENV_REFERENCE = /\$\{(?:env:)?([A-Z_][A-Z0-9_]*)\}/g;
+
+function collectEnvironmentDeclarations(repoRoot: string): {
+  variables: string[];
+  diagnostics: string[];
+} {
+  const variables = new Set<string>();
+  const diagnostics: string[] = [];
+
+  for (const relativePath of ENV_CONFIG_PATHS) {
+    const configPath = path.join(repoRoot, relativePath);
+    if (!storage.existsSync(configPath)) continue;
+
+    try {
+      const config = parseJsonObject(
+        readRequiredFile(configPath, relativePath),
+        relativePath,
+      );
+      const servers = config.mcpServers ?? config.servers;
+      if (servers === undefined) continue;
+      if (!isRecord(servers)) {
+        diagnostics.push(`${relativePath}: servers must be a JSON object`);
+        continue;
+      }
+
+      for (const serverName of Object.keys(servers).sort((a, b) =>
+        a.localeCompare(b),
+      )) {
+        // Scaffolded EXAMPLE-* entries document integrations but are not enabled.
+        if (serverName.toUpperCase().startsWith('EXAMPLE-')) continue;
+        const server = servers[serverName];
+        if (!isRecord(server) || server.env === undefined) continue;
+        if (!isRecord(server.env)) {
+          diagnostics.push(
+            `${relativePath}: ${serverName}.env must be a JSON object`,
+          );
+          continue;
+        }
+
+        for (const envName of Object.keys(server.env).sort((a, b) =>
+          a.localeCompare(b),
+        )) {
+          const declaration = server.env[envName];
+          if (typeof declaration !== 'string') {
+            diagnostics.push(
+              `${relativePath}: ${serverName}.env.${envName} must be a string`,
+            );
+            continue;
+          }
+          for (const match of declaration.matchAll(ENV_REFERENCE)) {
+            if (match[1]) variables.add(match[1]);
+          }
+        }
+      }
+    } catch (error) {
+      diagnostics.push(`${relativePath}: ${errorMessage(error)}`);
+    }
+  }
+
+  return {
+    variables: [...variables].sort((a, b) => a.localeCompare(b)),
+    diagnostics: diagnostics.sort((a, b) => a.localeCompare(b)),
+  };
+}
+
+function checkEnvVars(repoRoot: string): HealthCheckItem {
+  const declarations = collectEnvironmentDeclarations(repoRoot);
+  if (declarations.diagnostics.length > 0) {
+    return fail(
+      'env-vars',
+      'Environment configuration declarations are invalid',
+      declarations.diagnostics,
+    );
+  }
+  if (declarations.variables.length === 0) {
+    return skip(
+      'env-vars',
+      'No required environment variables are declared by repository configuration',
+    );
+  }
+
+  const missing = declarations.variables.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    return fail(
+      'env-vars',
+      `${missing.length} required environment variable${missing.length === 1 ? ' is' : 's are'} missing`,
+      missing.map((name) => `missing: ${name}`),
+    );
+  }
+
+  return pass(
+    'env-vars',
+    `${declarations.variables.length} required environment variable${declarations.variables.length === 1 ? ' is' : 's are'} set`,
+  );
+}
+
+function buildHealthReport(
+  stateDir: string,
+  localSquadDir: string,
+  repoRoot: string,
+): HealthReport {
+  const checks: HealthCheckItem[] = [
+    checkTeam(stateDir),
+    checkRegistryAndCharters(stateDir),
+    checkRouting(stateDir),
+    checkStateBackend(localSquadDir, repoRoot),
+    checkEnvVars(repoRoot),
+  ];
+  return {
+    schema: HEALTH_SCHEMA,
+    status: checks.some((check) => check.status === 'fail') ? 'fail' : 'pass',
+    checks,
+  };
+}
+
+export function runSquadHealth(
+  squadDir: string,
+  repoRoot: string,
+): HealthReport {
+  return buildHealthReport(squadDir, squadDir, repoRoot);
+}
+
+function printHuman(report: HealthReport): void {
+  console.log(`squad health: ${report.status.toUpperCase()}`);
+  for (const check of report.checks) {
+    console.log(
+      `[${check.status.toUpperCase()}] ${check.id}: ${check.message}`,
+    );
+    for (const diagnostic of check.diagnostics ?? []) {
+      console.log(`  - ${diagnostic}`);
+    }
+  }
+}
+
+export async function runHealthCommand(
+  cwd: string,
+  args: string[],
+): Promise<number> {
+  const dirs = effectiveSquadDir(cwd);
+  const repoRoot = path.dirname(dirs.local.path);
+  const report = buildHealthReport(dirs.stateDir, dirs.local.path, repoRoot);
+
+  if (args.includes('--json')) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHuman(report);
+  }
+
+  return report.status === 'fail' ? 1 : 0;
+}

--- a/packages/squad-cli/src/cli/commands/health.ts
+++ b/packages/squad-cli/src/cli/commands/health.ts
@@ -395,7 +395,12 @@ function backendMatches(
   backend: StateBackend,
   configured: StateBackendType,
 ): boolean {
-  if (configured === 'local') return backend.name === 'local';
+  // `external-stub` is a documented placeholder that the SDK deliberately
+  // resolves to the local worktree backend, so a local resolution is the
+  // expected outcome rather than a silent fallback.
+  if (configured === 'local' || configured === 'external-stub') {
+    return backend.name === 'local';
+  }
   return backend.name === configured;
 }
 

--- a/packages/squad-cli/src/cli/commands/health.ts
+++ b/packages/squad-cli/src/cli/commands/health.ts
@@ -5,6 +5,7 @@
  */
 
 import path from 'node:path';
+import { parse as parseJsonc } from 'jsonc-parser';
 import {
   FSStorageProvider,
   resolveStateBackend,
@@ -278,7 +279,7 @@ function checkRegistryAndCharters(squadDir: string): HealthCheckItem {
   );
 }
 
-function loadRegistryKeys(squadDir: string): Set<string> {
+function loadKnownRoutingAgentKeys(squadDir: string): Set<string> {
   const registry = readRegistry(squadDir);
   const keys = new Set<string>();
   for (const [agentId, entry] of Object.entries(registry.agents)) {
@@ -286,6 +287,14 @@ function loadRegistryKeys(squadDir: string): Set<string> {
       throw new Error(`registry entry ${agentId} must be an object`);
     }
     keys.add(normalizeAgentRef(agentId));
+  }
+
+  const team = parseTeamMarkdown(
+    readRequiredFile(path.join(squadDir, 'team.md'), '.squad/team.md'),
+  );
+  for (const agent of team.agents) {
+    const key = normalizeAgentRef(agent.name);
+    if (key.startsWith('@')) keys.add(key);
   }
   return keys;
 }
@@ -305,9 +314,9 @@ function checkRouting(squadDir: string): HealthCheckItem {
       );
     }
 
-    let registryKeys: Set<string>;
+    let knownAgentKeys: Set<string>;
     try {
-      registryKeys = loadRegistryKeys(squadDir);
+      knownAgentKeys = loadKnownRoutingAgentKeys(squadDir);
     } catch {
       return fail(
         'routing',
@@ -332,7 +341,7 @@ function checkRouting(squadDir: string): HealthCheckItem {
       parsed.rules.flatMap((rule) => rule.agents);
     for (const agent of agentReferences) {
       const key = normalizeAgentRef(agent);
-      if (!key || !registryKeys.has(key)) {
+      if (!key || !knownAgentKeys.has(key)) {
         unresolved.add(agent);
       } else {
         referenced.add(key);
@@ -483,12 +492,151 @@ function checkStateBackend(
   }
 }
 
-const ENV_CONFIG_PATHS = [
-  '.mcp.json',
-  path.join('.copilot', 'mcp-config.json'),
-  path.join('.vscode', 'mcp.json'),
+const ENV_JSON_CONFIGS = [
+  { relativePath: '.mcp.json', serverKeys: ['mcpServers'] },
+  {
+    relativePath: path.join('.copilot', 'mcp-config.json'),
+    serverKeys: ['mcpServers'],
+  },
+  {
+    relativePath: path.join('.vscode', 'mcp.json'),
+    serverKeys: ['servers'],
+  },
+  {
+    relativePath: path.join('.vscode', 'settings.json'),
+    serverKeys: ['copilot.mcp.servers'],
+  },
 ] as const;
-const ENV_REFERENCE = /\$\{(?:env:)?([A-Z_][A-Z0-9_]*)\}/g;
+const ENV_REFERENCE =
+  /\$(?:\{(?:env:)?([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))(?![A-Za-z0-9_])/g;
+
+function collectEnvironmentReferences(
+  declaration: string,
+  variables: Set<string>,
+): void {
+  for (const match of declaration.matchAll(ENV_REFERENCE)) {
+    const name = match[1] ?? match[2];
+    if (name) variables.add(name);
+  }
+}
+
+function parseJsoncObject(
+  content: string,
+  displayPath: string,
+): Record<string, unknown> {
+  const errors: Array<{ error: number; offset: number; length: number }> = [];
+  const parsed = parseJsonc(content, errors, { allowTrailingComma: true });
+  if (errors.length > 0) {
+    throw new Error(`${displayPath} contains invalid JSON`);
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(`${displayPath} root must be a JSON object`);
+  }
+  return parsed;
+}
+
+function collectServerEnvironmentDeclarations(
+  servers: unknown,
+  relativePath: string,
+  variables: Set<string>,
+  diagnostics: string[],
+): void {
+  if (!isRecord(servers)) {
+    diagnostics.push(`${relativePath}: servers must be a JSON object`);
+    return;
+  }
+
+  for (const serverName of Object.keys(servers).sort((a, b) =>
+    a.localeCompare(b),
+  )) {
+    if (serverName.toUpperCase().startsWith('EXAMPLE-')) continue;
+    const server = servers[serverName];
+    if (!isRecord(server) || server.env === undefined) continue;
+    if (!isRecord(server.env)) {
+      diagnostics.push(
+        `${relativePath}: ${serverName}.env must be a JSON object`,
+      );
+      continue;
+    }
+
+    for (const envName of Object.keys(server.env).sort((a, b) =>
+      a.localeCompare(b),
+    )) {
+      const declaration = server.env[envName];
+      if (typeof declaration !== 'string') {
+        diagnostics.push(
+          `${relativePath}: ${serverName}.env.${envName} must be a string`,
+        );
+        continue;
+      }
+      collectEnvironmentReferences(declaration, variables);
+    }
+  }
+}
+
+function collectAgentFrontmatterDeclarations(
+  repoRoot: string,
+  variables: Set<string>,
+  diagnostics: string[],
+): void {
+  const relativePath = path.join('.github', 'agents', 'squad.agent.md');
+  const agentPath = path.join(repoRoot, relativePath);
+  if (!storage.existsSync(agentPath)) return;
+
+  try {
+    const content = storage.readSync(agentPath) ?? '';
+    const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1];
+    if (!frontmatter || !/^mcp-servers:\s*$/m.test(frontmatter)) return;
+
+    const lines = frontmatter.split(/\r?\n/);
+    let inMcpServers = false;
+    let currentServer: string | undefined;
+    let inEnvironment = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const indent = line.length - line.trimStart().length;
+
+      if (indent === 0) {
+        inMcpServers = trimmed === 'mcp-servers:';
+        currentServer = undefined;
+        inEnvironment = false;
+        continue;
+      }
+      if (!inMcpServers) continue;
+      if (indent === 2 && trimmed.endsWith(':')) {
+        currentServer = trimmed.slice(0, -1).trim();
+        inEnvironment = false;
+        continue;
+      }
+      if (indent === 4) {
+        inEnvironment = trimmed === 'env:';
+        continue;
+      }
+      if (
+        indent >= 6 &&
+        inEnvironment &&
+        currentServer &&
+        !currentServer.toUpperCase().startsWith('EXAMPLE-')
+      ) {
+        const separator = trimmed.indexOf(':');
+        if (separator === -1) {
+          diagnostics.push(
+            `${relativePath}: ${currentServer}.env declaration is invalid`,
+          );
+          continue;
+        }
+        collectEnvironmentReferences(
+          trimmed.slice(separator + 1).trim().replace(/^['"]|['"]$/g, ''),
+          variables,
+        );
+      }
+    }
+  } catch (error) {
+    diagnostics.push(`${relativePath}: ${errorMessage(error)}`);
+  }
+}
 
 function collectEnvironmentDeclarations(repoRoot: string): {
   variables: string[];
@@ -497,55 +645,30 @@ function collectEnvironmentDeclarations(repoRoot: string): {
   const variables = new Set<string>();
   const diagnostics: string[] = [];
 
-  for (const relativePath of ENV_CONFIG_PATHS) {
+  for (const { relativePath, serverKeys } of ENV_JSON_CONFIGS) {
     const configPath = path.join(repoRoot, relativePath);
     if (!storage.existsSync(configPath)) continue;
 
     try {
-      const config = parseJsonObject(
+      const config = parseJsoncObject(
         readRequiredFile(configPath, relativePath),
         relativePath,
       );
-      const servers = config.mcpServers ?? config.servers;
+      const servers = serverKeys
+        .map((key) => config[key])
+        .find((value) => value !== undefined);
       if (servers === undefined) continue;
-      if (!isRecord(servers)) {
-        diagnostics.push(`${relativePath}: servers must be a JSON object`);
-        continue;
-      }
-
-      for (const serverName of Object.keys(servers).sort((a, b) =>
-        a.localeCompare(b),
-      )) {
-        // Scaffolded EXAMPLE-* entries document integrations but are not enabled.
-        if (serverName.toUpperCase().startsWith('EXAMPLE-')) continue;
-        const server = servers[serverName];
-        if (!isRecord(server) || server.env === undefined) continue;
-        if (!isRecord(server.env)) {
-          diagnostics.push(
-            `${relativePath}: ${serverName}.env must be a JSON object`,
-          );
-          continue;
-        }
-
-        for (const envName of Object.keys(server.env).sort((a, b) =>
-          a.localeCompare(b),
-        )) {
-          const declaration = server.env[envName];
-          if (typeof declaration !== 'string') {
-            diagnostics.push(
-              `${relativePath}: ${serverName}.env.${envName} must be a string`,
-            );
-            continue;
-          }
-          for (const match of declaration.matchAll(ENV_REFERENCE)) {
-            if (match[1]) variables.add(match[1]);
-          }
-        }
-      }
+      collectServerEnvironmentDeclarations(
+        servers,
+        relativePath,
+        variables,
+        diagnostics,
+      );
     } catch (error) {
       diagnostics.push(`${relativePath}: ${errorMessage(error)}`);
     }
   }
+  collectAgentFrontmatterDeclarations(repoRoot, variables, diagnostics);
 
   return {
     variables: [...variables].sort((a, b) => a.localeCompare(b)),
@@ -610,6 +733,31 @@ export function runSquadHealth(
   return buildHealthReport(squadDir, squadDir, repoRoot);
 }
 
+function buildResolutionFailureReport(
+  error: unknown,
+  repoRoot: string,
+): HealthReport {
+  const diagnostic = [`error: ${errorKind(error)}`];
+  const checks: HealthCheckItem[] = [
+    fail('team', 'Squad state directory could not be resolved', diagnostic),
+    fail(
+      'registry-charters',
+      'Registry and charters could not be checked because Squad state could not be resolved',
+    ),
+    fail(
+      'routing',
+      'Routing could not be checked because Squad state could not be resolved',
+    ),
+    fail(
+      'state-backend',
+      'Configured Squad state could not be resolved',
+      diagnostic,
+    ),
+    checkEnvVars(repoRoot),
+  ];
+  return { schema: HEALTH_SCHEMA, status: 'fail', checks };
+}
+
 function printHuman(report: HealthReport): void {
   console.log(`squad health: ${report.status.toUpperCase()}`);
   for (const check of report.checks) {
@@ -626,9 +774,18 @@ export async function runHealthCommand(
   cwd: string,
   args: string[],
 ): Promise<number> {
-  const dirs = effectiveSquadDir(cwd);
-  const repoRoot = path.dirname(dirs.local.path);
-  const report = buildHealthReport(dirs.stateDir, dirs.local.path, repoRoot);
+  let report: HealthReport;
+  try {
+    const dirs = effectiveSquadDir(cwd);
+    const repoRoot = path.dirname(dirs.local.path);
+    report = buildHealthReport(
+      dirs.stateDir,
+      dirs.backendConfigDir,
+      repoRoot,
+    );
+  } catch (error) {
+    report = buildResolutionFailureReport(error, path.resolve(cwd));
+  }
 
   if (args.includes('--json')) {
     console.log(JSON.stringify(report, null, 2));

--- a/packages/squad-cli/src/cli/core/effective-squad-dir.ts
+++ b/packages/squad-cli/src/cli/core/effective-squad-dir.ts
@@ -7,8 +7,13 @@
  * @module cli/core/effective-squad-dir
  */
 
+import path from 'node:path';
 import { detectSquadDir, type SquadDirInfo } from './detect-squad-dir.js';
-import { loadDirConfig, resolveExternalStateDir } from '@bradygaster/squad-sdk';
+import {
+  loadDirConfig,
+  resolveExternalStateDir,
+} from '@bradygaster/squad-sdk';
+import { resolveSquadPaths } from '@bradygaster/squad-sdk/resolution';
 
 /**
  * Resolve the effective state directory from a local .squad/ path.
@@ -30,6 +35,8 @@ export interface EffectiveSquadDirs {
   local: SquadDirInfo;
   /** The effective state directory (external dir when externalized, otherwise local .squad/) */
   stateDir: string;
+  /** Directory whose config declares the active state backend */
+  backendConfigDir: string;
 }
 
 /**
@@ -42,5 +49,14 @@ export interface EffectiveSquadDirs {
  */
 export function effectiveSquadDir(dest: string): EffectiveSquadDirs {
   const local = detectSquadDir(dest);
-  return { local, stateDir: resolveStateDir(local.path) };
+  const paths = resolveSquadPaths(dest);
+  const teamSquadDir =
+    paths?.mode === 'remote'
+      ? path.join(paths.teamDir, paths.name)
+      : local.path;
+  return {
+    local,
+    stateDir: resolveStateDir(teamSquadDir),
+    backendConfigDir: teamSquadDir,
+  };
 }

--- a/packages/squad-cli/templates/routing.md
+++ b/packages/squad-cli/templates/routing.md
@@ -6,14 +6,9 @@ How to decide who handles what.
 
 | Work Type | Route To | Examples |
 |-----------|----------|----------|
-| {domain 1} | {Name} | {example tasks} |
-| {domain 2} | {Name} | {example tasks} |
-| {domain 3} | {Name} | {example tasks} |
-| Code review | {Name} | Review PRs, check quality, suggest improvements |
-| Testing | {Name} | Write tests, find edge cases, verify fixes |
-| Scope & priorities | {Name} | What to build next, trade-offs, decisions |
-| Session logging | Scribe | Automatic — never needs routing |
-| RAI review | Rai | Content safety, bias checks, credential detection, ethical review |
+
+Preset installation adds concrete routes for the configured team. Add or edit rows
+here only when their agent names also exist in the casting registry.
 
 ## Issue Routing
 

--- a/packages/squad-sdk/src/agents/charter-compiler.ts
+++ b/packages/squad-sdk/src/agents/charter-compiler.ts
@@ -264,6 +264,17 @@ export function parseCharterMarkdown(content: string): ParsedCharter {
     const styleMatch = identityContent.match(/\*\*Style:\*\*\s*(.+)/i);
     if (styleMatch) result.identity.style = styleMatch[1]!.trim();
   }
+
+  // Legacy charters identify the agent in the H1 instead of an Identity section.
+  if (!result.identity.name || !result.identity.role) {
+    const titleMatch = content.match(
+      /^#\s+(.+?)\s+(?:—|–|-)\s+(.+?)\s*$/m,
+    );
+    if (titleMatch) {
+      result.identity.name ??= titleMatch[1]!.trim();
+      result.identity.role ??= titleMatch[2]!.trim();
+    }
+  }
   
   // Extract ## What I Own section
   const ownershipMatch = content.match(/##\s+What I Own\s*\n([\s\S]*?)(?=\n##|\n---|$)/i);

--- a/packages/squad-sdk/src/config/markdown-migration.ts
+++ b/packages/squad-sdk/src/config/markdown-migration.ts
@@ -239,8 +239,8 @@ function parseTeamTable(lines: string[]): ParsedAgent[] {
 
     const cells = trimmed.split('|').map((c) => c.trim()).filter(Boolean);
 
-    // Detect header row
-    if (!headerCols && cells.some((c) => /name/i.test(c))) {
+    // Reset the column mapping for each roster table in the document.
+    if (cells.some((c) => /^name$/i.test(c.replace(/[*_`]/g, '').trim()))) {
       headerCols = cells.map((c) => c.toLowerCase());
       continue;
     }
@@ -289,58 +289,83 @@ function parseTeamTable(lines: string[]): ParsedAgent[] {
  */
 export function parseRoutingRulesMarkdown(
   content: string,
-): { rules: ParsedRoutingRule[]; warnings: string[] } {
+): {
+  rules: ParsedRoutingRule[];
+  warnings: string[];
+  agentReferences?: string[];
+} {
   content = normalizeEol(content);
   const rules: ParsedRoutingRule[] = [];
   const warnings: string[] = [];
+  const agentReferences: string[] = [];
 
   if (!content || !content.trim()) {
-    return { rules, warnings };
+    return { rules, warnings, agentReferences };
   }
 
   const lines = content.split('\n');
   let inTable = false;
-  let headerPassed = false;
+  let headerColumns: string[] = [];
 
   for (const line of lines) {
     const trimmed = line.trim();
 
-    // Detect routing table
-    if (/##\s*routing\s*table/i.test(trimmed)) {
+    // Detect routing table section (also accepts "## Work Type → Agent" used by this project's routing.md)
+    if (/##\s*routing\s*table/i.test(trimmed) || /##\s*work\s*type\s*.{0,5}agent/i.test(trimmed)) {
       inTable = true;
-      headerPassed = false;
+      headerColumns = [];
       continue;
     }
 
     // New section ends the table
-    if (inTable && /^##\s+/.test(trimmed) && !/routing\s*table/i.test(trimmed)) {
+    if (inTable && /^##\s+/.test(trimmed) && !/routing\s*table/i.test(trimmed) && !/work\s*type\s*.{0,5}agent/i.test(trimmed)) {
       inTable = false;
       continue;
     }
 
     if (inTable && trimmed.startsWith('|')) {
-      // Header row
-      if (/work\s*type|pattern/i.test(trimmed)) {
-        headerPassed = true;
+      const cells = parseMarkdownTableCells(trimmed);
+      if (
+        headerColumns.length === 0 &&
+        cells.some((cell) => /^(work\s*type|pattern)$/i.test(cell))
+      ) {
+        headerColumns = cells.map((cell) => cell.toLowerCase());
         continue;
       }
-      // Separator
-      if (/^[|:\-\s]+$/.test(trimmed)) continue;
+      if (cells.every((cell) => /^[-:]+$/.test(cell))) continue;
+      if (headerColumns.length === 0) continue;
 
-      if (!headerPassed) continue;
+      const workTypeIndex = headerColumns.findIndex((column) =>
+        /^(work\s*type|pattern)$/.test(column),
+      );
+      const agentIndexes = headerColumns
+        .map((column, index) =>
+          /^(route\s*to|agent|primary|secondary|owner)$/.test(column)
+            ? index
+            : -1,
+        )
+        .filter((index) => index >= 0);
+      const examplesIndex = headerColumns.findIndex((column) =>
+        /^examples?$/.test(column),
+      );
+      const workType = cells[workTypeIndex];
+      const agents = agentIndexes.flatMap((index) =>
+        (cells[index] ?? '')
+          .split(',')
+          .map((agent) => agent.trim())
+          .filter((agent) => agent.length > 0 && !/^[—-]+$/.test(agent)),
+      );
+      const examples =
+        examplesIndex >= 0
+          ? (cells[examplesIndex] ?? '')
+              .split(',')
+              .map((example) => example.trim())
+              .filter(Boolean)
+          : undefined;
 
-      const cells = trimmed.split('|').map((c) => c.trim()).filter(Boolean);
-      if (cells.length >= 2) {
-        const workType = cells[0];
-        const agents = cells[1]!.split(',').map((a) => a.trim()).filter(Boolean);
-        const examples =
-          cells.length >= 3
-            ? cells[2]!.split(',').map((e) => e.trim()).filter(Boolean)
-            : undefined;
-
-        if (workType && agents.length > 0) {
-          rules.push({ workType, agents, examples });
-        }
+      if (workType && agents.length > 0) {
+        rules.push({ workType, agents, examples });
+        agentReferences.push(...agents);
       }
     }
   }
@@ -349,7 +374,60 @@ export function parseRoutingRulesMarkdown(
     warnings.push('Could not parse any routing rules from routing.md');
   }
 
-  return { rules, warnings };
+  agentReferences.push(...parseModuleOwnershipAgentReferences(lines));
+
+  return { rules, warnings, agentReferences };
+}
+
+function parseModuleOwnershipAgentReferences(lines: string[]): string[] {
+  const references: string[] = [];
+  let inTable = false;
+  let agentColumns: number[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (/^##\s+module\s+ownership\b/i.test(trimmed)) {
+      inTable = true;
+      agentColumns = [];
+      continue;
+    }
+    if (inTable && /^##\s+/.test(trimmed)) break;
+    if (!inTable || !trimmed.startsWith('|')) continue;
+
+    const cells = parseMarkdownTableCells(trimmed);
+    if (
+      agentColumns.length === 0 &&
+      cells.some((cell) => /^(primary|secondary|owner|agent)$/i.test(cell))
+    ) {
+      agentColumns = cells
+        .map((cell, index) =>
+          /^(primary|secondary|owner|agent)$/i.test(cell) ? index : -1,
+        )
+        .filter((index) => index >= 0);
+      continue;
+    }
+    if (cells.every((cell) => /^[-:]+$/.test(cell))) continue;
+
+    for (const column of agentColumns) {
+      const value = cells[column];
+      if (!value || /^[—-]+$/.test(value)) continue;
+      references.push(
+        ...value
+          .split(',')
+          .map((agent) => agent.trim())
+          .filter(Boolean),
+      );
+    }
+  }
+
+  return references;
+}
+
+function parseMarkdownTableCells(line: string): string[] {
+  const cells = line.split('|').map((cell) => cell.trim());
+  if (cells[0] === '') cells.shift();
+  if (cells.at(-1) === '') cells.pop();
+  return cells;
 }
 
 // ============================================================================

--- a/packages/squad-sdk/src/config/markdown-migration.ts
+++ b/packages/squad-sdk/src/config/markdown-migration.ts
@@ -355,12 +355,16 @@ export function parseRoutingRulesMarkdown(
           .map((agent) => agent.trim())
           .filter((agent) => agent.length > 0 && !/^[—-]+$/.test(agent)),
       );
-      const examples =
+      const parsedExamples =
         examplesIndex >= 0
           ? (cells[examplesIndex] ?? '')
               .split(',')
               .map((example) => example.trim())
               .filter(Boolean)
+          : undefined;
+      const examples =
+        parsedExamples && parsedExamples.length > 0
+          ? parsedExamples
           : undefined;
 
       if (workType && agents.length > 0) {

--- a/packages/squad-sdk/templates/routing.md
+++ b/packages/squad-sdk/templates/routing.md
@@ -6,14 +6,9 @@ How to decide who handles what.
 
 | Work Type | Route To | Examples |
 |-----------|----------|----------|
-| {domain 1} | {Name} | {example tasks} |
-| {domain 2} | {Name} | {example tasks} |
-| {domain 3} | {Name} | {example tasks} |
-| Code review | {Name} | Review PRs, check quality, suggest improvements |
-| Testing | {Name} | Write tests, find edge cases, verify fixes |
-| Scope & priorities | {Name} | What to build next, trade-offs, decisions |
-| Session logging | Scribe | Automatic — never needs routing |
-| RAI review | Rai | Content safety, bias checks, credential detection, ethical review |
+
+Preset installation adds concrete routes for the configured team. Add or edit rows
+here only when their agent names also exist in the casting registry.
 
 ## Issue Routing
 

--- a/templates/routing.md
+++ b/templates/routing.md
@@ -6,14 +6,9 @@ How to decide who handles what.
 
 | Work Type | Route To | Examples |
 |-----------|----------|----------|
-| {domain 1} | {Name} | {example tasks} |
-| {domain 2} | {Name} | {example tasks} |
-| {domain 3} | {Name} | {example tasks} |
-| Code review | {Name} | Review PRs, check quality, suggest improvements |
-| Testing | {Name} | Write tests, find edge cases, verify fixes |
-| Scope & priorities | {Name} | What to build next, trade-offs, decisions |
-| Session logging | Scribe | Automatic — never needs routing |
-| RAI review | Rai | Content safety, bias checks, credential detection, ethical review |
+
+Preset installation adds concrete routes for the configured team. Add or edit rows
+here only when their agent names also exist in the casting registry.
 
 ## Issue Routing
 

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { compileCharter, type CharterCompileOptions } from '@bradygaster/squad-sdk/agents';
+import {
+  compileCharter,
+  parseCharterMarkdown,
+  type CharterCompileOptions,
+} from '@bradygaster/squad-sdk/agents';
 import { resolveModel, type ModelResolutionOptions } from '@bradygaster/squad-sdk/agents';
 import { ConfigurationError } from '@bradygaster/squad-sdk/adapter/errors';
 
@@ -94,6 +98,19 @@ describe('Charter Compilation (M1-8)', () => {
   });
 
   describe('Charter Parsing', () => {
+    it('should parse legacy name and role from the title', () => {
+      const charter = parseCharterMarkdown(`# Marquez — CLI UX Designer
+
+## Role
+Reviews command-line user experience.
+`);
+
+      expect(charter.identity).toMatchObject({
+        name: 'Marquez',
+        role: 'CLI UX Designer',
+      });
+    });
+
     it('should parse Identity section with name, role, expertise, style', () => {
       // This would test parseCharterMarkdown with real markdown content
       // For now, we test the exported function behavior

--- a/test/cli/health-command.test.ts
+++ b/test/cli/health-command.test.ts
@@ -1,0 +1,690 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const { mockResolveStateBackend, mockVerifyStateBackend } = vi.hoisted(() => ({
+  mockResolveStateBackend: vi.fn(),
+  mockVerifyStateBackend: vi.fn(),
+}));
+
+vi.mock('@bradygaster/squad-sdk', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@bradygaster/squad-sdk')>();
+  return {
+    ...actual,
+    resolveStateBackend: mockResolveStateBackend,
+    verifyStateBackend: mockVerifyStateBackend,
+  };
+});
+
+import {
+  runHealthCommand,
+  runSquadHealth,
+  type HealthCheckId,
+  type HealthCheckItem,
+  type HealthReport,
+} from '../../packages/squad-cli/src/cli/commands/health.js';
+
+const TEAM = `# Test Team
+
+## Members
+
+| Name | Role | Skills | Status |
+|------|------|--------|--------|
+| Alpha | Developer | TypeScript | Active |
+`;
+
+const MULTI_TABLE_TEAM = `# Test Team
+
+## Coordinator
+
+| Name | Role | Status |
+|------|------|--------|
+| Squad | Coordinator | Active |
+
+## Members
+
+| Name | Role | Skills | Status |
+|------|------|--------|--------|
+| Alpha | Developer | TypeScript | Active |
+`;
+
+const ROUTING = `# Routing
+
+## Work Type \u2192 Agent
+
+| Work Type | Agent | Examples |
+|-----------|-------|----------|
+| feature | Alpha | New work |
+`;
+
+const CHARTER = `# Alpha
+
+## Identity
+
+**Name:** Alpha
+**Role:** Developer
+`;
+
+let repoRoot: string;
+let squadDir: string;
+const savedEnvironment = new Map<string, string | undefined>();
+
+function write(relativePath: string, content: string): void {
+  const filePath = path.join(repoRoot, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, 'utf8');
+}
+
+function writeSquad(relativePath: string, content: string): void {
+  write(path.join('.squad', relativePath), content);
+}
+
+function createHealthyState(): void {
+  writeSquad('team.md', TEAM);
+  writeSquad(
+    path.join('casting', 'registry.json'),
+    JSON.stringify({
+      agents: {
+        alpha: {
+          created_at: '2026-01-01T00:00:00.000Z',
+          persistent_name: 'Alpha',
+          status: 'active',
+        },
+      },
+    }),
+  );
+  writeSquad(path.join('agents', 'alpha', 'charter.md'), CHARTER);
+  writeSquad('routing.md', ROUTING);
+  writeSquad('config.json', JSON.stringify({ version: 1 }));
+}
+
+function check(report: HealthReport, id: HealthCheckId): HealthCheckItem {
+  const result = report.checks.find((item) => item.id === id);
+  if (!result) throw new Error(`missing health check ${id}`);
+  return result;
+}
+
+function setEnvironment(name: string, value: string | undefined): void {
+  if (!savedEnvironment.has(name)) {
+    savedEnvironment.set(name, process.env[name]);
+  }
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  repoRoot = mkdtempSync(path.join(tmpdir(), 'squad-health-'));
+  squadDir = path.join(repoRoot, '.squad');
+  createHealthyState();
+  mockResolveStateBackend.mockReturnValue({ name: 'local' });
+  mockVerifyStateBackend.mockReturnValue({ ok: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(repoRoot, { recursive: true, force: true });
+  for (const [name, value] of savedEnvironment) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+  savedEnvironment.clear();
+});
+
+describe('health report contract', () => {
+  it('emits the stable schema and deterministic check order', () => {
+    const report = runSquadHealth(squadDir, repoRoot);
+
+    expect(report).toEqual({
+      schema: 'squad-health/v1',
+      status: 'pass',
+      checks: expect.any(Array),
+    });
+    expect(report.checks.map((item) => item.id)).toEqual([
+      'team',
+      'registry-charters',
+      'routing',
+      'state-backend',
+      'env-vars',
+    ]);
+    expect(report.checks.map((item) => item.status)).toEqual([
+      'pass',
+      'pass',
+      'pass',
+      'skip',
+      'skip',
+    ]);
+  });
+
+  it('keeps evaluating after a failure and makes the overall result fail', () => {
+    unlinkSync(path.join(squadDir, 'team.md'));
+
+    const report = runSquadHealth(squadDir, repoRoot);
+
+    expect(report.status).toBe('fail');
+    expect(report.checks).toHaveLength(5);
+    expect(check(report, 'team').status).toBe('fail');
+  });
+});
+
+describe('team readiness', () => {
+  it.each([
+    ['missing', undefined],
+    ['empty', ''],
+    ['malformed', '# Team without a roster'],
+  ])('fails for a %s team file', (_caseName, content) => {
+    const teamPath = path.join(squadDir, 'team.md');
+    if (content === undefined) {
+      unlinkSync(teamPath);
+    } else {
+      writeFileSync(teamPath, content, 'utf8');
+    }
+
+    expect(check(runSquadHealth(squadDir, repoRoot), 'team').status).toBe(
+      'fail',
+    );
+  });
+
+  it('fails on duplicate parsed agent names', () => {
+    writeSquad(
+      'team.md',
+      TEAM.replace(
+        '| Alpha | Developer | TypeScript | Active |',
+        '| Alpha | Developer | TypeScript | Active |\n| alpha | Tester | Vitest | Active |',
+      ),
+    );
+
+    const result = check(runSquadHealth(squadDir, repoRoot), 'team');
+
+    expect(result.status).toBe('fail');
+    expect(result.diagnostics).toEqual(['duplicate: alpha']);
+  });
+
+  it('parses multiple roster tables with their own column contracts', () => {
+    writeSquad('team.md', MULTI_TABLE_TEAM);
+
+    const result = check(runSquadHealth(squadDir, repoRoot), 'team');
+
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('2 members');
+  });
+});
+
+describe('registry and charter readiness', () => {
+  it.each([
+    ['missing', undefined],
+    ['empty', ''],
+    ['invalid JSON', '{'],
+    ['missing agents', '{}'],
+    ['empty agents', '{"agents":{}}'],
+  ])('fails for a %s casting registry', (_caseName, content) => {
+    const registryPath = path.join(squadDir, 'casting', 'registry.json');
+    if (content === undefined) {
+      unlinkSync(registryPath);
+    } else {
+      writeFileSync(registryPath, content, 'utf8');
+    }
+
+    expect(
+      check(runSquadHealth(squadDir, repoRoot), 'registry-charters').status,
+    ).toBe('fail');
+  });
+
+  it('validates retired charters from the alumni directory', () => {
+    writeSquad(
+      path.join('casting', 'registry.json'),
+      JSON.stringify({
+        agents: {
+          alpha: { persistent_name: 'Alpha', status: 'retired' },
+        },
+      }),
+    );
+    unlinkSync(path.join(squadDir, 'agents', 'alpha', 'charter.md'));
+    writeSquad(
+      path.join('agents', '_alumni', 'alpha', 'charter.md'),
+      '# Alpha — Developer\n\n## Role\nReviews CLI behavior.\n',
+    );
+
+    expect(
+      check(runSquadHealth(squadDir, repoRoot), 'registry-charters').status,
+    ).toBe('pass');
+  });
+
+  it('fails for a malformed registry entry instead of throwing', () => {
+    writeSquad(
+      path.join('casting', 'registry.json'),
+      '{"agents":{"alpha":null}}',
+    );
+
+    const result = check(
+      runSquadHealth(squadDir, repoRoot),
+      'registry-charters',
+    );
+
+    expect(result.status).toBe('fail');
+    expect(result.diagnostics).toEqual([
+      'alpha: registry entry must be an object',
+    ]);
+  });
+
+  it('fails for an unsupported registry status', () => {
+    writeSquad(
+      path.join('casting', 'registry.json'),
+      '{"agents":{"alpha":{"persistent_name":"Alpha","status":"unknown"}}}',
+    );
+
+    const result = check(
+      runSquadHealth(squadDir, repoRoot),
+      'registry-charters',
+    );
+
+    expect(result.status).toBe('fail');
+    expect(result.diagnostics).toEqual([
+      'alpha: registry entry has invalid status',
+    ]);
+  });
+
+  it('requires a charter for every registry entry, including retired entries', () => {
+    writeSquad(
+      path.join('casting', 'registry.json'),
+      JSON.stringify({
+        agents: {
+          alpha: { persistent_name: 'Alpha', status: 'retired' },
+        },
+      }),
+    );
+    unlinkSync(path.join(squadDir, 'agents', 'alpha', 'charter.md'));
+
+    expect(
+      check(runSquadHealth(squadDir, repoRoot), 'registry-charters').status,
+    ).toBe('fail');
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['empty', ''],
+    [
+      'invalid',
+      '## Identity\n\n**Name:** Different\n**Role:** Developer\n',
+    ],
+  ])('fails for a %s charter', (_caseName, content) => {
+    const charterPath = path.join(
+      squadDir,
+      'agents',
+      'alpha',
+      'charter.md',
+    );
+    if (content === undefined) {
+      unlinkSync(charterPath);
+    } else {
+      writeFileSync(charterPath, content, 'utf8');
+    }
+
+    expect(
+      check(runSquadHealth(squadDir, repoRoot), 'registry-charters').status,
+    ).toBe('fail');
+  });
+});
+
+describe('routing readiness', () => {
+  it('passes the initialized template after preset routes are appended', () => {
+    const template = readFileSync(
+      path.join(
+        process.cwd(),
+        'packages',
+        'squad-sdk',
+        'templates',
+        'routing.md',
+      ),
+      'utf8',
+    );
+    writeSquad('routing.md', `${template}\n${ROUTING}`);
+
+    expect(check(runSquadHealth(squadDir, repoRoot), 'routing').status).toBe(
+      'pass',
+    );
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['empty', ''],
+    ['malformed', '# Routing without a table'],
+  ])('fails for a %s routing file', (_caseName, content) => {
+    const routingPath = path.join(squadDir, 'routing.md');
+    if (content === undefined) {
+      unlinkSync(routingPath);
+    } else {
+      writeFileSync(routingPath, content, 'utf8');
+    }
+
+    expect(check(runSquadHealth(squadDir, repoRoot), 'routing').status).toBe(
+      'fail',
+    );
+  });
+
+  it('fails closed when the registry cannot be used for cross-reference', () => {
+    writeSquad(path.join('casting', 'registry.json'), '{');
+
+    const result = check(runSquadHealth(squadDir, repoRoot), 'routing');
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('registry is invalid');
+  });
+
+  it('reports unknown agents deterministically', () => {
+    writeSquad(
+      'routing.md',
+      ROUTING.replace(
+        '| feature | Alpha | New work |',
+        '| feature | Zulu, Missing | New work |',
+      ),
+    );
+
+    const result = check(runSquadHealth(squadDir, repoRoot), 'routing');
+
+    expect(result.status).toBe('fail');
+    expect(result.diagnostics).toEqual([
+      'unknown agent: Missing',
+      'unknown agent: Zulu',
+    ]);
+  });
+
+  it('rejects duplicate work types', () => {
+    writeSquad(
+      'routing.md',
+      ROUTING.replace(
+        '| feature | Alpha | New work |',
+        '| feature | Alpha | New work |\n| Feature | Alpha | More work |',
+      ),
+    );
+
+    const result = check(runSquadHealth(squadDir, repoRoot), 'routing');
+
+    expect(result.status).toBe('fail');
+    expect(result.diagnostics).toEqual(['duplicate work type: Feature']);
+  });
+
+  it('validates agent references in module ownership', () => {
+    writeSquad(
+      'routing.md',
+      `${ROUTING}
+## Module Ownership
+
+| Module | Primary | Secondary |
+|--------|---------|-----------|
+| src/cli | Alpha | Ghost |
+`,
+    );
+
+    const result = check(runSquadHealth(squadDir, repoRoot), 'routing');
+
+    expect(result.status).toBe('fail');
+    expect(result.diagnostics).toEqual(['unknown agent: Ghost']);
+  });
+
+  it('validates secondary agents in the work-type routing table', () => {
+    writeSquad(
+      'routing.md',
+      `## Routing Table
+
+| Work Type | Primary | Secondary |
+|-----------|---------|-----------|
+| feature | Alpha | Ghost |
+`,
+    );
+
+    const result = check(runSquadHealth(squadDir, repoRoot), 'routing');
+
+    expect(result.status).toBe('fail');
+    expect(result.diagnostics).toEqual(['unknown agent: Ghost']);
+  });
+});
+
+describe('state backend readiness', () => {
+  it('skips when no backend is configured', () => {
+    expect(
+      check(runSquadHealth(squadDir, repoRoot), 'state-backend').status,
+    ).toBe('skip');
+    expect(mockResolveStateBackend).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['empty config', ''],
+    ['invalid config', '{'],
+    ['non-string backend', '{"stateBackend":42}'],
+    ['empty backend', '{"stateBackend":""}'],
+    ['unknown backend', '{"stateBackend":"unknown"}'],
+  ])('fails closed for %s', (_caseName, config) => {
+    writeSquad('config.json', config);
+
+    expect(
+      check(runSquadHealth(squadDir, repoRoot), 'state-backend').status,
+    ).toBe('fail');
+  });
+
+  it('checks a configured local backend through the SDK primitives', () => {
+    writeSquad('config.json', '{"stateBackend":"local"}');
+
+    const result = check(
+      runSquadHealth(squadDir, repoRoot),
+      'state-backend',
+    );
+
+    expect(result.status).toBe('pass');
+    expect(mockResolveStateBackend).toHaveBeenCalledWith(
+      squadDir,
+      repoRoot,
+      'local',
+    );
+    expect(mockVerifyStateBackend).toHaveBeenCalledWith({ name: 'local' });
+  });
+
+  it('fails when configured backend resolution falls back', () => {
+    writeSquad('config.json', '{"stateBackend":"orphan"}');
+    mockResolveStateBackend.mockReturnValue({ name: 'local' });
+
+    const result = check(
+      runSquadHealth(squadDir, repoRoot),
+      'state-backend',
+    );
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('could not be initialized');
+  });
+
+  it('fails when a configured backend is unreachable without leaking errors', () => {
+    writeSquad('config.json', '{"stateBackend":"orphan"}');
+    mockResolveStateBackend.mockReturnValue({ name: 'orphan' });
+    mockVerifyStateBackend.mockReturnValue({
+      ok: false,
+      error: 'https://secret-token@example.invalid/private/state',
+    });
+
+    const report = runSquadHealth(squadDir, repoRoot);
+    const serialized = JSON.stringify(report);
+
+    expect(check(report, 'state-backend').status).toBe('fail');
+    expect(serialized).not.toContain('secret-token');
+    expect(serialized).not.toContain('example.invalid');
+  });
+
+  it('fails closed when an explicitly configured backend cannot be checked', () => {
+    writeSquad('config.json', '{"stateBackend":"external-stub"}');
+    mockResolveStateBackend.mockReturnValue({ name: 'local' });
+
+    expect(
+      check(runSquadHealth(squadDir, repoRoot), 'state-backend').status,
+    ).toBe('fail');
+  });
+});
+
+describe('environment readiness', () => {
+  it('skips when repository configuration declares no required variables', () => {
+    expect(check(runSquadHealth(squadDir, repoRoot), 'env-vars').status).toBe(
+      'skip',
+    );
+  });
+
+  it('ignores disabled example MCP server declarations', () => {
+    setEnvironment('HEALTH_EXAMPLE_TOKEN', undefined);
+    write(
+      path.join('.copilot', 'mcp-config.json'),
+      JSON.stringify({
+        mcpServers: {
+          'EXAMPLE-service': {
+            env: { TOKEN: '${HEALTH_EXAMPLE_TOKEN}' },
+          },
+        },
+      }),
+    );
+
+    expect(check(runSquadHealth(squadDir, repoRoot), 'env-vars').status).toBe(
+      'skip',
+    );
+  });
+
+  it('reports only sorted missing variable names from MCP declarations', () => {
+    setEnvironment('HEALTH_ALPHA_TOKEN', undefined);
+    setEnvironment('HEALTH_ZULU_TOKEN', undefined);
+    write(
+      path.join('.copilot', 'mcp-config.json'),
+      JSON.stringify({
+        mcpServers: {
+          service: {
+            env: {
+              TOKEN_Z: '${HEALTH_ZULU_TOKEN}',
+              TOKEN_A: '${HEALTH_ALPHA_TOKEN}',
+            },
+          },
+        },
+      }),
+    );
+
+    const result = check(runSquadHealth(squadDir, repoRoot), 'env-vars');
+
+    expect(result.status).toBe('fail');
+    expect(result.diagnostics).toEqual([
+      'missing: HEALTH_ALPHA_TOKEN',
+      'missing: HEALTH_ZULU_TOKEN',
+    ]);
+  });
+
+  it('passes when declared variables are set and never emits their values', () => {
+    const secret = 'health-secret-value-1605';
+    setEnvironment('HEALTH_REQUIRED_TOKEN', secret);
+    write(
+      '.mcp.json',
+      JSON.stringify({
+        mcpServers: {
+          service: {
+            env: { TOKEN: '${HEALTH_REQUIRED_TOKEN}' },
+          },
+        },
+      }),
+    );
+
+    const report = runSquadHealth(squadDir, repoRoot);
+
+    expect(check(report, 'env-vars').status).toBe('pass');
+    expect(JSON.stringify(report)).not.toContain(secret);
+  });
+
+  it('supports VS Code env declarations and fails malformed configuration', () => {
+    setEnvironment('HEALTH_VSCODE_TOKEN', undefined);
+    write(
+      path.join('.vscode', 'mcp.json'),
+      JSON.stringify({
+        servers: {
+          service: { env: { TOKEN: '${env:HEALTH_VSCODE_TOKEN}' } },
+        },
+      }),
+    );
+
+    expect(check(runSquadHealth(squadDir, repoRoot), 'env-vars')).toMatchObject({
+      status: 'fail',
+      diagnostics: ['missing: HEALTH_VSCODE_TOKEN'],
+    });
+
+    write(path.join('.vscode', 'mcp.json'), '{');
+    expect(check(runSquadHealth(squadDir, repoRoot), 'env-vars')).toMatchObject({
+      status: 'fail',
+      message: 'Environment configuration declarations are invalid',
+    });
+  });
+});
+
+describe('CLI output and exit semantics', () => {
+  it('emits deterministic JSON and returns zero for a healthy state', async () => {
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+      logs.push(String(line));
+    });
+
+    const exitCode = await runHealthCommand(repoRoot, ['--json']);
+    const report = JSON.parse(logs.join('\n')) as HealthReport;
+
+    expect(exitCode).toBe(0);
+    expect(report.schema).toBe('squad-health/v1');
+    expect(report.status).toBe('pass');
+  });
+
+  it('returns one and keeps JSON structured when any check fails', async () => {
+    unlinkSync(path.join(squadDir, 'team.md'));
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+      logs.push(String(line));
+    });
+
+    const exitCode = await runHealthCommand(repoRoot, ['--json']);
+    const report = JSON.parse(logs.join('\n')) as HealthReport;
+
+    expect(exitCode).toBe(1);
+    expect(report.status).toBe('fail');
+    expect(report.checks).toHaveLength(5);
+  });
+
+  it('keeps human output useful and secret-free', async () => {
+    const secret = 'human-output-secret-1605';
+    setEnvironment('HEALTH_HUMAN_TOKEN', secret);
+    write(
+      '.mcp.json',
+      JSON.stringify({
+        mcpServers: {
+          service: { env: { TOKEN: '${HEALTH_HUMAN_TOKEN}' } },
+        },
+      }),
+    );
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+      logs.push(String(line));
+    });
+
+    expect(await runHealthCommand(repoRoot, [])).toBe(0);
+    const output = logs.join('\n');
+    expect(output).toContain('squad health: PASS');
+    expect(output).toContain('[PASS] team:');
+    expect(output).not.toContain(secret);
+  });
+});

--- a/test/cli/health-command.test.ts
+++ b/test/cli/health-command.test.ts
@@ -7,6 +7,7 @@ import {
   vi,
 } from 'vitest';
 import {
+  cpSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -460,6 +461,24 @@ describe('routing readiness', () => {
     expect(result.status).toBe('fail');
     expect(result.diagnostics).toEqual(['unknown agent: Ghost']);
   });
+
+  it('accepts a platform coding agent declared in team.md', () => {
+    writeSquad(
+      'team.md',
+      TEAM.replace(
+        '| Alpha | Developer | TypeScript | Active |',
+        '| Alpha | Developer | TypeScript | Active |\n| @copilot | Coding Agent | TypeScript | Active |',
+      ),
+    );
+    writeSquad(
+      'routing.md',
+      ROUTING.replace('| feature | Alpha |', '| feature | @copilot |'),
+    );
+
+    expect(check(runSquadHealth(squadDir, repoRoot), 'routing').status).toBe(
+      'pass',
+    );
+  });
 });
 
 describe('state backend readiness', () => {
@@ -633,6 +652,54 @@ describe('environment readiness', () => {
       message: 'Environment configuration declarations are invalid',
     });
   });
+
+  it('supports VS Code settings, bare references, and mixed-case names', () => {
+    setEnvironment('AzureToken', undefined);
+    setEnvironment('db_password', undefined);
+    write(
+      path.join('.vscode', 'settings.json'),
+      `{
+        // VS Code settings are JSONC.
+        "copilot.mcp.servers": {
+          "service": {
+            "env": {
+              "TOKEN": "$AzureToken",
+              "PASSWORD": "\${env:db_password}",
+            },
+          },
+        },
+      }`,
+    );
+
+    expect(check(runSquadHealth(squadDir, repoRoot), 'env-vars')).toMatchObject({
+      status: 'fail',
+      diagnostics: ['missing: AzureToken', 'missing: db_password'],
+    });
+  });
+
+  it('discovers environment declarations in Squad agent frontmatter', () => {
+    setEnvironment('FrontmatterToken', undefined);
+    write(
+      path.join('.github', 'agents', 'squad.agent.md'),
+      `---
+name: squad
+mcp-servers:
+  service:
+    type: local
+    command: node
+    env:
+      TOKEN: \${FrontmatterToken}
+---
+
+# Squad
+`,
+    );
+
+    expect(check(runSquadHealth(squadDir, repoRoot), 'env-vars')).toMatchObject({
+      status: 'fail',
+      diagnostics: ['missing: FrontmatterToken'],
+    });
+  });
 });
 
 describe('CLI output and exit semantics', () => {
@@ -663,6 +730,62 @@ describe('CLI output and exit semantics', () => {
     expect(exitCode).toBe(1);
     expect(report.status).toBe('fail');
     expect(report.checks).toHaveLength(5);
+  });
+
+  it('uses linked team state and its backend configuration', async () => {
+    const remoteSquadDir = path.join(repoRoot, 'shared-team', '.squad');
+    cpSync(squadDir, remoteSquadDir, { recursive: true });
+    rmSync(path.join(squadDir, 'agents'), { recursive: true });
+    rmSync(path.join(squadDir, 'casting'), { recursive: true });
+    unlinkSync(path.join(squadDir, 'team.md'));
+    unlinkSync(path.join(squadDir, 'routing.md'));
+    writeSquad(
+      'config.json',
+      JSON.stringify({ version: 1, teamRoot: 'shared-team' }),
+    );
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+      logs.push(String(line));
+    });
+
+    const exitCode = await runHealthCommand(repoRoot, ['--json']);
+    const report = JSON.parse(logs.join('\n')) as HealthReport;
+
+    expect(exitCode).toBe(0);
+    expect(report.status).toBe('pass');
+    expect(check(report, 'registry-charters').status).toBe('pass');
+  });
+
+  it('emits the full JSON contract when state resolution fails', async () => {
+    writeSquad(
+      'config.json',
+      JSON.stringify({
+        version: 1,
+        teamRoot: '.',
+        projectKey: '../escape',
+        stateLocation: 'external',
+      }),
+    );
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: unknown) => {
+      logs.push(String(line));
+    });
+
+    const exitCode = await runHealthCommand(repoRoot, ['--json']);
+    const report = JSON.parse(logs.join('\n')) as HealthReport;
+
+    expect(exitCode).toBe(1);
+    expect(report).toMatchObject({
+      schema: 'squad-health/v1',
+      status: 'fail',
+    });
+    expect(report.checks.map((item) => item.id)).toEqual([
+      'team',
+      'registry-charters',
+      'routing',
+      'state-backend',
+      'env-vars',
+    ]);
   });
 
   it('keeps human output useful and secret-free', async () => {

--- a/test/cli/health-command.test.ts
+++ b/test/cli/health-command.test.ts
@@ -549,8 +549,32 @@ describe('state backend readiness', () => {
     expect(serialized).not.toContain('example.invalid');
   });
 
-  it('fails closed when an explicitly configured backend cannot be checked', () => {
+  it('accepts the external-stub placeholder resolving to the local backend', () => {
     writeSquad('config.json', '{"stateBackend":"external-stub"}');
+    mockResolveStateBackend.mockReturnValue({ name: 'local' });
+
+    const result = check(runSquadHealth(squadDir, repoRoot), 'state-backend');
+
+    expect(
+      result.status,
+      'external-stub is a documented placeholder that the SDK resolves to the ' +
+        'local backend, so a local resolution must not fail readiness',
+    ).toBe('pass');
+  });
+
+  it('accepts the deprecated external alias resolving to the local backend', () => {
+    writeSquad('config.json', '{"stateBackend":"external"}');
+    mockResolveStateBackend.mockReturnValue({ name: 'local' });
+
+    expect(
+      check(runSquadHealth(squadDir, repoRoot), 'state-backend').status,
+      'the deprecated "external" alias resolves to external-stub, which the SDK ' +
+        'implements with the local backend',
+    ).toBe('pass');
+  });
+
+  it('fails closed when an explicitly configured backend cannot be checked', () => {
+    writeSquad('config.json', '{"stateBackend":"two-layer"}');
     mockResolveStateBackend.mockReturnValue({ name: 'local' });
 
     expect(

--- a/test/effective-squad-dir.test.ts
+++ b/test/effective-squad-dir.test.ts
@@ -128,6 +128,21 @@ describe('effectiveSquadDir()', () => {
     expect(stateDir).toBe(join(globalDir, 'projects', projectKey));
   });
 
+  it('resolves linked team state and backend config from the remote team root', () => {
+    scaffold('.squad', 'shared-team/.squad');
+    const squadDir = join(TMP, '.squad');
+    writeConfig(squadDir, {
+      version: 1,
+      teamRoot: 'shared-team',
+    });
+
+    const { local, stateDir, backendConfigDir } = effectiveSquadDir(TMP);
+
+    expect(local.path).toBe(squadDir);
+    expect(stateDir).toBe(join(TMP, 'shared-team', '.squad'));
+    expect(backendConfigDir).toBe(stateDir);
+  });
+
   it('preserves SquadDirInfo metadata in local field', () => {
     scaffold('.squad');
     const { local } = effectiveSquadDir(TMP);

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -2348,3 +2348,111 @@ describe('gh-aw: threat detection taxonomy — parse_error must not map to agent
     expect(signalBlock).toContain('agentic-detection-failed');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Test: Shared bootstrap health-before-dispatch contract (#1605)
+//
+// The shared squad.md bootstrap must invoke `squad health --json` after init
+// and before any artifact upload or dispatch. Health failure must stop the
+// dispatch path visibly — no continue-on-error on the health step.
+// ---------------------------------------------------------------------------
+
+describe('gh-aw: shared bootstrap health-before-dispatch contract (#1605)', () => {
+  const sharedContent = readText(join(SHARED_DIR, 'squad.md'));
+
+  it('squad health --json appears in the shared bootstrap', () => {
+    expect(sharedContent).toMatch(/npx\s+--yes\s+"@bradygaster\/squad-cli@\$\{SQUAD_CLI_VERSION\}"\s+health\s+--json/);
+  });
+
+  it('health uses --json flag for structured CI output', () => {
+    expect(sharedContent).toMatch(/health --json/);
+  });
+
+  it('squad health --json appears after squad init (command ordering)', () => {
+    const initIdx = sharedContent.indexOf('init --preset default');
+    const healthIdx = sharedContent.indexOf('health --json');
+    expect(initIdx, 'squad init must appear in the shared bootstrap').toBeGreaterThan(-1);
+    expect(healthIdx, 'squad health --json must appear in the shared bootstrap').toBeGreaterThan(-1);
+    expect(healthIdx, 'health must come after init').toBeGreaterThan(initIdx);
+  });
+
+  it('squad health --json appears before upload-artifact (before dispatch)', () => {
+    const healthIdx = sharedContent.indexOf('health --json');
+    const uploadIdx = sharedContent.indexOf('upload-artifact');
+    expect(healthIdx, 'squad health --json must appear in the shared bootstrap').toBeGreaterThan(-1);
+    expect(uploadIdx, 'upload-artifact must appear in the shared bootstrap').toBeGreaterThan(-1);
+    expect(healthIdx, 'health must come before artifact upload').toBeLessThan(uploadIdx);
+  });
+
+  it('health step has no continue-on-error (fail-fast contract)', () => {
+    const lines = sharedContent.split('\n');
+    const healthLineIdx = lines.findIndex(l => l.includes('health --json'));
+    expect(healthLineIdx, 'health command must appear in the shared bootstrap').toBeGreaterThan(-1);
+
+    // Walk back to the "- name:" that opens this step.
+    let stepStart = healthLineIdx;
+    while (stepStart > 0 && !lines[stepStart].match(/^\s+-\s+name:/)) {
+      stepStart--;
+    }
+    // Walk forward to the next "- name:" or end of the pre-steps block.
+    let stepEnd = healthLineIdx + 1;
+    while (stepEnd < lines.length && !lines[stepEnd].match(/^\s+-\s+name:/) && !lines[stepEnd].match(/^steps:/)) {
+      stepEnd++;
+    }
+    const stepBlock = lines.slice(stepStart, stepEnd).join('\n');
+
+    expect(stepBlock, 'health step must contain the health command').toContain('health --json');
+    expect(
+      stepBlock,
+      'health step must NOT have continue-on-error: true — health failure must stop dispatch',
+    ).not.toMatch(/continue-on-error:\s*true/);
+  });
+
+  it('step ordering in pre-steps: init → health → upload', () => {
+    const preStepsStart = sharedContent.indexOf('pre-steps:');
+    expect(preStepsStart, 'pre-steps: block must exist in the shared bootstrap').toBeGreaterThan(-1);
+    const preStepsSection = sharedContent.slice(preStepsStart);
+
+    const initStepIdx = preStepsSection.indexOf('Initialize Squad team');
+    const healthStepIdx = preStepsSection.indexOf('Run Squad health check');
+    const uploadStepIdx = preStepsSection.indexOf('Upload Squad state artifact');
+
+    expect(initStepIdx, '"Initialize Squad team" step must exist').toBeGreaterThan(-1);
+    expect(healthStepIdx, '"Run Squad health check" step must exist').toBeGreaterThan(-1);
+    expect(uploadStepIdx, '"Upload Squad state artifact" step must exist').toBeGreaterThan(-1);
+
+    expect(healthStepIdx, 'health check must follow init').toBeGreaterThan(initStepIdx);
+    expect(healthStepIdx, 'health check must precede upload').toBeLessThan(uploadStepIdx);
+  });
+
+  it('health step uses the same CLI version mechanism as init', () => {
+    const lines = sharedContent.split('\n');
+    const healthLineIdx = lines.findIndex(l => l.includes('health --json'));
+    expect(healthLineIdx).toBeGreaterThan(-1);
+
+    const healthLine = lines[healthLineIdx];
+    expect(healthLine, 'health must use npx').toContain('npx');
+    expect(healthLine, 'health must reference squad-cli package').toContain('@bradygaster/squad-cli@');
+    expect(healthLine, 'health must use the SQUAD_CLI_VERSION variable').toContain('SQUAD_CLI_VERSION');
+  });
+
+  it('continue-on-error on the restore step does not shield health failure from stopping dispatch', () => {
+    // The agent-job restore step may carry continue-on-error: true — that is deliberate
+    // (it lets the agent-job body explain a missing artifact). The HEALTH step in the
+    // activation job must NOT carry it: activation-job failure blocks the agent job.
+    const lines = sharedContent.split('\n');
+    const restoreLineIdx = lines.findIndex(l => l.includes('Restore Squad state from activation artifact'));
+    expect(restoreLineIdx, 'restore step must exist').toBeGreaterThan(-1);
+
+    // Examine only the activation-job section (before the restore step).
+    const activationSection = lines.slice(0, restoreLineIdx).join('\n');
+    const healthStepStart = activationSection.lastIndexOf('Run Squad health check');
+    expect(healthStepStart, '"Run Squad health check" step must appear before the restore step').toBeGreaterThan(-1);
+
+    const healthStepBlock = activationSection.slice(healthStepStart);
+    expect(
+      healthStepBlock,
+      'health step in the activation job must not carry continue-on-error: true',
+    ).not.toMatch(/continue-on-error:\s*true/);
+  });
+});

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -11,6 +11,7 @@
 import { afterAll, describe, it, expect } from 'vitest';
 import { cpSync, readFileSync, existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
 import { execFileSync, execSync, spawnSync } from 'node:child_process';
 import { minimatch } from 'minimatch';
 import { POSIX_SHELL, NO_POSIX_SHELL_MESSAGE, requirePosixShell } from './posix-shell';
@@ -2454,5 +2455,87 @@ describe('gh-aw: shared bootstrap health-before-dispatch contract (#1605)', () =
       healthStepBlock,
       'health step in the activation job must not carry continue-on-error: true',
     ).not.toMatch(/continue-on-error:\s*true/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test: Uncast scaffolds must still initialize before the health gate (#1605)
+//
+// The activation job skips `squad init` when `.squad/team.md` already lists
+// roster entries. A scaffolded team.md carries only the table header and the
+// separator row, and counting those as a roster skips init — which, now that
+// readiness runs before dispatch, fails the activation job and blocks every
+// agent instead of casting the team.
+// ---------------------------------------------------------------------------
+
+describe('gh-aw: activation roster guard counts only data rows (#1605)', () => {
+  const sharedContent = readText(join(SHARED_DIR, 'squad.md'));
+
+  function initStepScript(): string {
+    const lines = sharedContent.split('\n');
+    const start = lines.findIndex((l) => l.includes('Initialize Squad team'));
+    expect(start, '"Initialize Squad team" step must exist').toBeGreaterThan(-1);
+    let end = start + 1;
+    while (end < lines.length && !/^\s+-\s+name:/.test(lines[end])) end++;
+    return lines.slice(start, end).join('\n');
+  }
+
+  /** Runs the step's roster guard against a team.md fixture. */
+  function skipsInit(teamContent: string): boolean {
+    const dir = mkdtempSync(join(tmpdir(), 'squad-roster-guard-'));
+    try {
+      const teamPath = join(dir, 'team.md');
+      writeFileSync(teamPath, teamContent);
+      const script = initStepScript();
+      const guard = script.match(/if \[ -f "\.squad\/team\.md" \] && ([\s\S]*?); then/)?.[1];
+      expect(
+        guard,
+        'roster guard must remain extractable from the "Initialize Squad team" step',
+      ).toBeDefined();
+
+      const result = spawnSync(
+        requirePosixShell(),
+        ['-c', (guard as string).replace(/\.squad\/team\.md/g, teamPath)],
+        { encoding: 'utf8' },
+      );
+      return result.status === 0;
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  const HEADER = '## Members\n\n| Name | Role | Charter | Status |\n|------|------|---------|--------|\n';
+
+  it('keeps the roster guard runnable in a plain POSIX shell', () => {
+    // The fixtures below execute the guard through `requirePosixShell()`, which is
+    // `/bin/sh` on Linux. Process substitution is a bash extension, so a guard that
+    // used it would fail there for the wrong reason and make the fixtures below
+    // report on shell support instead of roster semantics.
+    expect(
+      initStepScript(),
+      'roster guard must not use bash-only process substitution',
+    ).not.toContain('<(');
+  });
+
+  it('runs init for a scaffolded team.md that has no cast members', () => {
+    expect(
+      skipsInit(`${HEADER}\n## Project Context\n`),
+      'header and separator rows are not roster entries — skipping init here leaves ' +
+        'an uncast team that fails readiness and blocks every dispatch',
+    ).toBe(false);
+  });
+
+  it('preserves a committed cast rather than re-running init', () => {
+    expect(
+      skipsInit(`${HEADER}| Flight | Lead | \`.squad/agents/flight/charter.md\` | ✅ Active |\n\n## Project Context\n`),
+      'a team.md with real roster rows must still skip init (#1657)',
+    ).toBe(true);
+  });
+
+  it('ignores roster-shaped rows outside the Members section', () => {
+    expect(
+      skipsInit(`## Coordinator\n\n| Name | Role | Notes |\n|------|------|-------|\n| Squad | Coordinator | Routes work. |\n\n${HEADER}\n`),
+      'only the Members table describes the cast; the Coordinator table is always present',
+    ).toBe(false);
   });
 });

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -382,6 +382,53 @@ describe('MarkdownMigration', () => {
       const { warnings } = parseRoutingRulesMarkdown('## Routing Table\nEmpty');
       expect(warnings.length).toBeGreaterThan(0);
     });
+
+    it("should parse ## Work Type \u2192 Agent heading (this project's routing.md format)", () => {
+      const md = `
+## Work Type \u2192 Agent
+
+| Work Type | Agent | Examples |
+|-----------|-------|---------|
+| Core runtime | EECOM | adapter, session pool |
+| Tests | FIDO | unit tests, coverage |
+`;
+      const { rules, warnings } = parseRoutingRulesMarkdown(md);
+      expect(rules).toHaveLength(2);
+      expect(rules[0]!.workType).toBe('Core runtime');
+      expect(rules[0]!.agents).toEqual(['EECOM']);
+      expect(rules[1]!.workType).toBe('Tests');
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('should expose agent references from module ownership', () => {
+      const md = `## Routing Table
+
+| Work Type | Route To |
+|-----------|----------|
+| feature | Lead |
+
+## Module Ownership
+
+| Module | Primary | Secondary |
+|--------|---------|-----------|
+| src/cli | EECOM | CONTROL |
+| src/docs | PAO | — |
+`;
+      const { agentReferences } = parseRoutingRulesMarkdown(md);
+      expect(agentReferences).toEqual(['Lead', 'EECOM', 'CONTROL', 'PAO']);
+    });
+
+    it('should parse primary and secondary routing agents', () => {
+      const md = `## Routing Table
+
+| Work Type | Primary | Secondary |
+|-----------|---------|-----------|
+| feature | EECOM | CONTROL, FIDO |
+`;
+      const { rules, agentReferences } = parseRoutingRulesMarkdown(md);
+      expect(rules[0]!.agents).toEqual(['EECOM', 'CONTROL', 'FIDO']);
+      expect(agentReferences).toEqual(['EECOM', 'CONTROL', 'FIDO']);
+    });
   });
 
   // ---------- decisions.md ----------

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -48,9 +48,10 @@
 #
 # Optional custom Squad CLI version:
 #   vars.SQUAD_CLI_VERSION
-#   Default is '0.14.0' — the first release containing `squad health`.
-#   NOTE: This shared component becomes fully operational only after @bradygaster/squad-cli@0.14.0
-#   is published. Import this workflow only from refs that post-date that release.
+# Default is 0.14.0.
+#   This is the first release containing `squad health`. The shared component
+#   becomes fully operational only after that release is published.
+#   Import this workflow only from refs that post-date that release.
 #
 # Optional model override:
 #   vars.SQUAD_MODEL
@@ -71,6 +72,8 @@ engine:
 
 jobs:
   activation:
+    env:
+      SQUAD_CLI_VERSION: ${{ vars.SQUAD_CLI_VERSION || '0.14.0' }}
     pre-steps:
       - name: Mint Squad GitHub App token
         id: squad-app-token
@@ -83,7 +86,6 @@ jobs:
 
       - name: Initialize Squad team
         env:
-          SQUAD_CLI_VERSION: ${{ vars.SQUAD_CLI_VERSION || '0.14.0' }}
           GH_TOKEN: ${{ steps.squad-app-token.outputs.token || secrets.SQUAD_GITHUB_TOKEN || github.token }}
         run: |
           # Preserve committed cast state: if .squad/team.md already exists with
@@ -97,7 +99,6 @@ jobs:
 
       - name: Run Squad health check
         env:
-          SQUAD_CLI_VERSION: ${{ vars.SQUAD_CLI_VERSION || '0.14.0' }}
           GH_TOKEN: ${{ steps.squad-app-token.outputs.token || secrets.SQUAD_GITHUB_TOKEN || github.token }}
         run: |
           npx --yes "@bradygaster/squad-cli@${SQUAD_CLI_VERSION}" health --json

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -48,7 +48,9 @@
 #
 # Optional custom Squad CLI version:
 #   vars.SQUAD_CLI_VERSION
-#   Default is 0.12.0.
+#   Default is '0.14.0' — the first release containing `squad health`.
+#   NOTE: This shared component becomes fully operational only after @bradygaster/squad-cli@0.14.0
+#   is published. Import this workflow only from refs that post-date that release.
 #
 # Optional model override:
 #   vars.SQUAD_MODEL
@@ -81,7 +83,7 @@ jobs:
 
       - name: Initialize Squad team
         env:
-          SQUAD_CLI_VERSION: ${{ vars.SQUAD_CLI_VERSION || '0.12.0' }}
+          SQUAD_CLI_VERSION: ${{ vars.SQUAD_CLI_VERSION || '0.14.0' }}
           GH_TOKEN: ${{ steps.squad-app-token.outputs.token || secrets.SQUAD_GITHUB_TOKEN || github.token }}
         run: |
           # Preserve committed cast state: if .squad/team.md already exists with
@@ -92,6 +94,13 @@ jobs:
             echo "No existing squad team found — running squad init."
             npx --yes "@bradygaster/squad-cli@${SQUAD_CLI_VERSION}" init --preset default --state-backend local
           fi
+
+      - name: Run Squad health check
+        env:
+          SQUAD_CLI_VERSION: ${{ vars.SQUAD_CLI_VERSION || '0.14.0' }}
+          GH_TOKEN: ${{ steps.squad-app-token.outputs.token || secrets.SQUAD_GITHUB_TOKEN || github.token }}
+        run: |
+          npx --yes "@bradygaster/squad-cli@${SQUAD_CLI_VERSION}" health --json
 
       - name: Upload Squad state artifact
         if: success()
@@ -125,9 +134,10 @@ agent sandbox:
    activation job. This step optionally mints a GitHub App installation token (or
    uses a supplied PAT), checks whether `.squad/team.md` already exists with
    roster entries (preserving any previously committed cast), and only runs
-   `squad init` if no usable team is found. The resulting `.squad/` team state
-   plus `.github/agents/squad.agent.md` are uploaded as a `squad-state` artifact
-   — all inside the activation job with unrestricted egress.
+   `squad init` if no usable team is found. It then runs `squad health --json`
+   and uploads the resulting `.squad/` team state plus
+   `.github/agents/squad.agent.md` only when readiness checks pass — all inside
+   the activation job with unrestricted egress.
 
 2. **`steps:`** (agent job) — downloads the `squad-state` artifact and restores it
    into the workspace. The Squad CLI is never installed here; only the files it

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -90,7 +90,15 @@ jobs:
         run: |
           # Preserve committed cast state: if .squad/team.md already exists with
           # roster entries, skip init to avoid overwriting a merged cast (#1657).
-          if [ -f ".squad/team.md" ] && grep -q '^[|]' <(sed -n '/^## Members/,/^## /p' .squad/team.md | tail -n +2); then
+          # Only data rows count as roster entries: a scaffolded team.md carries
+          # the table header and separator, and treating those as a cast skips
+          # init, leaving a team the readiness check then rejects (#1605).
+          if [ -f ".squad/team.md" ] && awk '
+            /^## Members/ { in_members = 1; next }
+            /^## / { in_members = 0 }
+            in_members && /^\|/ && !/^\|[[:space:]]*Name[[:space:]]*\|/ && /[[:alnum:]]/ { found = 1 }
+            END { exit found ? 0 : 1 }
+          ' .squad/team.md; then
             echo "✓ Existing squad team detected with roster entries — skipping init."
           else
             echo "No existing squad team found — running squad init."


### PR DESCRIPTION
## Summary
- add `squad health` with deterministic `squad-health/v1` JSON and useful human output
- validate team, registry/charters, routing references, configured state backend, and declared environment variables
- fail closed before gh-aw dispatch and keep generated routing templates ready for post-init validation

## Validation
- bundled and executed `squad health --json` against this repository: pass
- verified missing Squad state exits 1 with all five structured checks
- strict gh-aw shared-workflow compile: 0 warnings
- esbuild syntax checks for changed TypeScript: pass
- repository parser validation: 23 team members, 41 valid registry charters, 19 routing rules, no charter failures
- full Vitest, ESLint, typecheck, and package build unavailable locally because the required Microsoft npm proxy returns 404 for pinned `vitest@4.1.11`; manifests and lockfile were not changed

Closes #1605