### PR TITLE
fix(gh-aw): upsert lifecycle state deterministically

### DIFF
--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { compileFunction, constants as vmConstants } from 'node:vm';
+
+const sharedWorkflow = readFileSync('workflows/shared/squad.md', 'utf8');
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function lifecycleScript(): string {
+  const lines = sharedWorkflow.split(/\r?\n/);
+  const step = lines.findIndex((line) => line.includes('- name: Upsert Squad lifecycle state'));
+  expect(step).toBeGreaterThan(-1);
+  const start = lines.findIndex((line, index) => index > step && /^\s+script:\s*\|$/.test(line));
+  expect(start).toBeGreaterThan(step);
+  const indent = lines[start].match(/^\s*/)![0].length;
+  const script: string[] = [];
+
+  for (let index = start + 1; index < lines.length; index++) {
+    const line = lines[index];
+    if (line.trim() && line.match(/^\s*/)![0].length <= indent) break;
+    script.push(line.trim() ? line.slice(indent + 2) : '');
+  }
+  return script.join('\n');
+}
+
+interface Comment {
+  id: number;
+  body: string;
+  created_at: string;
+  user: { login: string };
+}
+
+async function runLifecycleUpsert(items: unknown[], comments: Comment[] = []) {
+  const directory = mkdtempSync(join(tmpdir(), 'squad-lifecycle-'));
+  tempDirectories.push(directory);
+  const outputPath = join(directory, 'agent-output.json');
+  writeFileSync(outputPath, JSON.stringify({ items }));
+
+  const created: Array<Record<string, unknown>> = [];
+  const updated: Array<Record<string, unknown>> = [];
+  const failures: string[] = [];
+  const github = {
+    paginate: async () => comments,
+    rest: {
+      issues: {
+        listComments: () => undefined,
+        createComment: async (params: Record<string, unknown>) => created.push(params),
+        updateComment: async (params: Record<string, unknown>) => updated.push(params),
+      },
+    },
+  };
+  const context = { repo: { owner: 'octodemo', repo: 'consumer' } };
+  const previousOutput = process.env.GH_AW_AGENT_OUTPUT;
+  const previousIssue = process.env.ISSUE_NUMBER;
+  process.env.GH_AW_AGENT_OUTPUT = outputPath;
+  process.env.ISSUE_NUMBER = '5';
+
+  try {
+    const compiled = compileFunction(
+      `return (async () => {\n${lifecycleScript()}\n})();`,
+      ['github', 'context', 'core'],
+      { importModuleDynamically: vmConstants.USE_MAIN_CONTEXT_DEFAULT_LOADER },
+    ) as (...args: unknown[]) => Promise<unknown>;
+    await compiled(github, context, { setFailed: (message: string) => failures.push(message) });
+  } finally {
+    if (previousOutput === undefined) delete process.env.GH_AW_AGENT_OUTPUT;
+    else process.env.GH_AW_AGENT_OUTPUT = previousOutput;
+    if (previousIssue === undefined) delete process.env.ISSUE_NUMBER;
+    else process.env.ISSUE_NUMBER = previousIssue;
+  }
+
+  return { created, updated, failures };
+}
+
+describe('#1916: deterministic lifecycle safe output', () => {
+  const body = '## Planning Lifecycle\n\n**Current state:** Planned';
+
+  it('creates the first tracker with the fixed structured envelope', async () => {
+    const result = await runLifecycleUpsert([
+      { type: 'upsert_lifecycle_state', body },
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].issue_number).toBe(5);
+    expect(result.created[0].body).toContain(body);
+    expect(result.created[0].body).toContain(
+      '{"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":5,"phases":[]}',
+    );
+  });
+
+  it('updates the newest trusted tracker in place', async () => {
+    const marker = '{"squad_artifact":"lifecycle-state"}';
+    const result = await runLifecycleUpsert(
+      [{ type: 'upsert_lifecycle_state', body }],
+      [
+        {
+          id: 10,
+          body: marker,
+          created_at: '2026-08-27T23:00:00Z',
+          user: { login: 'github-actions[bot]' },
+        },
+        {
+          id: 20,
+          body: marker,
+          created_at: '2026-08-28T00:00:00Z',
+          user: { login: 'github-actions[bot]' },
+        },
+        {
+          id: 30,
+          body: marker,
+          created_at: '2026-08-28T01:00:00Z',
+          user: { login: 'untrusted-user' },
+        },
+      ],
+    );
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toEqual([]);
+    expect(result.updated).toHaveLength(1);
+    expect(result.updated[0].comment_id).toBe(20);
+  });
+
+  it('rejects malformed or duplicate lifecycle output', async () => {
+    const malformed = await runLifecycleUpsert([
+      { type: 'upsert_lifecycle_state', body: 'not a lifecycle body' },
+    ]);
+    const duplicate = await runLifecycleUpsert([
+      { type: 'upsert_lifecycle_state', body },
+      { type: 'upsert_lifecycle_state', body },
+    ]);
+
+    expect(malformed.failures).toEqual([
+      'Lifecycle body must begin with "## Planning Lifecycle".',
+    ]);
+    expect(duplicate.failures).toEqual(['Expected exactly one lifecycle update, found 2.']);
+  });
+});

--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -945,7 +945,7 @@ describe('#1914: research creates the planning lifecycle state', () => {
     )?.[1] ?? '';
 
     expect(lifecycle).toContain(
-      'data: {"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":{issue_number},"phases":[]}',
+      'Call `upsert_lifecycle_state` once with the complete lifecycle body.',
     );
     expect(lifecycle).toContain('Set Research = `✅ Done`');
     expect(lifecycle).toContain('state = Researched');
@@ -968,13 +968,13 @@ describe('#1916: fast-path commands maintain the planning lifecycle state', () =
   const plan = skillBlock(squad, 'squad-plan');
   const revise = skillBlock(squad, 'squad-plan-revise');
   const activate = skillBlock(squad, 'squad-plan-accept');
-  const lifecycleEnvelope =
-    'data: {"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":{issue_number},"phases":[]}';
+  const lifecycleUpsert =
+    'Call `upsert_lifecycle_state` once with the complete lifecycle body.';
 
   it('updates lifecycle state after creating a fast plan', () => {
     const lifecycle = plan.match(/Step 4: Update Lifecycle([\s\S]*)$/)?.[1] ?? '';
 
-    expect(lifecycle).toContain(lifecycleEnvelope);
+    expect(lifecycle).toContain(lifecycleUpsert);
     expect(lifecycle).toContain('Set Plan = `✅ Done`');
     expect(lifecycle).toContain('state = Planned');
     expect(lifecycle).toContain('last command = `/squad plan`');
@@ -983,7 +983,7 @@ describe('#1916: fast-path commands maintain the planning lifecycle state', () =
   });
 
   it('preserves planned lifecycle state after revising a fast plan', () => {
-    expect(revise).toContain(lifecycleEnvelope);
+    expect(revise).toContain(lifecycleUpsert);
     expect(revise).toContain('Keep Plan = `✅ Done`');
     expect(revise).toContain('state = Planned');
     expect(revise).toContain('last command =\n   `/squad plan revise`');
@@ -994,7 +994,7 @@ describe('#1916: fast-path commands maintain the planning lifecycle state', () =
     const lifecycle =
       activate.match(/Step 5: Update Fast-Path Lifecycle([\s\S]*)$/)?.[1] ?? '';
 
-    expect(lifecycle).toContain(lifecycleEnvelope);
+    expect(lifecycle).toContain(lifecycleUpsert);
     expect(lifecycle).toContain('record phase `{N}` activated');
     expect(lifecycle).toContain('point next to the next unactivated phase');
     expect(lifecycle).toContain('Activation = `✅ Done`');

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -379,10 +379,46 @@ describe('gh-aw: safe-output configuration', () => {
     expect(safeOutputs['add-comment'], 'add-comment should exist').toBeDefined();
   });
 
+  it('keeps built-in comment targets explicit (#1916)', () => {
+    expect(safeOutputs['add-comment'].target).toBe('*');
+    expect(safeOutputs['add-comment']['allows-comment-ids']).toBeUndefined();
+  });
+
   it('create-issue max is 75 (supports large plans, forward-port of #1683)', () => {
     const ci = safeOutputs['create-issue'];
     expect(ci, 'create-issue block must exist').toBeDefined();
     expect(ci['max'], 'create-issue max must be 75 — do not reduce below this').toBe(75);
+  });
+});
+
+describe('#1916: lifecycle comment updates use a deterministic safe-output job', () => {
+  const workflow = readText(SQUAD_WORKFLOW);
+  const shared = readText(join(SHARED_DIR, 'squad.md'));
+
+  it('defines a bounded, permission-scoped lifecycle upsert', () => {
+    expect(shared).toContain('upsert-lifecycle-state:');
+    expect(shared).toContain('needs: safe_outputs');
+    expect(shared).toContain('issues: write');
+    expect(shared).toContain('pull-requests: write');
+    expect(shared).toContain('max: 1');
+  });
+
+  it('selects only bot-authored lifecycle artifacts and chooses the newest', () => {
+    expect(shared).toContain('comment.user?.login === "github-actions[bot]"');
+    expect(shared).toContain('includes(marker)');
+    expect(shared).toContain('.sort((left, right)');
+    expect(shared).toContain('const current = matches.at(-1);');
+  });
+
+  it('updates in place or creates the first lifecycle comment', () => {
+    expect(shared).toContain('github.rest.issues.updateComment');
+    expect(shared).toContain('comment_id: current.id');
+    expect(shared).toContain('github.rest.issues.createComment');
+  });
+
+  it('requires one lifecycle upsert with a complete body', () => {
+    expect(workflow).toContain('call `upsert_lifecycle_state` once');
+    expect(workflow).toContain('updates the newest trusted tracker or creates the first one');
   });
 });
 
@@ -1021,7 +1057,7 @@ describe('gh-aw: inline skill extraction', () => {
     ...imports
       .map(rel => join(WORKFLOWS_DIR, rel))
       .filter(existsSync)
-      .map(readText),
+      .map(path => readText(path).replace(/^---\n[\s\S]*?\n---\n/, '')),
     readText(SQUAD_WORKFLOW).replace(/^---\n[\s\S]*?\n---\n/, ''),
   ].join('\n');
 
@@ -1239,6 +1275,16 @@ describe('gh-aw: compiled workflow shell input security contract', () => {
     expect(compiled).toContain('{{#runtime-import .github/workflows/shared/squad-planning-ontology.md}}');
     expect(compiled).toContain('{{#runtime-import .github/workflows/squad.md}}');
     expect(compiled).not.toMatch(/<!-- squad-[\w-]+(?:-v\d+)? -->/);
+  }, 20000);
+
+  it('compiles the lifecycle upsert as a post-safe-output job (#1916)', () => {
+    const compiled = lockText();
+    expect(compiled).toContain('  upsert_lifecycle_state:');
+    expect(compiled).toMatch(
+      /upsert_lifecycle_state:[\s\S]*?needs:[\s\S]*?- safe_outputs/,
+    );
+    expect(compiled).toContain('name: Upsert Squad lifecycle state');
+    expect(compiled).toContain('comment_id: current.id');
   }, 20000);
 
   it('preserves the standalone release selection in the compiled install step (#1884)', () => {

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -71,6 +71,98 @@ engine:
 ambient-folders:
   - .squad
 
+safe-outputs:
+  jobs:
+    upsert-lifecycle-state:
+      description: Update the single Squad planning lifecycle comment for this issue.
+      runs-on: ubuntu-slim
+      needs: safe_outputs
+      permissions:
+        issues: write
+        pull-requests: write
+      max: 1
+      output: Lifecycle state updated.
+      inputs:
+        body:
+          description: Complete lifecycle Markdown beginning with "## Planning Lifecycle"; omit structured data.
+          required: true
+          type: string
+      steps:
+        - name: Upsert Squad lifecycle state
+          uses: actions/github-script@v9
+          env:
+            ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.issue_number }}
+          with:
+            script: |
+              const { readFileSync } = await import("node:fs");
+              const issueNumber = Number(process.env.ISSUE_NUMBER);
+              if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+                core.setFailed("A valid issue or pull request number is required.");
+                return;
+              }
+
+              const output = JSON.parse(readFileSync(process.env.GH_AW_AGENT_OUTPUT, "utf8"));
+              const items = (output.items || []).filter(
+                (item) => item.type === "upsert_lifecycle_state",
+              );
+              if (items.length !== 1) {
+                core.setFailed(`Expected exactly one lifecycle update, found ${items.length}.`);
+                return;
+              }
+
+              const body = String(items[0].body || "")
+                .replace(/<!--[\s\S]*?-->/g, "")
+                .trim();
+              if (!body.startsWith("## Planning Lifecycle")) {
+                core.setFailed('Lifecycle body must begin with "## Planning Lifecycle".');
+                return;
+              }
+              if (body.length > 50000) {
+                core.setFailed("Lifecycle body exceeds 50,000 characters.");
+                return;
+              }
+              if (body.includes("Structured data:") || body.replace(/\s/g, "").includes('"squad_artifact":"lifecycle-state"')) {
+                core.setFailed("Lifecycle body must omit structured data.");
+                return;
+              }
+
+              const data = JSON.stringify({
+                squad_artifact: "lifecycle-state",
+                schema_version: "1",
+                origin_issue: issueNumber,
+                phases: [],
+              });
+              const finalBody = `${body}\n\nStructured data:\n\n\`\`\`json\n${data}\n\`\`\``;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                ...context.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              const marker = '"squad_artifact":"lifecycle-state"';
+              const matches = comments
+                .filter((comment) =>
+                  comment.user?.login === "github-actions[bot]" &&
+                  String(comment.body || "").replace(/\s/g, "").includes(marker),
+                )
+                .sort((left, right) =>
+                  String(left.created_at).localeCompare(String(right.created_at)),
+                );
+              const current = matches.at(-1);
+
+              if (current) {
+                await github.rest.issues.updateComment({
+                  ...context.repo,
+                  comment_id: current.id,
+                  body: finalBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: issueNumber,
+                  body: finalBody,
+                });
+              }
+
 jobs:
   activation:
     steps:

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -115,9 +115,8 @@ safe-outputs:
 
 ## Planning Artifact Data Contract (all modes)
 
-gh-aw removes HTML comments from prompts and sanitized output bodies. Never use HTML comments as Squad state markers.
-
-Every machine-readable planning comment MUST include safe-output `data` with:
+gh-aw strips HTML comments, so never use them as state markers. Every
+machine-readable planning comment MUST include safe-output `data`:
 
 ```json
 {
@@ -128,12 +127,13 @@ Every machine-readable planning comment MUST include safe-output `data` with:
 }
 ```
 
-Use the triggering issue number for `origin_issue`. Because gh-aw requires every declared schema property, emit `phases: []` for non-phase artifacts and the accumulated phase numbers for phase-state artifacts. Validation results remain in the human-readable body. gh-aw appends the validated envelope as a `Structured data:` fenced JSON block in the GitHub body.
+Use the triggering issue for `origin_issue`; emit `phases: []` except for
+accumulated phase-state numbers. Keep validation in the readable body. Locate
+artifacts by paginating all comments, matching the exact structured fields, and
+choosing the newest match.
 
-When locating artifacts:
-1. **Paginate fully** — fetch ALL comments (paginate if >30).
-2. **Parse structured data** — match exact `squad_artifact`, `schema_version: "1"`, and the current `origin_issue`.
-3. **Latest = newest** — if multiple comments match, use the most recent.
+For each lifecycle-state write, call `upsert_lifecycle_state` once with the
+complete body. It updates the newest trusted tracker or creates the first one.
 
 # Squad — `/squad` Slash Command
 
@@ -1107,8 +1107,7 @@ Structure: `## 🔬 Squad Research — {Title}` → Summary (2-3 sentences) → 
 
 ##### Step 4: Update Lifecycle
 
-Find/create the single `lifecycle-state` artifact comment. Include
-`data: {"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
+Call `upsert_lifecycle_state` once with the complete lifecycle body.
 Set Research = `✅ Done`, state = Researched, last command = `/squad research`,
 next = `/squad triage`, and also available = `/squad plan`.
 
@@ -1171,9 +1170,7 @@ Do NOT create issues.
 
 ##### Step 4: Update Lifecycle
 
-Find/create the single `lifecycle-state` artifact comment; never post a second
-lifecycle tracker. Include
-`data: {"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
+Call `upsert_lifecycle_state` once with the complete lifecycle body.
 Set Plan = `✅ Done`, state = Planned, last command = `/squad plan`, next =
 `/squad activate`, and also available = `/squad plan revise <feedback>`.
 
@@ -1269,9 +1266,7 @@ that was not created.
 
 ##### Step 5: Update Fast-Path Lifecycle
 
-Find/create the single `lifecycle-state` artifact comment; never post a second
-lifecycle tracker. Include
-`data: {"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
+Call `upsert_lifecycle_state` once with the complete lifecycle body.
 
 - Phase-specific: keep Plan = `✅ Done`, record phase `{N}` activated, set the
   last command to the invoked `/squad activate phase {N}` or legacy alias, and
@@ -1292,8 +1287,7 @@ description: Revise an existing plan artifact from reviewer feedback.
 3. Apply feedback to plan.
 4. **EDIT the existing artifact comment** (never post a duplicate).
 5. Prepend revision note.
-6. Find/create the single `lifecycle-state` artifact comment and include
-   `data: {"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
+6. Call `upsert_lifecycle_state` once with the complete lifecycle body.
    Keep Plan = `✅ Done`, state = Planned, set last command =
    `/squad plan revise`, next = `/squad activate`, and also available =
    `/squad plan revise <feedback>`.
@@ -1333,7 +1327,7 @@ Structure: `## 🔍 Squad Triage — Dispositions` → Intent + reference lines 
 
 ##### Step 4: Update Lifecycle
 
-Find/create the `lifecycle-state` artifact comment. Include `data: {"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":{issue_number},"phases":[]}`. Set Triage = `✅ Done`, state = Triaged, next = `/squad plan program`.
+Call `upsert_lifecycle_state` once with the complete lifecycle body. Set Triage = `✅ Done`, state = Triaged, next = `/squad plan program`.
 
 ## skill: `squad-triage-revise`
 ---


### PR DESCRIPTION
## Summary
- add a permission-scoped custom safe output that updates the newest trusted lifecycle tracker or creates the first one
- route every lifecycle transition through the deterministic upsert while preserving the structured lifecycle envelope
- cover create, update, malformed, duplicate, prompt, and compiled-workflow behavior

## Validation
- 242 targeted GH-AW tests passed
- all four workflows strict-compiled with gh-aw v0.86.2
- package build passed

Closes #1916