### PR TITLE
fix(gh-aw): emit one planning metadata block

### DIFF
--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -1032,6 +1032,27 @@ describe('#1922: fast-path planning proves research absence with pagination', ()
   });
 });
 
+describe('#1924: planning comments contain one gh-aw structured-data envelope', () => {
+  const plan = skillBlock(squad, 'squad-plan');
+  const contract =
+    squad.match(
+      /## Planning Artifact Data Contract \(all modes\)([\s\S]*?)# Squad — `\/squad` Slash Command/,
+    )?.[1] ?? '';
+  const postPlan = plan.match(/Step 3: Post Plan([\s\S]*?)Step 4: Update Lifecycle/)?.[1] ?? '';
+
+  it('requires every planning mode to pass metadata only through data', () => {
+    expect(contract).toMatch(/only through the safe-output\s+tool's `data` argument/);
+    expect(contract).toContain('Never include a `Structured data:` heading');
+    expect(contract).toContain('gh-aw appends exactly one validated block');
+  });
+
+  it('repeats the no-embedded-metadata rule at the fast-plan call site', () => {
+    expect(postPlan).toContain('The `body` MUST NOT contain a `Structured data:` block');
+    expect(postPlan).toMatch(/pass\s+the envelope only through `data`/);
+    expect(postPlan).toContain('gh-aw appends it exactly once');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // #1772 (defense-in-depth) — empty workflow_dispatch probe is guarded, not
 // turned into a junk issue. Pairs with EECOM's dispatch-workflow max fix

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -128,9 +128,11 @@ machine-readable planning comment MUST include safe-output `data`:
 ```
 
 Use the triggering issue for `origin_issue`; emit `phases: []` except for
-accumulated phase-state numbers. Keep validation in the readable body. Locate
-artifacts by paginating all comments, matching the exact structured fields, and
-choosing the newest match.
+accumulated phase-state numbers. Pass this envelope only through the safe-output
+tool's `data` argument. Never include a `Structured data:` heading or fenced
+metadata in the readable `body`; gh-aw appends exactly one validated block. Keep
+validation in the readable body. Locate artifacts by paginating all comments,
+matching the exact structured fields, and choosing the newest match.
 
 For each lifecycle-state write, call `upsert_lifecycle_state` once with the
 complete body. It updates the newest trusted tracker or creates the first one.
@@ -1169,6 +1171,8 @@ Break into discrete work items. **Minimum 3 items** unless genuinely atomic (exp
 ##### Step 3: Post Plan
 
 `add-comment` with `data: {"squad_artifact":"plan","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
+The `body` MUST NOT contain a `Structured data:` block or fenced metadata; pass
+the envelope only through `data` so gh-aw appends it exactly once.
 
 Structure: `## 📋 Squad Plan — {Title}` → reference line → Phase tables (# | Title | Owner | Size | Depends On) → Details per item (Scope, Acceptance criteria, Notes) → Dependency Graph → Execution Notes → Next Steps (`/squad activate` preferred, `/squad activate phase 1`, `/squad plan revise`, `/squad plan`; `/squad plan accept` remains a supported legacy alias).
 


### PR DESCRIPTION
## Summary
- require planning artifact bodies to remain human-readable Markdown only
- pass structured envelopes exclusively through safe-output `data`
- make gh-aw the sole appender of the validated `Structured data:` block
- repeat the rule at the `/squad plan` call site and enforce it with prompt-contract tests

## Reproduction
A clean consumer plan included one agent-authored structured-data block in its body, then gh-aw appended the same validated envelope a second time.

## Validation
- 243 targeted GH-AW plan and quality tests passed
- targeted ESLint passed
- build passed with `SKIP_BUILD_BUMP=1`

Closes #1924