### PR TITLE
fix(cli): preserve user env on squad_state entry in .mcp.json

### DIFF
--- a/.changeset/preserve-mcp-json-env.md
+++ b/.changeset/preserve-mcp-json-env.md
@@ -1,0 +1,9 @@
+---
+'@bradygaster/squad-cli': patch
+---
+
+Preserve user-supplied `env` on the `squad_state` entry in `.mcp.json`
+
+`squad init` and `squad upgrade` rebuilt the `squad_state` entry from scratch on every run, hardcoding `env: {}`. Users behind a corporate npm proxy — who must set `npm_config_registry` there for the MCP server to launch at all — lost that setting every time they ran either command, and the idempotency check could never short-circuit for them, so the file was rewritten on every invocation.
+
+`env` is now carried forward verbatim. `command` and `args` remain Squad-managed so the version pin still refreshes.

--- a/packages/squad-cli/src/cli/core/mcp-root.ts
+++ b/packages/squad-cli/src/cli/core/mcp-root.ts
@@ -21,7 +21,7 @@
  *
  * Safety: we refuse to overwrite a malformed `.mcp.json` rather than
  * silently clobber a user-edited file; other `mcpServers.*` entries are
- * preserved byte-for-byte through the JSON round-trip, and user-supplied
+ * preserved semantically through the JSON round-trip, and user-supplied
  * `env` values on the `squad_state` entry survive re-runs.
  *
  * @module cli/core/mcp-root

--- a/packages/squad-cli/src/cli/core/mcp-root.ts
+++ b/packages/squad-cli/src/cli/core/mcp-root.ts
@@ -21,7 +21,8 @@
  *
  * Safety: we refuse to overwrite a malformed `.mcp.json` rather than
  * silently clobber a user-edited file; other `mcpServers.*` entries are
- * preserved byte-for-byte through the JSON round-trip.
+ * preserved byte-for-byte through the JSON round-trip, and user-supplied
+ * `env` values on the `squad_state` entry survive re-runs.
  *
  * @module cli/core/mcp-root
  */
@@ -96,22 +97,30 @@ export function ensureSquadStateMcpInRoot(
   }
 
   const existing = parsed.mcpServers[key];
+
+  // `command`/`args` are Squad-managed (they carry the version pin) and are
+  // always refreshed. `env` is user territory — Squad writes no keys into it,
+  // so anything already there (corporate npm proxy settings, for example) is
+  // carried forward rather than reset. See bradygaster/squad#1893.
+  const hasUsableEnv =
+    !!existing?.env && typeof existing.env === 'object' && !Array.isArray(existing.env);
   const desired: McpServerEntry = {
     command: spec.command,
     args: [...spec.args],
-    env: {},
+    env: hasUsableEnv ? { ...existing!.env } : {},
     tools: ['*'],
   };
 
+  // `desired.env` is a verbatim copy of `existing.env` whenever the latter is a
+  // usable object, so `hasUsableEnv` is the whole env comparison. A malformed
+  // `env` (array/string/null) is normalized to `{}` above and must be rewritten.
   if (
     existing &&
     existing.command === desired.command &&
     Array.isArray(existing.args) &&
     existing.args.length === desired.args!.length &&
     existing.args.every((a, i) => a === desired.args![i]) &&
-    existing.env &&
-    typeof existing.env === 'object' &&
-    Object.keys(existing.env).length === 0 &&
+    hasUsableEnv &&
     Array.isArray(existing.tools) &&
     existing.tools.length === 1 &&
     existing.tools[0] === '*'

--- a/test/mcp-root-write.test.ts
+++ b/test/mcp-root-write.test.ts
@@ -10,6 +10,8 @@
  *     and preserves siblings.
  *   - Malformed `.mcp.json` is refused (throws) rather than overwritten.
  *   - Idempotency: re-writing the same spec is a no-op (written === false).
+ *   - User-supplied `env` on the squad_state entry survives re-runs
+ *     (bradygaster/squad#1893).
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -96,6 +98,75 @@ describe('iter-8 mcp-root: repo-root .mcp.json writer + project tombstone', () =
 
     const second = ensureSquadStateMcpInRoot(tmpProject, '0.9.6-preview.14', PINNED_SPEC);
     expect(second.written).toBe(false);
+  });
+
+  it('preserves user-supplied env on the squad_state entry (#1893)', () => {
+    const cfgPath = getProjectMcpJsonPath(tmpProject);
+    fs.writeFileSync(
+      cfgPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            squad_state: {
+              command: 'npx',
+              args: ['-y', '@bradygaster/squad-cli@0.0.1-old', 'state-mcp'],
+              env: {
+                npm_config_registry: 'https://internal-proxy.example/npm/',
+                npm_config_allow_remote: 'all',
+              },
+              tools: ['*'],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = ensureSquadStateMcpInRoot(tmpProject, '0.9.6-preview.14', PINNED_SPEC);
+    expect(result.written).toBe(true);
+
+    const entry = JSON.parse(fs.readFileSync(cfgPath, 'utf8')).mcpServers.squad_state;
+    // env is user territory — carried forward verbatim.
+    expect(entry.env).toEqual({
+      npm_config_registry: 'https://internal-proxy.example/npm/',
+      npm_config_allow_remote: 'all',
+    });
+    // command/args are Squad-managed — refreshed to the new pin.
+    expect(entry.args).toEqual(PINNED_SPEC.args);
+    expect(entry.tools).toEqual(['*']);
+  });
+
+  it('is idempotent when the entry carries a user env — no rewrite churn (#1893)', () => {
+    const cfgPath = getProjectMcpJsonPath(tmpProject);
+    ensureSquadStateMcpInRoot(tmpProject, '0.9.6-preview.14', PINNED_SPEC);
+
+    const withEnv = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    withEnv.mcpServers.squad_state.env = { npm_config_registry: 'https://internal-proxy.example/npm/' };
+    fs.writeFileSync(cfgPath, JSON.stringify(withEnv, null, 2) + '\n');
+
+    const second = ensureSquadStateMcpInRoot(tmpProject, '0.9.6-preview.14', PINNED_SPEC);
+    expect(second.written).toBe(false);
+
+    // Untouched on disk.
+    const entry = JSON.parse(fs.readFileSync(cfgPath, 'utf8')).mcpServers.squad_state;
+    expect(entry.env).toEqual({ npm_config_registry: 'https://internal-proxy.example/npm/' });
+  });
+
+  it('normalizes a malformed env on the squad_state entry to an empty object', () => {
+    const cfgPath = getProjectMcpJsonPath(tmpProject);
+    fs.writeFileSync(
+      cfgPath,
+      JSON.stringify({
+        mcpServers: {
+          squad_state: { command: 'npx', args: [...PINNED_SPEC.args], env: 'nope', tools: ['*'] },
+        },
+      }),
+    );
+
+    const result = ensureSquadStateMcpInRoot(tmpProject, '0.9.6-preview.14', PINNED_SPEC);
+    expect(result.written).toBe(true);
+    expect(JSON.parse(fs.readFileSync(cfgPath, 'utf8')).mcpServers.squad_state.env).toEqual({});
   });
 
   it('tombstone removes squad_state from .copilot/mcp-config.json while preserving siblings', () => {


### PR DESCRIPTION
Closes #1893

## Problem

`ensureSquadStateMcpInRoot` rebuilt the `squad_state` entry in the repo-root `.mcp.json` from scratch on every `squad init` and every `squad upgrade`, hardcoding `env: {}`.

Users behind a corporate npm proxy have to put `npm_config_registry` in that `env` block for the MCP server to launch at all. That setting was erased by the very next `init` or `upgrade`. Reported in the Squad Teams channel by Jonathan Fischer, who saw it as `.mcp.json` being wiped — fair, since `squad_state` was the only entry in his file.

There was a second-order effect too: the idempotency short-circuit required `Object.keys(existing.env).length === 0`, so a non-empty `env` guaranteed a rewrite on *every* invocation. Affected users could never hit the no-op path.

`init` and `upgrade` share this code path exactly (`init.ts:401`, `init.ts:424`, `upgrade.ts:882`), so there was no workaround by choosing one over the other.

## Fix

`env` is now carried forward verbatim, and `hasUsableEnv` replaces the empty-env condition in the equality check so unchanged configs are genuinely left alone.

`command` and `args` remain Squad-managed — they carry the version pin and should keep refreshing. A malformed `env` (array, string, null) is still normalized to `{}`.

## Tests

Three cases added to `test/mcp-root-write.test.ts`:

- User `env` survives an upgrade that bumps the pinned version.
- An entry carrying a user `env` reports `written: false` on re-run and is untouched on disk.
- A malformed `env` is normalized to `{}`.

The first two fail on `dev` and pass with this change:

```
FAIL  preserves user-supplied env on the squad_state entry (#1893)
FAIL  is idempotent when the entry carries a user env — no rewrite churn (#1893)
```

Full file passes with the fix: 9/9.

## Notes for reviewers

- `mcp-root.ts` is not in the protected-files list and already imports `FSStorageProvider`, so the zero-dependency bootstrap rule does not apply here.
- Other fields on the `squad_state` entry are still fully Squad-managed. Preserving arbitrary unknown keys is the same class of problem but has different semantics per key, so I left it out of scope rather than expand this PR.
- `npm run build` currently fails on `dev` in `packages/squad-sdk/src/adapter/client.ts` with `@github/copilot-sdk` API drift (`RuntimeConnection`, `onLifecycle`, `tokenPrices`). I confirmed the identical failure with my changes stashed, so it is pre-existing and unrelated. `tsc --noEmit` on `packages/squad-cli` reports no errors in `mcp-root.ts`. Two pre-existing failures in `test/cli/init-upgrade-parity.test.ts` likewise reproduce on clean `dev`.
