### PR TITLE
test(gh-aw): enforce dispatcher-first install order

### DIFF
--- a/test/gh-aw-implement-workflow.test.ts
+++ b/test/gh-aw-implement-workflow.test.ts
@@ -237,15 +237,29 @@ describe('gh-aw implement workflows', () => {
   });
 
   it('documents one-command installation in dependency order', () => {
-    const dispatcherIndex = guide.indexOf('bradygaster/squad/workflows/squad.md@dev');
-    const workerIndex = guide.indexOf('bradygaster/squad/workflows/squad-implement-worker.md@dev');
-    const reviewerIndex = guide.indexOf('bradygaster/squad/workflows/squad-review.md@dev');
+    const paths = [
+      'bradygaster/squad/workflows/squad.md@dev',
+      'bradygaster/squad/workflows/squad-implement-worker.md@dev',
+      'bradygaster/squad/workflows/squad-review.md@dev',
+    ];
+    const orderedInstallCommand = [
+      'gh aw add \\',
+      `  ${paths[0]} \\`,
+      `  ${paths[1]} \\`,
+      `  ${paths[2]}`,
+    ].join('\n');
+    const normalizedGuide = guide.replace(/\r\n/g, '\n');
+    const hasOrderedInstallCommand = (markdown: string): boolean =>
+      [...markdown.matchAll(/```bash\n([\s\S]*?)\n```/g)]
+        .some(match => match[1].includes(orderedInstallCommand));
 
-    expect(dispatcherIndex).toBeGreaterThan(-1);
-    expect(workerIndex).toBeGreaterThan(-1);
-    expect(reviewerIndex).toBeGreaterThan(-1);
-    expect(workerIndex).toBeGreaterThan(dispatcherIndex);
-    expect(reviewerIndex).toBeGreaterThan(workerIndex);
+    expect(hasOrderedInstallCommand(normalizedGuide)).toBe(true);
+
+    const reorderedGuide = normalizedGuide.replaceAll(
+      `${paths[0]} \\\n  ${paths[1]}`,
+      `${paths[1]} \\\n  ${paths[0]}`,
+    );
+    expect(hasOrderedInstallCommand(reorderedGuide)).toBe(false);
     expect(guide).toMatch(
       /Keep the dispatcher first\. `gh aw add` discovers its implementation-worker and\s+reviewer dependencies while compiling it; the explicit worker and reviewer\s+entries then confirm the complete install surface without creating duplicates\./,
     );

--- a/test/gh-aw-implement-workflow.test.ts
+++ b/test/gh-aw-implement-workflow.test.ts
@@ -237,12 +237,18 @@ describe('gh-aw implement workflows', () => {
   });
 
   it('documents one-command installation in dependency order', () => {
-    const workerIndex = guide.indexOf('bradygaster/squad/workflows/squad-implement-worker.md@dev');
     const dispatcherIndex = guide.indexOf('bradygaster/squad/workflows/squad.md@dev');
+    const workerIndex = guide.indexOf('bradygaster/squad/workflows/squad-implement-worker.md@dev');
+    const reviewerIndex = guide.indexOf('bradygaster/squad/workflows/squad-review.md@dev');
 
+    expect(dispatcherIndex).toBeGreaterThan(-1);
     expect(workerIndex).toBeGreaterThan(-1);
-    expect(dispatcherIndex).toBeGreaterThan(workerIndex);
-    expect(guide).toContain('The single command installs the dedicated worker first');
+    expect(reviewerIndex).toBeGreaterThan(-1);
+    expect(workerIndex).toBeGreaterThan(dispatcherIndex);
+    expect(reviewerIndex).toBeGreaterThan(workerIndex);
+    expect(guide).toMatch(
+      /Keep the dispatcher first\. `gh aw add` discovers its implementation-worker and\s+reviewer dependencies while compiling it; the explicit worker and reviewer\s+entries then confirm the complete install surface without creating duplicates\./,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- correct the stale install-order regression assertion to require dispatcher, implementation worker, then reviewer
- verify all three workflow entries are present
- assert the current dispatcher-first dependency-discovery explanation

## Validation

- `test/gh-aw-implement-workflow.test.ts`: 14 passed with cached Vitest 4.1.9
- targeted ESLint passed with the cached ESLint 10.8.1 TypeScript test configuration
- dispatcher/worker mutation: focused assertion failed as expected
- worker/reviewer mutation: focused assertion failed as expected
- `git diff --check` passed

The mandated npm proxy does not provide locked `vitest@4.1.11`; manifests and lockfiles are unchanged.

Working as FIDO (Quality Owner).

Closes #1878
