### PR TITLE
feat(gh-aw): add activate fast-path alias

### DIFF
--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -314,8 +314,10 @@ wins: `/squad plan accept scope` is not treated as `/squad plan`.
 | Planning | `/squad plan implementation` | Decompose a program plan into PR-sized tasks | Requires a program plan first |
 | Planning | `/squad plan validate` | Validate plan readiness before acceptance | Checks dependencies, decisions, sizing |
 | Planning | `/squad plan revise <feedback>` | Revise the current plan based on feedback | Works at any planning stage |
-| Acceptance | `/squad plan accept` | **Fast path:** accept all phases of scope + implementation + activate | Creates GitHub issues immediately |
-| Acceptance | `/squad plan accept phase {N}` | Accept only Phase N of a plan (incremental, in order) | Combines scope + impl + activate for that phase |
+| Activation | `/squad activate` | **Recommended fast path:** review and accept the latest fast plan, then create its GitHub issues | Requires write, maintain, or admin permission |
+| Activation | `/squad activate phase {N}` | Review, accept, and create issues for only Phase N of the latest fast plan | Incremental and in order |
+| Acceptance | `/squad plan accept` | Legacy alias for `/squad activate` | Preserved for backward compatibility |
+| Acceptance | `/squad plan accept phase {N}` | Legacy alias for `/squad activate phase {N}` | Preserved for backward compatibility |
 | Acceptance | `/squad plan accept scope` | Approve the program plan scope | Locks strategic structure before decomposition |
 | Acceptance | `/squad plan accept implementation` | Approve all phases of the implementation plan | Issues are not created until activate |
 | Acceptance | `/squad plan accept implementation phase {N}` | Accept only Phase N of the implementation plan | Also auto-activates when prior phases are ready |
@@ -482,7 +484,26 @@ All agents are renamed and their files updated accordingly.
 Squad's SDLC commands let you go from an issue to a fully decomposed, agent-assigned
 backlog without leaving the issue thread.
 
-### The full lifecycle
+### Recommended lifecycle: research → plan → activate
+
+For most work, use the clear three-step lifecycle:
+
+```text
+/squad research
+/squad plan
+/squad activate
+```
+
+`/squad research` gathers evidence, `/squad plan` proposes a combined program and
+implementation plan for review, and `/squad activate` reviews and accepts the
+latest fast plan before creating its GitHub issues. Activation is a mutating
+command, so the actor needs write, maintain, or admin repository permission.
+
+To activate one phase at a time, use `/squad activate phase {N}`. The existing
+`/squad plan accept` and `/squad plan accept phase {N}` commands remain supported
+as legacy aliases with identical behavior.
+
+### Granular lifecycle
 
 ```
 research → triage → plan program → plan implementation → accept → activate
@@ -513,14 +534,16 @@ next command. `Also available` shows alternative valid commands at this point in
 the lifecycle. This means you never have to remember the state machine — the
 issue thread always shows what's next.
 
-### Fast paths (backward compatible)
+### Fast paths and compatibility aliases
 
 You don't have to use every step. Fast-path commands combine multiple stages:
 
 | Fast path | Equivalent to | Stages skipped |
 |-----------|---------------|----------------|
 | `/squad plan` | `/squad plan program` + `/squad plan implementation` | Separate triage classification; separate scope review gate |
-| `/squad plan accept` | `/squad plan accept scope` + `/squad plan accept implementation` + `/squad plan activate` | Separate scope lock step; separate implementation approval step; issues created immediately |
+| `/squad activate` | `/squad plan accept scope` + `/squad plan accept implementation` + `/squad plan activate` | Separate scope lock step; separate implementation approval step; issues created immediately |
+
+`/squad plan accept` remains a backward-compatible alias for `/squad activate`.
 
 #### What you give up with each fast path
 
@@ -531,7 +554,7 @@ You don't have to use every step. Fast-path commands combine multiple stages:
 - **Risk:** Scope may be broader or narrower than intended because exclusions were never explicitly classified. Triage is where you tell Squad "don't plan that" — without it, Squad infers scope from research findings alone.
 - **Good for:** Small, well-understood features where you already know the scope and trust Squad's decomposition without a formal review gate.
 
-**`/squad plan accept` (skipping separate scope lock and implementation review)**
+**`/squad activate` (skipping separate scope lock and implementation review)**
 
 - **Skips:** Separate `/squad plan accept scope` — you cannot review and approve strategic structure before decomposition runs
 - **Skips:** Separate `/squad plan accept implementation` — the task breakdown goes directly to GitHub issue creation without a standalone review step
@@ -708,17 +731,16 @@ supersedes the previous one.
 
 ### Examples
 
-**Small project — fast path (4 commands):**
+**Small project — recommended fast path (3 commands):**
 
+```text
+1. /squad research → Deep repo analysis
+2. /squad plan     → Program + implementation plan for review
+3. /squad activate → Accept the reviewed plan and create issues
 ```
-1. /squad research                → Deep repo analysis
-   Next step shown: "/squad triage" or "/squad plan" (fast path)
-2. /squad plan                    → Program + implementation in one pass
-   Next action: "/squad plan accept"
-3. /squad plan revise fewer tasks → Adjusted plan
-   Next action: "/squad plan accept"
-4. /squad plan accept             → Issues created
-```
+
+If the plan needs changes, run `/squad plan revise <feedback>` before activation.
+`/squad plan accept` remains an equivalent legacy command.
 
 **Large project — granular lifecycle (7+ commands):**
 

--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -314,8 +314,8 @@ wins: `/squad plan accept scope` is not treated as `/squad plan`.
 | Planning | `/squad plan implementation` | Decompose a program plan into PR-sized tasks | Requires a program plan first |
 | Planning | `/squad plan validate` | Validate plan readiness before acceptance | Checks dependencies, decisions, sizing |
 | Planning | `/squad plan revise <feedback>` | Revise the current plan based on feedback | Works at any planning stage |
-| Activation | `/squad activate` | **Recommended fast path:** review and accept the latest fast plan, then create its GitHub issues | Requires write, maintain, or admin permission |
-| Activation | `/squad activate phase {N}` | Review, accept, and create issues for only Phase N of the latest fast plan | Incremental and in order |
+| Activation | `/squad activate` | **Recommended fast path:** review and accept the latest fast plan, then create its GitHub issues | Requires an existing fast plan from `/squad plan` and write, maintain, or admin permission |
+| Activation | `/squad activate phase {N}` | Review, accept, and create issues for only Phase N of the latest fast plan | Requires an existing fast plan from `/squad plan` and write, maintain, or admin permission; incremental and in order |
 | Acceptance | `/squad plan accept` | Legacy alias for `/squad activate` | Preserved for backward compatibility |
 | Acceptance | `/squad plan accept phase {N}` | Legacy alias for `/squad activate phase {N}` | Preserved for backward compatibility |
 | Acceptance | `/squad plan accept scope` | Approve the program plan scope | Locks strategic structure before decomposition |

--- a/test/gh-aw-command-parse.test.ts
+++ b/test/gh-aw-command-parse.test.ts
@@ -170,10 +170,13 @@ describe('gh-aw: /squad command parsing (#1824)', () => {
     const dispatched = [
       'implement', // squad-implement-worker.md relay, and the schema's examples
       'research',
+      'activate',
+      'activate phase 2',
       'cast',
       'status',
       'connect org/repo',
       'plan accept implementation phase 2',
+      'plan accept',
     ];
 
     it.each(dispatched)('dispatching %j reaches its mode instead of failing the run', cmd => {
@@ -352,6 +355,7 @@ describe('gh-aw: /squad command parsing (#1824)', () => {
       'plan program revise',
       'plan implementation',
       'plan validate',
+      'activate',
       'plan accept',
       'plan accept scope',
       'plan accept implementation',
@@ -432,6 +436,35 @@ describe('gh-aw: /squad command parsing (#1824)', () => {
       expect(ag4).toContain('admin');
       expect(ag4).toContain('maintain');
       expect(ag4).toContain('write');
+    });
+
+    it('keeps activate phase variants behind authorization', () => {
+      expect(ag1).toContain('Anything outside the allow-list');
+      expect(classifyMode('activate')).toBe('AUTH_REQUIRED');
+      expect(workflow).toContain('`activate phase {N}` → `activate`');
+    });
+  });
+
+  describe('/squad activate fast-path alias', () => {
+    const pc2 = workflow.slice(
+      workflow.indexOf('### Step PC-2:'),
+      workflow.indexOf(PC3_HEADING)
+    );
+
+    it.each([
+      ['activate', 'activate'],
+      ['activate phase 2', 'activate phase 2'],
+      ['plan accept', 'plan accept'],
+    ])('extracts %j without changing the command arguments', (command, expected) => {
+      expect(parse(`/squad ${command}`)).toBe(expected);
+      expect(parseDispatch(command)).toBe(expected);
+    });
+
+    it('routes the alias as its own one-token mode after longer plan commands', () => {
+      const twoTokenModes = pc2.indexOf('`plan implementation` (2)');
+      const activateMode = pc2.indexOf('`activate` (1)');
+      expect(twoTokenModes).toBeGreaterThan(-1);
+      expect(activateMode).toBeGreaterThan(twoTokenModes);
     });
   });
 });

--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -19,6 +19,7 @@ const WORKFLOWS_DIR = join(process.cwd(), 'workflows');
 const SQUAD_WORKFLOW = join(WORKFLOWS_DIR, 'squad.md');
 const ONTOLOGY = join(WORKFLOWS_DIR, 'shared', 'squad-planning-ontology.md');
 const TEAM = join(process.cwd(), '.squad', 'team.md');
+const GH_AW_GUIDE = join(process.cwd(), 'docs', 'src', 'content', 'docs', 'guide', 'gh-aw.md');
 
 function readText(filePath: string): string {
   return readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
@@ -96,6 +97,7 @@ function agentBlock(markdown: string, name: string): string {
 const squad = readText(SQUAD_WORKFLOW);
 const ontology = readText(ONTOLOGY);
 const team = readText(TEAM);
+const guide = readText(GH_AW_GUIDE);
 
 // ---------------------------------------------------------------------------
 // team.md parsing — Name column vs Role column
@@ -274,6 +276,42 @@ describe('#1903: fast-path planning binds certified roster owners end to end', (
     expect(accept).toMatch(/Report the exact number of created task issues/i);
     expect(accept).toMatch(/whether dependencies use native edges or the body-reference fallback/i);
     expect(accept).toMatch(/Never\s+claim an epic, phase issue, sub-issue relationship, or native dependency edge/i);
+  });
+});
+
+describe('/squad activate reuses the fast-path acceptance lifecycle', () => {
+  const modes = squad.match(/^## Modes\n([\s\S]*?)(?=\n## )/m)?.[1] ?? '';
+  const execute = squad.match(/^## Execute Mode\n([\s\S]*?)(?=\n## )/m)?.[1] ?? '';
+  const plan = skillBlock(squad, 'squad-plan');
+  const accept = skillBlock(squad, 'squad-plan-accept');
+
+  it('declares whole-plan and phase-aware activate commands', () => {
+    expect(modes).toContain('| `/squad activate` | Activate |');
+    expect(modes).toContain('| `/squad activate phase {N}` | Activate |');
+  });
+
+  it('routes activate to the existing squad-plan-accept skill', () => {
+    expect(execute).toContain('| `activate` | `squad-plan-accept` |');
+    expect(squad.match(/^## skill: `squad-plan-accept`$/gm)).toHaveLength(1);
+  });
+
+  it('prefers activate in fast-plan next steps while retaining the legacy alias', () => {
+    expect(plan).toMatch(/Next Steps \(`\/squad activate` preferred/);
+    expect(plan).toContain('`/squad plan accept` remains a supported legacy alias');
+    expect(accept).toContain('`/squad activate` [phase {N}] (recommended)');
+    expect(accept).toContain('`/squad plan accept` [phase {N}]');
+    expect(accept).toContain('(supported legacy alias)');
+  });
+
+  it('documents the recommended three-step lifecycle and both compatibility paths', () => {
+    expect(guide).toContain('### Recommended lifecycle: research → plan → activate');
+    expect(guide).toMatch(/\/squad research\n\/squad plan\n\/squad activate/);
+    expect(guide).toMatch(
+      /`\/squad activate` reviews and accepts the\s+latest fast plan before creating its GitHub issues/
+    );
+    expect(guide).toContain('`/squad plan accept` remains a backward-compatible alias');
+    expect(guide).toContain('### Granular lifecycle');
+    expect(guide).toContain('| Activation | `/squad plan activate` |');
   });
 });
 

--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -286,8 +286,14 @@ describe('/squad activate reuses the fast-path acceptance lifecycle', () => {
   const accept = skillBlock(squad, 'squad-plan-accept');
 
   it('declares whole-plan and phase-aware activate commands', () => {
-    expect(modes).toContain('| `/squad activate` | Activate |');
-    expect(modes).toContain('| `/squad activate phase {N}` | Activate |');
+    expect(modes).toContain('| `/squad activate` | Activate (recommended fast-path) |');
+    expect(modes).toContain(
+      '| `/squad activate phase {N}` | Activate (recommended fast-path) |'
+    );
+    expect(modes).toContain('| `/squad plan accept` | Plan Accept (legacy alias) |');
+    expect(modes).toContain(
+      '| `/squad plan accept phase {N}` | Plan Accept (legacy alias) |'
+    );
   });
 
   it('routes activate to the existing squad-plan-accept skill', () => {
@@ -312,6 +318,12 @@ describe('/squad activate reuses the fast-path acceptance lifecycle', () => {
     expect(guide).toContain('`/squad plan accept` remains a backward-compatible alias');
     expect(guide).toContain('### Granular lifecycle');
     expect(guide).toContain('| Activation | `/squad plan activate` |');
+    expect(guide).toContain(
+      '| Activation | `/squad activate` | **Recommended fast path:** review and accept the latest fast plan, then create its GitHub issues | Requires an existing fast plan from `/squad plan` and write, maintain, or admin permission |'
+    );
+    expect(guide).toContain(
+      '| Activation | `/squad activate phase {N}` | Review, accept, and create issues for only Phase N of the latest fast plan | Requires an existing fast plan from `/squad plan` and write, maintain, or admin permission; incremental and in order |'
+    );
   });
 });
 

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -1132,18 +1132,17 @@ describe('gh-aw: inline skill extraction', () => {
 
     const dispatchTable = readText(SQUAD_WORKFLOW);
     for (const { mode } of modes) {
+      const normalizedMode = mode.replace(/\([^)]*\)/g, '').trim();
       const slug =
         'squad-' +
-        mode
-          .replace(/\([^)]*\)/g, '')
-          .trim()
+        normalizedMode
           .toLowerCase()
           .replace(/[^a-z0-9]+/g, '-')
           .replace(/(^-|-$)/g, '');
 
       const hasSkill = skillNames.has(slug);
       // Some modes legitimately share a playbook; accept an explicit mapping row.
-      const hasMapping = new RegExp(`\\|[^|\\n]*${mode.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}[^|\\n]*\\|[^|\\n]*squad-`, 'i').test(dispatchTable);
+      const hasMapping = new RegExp(`\\|[^|\\n]*${normalizedMode.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}[^|\\n]*\\|[^|\\n]*squad-`, 'i').test(dispatchTable);
 
       expect(
         hasSkill || hasMapping,

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -234,10 +234,10 @@ Repository owners must configure Copilot setup steps separately when needed.
 | `/squad plan program revise <feedback>` | Plan Program Revise |
 | `/squad plan implementation` | Plan Implementation |
 | `/squad plan validate` | Plan Validate |
-| `/squad activate` | Activate |
-| `/squad activate phase {N}` | Activate |
-| `/squad plan accept` | Plan Accept (fast-path) |
-| `/squad plan accept phase {N}` | Plan Accept |
+| `/squad activate` | Activate (recommended fast-path) |
+| `/squad activate phase {N}` | Activate (recommended fast-path) |
+| `/squad plan accept` | Plan Accept (legacy alias) |
+| `/squad plan accept phase {N}` | Plan Accept (legacy alias) |
 | `/squad plan accept scope` | Plan Accept Scope |
 | `/squad plan accept implementation` | Plan Accept Implementation |
 | `/squad plan accept implementation phase {N}` | Plan Accept Implementation |

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -234,6 +234,8 @@ Repository owners must configure Copilot setup steps separately when needed.
 | `/squad plan program revise <feedback>` | Plan Program Revise |
 | `/squad plan implementation` | Plan Implementation |
 | `/squad plan validate` | Plan Validate |
+| `/squad activate` | Activate |
+| `/squad activate phase {N}` | Activate |
 | `/squad plan accept` | Plan Accept (fast-path) |
 | `/squad plan accept phase {N}` | Plan Accept |
 | `/squad plan accept scope` | Plan Accept Scope |
@@ -380,7 +382,7 @@ requested. First-token-wins is the contract; keep extraction anchored to
 3. Otherwise match **longest-prefix-first**:
    - `plan accept implementation` (3), `plan accept scope` (3), `plan program revise` (3)
    - `plan implementation` (2), `plan program` (2), `plan activate` (2), `plan validate` (2), `plan accept` (2), `plan revise` (2), `triage revise` (2)
-   - `cast-member` (1), `plan` (1), `cast`, `connect`, `adopt`, `retire`, `status`, `review`, `research`, `triage`, `implement`
+   - `cast-member` (1), `activate` (1), `plan` (1), `cast`, `connect`, `adopt`, `retire`, `status`, `review`, `research`, `triage`, `implement`
 4. No prefix matches → go to **Step PC-3**.
 5. **Phase selector:** If remaining args contain `phase {N}`, extract N.
 
@@ -508,7 +510,7 @@ When **Step AG-3** returned `REFUSE`:
    `⛔ /squad <parsed mode> was refused for @<actor> (repository permission: <observed tier or unresolved>). Mutating /squad modes require write, maintain, or admin repository permission. Ask a repository maintainer to run this command or grant the required access.`
 3. Stop immediately. Do not load **Execute Mode**, do not post success breadcrumbs for the requested mutating mode, and do not emit `dispatch-workflow`, `create-issue`, or `create-pull-request`.
 
-**Authorization-required modes guarded by this section:** `cast`, `connect`, `adopt`, `cast-member`, `retire`, `plan revise`, `triage`, `triage revise`, `plan program`, `plan program revise`, `plan implementation`, `plan validate`, `plan accept`, `plan accept scope`, `plan accept implementation`, `plan activate`, and `implement`. Phase variants inherit their base parsed mode: `plan accept phase {N}` → `plan accept`, `plan accept implementation phase {N}` → `plan accept implementation`, `plan activate phase {N}` → `plan activate`.
+**Authorization-required modes guarded by this section:** `cast`, `connect`, `adopt`, `cast-member`, `retire`, `plan revise`, `triage`, `triage revise`, `plan program`, `plan program revise`, `plan implementation`, `plan validate`, `activate`, `plan accept`, `plan accept scope`, `plan accept implementation`, `plan activate`, and `implement`. Phase variants inherit their base parsed mode: `activate phase {N}` → `activate`, `plan accept phase {N}` → `plan accept`, `plan accept implementation phase {N}` → `plan accept implementation`, `plan activate phase {N}` → `plan activate`.
 
 ## Execute Mode
 
@@ -536,6 +538,7 @@ Each mode's playbook ships as a **skill**. Enter this section only after **Actor
 | `plan program revise` | `squad-plan-program-revise` |
 | `plan implementation` | `squad-plan-implementation` |
 | `plan validate` | `squad-plan-validate` |
+| `activate` | `squad-plan-accept` |
 | `plan accept` | `squad-plan-accept` |
 | `plan accept scope` | `squad-plan-accept-scope` |
 | `plan accept implementation` | `squad-plan-accept-implementation` |
@@ -550,7 +553,7 @@ If the parsed mode's skill cannot be loaded, report the failure in plain languag
 
 ## Team Guard
 
-**Applies to:** Research, Triage, Plan, Plan Program, Plan Implementation, Plan Validate, Plan Revise, Triage Revise, Plan Accept, Plan Accept Scope, Plan Accept Implementation, Plan Activate.
+**Applies to:** Research, Triage, Plan, Plan Program, Plan Implementation, Plan Validate, Plan Revise, Triage Revise, Activate, Plan Accept, Plan Accept Scope, Plan Accept Implementation, Plan Activate.
 **Exempt:** Cast, Connect, Adopt, Cast Member, Retire, Status, Review Relay, Implement (these run their own pre-checks).
 
 ### Step TG-1: Check Team Presence
@@ -1070,7 +1073,7 @@ Break into discrete work items. **Minimum 3 items** unless genuinely atomic (exp
 
 `add-comment` with `data: {"squad_artifact":"plan","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
 
-Structure: `## 📋 Squad Plan — {Title}` → reference line → Phase tables (# | Title | Owner | Size | Depends On) → Details per item (Scope, Acceptance criteria, Notes) → Dependency Graph → Execution Notes → Next Steps (`/squad plan accept`, `/squad plan accept phase 1`, `/squad plan revise`, `/squad plan`).
+Structure: `## 📋 Squad Plan — {Title}` → reference line → Phase tables (# | Title | Owner | Size | Depends On) → Details per item (Scope, Acceptance criteria, Notes) → Dependency Graph → Execution Notes → Next Steps (`/squad activate` preferred, `/squad activate phase 1`, `/squad plan revise`, `/squad plan`; `/squad plan accept` remains a supported legacy alias).
 
 Re-check every `Owner` against the Step 1 certified set before posting. If any
 value is absent, re-resolve it to a certified active member and repeat the check;
@@ -1081,12 +1084,14 @@ Do NOT create issues.
 
 ## skill: `squad-plan-accept`
 ---
-description: Accept a plan (whole plan or a single phase) and record the accepted artifact.
+description: Review and activate a fast plan (whole plan or a single phase), accepting it and creating issues.
 ---
 
-`/squad plan accept` [phase {N}] — combines scope+impl+activation for simple workflows.
+`/squad activate` [phase {N}] (recommended) or `/squad plan accept` [phase {N}]
+(supported legacy alias) — review the latest fast plan, then combine
+scope+implementation acceptance and activation for simple workflows.
 
-**Behavior:** If `program` or `implementation` artifacts exist, run Accept Scope → Accept Impl → Activate in sequence. If only a `plan` artifact exists, use legacy behavior below.
+**Behavior:** If `program` or `implementation` artifacts exist, run Accept Scope → Accept Impl → Activate in sequence. If only a `plan` artifact exists, use the fast-path behavior below.
 
 **Acknowledge:** `🤖 Squad is creating the planned issues…`
 
@@ -1100,9 +1105,9 @@ Resolve which planning path this issue is on, in this order:
    **Accept Implementation** (`squad-plan-accept-implementation`) → **Activate**
    (`squad-plan-activate`) — each honoring its own preconditions (e.g. Accept
    Implementation requires a `validation` PASS). Then stop; do NOT run the
-   legacy fast-path steps below.
+   fast-path steps below.
 2. Otherwise, find the latest `plan` artifact. If found, continue with the
-   legacy fast-path behavior in the steps below.
+   fast-path behavior in the steps below.
 3. If none of `program`, `implementation`, or `plan` exist, reply "No plan found.
    Run `/squad plan` first." and stop.
 


### PR DESCRIPTION
## Summary
- add `/squad activate` and phase-aware activation as the recommended fast-path aliases
- route both aliases through the existing authorization guard and `squad-plan-accept` skill
- document the public `research → plan → activate` lifecycle while preserving granular and legacy commands
- add focused parser, authorization, routing, compatibility, and documentation regression coverage

## Validation
- `npm test -- --run test/gh-aw-command-parse.test.ts test/gh-aw-plan-lifecycle.test.ts test/gh-aw-quality.test.ts` (302 passed)
- `npm run build`
- consumer-layout `gh aw compile --strict --approve` followed by `gh aw compile --strict` (4 workflows succeeded; existing bots/slash-command warning only)