### PR TITLE
Harden Squad GH-AW consumer lifecycle

### DIFF
--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -15,7 +15,7 @@ This guide covers setup, every slash command, and daily usage patterns.
 
 ## Quick start
 
-Five steps from zero to a working Squad team:
+Seven steps from zero to a validated, reviewable Squad bootstrap:
 
 ```bash
 # 1. Install the gh-aw extension (one-time)
@@ -26,24 +26,47 @@ gh api --method PUT repos/{owner}/{repo}/actions/permissions/workflow \
   -f default_workflow_permissions=read \
   -F can_approve_pull_request_reviews=true
 
-# 3. Add the Squad workflows to your repo
+# 3. Create a bootstrap branch
+default_branch="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+git switch -c chore/squad-gh-aw-bootstrap
+
+# 4. Add the Squad workflows to your repo
 gh aw add \
   bradygaster/squad/workflows/squad.md@dev \
   bradygaster/squad/workflows/squad-implement-worker.md@dev \
   bradygaster/squad/workflows/squad-deps-worker.md@dev \
   bradygaster/squad/workflows/squad-review.md@dev
 
-# 4. Commit and push the workflow sources and generated files
-git add -- .gitattributes .github/workflows/ .github/skills/
-git commit -m "ci: add Squad agentic workflow"
-git push
+# 5. On first install, review the safe-update report.
+# If it contains only the documented Squad secrets and init action, approve it:
+gh aw compile --strict --approve
 
-# 5. Open an issue and type /squad cast — done!
+# 6. Always run the final strict compile without approval
+gh aw compile --strict
+
+# Verify every supported workflow has a source and generated lockfile
+for workflow in squad squad-implement-worker squad-deps-worker squad-review; do
+  test -f ".github/workflows/${workflow}.md"
+  test -f ".github/workflows/${workflow}.lock.yml"
+done
+
+# 7. Commit the generated files and open the bootstrap PR
+git add -- .gitattributes .github/aw/ .github/workflows/ .github/skills/
+git diff --cached --stat
+test -z "$(git diff --cached --diff-filter=D --name-only)"
+git commit -m "ci: add Squad agentic workflow"
+git push -u origin HEAD
+gh pr create \
+  --base "$default_branch" \
+  --title "ci: add Squad agentic workflow" \
+  --body "Installs and strictly compiles the supported Squad GH-AW workflows."
+gh pr edit --add-reviewer @copilot
+gh pr checks --watch
 ```
 
-After pushing, open an issue in your repo and write `/squad cast` in the body or
-a comment. Squad analyzes your codebase, composes a team of specialist agents,
-and opens a PR with the result.
+After the bootstrap PR is reviewed and merged, open an issue in your repo and
+write `/squad cast` in the body or a comment. Squad analyzes your codebase,
+composes a team of specialist agents, and opens a second PR with the result.
 
 ---
 
@@ -80,6 +103,16 @@ a link for you to create the pull request manually. A manually created pull
 request is authored by your account, and GitHub does not allow authors to
 approve their own pull requests.
 
+### Create a bootstrap branch
+
+```bash
+default_branch="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+git switch -c chore/squad-gh-aw-bootstrap
+```
+
+Keep the generated workflow install isolated on this branch until strict
+compilation and human review are complete.
+
 ### Install the workflows
 
 ```bash
@@ -98,39 +131,85 @@ The installed top-level workflow set is:
 
 - `squad.md` and `squad.lock.yml`
 - `squad-implement-worker.md` and `squad-implement-worker.lock.yml`
+- `squad-deps-worker.md` and `squad-deps-worker.lock.yml`
 - `squad-review.md` and `squad-review.lock.yml`
 
 > **Branch note:** `@dev` pulls from the latest development branch where new modes and fixes land first. Stay on `@dev` to get improvements as they ship. Once gh-aw support reaches stable, you can switch to `@main` or drop the ref entirely for the default branch.
 
 This registers the Squad workflow in your repository's agentic workflow
-configuration and automatically compiles the workflow definitions into
-deterministic `.lock.yml` files. Under normal conditions, no separate compile
-step is needed.
+configuration and compiles the workflow definitions into deterministic
+`.lock.yml` files. The supported bootstrap path still runs `gh aw compile
+--strict` explicitly before review so every installed source is validated
+together and the PR contains the exact generated lockfiles that passed.
 
-> **Safe-update approval:** If `gh aw add` reports unapproved safe-update
-> changes for restricted secrets (`SQUAD_GITHUB_APP_PRIVATE_KEY`,
-> `SQUAD_GITHUB_TOKEN`), review those changes and complete the approval with:
+### Review first-install safe updates
+
+On a clean repository, `gh aw add` reports these expected safe-update changes:
+
+- Restricted secrets: `SQUAD_GITHUB_APP_PRIVATE_KEY` and `SQUAD_GITHUB_TOKEN`
+- Action: `bradygaster/squad/.github/actions/squad-init`
+
+Review the report before approving it. If it contains only those documented
+entries, complete the first-install approval with:
 >
 > ```bash
-> gh aw compile --approve
+> gh aw compile --strict --approve
 > ```
->
-> This follow-up is only needed when the safe-update warning appears.
 
-### Commit the workflow files
+Stop and investigate if the report contains any other secret or action. The
+approval command is needed only when the safe-update warning appears; it is not
+a substitute for the final strict compile below.
+
+### Strictly compile the installed workflows
 
 ```bash
-git add -- .gitattributes .github/workflows/ .github/skills/
-git commit -m "ci: add Squad agentic workflow"
-git push
+gh aw compile --strict
 ```
 
-This command stages `.gitattributes` and files under `.github/workflows/` and
-`.github/skills/`.
+Run this exact command after any required first-install approval and before
+committing. It must report all four workflows succeeded. `squad.md` currently
+emits one known warning because both slash-command and `github-actions[bot]`
+triggers are configured; the bot trigger is required for controlled worker
+continuation dispatches. Any error or any additional warning is a stop condition.
 
-> **Troubleshooting:** If the lock files are missing or you need to regenerate
-> them manually, run `gh aw compile`. This is only needed if something went wrong
-> during `gh aw add`.
+Verify the complete source/lock surface:
+
+```bash
+for workflow in squad squad-implement-worker squad-deps-worker squad-review; do
+  test -f ".github/workflows/${workflow}.md"
+  test -f ".github/workflows/${workflow}.lock.yml"
+done
+```
+
+### Open the bootstrap pull request
+
+```bash
+git add -- .gitattributes .github/aw/ .github/workflows/ .github/skills/
+git diff --cached --stat
+test -z "$(git diff --cached --diff-filter=D --name-only)"
+git commit -m "ci: add Squad agentic workflow"
+git push -u origin HEAD
+gh pr create \
+  --base "$default_branch" \
+  --title "ci: add Squad agentic workflow" \
+  --body "Installs and strictly compiles the supported Squad GH-AW workflows."
+gh pr edit --add-reviewer @copilot
+gh pr checks --watch
+```
+
+This stages the workflow sources and lockfiles, the gh-aw manifest and pinned
+state under `.github/aw/`, the installed skills, and `.gitattributes`. Review
+the complete generated diff in the bootstrap PR, address Copilot review
+feedback, and wait for required checks. Merge only after human approval.
+
+`gh aw add` may also create `.vscode/settings.json` to enable Copilot for
+Markdown workflow files. The command above intentionally leaves that optional
+editor setting untracked. Delete it if you do not want the local setting, or
+stage it explicitly if your team wants to share it.
+
+> **Troubleshooting:** If the lock files are missing, rerun `gh aw compile
+> --strict`. Do not open or merge the bootstrap PR until all four source/lock
+> pairs exist and strict compilation succeeds.
 
 Downloaded workflow audit data is local diagnostic output and should not be
 committed. If a `.gitignore` is missing from `.github/aw/logs/`, add one there:
@@ -181,6 +260,27 @@ a Personal Access Token:
 | `SQUAD_GITHUB_TOKEN` | Secret | Fallback PAT when no GitHub App is configured |
 
 **Auth precedence:** GitHub App token → `SQUAD_GITHUB_TOKEN` → `github.token`.
+
+---
+
+## Supported-path validation checklist
+
+Use this checklist for the initial bootstrap and after any workflow update:
+
+| Stage | Action | Expected evidence |
+|-------|--------|-------------------|
+| Install | Run the four-workflow `gh aw add` command on a bootstrap branch | All four `.md`/`.lock.yml` pairs exist, with shared imports, `.github/aw/`, installed skills, and `.gitattributes` included in the diff |
+| Compile | Review any first-install safe-update report, approve only the documented entries, then run `gh aw compile --strict` without approval | All four workflows succeed, only the documented bot-trigger warning remains, and all eight source/lock files exist |
+| Bootstrap review | Open the PR, request `@copilot`, wait for checks, and merge only after human approval | The default branch receives the complete generated install as one human-reviewable change |
+| Activation | Run `/squad cast` after the bootstrap PR merges | The run resolves `v0.13.1` by default, installs the standalone bundle, initializes only when no committed team exists, runs health, and uploads `squad-state` |
+| Cast persistence | Review the Cast PR before merging | The PR contains `.squad/casting/policy.json`, `registry.json`, and `history.json`, plus the team, routing, charters, Copilot agent, and `meet-the-squad.md` |
+| Cast checks | Open the linked Cast PR and inspect its checks; if application CI is `action_required`, approve that workflow run and wait for it to finish | Copilot review and the repository's normal build, test, lint, and security checks complete before merge |
+| Handoffs | Run `/squad implement` on a ready issue, then `/squad review` on its PR | The dispatcher starts the appropriate isolated worker; the reviewer posts one advisory verdict for the current head SHA |
+| Rerun | Repeat the same command after a cancellation or uncertain result | Existing Cast and implementation PRs are detected instead of duplicated; an unchanged reviewed head is not reviewed twice |
+| Recovery | Fix the named failing activation step, then use **Re-run failed jobs**; for an interrupted command, rerun the identical `/squad` command | Activation uploads no partial state artifact, and command-specific idempotency resumes from GitHub's committed PR, issue, comment, and review state |
+
+If a work command auto-opens a Cast PR because no committed team exists, merge
+that PR and rerun the original command. Do not start a second Cast command.
 
 ---
 
@@ -254,6 +354,13 @@ When you run `/squad cast`, the workflow follows these steps:
 5. **Scaffolding** — generates all squad files (charters, routing, registry)
 6. **Pull request** — opens a PR on a `squad/cast-{repo}` branch with the full
    team for review
+
+The completion comment links the created Cast PR. Open that PR, mark it ready
+when it was created as a draft, request Copilot review, and wait for its checks.
+GitHub may require maintainer approval before application CI runs on a
+workflow-created branch; when the PR shows `action_required`, approve that
+workflow run from the checks view and wait for it to finish. Merge the Cast PR
+only after its generated files, review, and repository checks are complete.
 
 ### The casting brief
 
@@ -957,10 +1064,13 @@ Understanding the two-job architecture helps when debugging.
 The activation job runs with full network access:
 
 1. Optionally mints a GitHub App installation token
-2. Installs `@bradygaster/squad-cli` at the configured version
-3. Runs `squad init --preset default --state-backend local`
-4. Uploads `.squad/` and `.github/agents/squad.agent.md` as a `squad-state`
-   artifact
+2. Resolves `SQUAD_CLI_VERSION` (default `v0.13.1`) and downloads the matching
+   standalone GitHub Release bundle with checksum verification — no npm install
+3. Preserves a committed team with roster entries, or runs
+   `squad init --preset default --state-backend local` when no usable team exists
+4. Rejects `npx`-based MCP wiring and runs `squad health --json`
+5. On success, uploads `.squad/` and `.github/agents/squad.agent.md` as a
+   one-day `squad-state` artifact
 
 ### Job 2: Agent (network-restricted)
 
@@ -971,7 +1081,11 @@ The agent job runs inside the `gh aw` sandbox with no outbound network:
 3. Executes the Squad coordinator using only the pre-generated files
 
 The Squad CLI is never installed in the agent job — only the files it produced
-are used. State does not persist across runs.
+are used. Each run starts from the repository's committed state: a merged Cast
+PR persists the complete team and casting files, while activation-only scaffold
+state and uncommitted runtime output do not carry over. User-facing changes
+persist through Squad's guarded pull requests, issue comments, issues, and
+reviews.
 
 ---
 
@@ -992,7 +1106,7 @@ This re-compiles the workflow from source. If you have local customizations in y
 For manual recompilation of all workflows:
 
 ```bash
-gh aw compile
+gh aw compile --strict
 ```
 
 ---
@@ -1003,13 +1117,18 @@ gh aw compile
 |---------|-------|-----|
 | "Nothing to cast from" comment | Both repo and issue are empty | Add a README or write a casting brief in the issue body |
 | Cast produces a generic team | Issue body was empty, repo was analyzed alone | Write a detailed casting brief (see [example](#example-writing-a-casting-brief)) |
+| Cast completed but no PR link is visible | The completion response did not resolve the created PR | Open the repository's pull requests and find the newest `[squad] Cast` PR before rerunning; do not start a second Cast command |
+| Cast PR application CI shows `action_required` | GitHub requires maintainer approval for checks on the workflow-created branch | Approve the workflow run from the PR checks view, wait for normal repository CI, then continue review |
 | "Could not access" error on Connect/Adopt | Source repo is private or doesn't exist | Verify the source repo is accessible and contains a `.squad/` directory |
-| `/squad` command is ignored | Lock file not committed or workflow not compiled | Run `gh aw compile`, commit the lock file, and push |
+| `/squad` command is ignored | Lock file not committed or workflow not compiled | Run `gh aw compile --strict`, commit the lock file, and push |
 | Universe is full on cast-member | All character names in the universe are allocated | Retire an unused member first, or re-cast with `/squad cast` |
 | "No plan found" on plan accept | No `/squad plan` comment exists yet | Run `/squad plan` first to generate a plan for review |
-| Plan accept creates fewer issues than expected | `create-issue` safe-output has a max of 75 | Re-run the identical activation command — it is idempotent and picks up where it left off |
+| Plan activation creates fewer issues than the accepted plan declares | The run ended before every missing issue was created | Re-run the identical activation command — title matching resumes without duplicating existing issues |
 | `/squad implement` cannot create a PR | Actions is not allowed to create pull requests | Enable **Allow GitHub Actions to create and approve pull requests** in repository Actions settings |
 | Epic implementation dispatches no workers | Every child is blocked or already has an open implementation PR | Merge dependency PRs, then run `/squad implement` on the epic again |
+| Standalone activation fails before init | `SQUAD_CLI_VERSION` is invalid or its release assets are unavailable | Correct the variable or select a published release, then use **Re-run failed jobs** |
+| Squad health fails | Initialization or committed team state is incomplete | Inspect the `Run Squad health check` JSON, correct the reported state, and rerun; no `squad-state` artifact is uploaded on failure |
+| A command run was cancelled or its result is uncertain | The run stopped before a durable output was confirmed | Rerun the identical `/squad` command; Cast, implementation, activation, and review paths check existing GitHub state before creating output |
 
 ---
 

--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -156,9 +156,10 @@ entries, complete the first-install approval with:
 > gh aw compile --strict --approve
 > ```
 
-Stop and investigate if the report contains any other secret or action. The
-approval command is needed only when the safe-update warning appears; it is not
-a substitute for the final strict compile below.
+Stop and investigate if the report contains any other secret or action.
+
+This follow-up is only needed when the safe-update warning appears.
+It is not a substitute for the final strict compile below.
 
 ### Strictly compile the installed workflows
 

--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -651,7 +651,10 @@ After this, the plan is ready to activate.
 
 Creates GitHub issues from the accepted plan with proper labels (`squad`,
 `squad:{agent-name}`), acceptance criteria, dependency references, and phase
-assignments.
+assignments. Flat plans create one child issue per planned task directly under
+the originating issue; they do not add a duplicate epic. Dependencies use native
+`blockedBy` edges when the installed safe-output tool supports them, otherwise
+they remain explicit `Depends On` references in each issue body.
 
 ### Incremental phase acceptance
 

--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -255,10 +255,25 @@ describe('#1903: fast-path planning binds certified roster owners end to end', (
     expect(labelRule).toMatch(/only from that task's certified binding/i);
   });
 
-  it('preserves every declared dependency through body references and native edges', () => {
+  it('creates only the planned tasks under the origin issue for a flat plan', () => {
+    expect(accept).toMatch(/origin issue is always the root/i);
+    expect(accept).toMatch(/flat plan, create exactly one issue per[\s\S]*work-item row/i);
+    expect(accept).toMatch(/every task's parent to the origin issue/i);
+    expect(accept).toMatch(/Do not\s+create an additional epic, summary, root, or phase issue/i);
+  });
+
+  it('preserves every declared dependency through the safe-output capability', () => {
     expect(accept).toMatch(/Copy every frozen `Depends On` value into the created issue body/i);
-    expect(accept).toMatch(/For every non-empty frozen `Depends On` entry[\s\S]*`blockedBy`/i);
-    expect(accept).toMatch(/Do not infer,\s+drop, or reorder dependency edges/i);
+    expect(accept).toMatch(/Do not\s+infer, drop, or reorder dependencies/i);
+    expect(accept).toMatch(/native `blockedBy` relationships only when[\s\S]*safe-output[\s\S]*explicitly exposes/i);
+    expect(accept).toMatch(/Do not bypass safe outputs with\s+a direct write API call/i);
+    expect(accept).toMatch(/body references are\s+the expected fallback/i);
+  });
+
+  it('reports the created hierarchy and dependency mode without overclaiming', () => {
+    expect(accept).toMatch(/Report the exact number of created task issues/i);
+    expect(accept).toMatch(/whether dependencies use native edges or the body-reference fallback/i);
+    expect(accept).toMatch(/Never\s+claim an epic, phase issue, sub-issue relationship, or native dependency edge/i);
   });
 });
 

--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -206,16 +206,16 @@ describe('#1759: Owner/Agent bind to the cast Name column', () => {
     expect(isRoleStringLeak('Procedures')).toBe(false);
   });
 
-  it('squad-plan binds the Owner column to the team.md Name column', () => {
+  it('squad-plan binds the Owner column to a certified team.md Name cell', () => {
     const block = skillBlock(squad, 'squad-plan');
-    expect(block).toMatch(/Owner\/Agent binding rule/i);
-    expect(block).toContain('`Name` column');
-    expect(block).toContain('@copilot');
+    expect(block).toMatch(/Owner binding gate/i);
+    expect(block).toContain('`Name` cell');
+    expect(block).toMatch(/every work item `Owner` MUST match one certified name/i);
   });
 
   it('squad-plan-accept mints squad:{owner} from the cast Name, not a role', () => {
     const block = skillBlock(squad, 'squad-plan-accept');
-    expect(block).toContain('`Name` column');
+    expect(block).toMatch(/certified\s+active roster name/i);
     expect(block).toContain('`squad:{owner}`');
   });
 
@@ -224,6 +224,41 @@ describe('#1759: Owner/Agent bind to the cast Name column', () => {
     expect(block).toMatch(/Agent binding rule/i);
     expect(block).toContain('`Name` column');
     expect(block).toMatch(/appears verbatim in the `Name` column/);
+  });
+});
+
+describe('#1903: fast-path planning binds certified roster owners end to end', () => {
+  const plan = skillBlock(squad, 'squad-plan');
+  const accept = skillBlock(squad, 'squad-plan-accept');
+
+  it('requires every fast-path Owner to be certified before posting', () => {
+    const gate = plan.match(/3\. Use the `ROSTER_MEMBER:`[\s\S]*?(?=\n4\.)/)?.[0] ?? '';
+    expect(gate, 'squad-plan must contain an explicit certified-roster gate').not.toBe('');
+    expect(gate).toMatch(/every work item `Owner` MUST match one certified name/i);
+    expect(gate).toMatch(/never synthesize a\s+role, alias, or placeholder/i);
+    expect(gate).toMatch(/never use `@copilot` while a certified roster\s+exists/i);
+
+    const finalCheck = plan.match(/Re-check every `Owner`[\s\S]*?(?=\nDo NOT create issues)/)?.[0] ?? '';
+    expect(finalCheck).toMatch(/do not post until every row passes/i);
+    expect(finalCheck).toMatch(/Copy each row's `Depends On` value unchanged/i);
+  });
+
+  it('freezes each accepted row and derives its lowercase member label without remapping', () => {
+    const preflight = accept.match(/Before any `create-issue` call[\s\S]*?(?=\nFor each work item)/)?.[0] ?? '';
+    expect(preflight, 'squad-plan-accept must validate bindings before mutation').not.toBe('');
+    expect(preflight).toMatch(/original `Owner` and `Depends On` values/i);
+    expect(preflight).toMatch(/stop before mutation/i);
+    expect(preflight).toMatch(/never\s+substitute, re-route, or fall back/i);
+
+    const labelRule = accept.match(/^- Labels:.*$/m)?.[0] ?? '';
+    expect(labelRule).toMatch(/frozen row `Owner` lowercased/i);
+    expect(labelRule).toMatch(/only from that task's certified binding/i);
+  });
+
+  it('preserves every declared dependency through body references and native edges', () => {
+    expect(accept).toMatch(/Copy every frozen `Depends On` value into the created issue body/i);
+    expect(accept).toMatch(/For every non-empty frozen `Depends On` entry[\s\S]*`blockedBy`/i);
+    expect(accept).toMatch(/Do not infer,\s+drop, or reorder dependency edges/i);
   });
 });
 

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -2339,7 +2339,9 @@ describe('gh-aw: Auto-Cast UX guidance — canonical fallback and Cast PR body r
   it('Cast emits routing state that standalone health can parse', () => {
     expect(squadContent).toContain('section heading `## Routing Table`');
     expect(squadContent).toContain('headers `Work Type | Route To | Examples`');
+    expect(squadContent).toContain('exact active casting-registry `persistent_name`');
     expect(squadContent).toContain('multiple names comma-separated and no prose or annotations');
+    expect(squadContent).toContain('Do not route to always-on support roles');
   });
 });
 

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -2514,6 +2514,10 @@ describe('gh-aw: activation roster guard counts only data rows (#1605)', () => {
   it('runs initialization after gh-aw checks out the activation context', () => {
     expect(
       sharedContent,
+      'the generated activation checkout must include committed Squad state',
+    ).toMatch(/ambient-folders:\s*\n\s+- \.squad/);
+    expect(
+      sharedContent,
       'jobs.activation.steps runs after the generated activation checkout',
     ).toMatch(/jobs:\s*\n\s+activation:\s*\n\s+steps:/);
     expect(

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -2428,7 +2428,7 @@ describe('gh-aw: shared bootstrap health-before-dispatch contract (#1605)', () =
     while (stepStart > 0 && !lines[stepStart].match(/^\s+-\s+name:/)) {
       stepStart--;
     }
-    // Walk forward to the next "- name:" or end of the pre-steps block.
+    // Walk forward to the next "- name:" or end of the activation steps block.
     let stepEnd = healthLineIdx + 1;
     while (stepEnd < lines.length && !lines[stepEnd].match(/^\s+-\s+name:/) && !lines[stepEnd].match(/^steps:/)) {
       stepEnd++;
@@ -2442,14 +2442,17 @@ describe('gh-aw: shared bootstrap health-before-dispatch contract (#1605)', () =
     ).not.toMatch(/continue-on-error:\s*true/);
   });
 
-  it('step ordering in pre-steps: init → health → upload', () => {
-    const preStepsStart = sharedContent.indexOf('pre-steps:');
-    expect(preStepsStart, 'pre-steps: block must exist in the shared bootstrap').toBeGreaterThan(-1);
-    const preStepsSection = sharedContent.slice(preStepsStart);
+  it('step ordering after activation checkout: init → health → upload', () => {
+    const activationStepsStart = sharedContent.search(/jobs:\s*\n\s+activation:\s*\n\s+steps:/);
+    expect(
+      activationStepsStart,
+      'jobs.activation.steps must exist in the shared bootstrap',
+    ).toBeGreaterThan(-1);
+    const activationStepsSection = sharedContent.slice(activationStepsStart);
 
-    const initStepIdx = preStepsSection.indexOf('Initialize Squad team');
-    const healthStepIdx = preStepsSection.indexOf('Run Squad health check');
-    const uploadStepIdx = preStepsSection.indexOf('Upload Squad state artifact');
+    const initStepIdx = activationStepsSection.indexOf('Initialize Squad team');
+    const healthStepIdx = activationStepsSection.indexOf('Run Squad health check');
+    const uploadStepIdx = activationStepsSection.indexOf('Upload Squad state artifact');
 
     expect(initStepIdx, '"Initialize Squad team" step must exist').toBeGreaterThan(-1);
     expect(healthStepIdx, '"Run Squad health check" step must exist').toBeGreaterThan(-1);
@@ -2508,14 +2511,15 @@ describe('gh-aw: shared bootstrap health-before-dispatch contract (#1605)', () =
 describe('gh-aw: activation roster guard counts only data rows (#1605)', () => {
   const sharedContent = readText(join(SHARED_DIR, 'squad.md'));
 
-  it('checks out committed Squad state before deciding whether to initialize', () => {
-    const checkout = sharedContent.indexOf('- name: Checkout repository');
-    const initialize = sharedContent.indexOf('- name: Initialize Squad team');
-
-    expect(checkout, 'activation must check out the repository').toBeGreaterThan(-1);
-    expect(initialize, 'activation must initialize or preserve Squad state').toBeGreaterThan(-1);
-    expect(checkout, 'checkout must run before the roster preservation guard').toBeLessThan(initialize);
-    expect(sharedContent.slice(checkout, initialize)).toContain('uses: actions/checkout@v4');
+  it('runs initialization after gh-aw checks out the activation context', () => {
+    expect(
+      sharedContent,
+      'jobs.activation.steps runs after the generated activation checkout',
+    ).toMatch(/jobs:\s*\n\s+activation:\s*\n\s+steps:/);
+    expect(
+      sharedContent,
+      'pre-steps run before the generated activation checkout and cannot inspect committed state',
+    ).not.toMatch(/jobs:\s*\n\s+activation:\s*\n\s+pre-steps:/);
   });
 
   function initStepScript(): string {

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -2508,6 +2508,16 @@ describe('gh-aw: shared bootstrap health-before-dispatch contract (#1605)', () =
 describe('gh-aw: activation roster guard counts only data rows (#1605)', () => {
   const sharedContent = readText(join(SHARED_DIR, 'squad.md'));
 
+  it('checks out committed Squad state before deciding whether to initialize', () => {
+    const checkout = sharedContent.indexOf('- name: Checkout repository');
+    const initialize = sharedContent.indexOf('- name: Initialize Squad team');
+
+    expect(checkout, 'activation must check out the repository').toBeGreaterThan(-1);
+    expect(initialize, 'activation must initialize or preserve Squad state').toBeGreaterThan(-1);
+    expect(checkout, 'checkout must run before the roster preservation guard').toBeLessThan(initialize);
+    expect(sharedContent.slice(checkout, initialize)).toContain('uses: actions/checkout@v4');
+  });
+
   function initStepScript(): string {
     const lines = sharedContent.split('\n');
     const start = lines.findIndex((l) => l.includes('Initialize Squad team'));
@@ -2532,8 +2542,8 @@ describe('gh-aw: activation roster guard counts only data rows (#1605)', () => {
 
       const result = spawnSync(
         requirePosixShell(),
-        ['-c', (guard as string).replace(/\.squad\/team\.md/g, teamPath)],
-        { encoding: 'utf8' },
+        ['-c', (guard as string).replace(/\.squad\/team\.md/g, 'team.md')],
+        { cwd: dir, encoding: 'utf8' },
       );
       return result.status === 0;
     } finally {

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -2335,6 +2335,12 @@ describe('gh-aw: Auto-Cast UX guidance — canonical fallback and Cast PR body r
   it('Cast PR body instructs user to return to originating issue and rerun canonical command', () => {
     expect(squadContent).toMatch(/return to the originating issue and rerun.*\{canonical_command\}/s);
   });
+
+  it('Cast emits routing state that standalone health can parse', () => {
+    expect(squadContent).toContain('section heading `## Routing Table`');
+    expect(squadContent).toContain('headers `Work Type | Route To | Examples`');
+    expect(squadContent).toContain('multiple names comma-separated and no prose or annotations');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -290,6 +290,7 @@ function createTestWorkspace(prefix: string): string {
 // ---------------------------------------------------------------------------
 
 describe('gh-aw: safe-output configuration', () => {
+  const workflow = readText(SQUAD_WORKFLOW);
   const frontmatter = extractFrontmatter(SQUAD_WORKFLOW);
   const safeOutputs = extractSafeOutputs(frontmatter);
 
@@ -299,7 +300,7 @@ describe('gh-aw: safe-output configuration', () => {
 
   it('each safe-output has a max value that is a positive integer ≤ 1000', () => {
     for (const [name, config] of Object.entries(safeOutputs)) {
-      if (name === 'data') continue;
+      if (name === 'data' || name === 'messages') continue;
       expect(config.max, `${name} should have a max field`).toBeDefined();
       const max = config.max as number;
       expect(max, `${name}.max should be > 0`).toBeGreaterThan(0);
@@ -343,6 +344,21 @@ describe('gh-aw: safe-output configuration', () => {
     expect(pr.max, 'should have max').toBeDefined();
     expect(pr['allowed-base-branches'], 'should have allowed-base-branches').toBeDefined();
     expect(pr['auto-close-issue'], 'Cast PR must not close the originating work issue').toBe(false);
+  });
+
+  it('reports the verified pull request after safe-output creation', () => {
+    const cast = workflow.slice(
+      workflow.indexOf('## skill: `squad-cast`'),
+      workflow.indexOf('## skill: `squad-review-relay`'),
+    );
+
+    expect(frontmatter).toContain(
+      'pull-request-created: "🤖 Squad created [PR #{item_number}]({item_url}) for review.',
+    );
+    expect(cast).toContain(
+      '`safe-outputs.messages.pull-request-created` notification runs after PR creation',
+    );
+    expect(cast).not.toContain('**PR:** #{pr_number}');
   });
 
   it('defines the minimum schema-validated durable artifact envelope', () => {

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -343,6 +343,9 @@ describe('gh-aw: safe-output configuration', () => {
     expect(pr.labels, 'should have labels').toBeDefined();
     expect(pr.max, 'should have max').toBeDefined();
     expect(pr['allowed-base-branches'], 'should have allowed-base-branches').toBeDefined();
+    expect(pr['allowed-files'], 'Cast PR must allow generated agent definitions').toContain(
+      '.github/agents/*.agent.md',
+    );
     expect(pr['auto-close-issue'], 'Cast PR must not close the originating work issue').toBe(false);
   });
 

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -358,6 +358,7 @@ describe('gh-aw: safe-output configuration', () => {
     expect(frontmatter).toContain(
       'pull-request-created: "🤖 Squad created [PR #{item_number}]({item_url}) for review.',
     );
+    expect(safeOutputs.messages['append-only-comments']).toBe(true);
     expect(cast).toContain(
       '`safe-outputs.messages.pull-request-created` notification runs after PR creation',
     );

--- a/test/standalone-release-workflow.test.ts
+++ b/test/standalone-release-workflow.test.ts
@@ -14,6 +14,10 @@ import { join } from 'node:path';
 const WORKFLOWS = join(process.cwd(), '.github', 'workflows');
 const release = readFileSync(join(WORKFLOWS, 'squad-release.yml'), 'utf8');
 const standalone = readFileSync(join(WORKFLOWS, 'squad-standalone-release.yml'), 'utf8');
+const ghAwGuide = readFileSync(
+  join(process.cwd(), 'docs', 'src', 'content', 'docs', 'guide', 'gh-aw.md'),
+  'utf8',
+);
 
 describe('standalone release handoff', () => {
   it('supports a confirmation-gated manual release from dev only', () => {
@@ -70,5 +74,33 @@ describe('standalone release handoff', () => {
       "TAG: ${{ inputs.release_tag || github.event.release.tag_name || (github.ref_type == 'tag' && github.ref_name) }}";
     expect(standalone.match(new RegExp(tagExpression.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')))
       .toHaveLength(3);
+  });
+
+  it('documents the strict, reviewable four-workflow bootstrap', () => {
+    expect(ghAwGuide).toContain('gh aw compile --strict --approve');
+    expect(ghAwGuide).toContain('gh aw compile --strict');
+    expect(ghAwGuide).toContain('gh pr create');
+    expect(ghAwGuide).toContain('gh pr edit --add-reviewer @copilot');
+    expect(ghAwGuide).toContain('gh pr checks --watch');
+    expect(ghAwGuide).toContain('.github/aw/');
+    expect(ghAwGuide).toContain('`.vscode/settings.json`');
+    expect(ghAwGuide).toContain('SQUAD_GITHUB_APP_PRIVATE_KEY');
+    expect(ghAwGuide).toContain('SQUAD_GITHUB_TOKEN');
+    expect(ghAwGuide).toContain('both slash-command and `github-actions[bot]`');
+    expect(ghAwGuide).toContain('The completion comment links the created Cast PR');
+    expect(ghAwGuide).toContain('application CI is `action_required`');
+    expect(ghAwGuide).toContain(
+      '`squad-deps-worker.md` and `squad-deps-worker.lock.yml`',
+    );
+  });
+
+  it('documents the v0.13.1 npm-free activation and committed-state boundary', () => {
+    expect(ghAwGuide).toContain(
+      'standalone GitHub Release bundle with checksum verification',
+    );
+    expect(ghAwGuide).toContain('a merged Cast');
+    expect(ghAwGuide).not.toContain('Installs `@bradygaster/squad-cli`');
+    expect(ghAwGuide).not.toContain('State does not persist across runs.');
+    expect(ghAwGuide).not.toContain('`create-issue` safe-output has a max of 75');
   });
 });

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -72,10 +72,7 @@ engine:
 
 jobs:
   activation:
-    pre-steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
+    steps:
       - name: Mint Squad GitHub App token
         id: squad-app-token
         if: ${{ vars.SQUAD_GITHUB_APP_ID != '' }}
@@ -178,7 +175,7 @@ steps:
 This shared component handles the entire Squad install/init lifecycle outside the
 agent sandbox:
 
-1. **`jobs.activation.pre-steps`** — the repository is already checked out by the
+1. **`jobs.activation.steps`** — the repository is already checked out by the
    activation job. This step optionally mints a GitHub App installation token (or
    uses a supplied PAT), downloads the selected standalone GitHub Release bundle,
    checks whether `.squad/team.md` already exists with roster entries (preserving

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -35,10 +35,9 @@
 # `squad init` writes is picked up by that mechanism. Additionally, `engine.agent`
 # is set to `squad`, so the compiler emits `--agent squad` on the Copilot invocation.
 #
-# `ambient-folders` (gh-aw main): upstream now uses a top-level
-# `ambient-folders: [.squad, .github/agents]` key to bundle Squad's files into the
-# standard activation artifact. That feature is unreleased on stable — once it ships,
-# the explicit artifact upload/download below can be replaced.
+# `ambient-folders` adds committed `.squad/` state to gh-aw's activation checkout
+# so the roster guard can preserve an existing cast. The explicit artifact below
+# remains the fail-fast handoff for the standalone distribution.
 #
 # Optional custom credentials for `squad init`:
 #   vars.SQUAD_GITHUB_APP_ID / secrets.SQUAD_GITHUB_APP_PRIVATE_KEY / vars.SQUAD_GITHUB_APP_OWNER
@@ -69,6 +68,8 @@ engine:
   id: copilot
   version: 1.0.78
   agent: squad
+ambient-folders:
+  - .squad
 
 jobs:
   activation:

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -73,6 +73,9 @@ engine:
 jobs:
   activation:
     pre-steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Mint Squad GitHub App token
         id: squad-app-token
         if: ${{ vars.SQUAD_GITHUB_APP_ID != '' }}

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -48,6 +48,8 @@ tools:
     mode: gh-proxy
     toolsets: [default]
 safe-outputs:
+  messages:
+    pull-request-created: "🤖 Squad created [PR #{item_number}]({item_url}) for review. If its checks show `action_required`, approve the workflow run before merging."
   data:
     type: object
     properties:
@@ -745,7 +747,9 @@ Create `meet-the-squad.md` at repo root with: title, universe name, team table (
 
 ##### Step 7: Post Completion
 
-`add-comment`: `🧑‍🤝‍🧑 Your Squad is ready for review.\n\n**PR:** #{pr_number}\n\nMerge the PR to activate your team. Run /squad status afterward to verify.`
+Do not emit a separate `add-comment`. The configured
+`safe-outputs.messages.pull-request-created` notification runs after PR creation
+and includes the verified PR number, URL, and CI-approval guidance.
 
 ## skill: `squad-review-relay`
 ---

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -96,7 +96,7 @@ safe-outputs:
       - "squad/*"
     allowed-files:
       - ".squad/**"
-      - ".github/agents/squad.agent.md"
+      - ".github/agents/*.agent.md"
       - "meet-the-squad.md"
     protected-files: allowed
     max-patch-files: 500

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -49,6 +49,7 @@ tools:
     toolsets: [default]
 safe-outputs:
   messages:
+    append-only-comments: true
     pull-request-created: "🤖 Squad created [PR #{item_number}]({item_url}) for review. If its checks show `action_required`, approve the workflow run before merging."
   data:
     type: object

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -731,7 +731,7 @@ Create/replace:
 
 1. **`.squad/team.md`** — Roster table: Coordinator (Squad), Members (Name|Role|Charter path|Status), always-on (Scribe, Ralph, Rai), Coding Agent (@copilot with `copilot-auto-assign: false`).
 2. **`.squad/agents/{id}/charter.md`** — Per agent: `# Name — Role`, Identity block (name, role, expertise, style), "What I Own", Boundaries (handle/don't), Model: auto.
-3. **`.squad/routing.md`** — Domain→agent routing table in the standalone health parser's format: section heading `## Routing Table`; headers `Work Type | Route To | Examples`; every `Route To` value is an exact roster `Name`, with multiple names comma-separated and no prose or annotations.
+3. **`.squad/routing.md`** — Domain→agent routing table in the standalone health parser's format: section heading `## Routing Table`; headers `Work Type | Route To | Examples`; every `Route To` value is an exact active casting-registry `persistent_name`, with multiple names comma-separated and no prose or annotations. Do not route to always-on support roles unless they are also active registry agents.
 4. **`.squad/casting/registry.json`** — From Step 3.
 5. **`.squad/casting/history.json`** — From Step 3.
 6. **`.squad/casting/policy.json`** — Standard policy with all 15 universes.

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1050,13 +1050,15 @@ Decompose issue into sub-issues as a comment. Does NOT create issues. Works on o
 
 1. Read issue body (the epic/brief).
 2. Find latest `research` artifact comment for this issue. If found, use as primary context. If not, do lightweight repo analysis.
-3. Read `.squad/team.md` if it exists. **Owner/Agent binding rule:** permitted
-   `Owner`/`Agent` values are Team Guard Step TG-2's certified roster set — the
-   `Name` column of `## Members` in **this repository's** `.squad/team.md` — plus
-   `@copilot`. Map each item's domain to a member via `.squad/routing.md` and emit
-   that member's exact `Name` cell — never a recalled name, never another column
-   (the `Role` column included). If none fits, use `@copilot`. Governs every
-   `Owner`/`Agent` column and `squad:{owner}` label downstream.
+3. Use the `ROSTER_MEMBER:` lines already emitted by mandatory Team Guard Step
+   TG-2 as the certified active roster set. **Owner binding gate:** when
+   `TEAM_PRESENT`, every work item `Owner` MUST match one certified name. Resolve
+   each item's domain through `.squad/routing.md`; if no exact rule exists, choose
+   the closest active member whose documented remit fits, but never synthesize a
+   role, alias, or placeholder and never use `@copilot` while a certified roster
+   exists. Preserve each selected member's exact `Name` cell in the plan. On
+   `ROSTER_UNREADABLE:`, stop instead of posting a plan. This gate governs every
+   `Owner` column and downstream `squad:{owner}` label.
 4. Text after `/squad plan` = planning guidance.
 
 ##### Step 2: Decompose
@@ -1069,7 +1071,10 @@ Break into discrete work items. **Minimum 3 items** unless genuinely atomic (exp
 
 Structure: `## 📋 Squad Plan — {Title}` → reference line → Phase tables (# | Title | Owner | Size | Depends On) → Details per item (Scope, Acceptance criteria, Notes) → Dependency Graph → Execution Notes → Next Steps (`/squad plan accept`, `/squad plan accept phase 1`, `/squad plan revise`, `/squad plan`).
 
-Re-check every `Owner` against the Step 1 permitted set before posting; a value absent from it is invalid and must be re-resolved.
+Re-check every `Owner` against the Step 1 certified set before posting. If any
+value is absent, re-resolve it to a certified active member and repeat the check;
+do not post until every row passes. Copy each row's `Depends On` value unchanged
+into the artifact.
 
 Do NOT create issues.
 
@@ -1112,20 +1117,31 @@ Resolve which planning path this issue is on, in this order:
 
 If plan has phases: Root → Phase issues → Task issues. Flat plan: tasks directly under root.
 
+Before any `create-issue` call, run Team Guard Step TG-2 and validate every
+accepted plan row. Freeze a binding for each task number containing that row's
+original `Owner` and `Depends On` values. If any `Owner` does not match a certified
+active roster name, stop before mutation and require `/squad plan revise`; never
+substitute, re-route, or fall back to another identity during acceptance.
+
 For each work item, `create-issue`:
 - Title: work item title
-- Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`) where `{owner}` is the `Owner` lowercased. Mint `squad:{owner}` **only** when that value matches a `ROSTER_MEMBER:` line from Team Guard Step TG-2 — its stdout (the certified roster set, from the `Name` column of `## Members` in `.squad/team.md`) is the sole source; never re-read team.md or recall a name. Uncertified `Owner`: apply only `squad`, fall back to `@copilot`. On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster.
+- Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`) where `{owner}` is the frozen row `Owner` lowercased. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster.
 - Body: scope, acceptance criteria, context (parent, phase, size, depends on, owner), notes, footer
 - Parent: phase issue (hierarchical) or root (flat)
 - Size: set Project field if available, else body `**Size:**` line
 
-Cross-phase deps: look up real issue numbers from prior acceptance comments.
+Copy every frozen `Depends On` value into the created issue body. Cross-phase
+deps: look up real issue numbers from prior acceptance comments without changing
+the declared task dependencies.
 
 Create in dependency order. Labels must have descriptions and colors.
 
 ##### Step 3: Native Dependency Edges
 
-Add `blockedBy` relationships via GitHub API. Graceful fallback to body-text references if unavailable.
+For every non-empty frozen `Depends On` entry, add the corresponding `blockedBy`
+relationship via GitHub API using the created issue-number map. Do not infer,
+drop, or reorder dependency edges. Graceful fallback to body-text references if
+unavailable.
 
 ##### Step 4: Post Summary
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -731,7 +731,7 @@ Create/replace:
 
 1. **`.squad/team.md`** — Roster table: Coordinator (Squad), Members (Name|Role|Charter path|Status), always-on (Scribe, Ralph, Rai), Coding Agent (@copilot with `copilot-auto-assign: false`).
 2. **`.squad/agents/{id}/charter.md`** — Per agent: `# Name — Role`, Identity block (name, role, expertise, style), "What I Own", Boundaries (handle/don't), Model: auto.
-3. **`.squad/routing.md`** — Domain→agent routing table.
+3. **`.squad/routing.md`** — Domain→agent routing table in the standalone health parser's format: section heading `## Routing Table`; headers `Work Type | Route To | Examples`; every `Route To` value is an exact roster `Name`, with multiple names comma-separated and no prose or annotations.
 4. **`.squad/casting/registry.json`** — From Step 3.
 5. **`.squad/casting/history.json`** — From Step 3.
 6. **`.squad/casting/policy.json`** — Standard policy with all 15 universes.

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1116,7 +1116,11 @@ Resolve which planning path this issue is on, in this order:
 
 ##### Step 2: Create Sub-Issues — Hierarchical
 
-If plan has phases: Root → Phase issues → Task issues. Flat plan: tasks directly under root.
+The origin issue is always the root. If the plan has explicit phases, create one
+phase issue per accepted phase under the origin issue, then create that phase's
+task issues under its phase issue. For a flat plan, create exactly one issue per
+accepted work-item row and set every task's parent to the origin issue. Do not
+create an additional epic, summary, root, or phase issue for a flat plan.
 
 Before any `create-issue` call, run Team Guard Step TG-2 and validate every
 accepted plan row. Freeze a binding for each task number containing that row's
@@ -1137,18 +1141,28 @@ the declared task dependencies.
 
 Create in dependency order. Labels must have descriptions and colors.
 
-##### Step 3: Native Dependency Edges
+##### Step 3: Preserve Dependencies
 
-For every non-empty frozen `Depends On` entry, add the corresponding `blockedBy`
-relationship via GitHub API using the created issue-number map. Do not infer,
-drop, or reorder dependency edges. Graceful fallback to body-text references if
-unavailable.
+For every non-empty frozen `Depends On` entry, preserve the corresponding task
+references in the created issue body using the created issue-number map. Do not
+infer, drop, or reorder dependencies.
+
+Add native `blockedBy` relationships only when an available approved safe-output
+tool explicitly exposes that field or operation. Do not bypass safe outputs with
+a direct write API call. When native edges are unavailable, body references are
+the expected fallback, and the acceptance summary MUST say that dependencies
+were preserved in issue bodies without native edges.
 
 ##### Step 4: Post Summary
 
 Artifact data varies:
 - Phase-specific: `data: {"squad_artifact":"phases-accepted","schema_version":"1","origin_issue":{issue_number},"phases":[{accumulated}]}` → Phase accepted table + remaining phases table
 - Full (no phases): `data: {"squad_artifact":"plan-accepted","schema_version":"1","origin_issue":{issue_number},"phases":[]}` → All issues table
+
+Report the exact number of created task issues, their actual parent hierarchy,
+and whether dependencies use native edges or the body-reference fallback. Never
+claim an epic, phase issue, sub-issue relationship, or native dependency edge
+that was not created.
 
 ## skill: `squad-plan-revise`
 ---


### PR DESCRIPTION
## Summary

- harden the published Squad GH-AW bootstrap, compilation, Cast handoff, and recovery guidance
- preserve committed `.squad` state during activation and require standalone-compatible Cast routing
- bind fast-path plan owners to the certified active roster and preserve accepted owner/dependency values
- make flat-plan activation create exactly the planned child tasks, with an explicit body-reference fallback when native dependency edges are unavailable
- keep Cast notifications deterministic and permit generated agent definitions through the narrow safe-output allowlist

## Consumer validation

A fresh private consumer repository completed the published flow through implementation readiness: bootstrap, Cast, status, research, plan, first acceptance, and idempotent repeat acceptance. The run stopped before `/squad implement`.

The validation reproduced and drove fixes for committed-state loss, standalone routing incompatibility, invalid support-role routes, roster binding, Cast output allowlisting, flat-plan hierarchy, and dependency-summary accuracy. Public-safe evidence is recorded on #1903.

## Validation

- `npm test -- test/gh-aw-quality.test.ts test/gh-aw-plan-lifecycle.test.ts test/standalone-release-workflow.test.ts` — 223 passed
- `npm run build` — passed
- gh-aw strict compilation in consumer layout — 4 workflows compiled; known slash-command/bot trigger warning only

## Security review

No new secret references, action dependencies, workflow permissions, or redirect changes. Direct write-API fallback is explicitly forbidden; mutations remain gated by approved safe-output capabilities.

Closes #1903