### PR TITLE
fix(gh-aw): accept lifecycle heading compatibility

### DIFF
--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -81,6 +81,7 @@ async function runLifecycleUpsert(items: unknown[], comments: Comment[] = []) {
 
 describe('#1916: deterministic lifecycle safe output', () => {
   const body = '## Planning Lifecycle\n\n**Current state:** Planned';
+  const legacyBody = '## 🧭 Squad Lifecycle State\n\n- **State:** Planned';
 
   it('creates the first tracker with the fixed structured envelope', async () => {
     const result = await runLifecycleUpsert([
@@ -100,7 +101,7 @@ describe('#1916: deterministic lifecycle safe output', () => {
   it('updates the newest trusted tracker in place', async () => {
     const marker = '{"squad_artifact":"lifecycle-state"}';
     const result = await runLifecycleUpsert(
-      [{ type: 'upsert_lifecycle_state', body }],
+      [{ type: 'upsert_lifecycle_state', body: legacyBody }],
       [
         {
           id: 10,
@@ -127,6 +128,7 @@ describe('#1916: deterministic lifecycle safe output', () => {
     expect(result.created).toEqual([]);
     expect(result.updated).toHaveLength(1);
     expect(result.updated[0].comment_id).toBe(20);
+    expect(result.updated[0].body).toContain(legacyBody);
   });
 
   it('rejects malformed or duplicate lifecycle output', async () => {
@@ -139,7 +141,7 @@ describe('#1916: deterministic lifecycle safe output', () => {
     ]);
 
     expect(malformed.failures).toEqual([
-      'Lifecycle body must begin with "## Planning Lifecycle".',
+      'Lifecycle body must begin with a recognized Squad lifecycle heading.',
     ]);
     expect(duplicate.failures).toEqual(['Expected exactly one lifecycle update, found 2.']);
   });

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -84,7 +84,7 @@ safe-outputs:
       output: Lifecycle state updated.
       inputs:
         body:
-          description: Complete lifecycle Markdown beginning with "## Planning Lifecycle"; omit structured data.
+          description: Complete lifecycle Markdown beginning with a recognized Squad lifecycle heading; omit structured data.
           required: true
           type: string
       steps:
@@ -113,8 +113,12 @@ safe-outputs:
               const body = String(items[0].body || "")
                 .replace(/<!--[\s\S]*?-->/g, "")
                 .trim();
-              if (!body.startsWith("## Planning Lifecycle")) {
-                core.setFailed('Lifecycle body must begin with "## Planning Lifecycle".');
+              const lifecycleHeadings = [
+                "## Planning Lifecycle",
+                "## 🧭 Squad Lifecycle State",
+              ];
+              if (!lifecycleHeadings.some((heading) => body.startsWith(heading))) {
+                core.setFailed("Lifecycle body must begin with a recognized Squad lifecycle heading.");
                 return;
               }
               if (body.length > 50000) {


### PR DESCRIPTION
## Summary
- accept both the planning ontology heading and the existing deployed Squad lifecycle heading in the deterministic lifecycle upsert job
- cover the deployed `## 🧭 Squad Lifecycle State` shape in the runtime regression test

## Reproduction
Consumer run https://github.com/octodemo/squad-gh-aw-e2e-20260827-02/actions/runs/33131232076 reached `upsert_lifecycle_state` but failed before mutation because the agent emitted the existing-compatible heading while the writer accepted only `## Planning Lifecycle`.

Closes #1916
