### PR TITLE
chore(release): prepare v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-08-26
+
+### Fixed
+
+- Allow runtime state tools to persist the casting policy, registry, and history keys required by the coordinator (`casting/policy`, `casting/registry`, and `casting/history`), while continuing to reject unrelated casting paths (#1876, #1898).
+
 ## [0.13.0] - 2026-08-25
 
 This release is focused on hardening the gh-aw (Agentic Workflows) integration shipped in v0.12.0: the install contract, workflow router, plan lifecycle, dispatch reliability, and CI coverage are all tightened. It also adds `squad health`, fixes `squad watch`/`squad loop` externalized-state routing, fixes `squad nap` archival, and hardens the SDK's state and scheduler paths.
@@ -539,5 +545,4 @@ First stable release since v0.9.4 (April 25). Consumes 97 changesets (sdk: 50, c
 - New entry point: `src/cli-entry.ts` (CLI bootstrap separated from library exports)
 - Migrated to npm workspace publishing (`@bradygaster/squad-sdk`, `@bradygaster/squad-cli`)
 - Changesets infrastructure for independent package versioning
-
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Allow runtime state tools to persist the casting policy, registry, and history keys required by the coordinator (`casting/policy`, `casting/registry`, and `casting/history`), while continuing to reject unrelated casting paths (#1876, #1898).
+- Allow runtime state tools to persist the casting policy, registry, and history keys required by the coordinator (`casting/policy.json`, `casting/registry.json`, and `casting/history.json`), while continuing to reject unrelated casting paths (#1876, #1898).
 
 ## [0.13.0] - 2026-08-25
 
@@ -545,4 +545,3 @@ First stable release since v0.9.4 (April 25). Consumes 97 changesets (sdk: 50, c
 - New entry point: `src/cli-entry.ts` (CLI bootstrap separated from library exports)
 - Migrated to npm workspace publishing (`@bradygaster/squad-sdk`, `@bradygaster/squad-cli`)
 - Changesets infrastructure for independent package versioning
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bradygaster/squad",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -8151,7 +8151,7 @@
     },
     "packages/squad-cli": {
       "name": "@bradygaster/squad-cli",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8192,7 +8192,7 @@
     },
     "packages/squad-sdk": {
       "name": "@bradygaster/squad-sdk",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^1.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "description": "Squad — Programmable multi-agent runtime for GitHub Copilot, built on @github/copilot-sdk",
   "type": "module",

--- a/packages/squad-cli/package.json
+++ b/packages/squad-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-cli",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Squad CLI — Command-line interface for the Squad multi-agent runtime",
   "type": "module",
   "bin": {

--- a/packages/squad-sdk/package.json
+++ b/packages/squad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradygaster/squad-sdk",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Squad SDK — Programmable multi-agent runtime for GitHub Copilot",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- bump the root, CLI, and SDK versions to `0.13.1`
- add the `0.13.1` changelog entry for the casting runtime state fix from #1898
- keep package-lock workspace metadata aligned

## Release evidence

- `v0.13.0` predates merge commit `31553830` from #1898
- both npm packages already published `0.13.0`, so the fix requires a new patch version
- `node --test test/*.test.cjs` passes (134/134)

After this merges to `dev`, a reviewed promotion PR will merge `dev` into `main`; the release and npm publish workflows will publish CLI and SDK `0.13.1`.

Closes #1876