### PR TITLE
fix: sync-skill-templates exits 0 when .squad/skills absent

### DIFF
--- a/scripts/sync-skill-templates.mjs
+++ b/scripts/sync-skill-templates.mjs
@@ -18,8 +18,8 @@ const targets = [
 console.log('🔄 Syncing skill templates from canonical source...\n');
 
 if (!existsSync(skillsSourceDir)) {
-  console.error(`❌ Source directory not found: ${skillsSourceDir}`);
-  process.exit(1);
+  console.log(`⏭️  Source directory not found: ${skillsSourceDir} — skipping sync (normal on main/preview)`);
+  process.exit(0);
 }
 
 const skillDirs = readdirSync(skillsSourceDir).filter(name => {


### PR DESCRIPTION
The sync-skill-templates.mjs prebuild script exits 1 when .squad/skills does not exist. On main and preview branches .squad/ is not tracked, so every build fails. This is release-blocking for v0.13.0 npm publish. Fix: exit 0 with a skip message when the source dir is absent.