### PR TITLE
fix(gh-aw): honor descriptive cast naming

### DIFF
--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -2347,7 +2347,7 @@ describe('gh-aw: Auto-Cast UX guidance — canonical fallback and Cast PR body r
 describe('gh-aw: Cast naming-mode contract (#1907)', () => {
   const squadContent = readText(SQUAD_WORKFLOW);
   const cast = squadContent.match(
-    /## skill: `squad-cast`\n[\s\S]*?(?=\n## skill:)/
+    /## skill: `squad-cast`\n[\s\S]*?(?=\n## skill:|$)/,
   )?.[0] ?? '';
 
   it('defaults an unqualified Cast request to descriptive role-based names', () => {
@@ -2365,7 +2365,7 @@ describe('gh-aw: Cast naming-mode contract (#1907)', () => {
 
   it('auto-selects a built-in universe only for themed names with no universe', () => {
     expect(cast).toMatch(
-      /Themed names requested without a universe.*auto-select.*built-in universe/s
+      /Themed names requested without a universe.*auto-select.*built-in universe/s,
     );
     expect(cast).toMatch(/capacity.*shape.*fit table/s);
   });

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -2344,6 +2344,33 @@ describe('gh-aw: Auto-Cast UX guidance — canonical fallback and Cast PR body r
   });
 });
 
+describe('gh-aw: Cast naming-mode contract (#1907)', () => {
+  const squadContent = readText(SQUAD_WORKFLOW);
+  const cast = squadContent.match(
+    /## skill: `squad-cast`\n[\s\S]*?(?=\n## skill:)/
+  )?.[0] ?? '';
+
+  it('defaults an unqualified Cast request to descriptive role-based names', () => {
+    expect(cast).toMatch(/No themed naming request.*descriptive mode/s);
+    expect(cast).toContain('short, unique functional names derived from roles');
+    expect(cast).toMatch(/every registry entry.*`universe`.*`"descriptive"`/s);
+    expect(cast).toMatch(/descriptive naming.*never invent.*fictional universe/s);
+    expect(cast).not.toContain('assign character names from a fictional universe');
+  });
+
+  it('uses an explicitly requested built-in or custom universe', () => {
+    expect(cast).toMatch(/Explicit built-in or custom universe request.*requested universe/s);
+    expect(cast).toMatch(/custom universe.*spoiler-safety rules/s);
+  });
+
+  it('auto-selects a built-in universe only for themed names with no universe', () => {
+    expect(cast).toMatch(
+      /Themed names requested without a universe.*auto-select.*built-in universe/s
+    );
+    expect(cast).toMatch(/capacity.*shape.*fit table/s);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // gh-aw: Threat detection taxonomy regression (#1701)
 //

--- a/test/standalone-release-workflow.test.ts
+++ b/test/standalone-release-workflow.test.ts
@@ -113,10 +113,10 @@ describe('standalone release handoff', () => {
 
     expect(squadWorkflow).toMatch(/No themed naming request.*descriptive mode/s);
     expect(squadWorkflow).toMatch(
-      /Explicit built-in or custom universe request.*requested universe/s
+      /Explicit built-in or custom universe request.*requested universe/s,
     );
     expect(squadWorkflow).toMatch(
-      /Themed names requested without a universe.*auto-select.*built-in universe/s
+      /Themed names requested without a universe.*auto-select.*built-in universe/s,
     );
   });
 });

--- a/test/standalone-release-workflow.test.ts
+++ b/test/standalone-release-workflow.test.ts
@@ -18,6 +18,7 @@ const ghAwGuide = readFileSync(
   join(process.cwd(), 'docs', 'src', 'content', 'docs', 'guide', 'gh-aw.md'),
   'utf8',
 );
+const squadWorkflow = readFileSync(join(process.cwd(), 'workflows', 'squad.md'), 'utf8');
 
 describe('standalone release handoff', () => {
   it('supports a confirmation-gated manual release from dev only', () => {
@@ -102,5 +103,20 @@ describe('standalone release handoff', () => {
     expect(ghAwGuide).not.toContain('Installs `@bradygaster/squad-cli`');
     expect(ghAwGuide).not.toContain('State does not persist across runs.');
     expect(ghAwGuide).not.toContain('`create-issue` safe-output has a max of 75');
+  });
+
+  it('keeps the Cast prompt aligned with the documented naming modes', () => {
+    expect(ghAwGuide).toContain('### Descriptive (default)');
+    expect(ghAwGuide).toContain('When you don\'t request a themed universe');
+    expect(ghAwGuide).toMatch(/themed\s+names without specifying a universe/);
+    expect(ghAwGuide).toContain('You can request **any universe**');
+
+    expect(squadWorkflow).toMatch(/No themed naming request.*descriptive mode/s);
+    expect(squadWorkflow).toMatch(
+      /Explicit built-in or custom universe request.*requested universe/s
+    );
+    expect(squadWorkflow).toMatch(
+      /Themed names requested without a universe.*auto-select.*built-in universe/s
+    );
   });
 });

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -657,10 +657,10 @@ gh pr list --state open --json number,url,headRefName --jq '[.[] | select(.headR
 
 ## skill: `squad-cast`
 ---
-description: "Cast a Squad team: analyze the repo, compose agents, assign character names, scaffold .squad/, open the Cast PR."
+description: "Cast a Squad team: analyze the repo, compose agents, resolve descriptive or themed names from the brief, scaffold .squad/, open the Cast PR."
 ---
 
-Analyze repo, compose team, assign character names from a fictional universe, generate `.squad/` scaffolding, open PR.
+Analyze repo, compose team, resolve names from the requested naming mode, generate `.squad/` scaffolding, open PR.
 
 **Acknowledge:** `🤖 Squad is analyzing your repo and assembling a team…`
 
@@ -677,6 +677,8 @@ Evaluate issue (title + body) and repo content to determine primary casting inpu
 | Any | Explicit team spec | **Issue is source of truth** |
 
 "Explicit source-of-truth signal" = issue reads like a team spec (role lists, team-size declarations, operating-model descriptions).
+
+Resolve naming intent from `{canonical_command}` and the primary casting input above. An explicit naming request in `{canonical_command}` wins; otherwise use the issue brief. Repo analysis informs roles but does not request themed naming.
 
 ##### Step 1: Repo Analysis
 
@@ -701,10 +703,13 @@ Every team gets a **Lead**. Then allocate specialists based on signals:
 
 Guidelines: 4–7 agents. Min: Lead + 2 specialists + 1 quality role. Scribe, Ralph, Rai are built-in (don't count).
 
-##### Step 3: Universe & Name Allocation
+##### Step 3: Naming Mode & Name Allocation
 
 1. Count agents from Step 2.
-2. Select universe (pick one whose capacity fits with minimal waste):
+2. Resolve exactly one naming mode:
+   - **No themed naming request:** use **descriptive mode**. Assign short, unique functional names derived from roles (for example Lead, Frontend, Backend, Tester). Do not select a fictional universe.
+   - **Explicit built-in or custom universe request:** use that requested universe.
+   - **Themed names requested without a universe:** auto-select one built-in universe using the capacity/shape fit table below, preferring the smallest capacity that fits the team and the shape that best matches the project.
 
 | Universe | Cap | Shape |
 |----------|-----|-------|
@@ -724,9 +729,12 @@ Guidelines: 4–7 agents. Min: Lead + 2 specialists + 1 quality role. Scribe, Ra
 | The Simpsons | 20 | large, comedy |
 | Marvel Cinematic Universe | 25 | large, action |
 
-3. Name rules: one universe only, pressure/function over authority, no spoilers, early-introduction names, Scribe/Ralph/Rai keep built-in names.
-4. Record in `.squad/casting/registry.json`: `{ "agents": { "{id}": { "created_at": "ISO", "persistent_name": "Name", "universe": "Universe", "legacy_named": false, "status": "active" } } }`
-5. Initialize `.squad/casting/history.json`: `{ "universe_usage_history": [{ "universe": "Name", "assigned_at": "ISO", "agent_count": N }], "assignment_cast_snapshots": {} }`
+3. Name rules:
+   - Descriptive mode: keep names role-derived, short, and unique; do not assign fictional character names.
+   - Themed modes: use one universe only, pressure/function over authority, no spoilers, and early-introduction names. For a custom universe, apply the same one-universe and spoiler-safety rules.
+   - Scribe, Ralph, and Rai keep their built-in names in every mode.
+4. Record in `.squad/casting/registry.json`: `{ "agents": { "{id}": { "created_at": "ISO", "persistent_name": "Name", "universe": "descriptive-or-Universe", "legacy_named": false, "status": "active" } } }`. In descriptive mode, set every registry entry's `universe` to `"descriptive"`; in themed modes, use the exact requested or selected universe.
+5. Initialize `.squad/casting/history.json`: `{ "universe_usage_history": [{ "universe": "descriptive-or-Universe", "assigned_at": "ISO", "agent_count": N }], "assignment_cast_snapshots": {} }`
 
 ##### Step 4: Generate Scaffolding
 
@@ -741,9 +749,11 @@ Create/replace:
 7. **`.squad/decisions/`** — Empty directory.
 8. **`.github/agents/squad.agent.md`** — Verify exists (from `squad init`), include in PR.
 
+Keep naming consistent across generated team state and the Cast PR summary. In descriptive mode, describe the choice as descriptive naming and never invent or mention a fictional universe.
+
 ##### Step 5: Generate meet-the-squad.md
 
-Create `meet-the-squad.md` at repo root with: title, universe name, team table (Name|Role|Specialty|How to talk), Always-On Support table, How to Work With Your Squad (label-based assignment with `9B8FCC` color, iteration commands, routing reference), "What Happened Here" block with analysis rationale (languages, structure, CI/CD, rationale), footer with cast date.
+Create `meet-the-squad.md` at repo root with: title, naming mode (`Descriptive` in descriptive mode; otherwise the exact universe name), team table (Name|Role|Specialty|How to talk), Always-On Support table, How to Work With Your Squad (label-based assignment with `9B8FCC` color, iteration commands, routing reference), "What Happened Here" block with analysis rationale (languages, structure, CI/CD, rationale), footer with cast date.
 
 ##### Step 6: Open PR
 


### PR DESCRIPTION
## Summary
- resolve Cast naming mode from the canonical command and issue brief
- default unqualified casts to short descriptive role names with `universe: "descriptive"`
- preserve explicit built-in/custom universes and auto-selection only for unspecified themed requests
- keep generated team state, Cast PR summaries, and `meet-the-squad.md` aligned with the resolved naming mode
- add focused workflow/guide contract coverage for all three branches

The defect reproduced in 3/3 independent clean-consumer installs; no private consumer identities or links are included.

## Validation
- focused GH-AW quality and guide tests (174 passed)
- `npm run build`
- strict consumer-layout compilation of `squad`, `squad-implement-worker`, `squad-deps-worker`, and `squad-review`

Closes #1907