### PR TITLE
chore(release): prepare CHANGELOG for v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-08-25
+
+### Added
+
+- (cli) Add `squad health` readiness diagnostics and fail-fast shared workflow integration, so workflows can gate on environment readiness before running (#1605).
+- (cli) Advertise real team capabilities in `.github/agents/squad.agent.md` so an outer Agentic Workflows coordinator can route to the squad correctly; the block regenerates on cast, init, and upgrade (#1608).
+- (cli) Support `{prompt}` token in custom watch/loop agent commands as an unambiguous placement for the generated prompt, with the existing `-p <prompt>` fallback preserved.
+- (cli) `squad doctor` now checks that every `eol=lf`-pinned file is actually LF on disk (not just in the index), names stale files, and points at `npm run fix:crlf`; closes #1793.
+- (cli) Two stop signals for `squad watch`/`squad loop` previously parsed but never read — `--sentinel-file <path>` and `.squad/ralph-stop` — are now wired to the graceful shutdown path; closes #1711.
+
+### Changed
+
+- (cli) Model catalog tiers and fallback routing updated for GPT-5.6 Sol, Terra, and Luna, and Gemini 3.1 Pro. Terra is the new default standard model for code and prompt tasks; Luna is its economy fallback.
+- (cli) Back up locally modified workflow files before `squad upgrade` refreshes them (#1493).
+
+### Fixed
+
+- (cli) `setupConsultMode` now verifies that `info/exclude` belongs to the repository rooted at `projectRoot` before writing; prevents hiding `.squad/` in the main checkout and all sibling worktrees when called from a linked worktree.
+- (cli) Watch's PID tracker cross-checks a live process's actual OS start time against `spawnedAt` before killing it, preventing collateral kills after a crash + PID reuse (#1641).
+- (cli) `LocalPollingProvider` parses script `task.ref` with quote awareness, fixing scheduler tasks on Windows paths with spaces (e.g. `C:\Program Files\nodejs\node.exe`); adds `TaskConfig.argv` as the unambiguous alternative.
+- (cli) `squad watch` and `squad loop` now route all capability state reads/writes through `stateRoot` (from `effectiveSquadDir().stateDir`) instead of constructing `.squad/` paths from `teamRoot`, fixing silent empty-state reads after `squad externalize`; closes #1490.
+- (cli) `squad nap` (`archiveDecisions`) no longer destroys decision history: archival now refuses to run when the destination is untracked and git-ignored, verifies entry count before trimming the source, and uses fence-aware record-boundary scanning. SDK adds `archiveEntries()`, `resolveTrackedDestination()`, `prepareInboxBodyForMerge()`; fixes #1774, #1783, #1760.
+- (sdk) `resolveSquadState()` now passes `rootDir: paths.teamDir` to `FSStorageProvider`, so the path-traversal guard actually validates state writes; also fixes `resolveSquadPaths()` treating `config.teamRoot: "."` as remote mode, which pointed `teamDir` one level above `.squad/`; fixes #1555.
+- (sdk) `parseAzureDevOpsRemote()` now decodes percent-encoded characters in org/project/repo segments for all three URL formats (`dev.azure.com`, SSH, legacy `visualstudio.com`); fixes #1526.
+- (sdk) Add `"max"` to `SquadReasoningEffort` and `VALID_REASONING_EFFORTS` to match Copilot SDK 1.0.9.
+
 ## [0.12.0] - 2026-08-12
 
 ### Added


### PR DESCRIPTION
## What

Promotes `[Unreleased]` to `[0.13.0] - 2026-08-25` in `CHANGELOG.md`, compiled from 15 pending changesets.

## Why this is required

`squad-promote.yml` validates `grep -q "## [$VERSION]" CHANGELOG.md` before merging `preview → main`. Without this entry the promote workflow fails and `v0.13.0` cannot ship.

## Merge order

1. Merge #1884 fix (Booster) → `dev`
2. Merge this PR → `dev`
3. Trigger **Squad Promote** (`workflow_dispatch`, `dry_run: false`) → `dev → preview → main`
4. `squad-release.yml` auto-fires → tag `v0.13.0` + GitHub Release created
5. `squad-npm-publish.yml` fires on `release: published` → `@bradygaster/squad-cli@0.13.0` on npm
6. Verify: `npm view @bradygaster/squad-cli@0.13.0 version`

## Version determination

| | Value |
|---|---|
| Published on npm | `0.12.0` |
| Latest GitHub release | `v0.12.0` |
| `package.json` on `dev` | `0.13.0` (bumped in #1705) |
| Next semver from changesets | `0.13.0` (highest bump: `minor`, from `squad-health` + `scribe-archival-integrity`) |

No version file changes are needed — `dev` is already at `0.13.0`.

## No automation changes

This PR touches only `CHANGELOG.md`. The existing release path (`squad-promote.yml` → `squad-release.yml` → `squad-npm-publish.yml`) is used unchanged.