### PR TITLE
fix(gh-aw): accept terminal lifecycle guidance

### DIFF
--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -106,6 +106,16 @@ describe('#1916: deterministic lifecycle safe output', () => {
     '**Last command:** `/squad plan`',
     '**Next recommended:** `/squad activate`',
   ].join('\n');
+  const terminalBody = [
+    '## 🧭 Squad Lifecycle State',
+    '',
+    '- **State:** Activated',
+    '- **Research:** ✅ Done',
+    '- **Plan:** ✅ Done',
+    '- **Activation:** ✅ Done',
+    '- **Last command:** `/squad activate`',
+    '- **Next action:** Track progress on the 5 created task issues; no further planning action required.',
+  ].join('\n');
 
   it('creates the first tracker with the fixed structured envelope', async () => {
     const result = await runLifecycleUpsert([
@@ -181,6 +191,33 @@ describe('#1916: deterministic lifecycle safe output', () => {
     expect(result.failures).toEqual([]);
     expect(result.created).toHaveLength(1);
     expect(result.created[0].body).toContain(issueHeadingBody);
+  });
+
+  it('accepts non-command guidance for the terminal Activated state', async () => {
+    const result = await runLifecycleUpsert([
+      { type: 'upsert_lifecycle_state', body: terminalBody },
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].body).toContain(terminalBody);
+  });
+
+  it('rejects non-command next actions for nonterminal states', async () => {
+    const result = await runLifecycleUpsert([
+      {
+        type: 'upsert_lifecycle_state',
+        body: body.replace(
+          '**Next action:** `/squad activate`',
+          '**Next action:** Wait for more information.',
+        ),
+      },
+    ]);
+
+    expect(result.failures).toEqual([
+      'Lifecycle body must include an H2 lifecycle heading plus state, last-command, and next-action fields.',
+    ]);
+    expect(result.created).toEqual([]);
   });
 
   it.each([

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -127,7 +127,13 @@ safe-outputs:
                 (/\bsquad\b/i.test(firstLine) || /\bplanning\b/i.test(firstLine));
               const hasState = /^(?:[-*]\s+)?\*\*(?:Current state|State):\*\*\s+\S+/im.test(body);
               const hasLastCommand = /^(?:[-*]\s+)?\*\*Last command:\*\*\s+`\/squad\b[^`]*`/im.test(body);
-              const hasNextAction = /^(?:[-*]\s+)?\*\*Next (?:action|command|recommended):\*\*\s+`\/squad\b[^`]*`/im.test(body);
+              const hasNextCommand = /^(?:[-*]\s+)?\*\*Next (?:action|command|recommended):\*\*\s+`\/squad\b[^`]*`/im.test(body);
+              const hasTerminalState =
+                /^(?:[-*]\s+)?\*\*(?:Current state|State):\*\*\s+Activated\s*$/im.test(body) &&
+                /^(?:[-*]\s+)?\*\*Activation:\*\*\s+✅\s+Done\s*$/im.test(body) &&
+                /^(?:[-*]\s+)?\*\*Last command:\*\*\s+`\/squad (?:activate|plan accept)`\s*$/im.test(body) &&
+                /^(?:[-*]\s+)?\*\*Next (?:action|command|recommended):\*\*\s+\S.+$/im.test(body);
+              const hasNextAction = hasNextCommand || hasTerminalState;
               if (!hasLifecycleHeading || !hasState || !hasLastCommand || !hasNextAction) {
                 core.setFailed("Lifecycle body must include an H2 lifecycle heading plus state, last-command, and next-action fields.");
                 return;


### PR DESCRIPTION
## Summary
- accept human next-action guidance only for terminal Activated lifecycle state
- require Activation Done and `/squad activate` (or the supported legacy alias) before the terminal exception applies
- keep all nonterminal next actions bound to a backticked `/squad` command
- cover the exact consumer reproduction and the nonterminal rejection case

## Reproduction
`/squad activate` created all five task issues and the acceptance artifact, then the lifecycle job rejected the valid terminal guidance and left the tracker stale at Planned.

## Validation
- 253 targeted GH-AW lifecycle, plan, and quality tests passed
- targeted ESLint passed
- build passed with `SKIP_BUILD_BUMP=1`

Closes #1926