### PR TITLE
fix: publish standalone bundles with releases

### DIFF
--- a/.github/workflows/squad-release.yml
+++ b/.github/workflows/squad-release.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      created: ${{ steps.check_tag.outputs.exists == 'false' }}
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
         with:
@@ -79,3 +82,15 @@ jobs:
         run: |
           gh release view "${{ steps.version.outputs.tag }}"
           echo "✅ Release ${{ steps.version.outputs.tag }} created and verified."
+
+  standalone:
+    name: Publish standalone bundles
+    needs: release
+    if: needs.release.outputs.created == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/squad-standalone-release.yml
+    with:
+      upload: true
+      release_tag: ${{ needs.release.outputs.tag }}
+      source_ref: ${{ needs.release.outputs.tag }}

--- a/.github/workflows/squad-standalone-release.yml
+++ b/.github/workflows/squad-standalone-release.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Upload to release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}
+          TAG: ${{ inputs.release_tag || github.event.release.tag_name || (github.ref_type == 'tag' && github.ref_name) }}
         working-directory: artifacts
         run: |
           set -euo pipefail
@@ -251,7 +251,7 @@ jobs:
 
       - name: Generate manifests
         env:
-          TAG: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}
+          TAG: ${{ inputs.release_tag || github.event.release.tag_name || (github.ref_type == 'tag' && github.ref_name) }}
         run: |
           set -euo pipefail
           cat artifacts/*.sha256 > "${RUNNER_TEMP}/SHA256SUMS.txt"
@@ -273,7 +273,7 @@ jobs:
 
       - name: Summarize
         env:
-          TAG: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}
+          TAG: ${{ inputs.release_tag || github.event.release.tag_name || (github.ref_type == 'tag' && github.ref_name) }}
         run: |
           set -euo pipefail
           {

--- a/.github/workflows/squad-standalone-release.yml
+++ b/.github/workflows/squad-standalone-release.yml
@@ -14,6 +14,28 @@ name: Squad Standalone Bundles
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      node_version:
+        description: 'Node.js runtime version to vendor into the bundles'
+        required: false
+        default: '22.20.0'
+        type: string
+      upload:
+        description: 'Attach the built bundles to the requested release'
+        required: false
+        default: false
+        type: boolean
+      release_tag:
+        description: 'GitHub Release tag that receives the bundles'
+        required: false
+        default: ''
+        type: string
+      source_ref:
+        description: 'Git ref whose source is bundled'
+        required: false
+        default: ''
+        type: string
   workflow_dispatch:
     inputs:
       node_version:
@@ -26,6 +48,16 @@ on:
         required: false
         default: false
         type: boolean
+      release_tag:
+        description: 'GitHub Release tag that receives the bundles (defaults to the selected tag)'
+        required: false
+        default: ''
+        type: string
+      source_ref:
+        description: 'Git ref whose source is bundled (defaults to release_tag or the selected ref)'
+        required: false
+        default: ''
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,6 +104,8 @@ jobs:
             runner: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+        with:
+          ref: ${{ inputs.source_ref || inputs.release_tag || github.event.release.tag_name || github.ref }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 #v6
         with:
@@ -92,7 +126,10 @@ jobs:
           unzip -v | head -n 1
 
       - name: Build packages
-        run: npm run build
+        # Root prebuild synchronizes contributor-only .squad sources that are
+        # intentionally absent from release tags. Package builds consume the
+        # already-synchronized templates committed with the release.
+        run: npm -w packages/squad-sdk run build && npm -w packages/squad-cli run build
 
       - name: Build standalone bundle
         env:
@@ -189,7 +226,7 @@ jobs:
       - name: Upload to release
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.event.release.tag_name || github.ref_name }}
+          TAG: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}
         working-directory: artifacts
         run: |
           set -euo pipefail
@@ -214,7 +251,7 @@ jobs:
 
       - name: Generate manifests
         env:
-          TAG: ${{ github.event.release.tag_name || github.ref_name }}
+          TAG: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}
         run: |
           set -euo pipefail
           cat artifacts/*.sha256 > "${RUNNER_TEMP}/SHA256SUMS.txt"
@@ -236,7 +273,7 @@ jobs:
 
       - name: Summarize
         env:
-          TAG: ${{ github.event.release.tag_name || github.ref_name }}
+          TAG: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}
         run: |
           set -euo pipefail
           {
@@ -251,4 +288,3 @@ jobs:
             # shellcheck disable=SC2016
             echo '  validate with `winget validate --manifest <dir>`, then open the PR.'
           } >> "${GITHUB_STEP_SUMMARY}"
-

--- a/test/standalone-release-workflow.test.ts
+++ b/test/standalone-release-workflow.test.ts
@@ -56,7 +56,7 @@ describe('standalone release handoff', () => {
 
   it('uses the explicit release tag for bundles and packaging manifests', () => {
     const tagExpression =
-      'TAG: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}';
+      "TAG: ${{ inputs.release_tag || github.event.release.tag_name || (github.ref_type == 'tag' && github.ref_name) }}";
     expect(standalone.match(new RegExp(tagExpression.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')))
       .toHaveLength(3);
   });

--- a/test/standalone-release-workflow.test.ts
+++ b/test/standalone-release-workflow.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Regression guards for the standalone release handoff.
+ *
+ * GitHub suppresses release events created with GITHUB_TOKEN, so the normal
+ * release workflow must call the bundle workflow directly. Release tags also
+ * omit contributor-only .squad state, which means the bundle build must avoid
+ * the root prebuild synchronization step.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOWS = join(process.cwd(), '.github', 'workflows');
+const release = readFileSync(join(WORKFLOWS, 'squad-release.yml'), 'utf8');
+const standalone = readFileSync(join(WORKFLOWS, 'squad-standalone-release.yml'), 'utf8');
+
+describe('standalone release handoff', () => {
+  it('calls the reusable bundle workflow after creating a release', () => {
+    expect(release).toMatch(/release:\r?\n\s+runs-on:[\s\S]*?\s+outputs:/);
+    expect(release).toContain("created: ${{ steps.check_tag.outputs.exists == 'false' }}");
+    expect(release).toContain('tag: ${{ steps.version.outputs.tag }}');
+    expect(release).toMatch(
+      /standalone:\r?\n\s+name: Publish standalone bundles\r?\n\s+needs: release/,
+    );
+    expect(release).toContain("if: needs.release.outputs.created == 'true'");
+    expect(release).toContain('uses: ./.github/workflows/squad-standalone-release.yml');
+    expect(release).toContain('release_tag: ${{ needs.release.outputs.tag }}');
+    expect(release).toContain('source_ref: ${{ needs.release.outputs.tag }}');
+  });
+
+  it('uses only contents permission for the reusable release upload', () => {
+    expect(release).toMatch(
+      /standalone:[\s\S]*?permissions:\r?\n\s+contents: write[\s\S]*?uses: \.\/\.github\/workflows\/squad-standalone-release\.yml/,
+    );
+    expect(release).not.toContain('actions: write');
+  });
+
+  it('accepts explicit release and source refs for calls and manual backfills', () => {
+    expect(standalone).toMatch(/workflow_call:\r?\n\s+inputs:/);
+    expect(standalone).toMatch(/workflow_dispatch:\r?\n\s+inputs:/);
+    for (const input of ['node_version:', 'upload:', 'release_tag:', 'source_ref:']) {
+      expect(standalone.match(new RegExp(input, 'g'))?.length).toBe(2);
+    }
+    expect(standalone).toContain(
+      'ref: ${{ inputs.source_ref || inputs.release_tag || github.event.release.tag_name || github.ref }}',
+    );
+  });
+
+  it('builds package workspaces without the release-tag-incompatible root prebuild', () => {
+    expect(standalone).toContain(
+      'run: npm -w packages/squad-sdk run build && npm -w packages/squad-cli run build',
+    );
+    expect(standalone).not.toMatch(/^\s*run: npm run build\s*$/m);
+  });
+
+  it('uses the explicit release tag for bundles and packaging manifests', () => {
+    const tagExpression =
+      'TAG: ${{ inputs.release_tag || github.event.release.tag_name || github.ref_name }}';
+    expect(standalone.match(new RegExp(tagExpression.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')))
+      .toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

- call the standalone bundle workflow directly after creating a release, avoiding `GITHUB_TOKEN` event suppression
- build the SDK and CLI workspaces without the release-tag-incompatible root prebuild
- support explicit release and source refs for exact-version backfills
- add regression coverage for the release handoff and least-privilege permissions

## Testing

- `npm run build`
- `node --test test/*.test.cjs`
- `vitest run test/standalone-release-workflow.test.ts test/standalone-build.test.ts test/packaging-manifests.test.ts`

Closes #1593