### PR TITLE
fix(gh-aw): repair terminal lifecycle on rerun

### DIFF
--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -1003,8 +1003,14 @@ describe('#1916: fast-path commands maintain the planning lifecycle state', () =
   });
 
   it('repairs stale lifecycle state on an idempotent activate rerun', () => {
-    expect(activate).toMatch(
-      /already-accepted → verify the existing lifecycle state already[\s\S]*repair it if stale/,
+    expect(activate).toContain('**Whole-plan idempotency:**');
+    expect(activate).toContain('create no issues and post no acceptance');
+    expect(activate).toContain('inspect the newest lifecycle state');
+    expect(activate).toContain(
+      'call `upsert_lifecycle_state` exactly once with',
+    );
+    expect(activate).toContain(
+      'Return `noop` only when that lifecycle state',
     );
   });
 });

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1221,13 +1221,22 @@ Resolve which planning path this issue is on, in this order:
 ##### Step 1a: Phase Resolution
 
 1. Extract `requested_phase` from args (or null).
-2. Find the latest `phases-accepted` artifact and read its `phases` array → `accepted_phases` (or []).
-3. Validate: already-accepted → verify the existing lifecycle state already
-   reflects that completed phase or terminal activation, repair it if stale,
-   then stop with the next-available hint. Out-of-order → stop with sequential
-   hint.
-4. Filter items: by phase if set, by unaccepted if prior phases exist, all if fresh.
-5. If no items remain after filter: stop.
+2. Paginate all comments and select the newest `plan-accepted`,
+   `phases-accepted`, and `lifecycle-state` artifacts whose `origin_issue`
+   matches this issue.
+3. **Whole-plan idempotency:** when `requested_phase` is null and a matching
+   `plan-accepted` artifact exists, create no issues and post no acceptance
+   artifact. Before stopping, inspect the newest lifecycle state. If it is
+   missing or does not record State = Activated, Activation = `✅ Done`, and the
+   invoked activation command, call `upsert_lifecycle_state` exactly once with
+   the terminal body from Step 5. Return `noop` only when that lifecycle state
+   is already terminal and consistent. Then stop.
+4. **Phase-specific:** read `accepted_phases` from the latest matching
+   `phases-accepted` artifact (or `[]`). Already accepted → verify the lifecycle
+   reflects that phase, repair it if stale, then stop with the next-available
+   hint. Out of order → stop with the sequential hint.
+5. Filter items: by phase if set, by unaccepted if prior phases exist, all if fresh.
+6. If no items remain after filter: stop.
 
 ##### Step 2: Create Sub-Issues — Hierarchical
 


### PR DESCRIPTION
## Summary
- make whole-plan `plan-accepted` idempotency explicit before any activation early return
- require complete artifact pagination and lifecycle verification on reruns
- repair missing or stale terminal lifecycle state exactly once while preserving no-duplicate behavior
- allow `noop` only when the lifecycle tracker is already terminal and consistent

## Reproduction
Consumer run https://github.com/octodemo/squad-gh-aw-e2e-20260827-02/actions/runs/33138127543 correctly created no duplicate tasks or acceptance artifact, but returned only `noop`. `upsert_lifecycle_state` was skipped and tracker `5446690088` remained stale at Planned.

## Validation
- 253 targeted GH-AW tests passed
- targeted ESLint passed
- build passed with `SKIP_BUILD_BUMP=1`

## Security review
Prompt-contract only: no permissions, credentials, actions, dependencies, mutation limits, or trust boundaries changed. The fix narrows rerun behavior to the existing deterministic lifecycle safe-output job.

Closes #1928