### PR TITLE
fix(gh-aw): validate lifecycle structure

### DIFF
--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -80,8 +80,32 @@ async function runLifecycleUpsert(items: unknown[], comments: Comment[] = []) {
 }
 
 describe('#1916: deterministic lifecycle safe output', () => {
-  const body = '## Planning Lifecycle\n\n**Current state:** Planned';
-  const legacyBody = '## 🧭 Squad Lifecycle State\n\n- **State:** Planned';
+  const body = [
+    '## Planning Lifecycle',
+    '',
+    '**Current state:** Planned',
+    '**Last command:** `/squad plan`',
+    '**Next action:** `/squad activate`',
+  ].join('\n');
+  const legacyBody = [
+    '## 🧭 Squad Lifecycle State',
+    '',
+    '- **State:** Planned',
+    '- **Last command:** `/squad plan`',
+    '- **Next command:** `/squad activate`',
+  ].join('\n');
+  const issueHeadingBody = [
+    '## 🔄 Squad Lifecycle State — Issue #5',
+    '',
+    '| Stage | Status |',
+    '| --- | --- |',
+    '| Research | Done |',
+    '| Plan | Done |',
+    '',
+    '**Current state:** Planned',
+    '**Last command:** `/squad plan`',
+    '**Next recommended:** `/squad activate`',
+  ].join('\n');
 
   it('creates the first tracker with the fixed structured envelope', async () => {
     const result = await runLifecycleUpsert([
@@ -149,6 +173,32 @@ describe('#1916: deterministic lifecycle safe output', () => {
     expect(result.created[0].body).not.toContain('"origin_issue":999');
   });
 
+  it('accepts issue-specific lifecycle presentation headings', async () => {
+    const result = await runLifecycleUpsert([
+      { type: 'upsert_lifecycle_state', body: issueHeadingBody },
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].body).toContain(issueHeadingBody);
+  });
+
+  it.each([
+    ['state', body.replace('**Current state:** Planned\n', '')],
+    ['last command', body.replace('**Last command:** `/squad plan`\n', '')],
+    ['next action', body.replace('**Next action:** `/squad activate`', '')],
+  ])('rejects lifecycle output missing its %s field', async (_field, incompleteBody) => {
+    const result = await runLifecycleUpsert([
+      { type: 'upsert_lifecycle_state', body: incompleteBody },
+    ]);
+
+    expect(result.failures).toEqual([
+      'Lifecycle body must include an H2 lifecycle heading plus state, last-command, and next-action fields.',
+    ]);
+    expect(result.created).toEqual([]);
+    expect(result.updated).toEqual([]);
+  });
+
   it('rejects malformed or duplicate lifecycle output', async () => {
     const malformed = await runLifecycleUpsert([
       { type: 'upsert_lifecycle_state', body: 'not a lifecycle body' },
@@ -159,7 +209,7 @@ describe('#1916: deterministic lifecycle safe output', () => {
     ]);
 
     expect(malformed.failures).toEqual([
-      'Lifecycle body must begin with a recognized Squad lifecycle heading.',
+      'Lifecycle body must include an H2 lifecycle heading plus state, last-command, and next-action fields.',
     ]);
     expect(duplicate.failures).toEqual(['Expected exactly one lifecycle update, found 2.']);
   });

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -84,7 +84,7 @@ safe-outputs:
       output: Lifecycle state updated.
       inputs:
         body:
-          description: Complete lifecycle Markdown beginning with a recognized Squad lifecycle heading; omit structured data.
+          description: Complete lifecycle Markdown with an H2 lifecycle heading plus state, last-command, and next-action fields; structured data is normalized by the writer.
           required: true
           type: string
       steps:
@@ -120,12 +120,16 @@ safe-outputs:
               const body = rawBody
                 .replace(/\n+Structured data:\s*\n+```json\s*[\s\S]*?```\s*$/i, "")
                 .trim();
-              const lifecycleHeadings = [
-                "## Planning Lifecycle",
-                "## 🧭 Squad Lifecycle State",
-              ];
-              if (!lifecycleHeadings.some((heading) => body.startsWith(heading))) {
-                core.setFailed("Lifecycle body must begin with a recognized Squad lifecycle heading.");
+              const firstLine = body.split(/\r?\n/, 1)[0];
+              const hasLifecycleHeading =
+                /^##\s+/.test(firstLine) &&
+                /\blifecycle\b/i.test(firstLine) &&
+                (/\bsquad\b/i.test(firstLine) || /\bplanning\b/i.test(firstLine));
+              const hasState = /^(?:[-*]\s+)?\*\*(?:Current state|State):\*\*\s+\S+/im.test(body);
+              const hasLastCommand = /^(?:[-*]\s+)?\*\*Last command:\*\*\s+`\/squad\b[^`]*`/im.test(body);
+              const hasNextAction = /^(?:[-*]\s+)?\*\*Next (?:action|command|recommended):\*\*\s+`\/squad\b[^`]*`/im.test(body);
+              if (!hasLifecycleHeading || !hasState || !hasLastCommand || !hasNextAction) {
+                core.setFailed("Lifecycle body must include an H2 lifecycle heading plus state, last-command, and next-action fields.");
                 return;
               }
               if (body.includes("Structured data:") || body.replace(/\s/g, "").includes('"squad_artifact":"lifecycle-state"')) {


### PR DESCRIPTION
## Summary
- replace exact lifecycle heading allowlists with bounded structural validation
- accept the observed issue-scoped lifecycle heading and table presentation
- require state, last-command, and next-action fields before any lifecycle mutation
- preserve deterministic trusted-envelope and edit-in-place protections

## Validation
- 248 targeted GH-AW tests passed across lifecycle, quality, and plan contracts
- targeted ESLint passed
- build passed with `SKIP_BUILD_BUMP=1`

Closes #1916