### PR TITLE
fix(gh-aw): normalize lifecycle metadata

### DIFF
--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -131,6 +131,24 @@ describe('#1916: deterministic lifecycle safe output', () => {
     expect(result.updated[0].body).toContain(legacyBody);
   });
 
+  it('replaces agent-supplied trailing metadata with the trusted envelope', async () => {
+    const result = await runLifecycleUpsert([
+      {
+        type: 'upsert_lifecycle_state',
+        body: `${legacyBody}\n\nStructured data:\n\`\`\`json\n{"squad_artifact":"lifecycle-state","origin_issue":999}\n\`\`\``,
+      },
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].body).toContain(legacyBody);
+    expect((result.created[0].body as string).match(/Structured data:/g)).toHaveLength(1);
+    expect(result.created[0].body).toContain(
+      '{"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":5,"phases":[]}',
+    );
+    expect(result.created[0].body).not.toContain('"origin_issue":999');
+  });
+
   it('rejects malformed or duplicate lifecycle output', async () => {
     const malformed = await runLifecycleUpsert([
       { type: 'upsert_lifecycle_state', body: 'not a lifecycle body' },

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -110,8 +110,15 @@ safe-outputs:
                 return;
               }
 
-              const body = String(items[0].body || "")
+              const rawBody = String(items[0].body || "")
                 .replace(/<!--[\s\S]*?-->/g, "")
+                .trim();
+              if (rawBody.length > 50000) {
+                core.setFailed("Lifecycle body exceeds 50,000 characters.");
+                return;
+              }
+              const body = rawBody
+                .replace(/\n+Structured data:\s*\n+```json\s*[\s\S]*?```\s*$/i, "")
                 .trim();
               const lifecycleHeadings = [
                 "## Planning Lifecycle",
@@ -119,10 +126,6 @@ safe-outputs:
               ];
               if (!lifecycleHeadings.some((heading) => body.startsWith(heading))) {
                 core.setFailed("Lifecycle body must begin with a recognized Squad lifecycle heading.");
-                return;
-              }
-              if (body.length > 50000) {
-                core.setFailed("Lifecycle body exceeds 50,000 characters.");
                 return;
               }
               if (body.includes("Structured data:") || body.replace(/\s/g, "").includes('"squad_artifact":"lifecycle-state"')) {


### PR DESCRIPTION
## Summary
- strip a trailing agent-supplied lifecycle `Structured data` block before writing
- append only the deterministic trusted lifecycle envelope
- preserve rejection of embedded/non-trailing metadata and malformed lifecycle bodies
- add runtime regression coverage for the exact payload shape reproduced in the consumer

## Reproduction
Consumer run https://github.com/octodemo/squad-gh-aw-e2e-20260827-02/actions/runs/33132469848 reached `upsert_lifecycle_state` but failed before mutation because the agent included its normal trailing lifecycle structured-data block.

Closes #1916
