### PR TITLE
fix(gh-aw): exclude inline review comments

### DIFF
--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -288,7 +288,8 @@ that PR and rerun the original command. Do not start a second Cast command.
 ## Slash commands
 
 Every command starts with `/squad`. Type it in an issue body, issue comment, or
-PR review comment.
+PR conversation comment. On a pull request, post the command in the
+**Conversation** tab. Inline code-review threads do not trigger Squad commands.
 
 Commands are matched longest-prefix-first, so the most specific command string
 wins: `/squad plan accept scope` is not treated as `/squad plan`.
@@ -332,7 +333,7 @@ wins: `/squad plan accept scope` is not treated as `/squad plan`.
 |---------|-------------|
 | **Issue body** | Write `/squad cast` when creating a new issue |
 | **Issue comment** | Comment `/squad cast` on any existing issue |
-| **PR review comment** | Comment `/squad cast` on any pull request |
+| **PR conversation comment** | Comment `/squad cast` in the pull request conversation |
 | **Workflow dispatch** | Trigger manually from the Actions tab with a `command` input |
 
 For workflow dispatch, go to **Actions → Squad → Run workflow** and enter the

--- a/test/gh-aw-review-workflow.test.ts
+++ b/test/gh-aw-review-workflow.test.ts
@@ -167,7 +167,6 @@ describe('gh-aw advisory Squad reviewer', () => {
 
     expect(listInBlock(routerDispatch, 'workflows')).toContain('squad-review');
     expect(ROUTER).toContain('| `/squad review` | Review Relay |');
-    expect(ROUTER_FRONTMATTER).toContain('- pull_request_comment');
     expect(REVIEWER).not.toContain('slash_command:');
     expect(reviewTrigger).toMatch(/workflow_dispatch:\n\s+inputs:/);
     expect(reviewTrigger).toMatch(/pull_request:\n\s+types: \[ready_for_review, synchronize\]/);
@@ -182,6 +181,23 @@ describe('gh-aw advisory Squad reviewer', () => {
     expect(relayPayload.issue_number).toBeUndefined();
     expect(relay).not.toContain('"pr_number"');
     expect(relay).toContain('Never call the generic');
+  });
+
+  it('limits slash commands to issue and pull request conversation surfaces', () => {
+    const slashCommand = yamlBlock(ROUTER_FRONTMATTER, 'slash_command');
+    const guideSection = GUIDE.match(/## Slash commands[\s\S]*?(?=\n## Casting a team)/)?.[0] ?? '';
+
+    expect(listInBlock(slashCommand, 'events')).toEqual([
+      'issues',
+      'issue_comment',
+      'pull_request_comment',
+    ]);
+    expect(slashCommand).not.toContain('pull_request_review_comment');
+    expect(ROUTER).toContain('PR conversation comment');
+    expect(ROUTER).not.toMatch(/PR review comment|pull request review comment/i);
+    expect(guideSection).toContain('PR conversation comment');
+    expect(guideSection).toContain('Inline code-review threads do not trigger Squad commands.');
+    expect(guideSection).not.toMatch(/PR review comment|pull request review comment/i);
   });
 
   it('materializes the documented install as complete source and lock pairs', () => {

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -13,7 +13,6 @@ on:
       - issues
       - issue_comment
       - pull_request_comment
-      - pull_request_review_comment
   workflow_dispatch:
     inputs:
       command:
@@ -183,8 +182,8 @@ Resolve the slash command in this order:
    is empty, the activation guard above has already halted the run; never reach
    this step with an empty dispatched command. When it is non-empty, it is the
    trigger source; skip the remaining sources.
-2. **Issue comment / PR review comment:** `github.event.comment.body` — the full
-   comment text.
+2. **Issue comment / PR conversation comment:** `github.event.comment.body` —
+   the full comment text.
 3. **Issue body:** `github.event.issue.body` — the full issue description.
 4. Otherwise default to `cast` only for an explicit `/squad` slash command with
    no arguments.
@@ -937,8 +936,8 @@ slots.
 
 1. Resolve the target issue number using the Trigger Context resolution order:
    the interpolated dispatched issue number when non-empty, otherwise the
-   triggering issue. If invoked from a pull request review comment, explain that
-   `/squad implement` must be run from the target issue.
+   triggering issue. If invoked from a pull request conversation comment,
+   explain that `/squad implement` must be run from the target issue.
 2. Read the target issue title, body, labels, state, and relevant comments.
 3. Discover the target's open descendant issues using native GitHub sub-issue
    relationships, descending recursively through **every** level of the


### PR DESCRIPTION
## Summary
- remove inline PR review-thread comments from the `/squad` slash-command trigger
- preserve commands in issues, issue comments, and PR conversation comments
- align prompt guidance and public docs with the supported conversation surface
- add regression coverage for the trigger and documentation contract

## Validation
- `npm test -- test/gh-aw-review-workflow.test.ts test/gh-aw-quality.test.ts`
- `npm run build`
- `npm exec eslint -- test/gh-aw-review-workflow.test.ts`
- `npm exec cspell --no-progress docs/src/content/docs/guide/gh-aw.md`
- strict gh-aw v0.86.2 consumer-layout compile of all four published workflows

Closes #1911