### PR TITLE
fix(gh-aw): paginate plan research context

### DIFF
--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -1009,6 +1009,29 @@ describe('#1916: fast-path commands maintain the planning lifecycle state', () =
   });
 });
 
+describe('#1922: fast-path planning proves research absence with pagination', () => {
+  const plan = skillBlock(squad, 'squad-plan');
+  const gatherContext =
+    plan.match(/Step 1: Gather Context([\s\S]*?)Step 2: Decompose/)?.[1] ?? '';
+
+  it('requires a complete structured-data scan before falling back', () => {
+    expect(gatherContext).toContain('Paginate **all** issue comments');
+    expect(gatherContext).toContain('`gh api --paginate`');
+    expect(gatherContext).toContain('`squad_artifact = research`');
+    expect(gatherContext).toContain('`origin_issue = {issue_number}`');
+    expect(gatherContext).toContain('newest matching comment by\n     `created_at`');
+    expect(gatherContext).toContain(
+      'Only when the completed scan has no match may you use lightweight',
+    );
+  });
+
+  it('forbids truncated comment discovery and fails closed on retrieval errors', () => {
+    expect(gatherContext).toMatch(/Do not use\s+`gh issue view --json comments`/);
+    expect(gatherContext).toMatch(/truncate comment output with `head` or\s+`tail`/);
+    expect(gatherContext).toContain('call `report_incomplete` and\n     stop');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // #1772 (defense-in-depth) — empty workflow_dispatch probe is guarded, not
 // turned into a junk issue. Pairs with EECOM's dispatch-workflow max fix

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1139,7 +1139,18 @@ update.
 ##### Step 1: Gather Context
 
 1. Read issue body (the epic/brief).
-2. Find latest `research` artifact comment for this issue. If found, use as primary context. If not, do lightweight repo analysis.
+2. Prove research context with a complete comment scan:
+   - Paginate **all** issue comments with `gh api --paginate` (or an equivalent
+     GitHub tool with an explicit pagination loop). Do not use
+     `gh issue view --json comments`, truncate comment output with `head` or
+     `tail`, or stop after the first page.
+   - Match the structured fields `squad_artifact = research` and
+     `origin_issue = {issue_number}`, then choose the newest matching comment by
+     `created_at`.
+   - If the complete scan fails or cannot finish, call `report_incomplete` and
+     stop. Only when the completed scan has no match may you use lightweight
+     repository analysis.
+   - When found, use the newest research artifact as the plan's primary context.
 3. Use the `ROSTER_MEMBER:` lines already emitted by mandatory Team Guard Step
    TG-2 as the certified active roster set. **Owner binding gate:** when
    `TEAM_PRESENT`, every work item `Owner` MUST match one certified name. Resolve


### PR DESCRIPTION
## Summary
- require `/squad plan` to paginate all issue comments before concluding research is absent
- match the structured research artifact and triggering issue, then choose the newest match
- forbid truncated `gh issue view` discovery
- fail closed when complete retrieval cannot finish instead of silently changing plan scope

## Reproduction
The clean consumer had a valid research artifact, but the agent used `gh issue view ... --json comments | head -100`, missed it, and published a fallback plan.

## Validation
- 241 targeted GH-AW plan and quality tests passed
- targeted ESLint passed
- build passed with `SKIP_BUILD_BUMP=1`

Closes #1922