### PR TITLE
fix(gh-aw): repair activated state deterministically

### DIFF
--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -13,9 +13,9 @@ afterEach(() => {
   }
 });
 
-function lifecycleScript(): string {
+function scriptForStep(stepName: string): string {
   const lines = sharedWorkflow.split(/\r?\n/);
-  const step = lines.findIndex((line) => line.includes('- name: Upsert Squad lifecycle state'));
+  const step = lines.findIndex((line) => line.includes(`- name: ${stepName}`));
   expect(step).toBeGreaterThan(-1);
   const start = lines.findIndex((line, index) => index > step && /^\s+script:\s*\|$/.test(line));
   expect(start).toBeGreaterThan(step);
@@ -28,6 +28,14 @@ function lifecycleScript(): string {
     script.push(line.trim() ? line.slice(indent + 2) : '');
   }
   return script.join('\n');
+}
+
+function lifecycleScript(): string {
+  return scriptForStep('Upsert Squad lifecycle state');
+}
+
+function lifecycleRepairScript(): string {
+  return scriptForStep('Repair terminal lifecycle after idempotent activation');
 }
 
 interface Comment {
@@ -77,6 +85,49 @@ async function runLifecycleUpsert(items: unknown[], comments: Comment[] = []) {
   }
 
   return { created, updated, failures };
+}
+
+async function runLifecycleRepair(
+  comments: Comment[],
+  command = '/squad activate',
+) {
+  const created: Array<Record<string, unknown>> = [];
+  const updated: Array<Record<string, unknown>> = [];
+  const failures: string[] = [];
+  const info: string[] = [];
+  const github = {
+    paginate: async () => comments,
+    rest: {
+      issues: {
+        listComments: () => undefined,
+        createComment: async (params: Record<string, unknown>) => created.push(params),
+        updateComment: async (params: Record<string, unknown>) => updated.push(params),
+      },
+    },
+  };
+  const context = { repo: { owner: 'octodemo', repo: 'consumer' } };
+  const previousIssue = process.env.ISSUE_NUMBER;
+  const previousCommand = process.env.SQUAD_COMMAND;
+  process.env.ISSUE_NUMBER = '5';
+  process.env.SQUAD_COMMAND = command;
+
+  try {
+    const compiled = compileFunction(
+      `return (async () => {\n${lifecycleRepairScript()}\n})();`,
+      ['github', 'context', 'core'],
+    ) as (...args: unknown[]) => Promise<unknown>;
+    await compiled(github, context, {
+      info: (message: string) => info.push(message),
+      setFailed: (message: string) => failures.push(message),
+    });
+  } finally {
+    if (previousIssue === undefined) delete process.env.ISSUE_NUMBER;
+    else process.env.ISSUE_NUMBER = previousIssue;
+    if (previousCommand === undefined) delete process.env.SQUAD_COMMAND;
+    else process.env.SQUAD_COMMAND = previousCommand;
+  }
+
+  return { created, updated, failures, info };
 }
 
 describe('#1916: deterministic lifecycle safe output', () => {
@@ -249,5 +300,84 @@ describe('#1916: deterministic lifecycle safe output', () => {
       'Lifecycle body must include an H2 lifecycle heading plus state, last-command, and next-action fields.',
     ]);
     expect(duplicate.failures).toEqual(['Expected exactly one lifecycle update, found 2.']);
+  });
+});
+
+describe('#1928: deterministic terminal lifecycle repair', () => {
+  const accepted = {
+    id: 10,
+    body: [
+      '## Plan accepted',
+      '',
+      'Structured data:',
+      '```json',
+      '{"squad_artifact":"plan-accepted","schema_version":"1","origin_issue":5,"phases":[]}',
+      '```',
+    ].join('\n'),
+    created_at: '2026-08-28T01:00:00Z',
+    user: { login: 'github-actions[bot]' },
+  };
+  const lifecycleEnvelope =
+    '{"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":5,"phases":[]}';
+  const stale = {
+    id: 20,
+    body: [
+      '## 🧭 Squad Lifecycle State',
+      '',
+      '**State:** Planned',
+      '**Last command:** `/squad plan`',
+      '**Next action:** `/squad activate`',
+      '',
+      'Structured data:',
+      '```json',
+      lifecycleEnvelope,
+      '```',
+    ].join('\n'),
+    created_at: '2026-08-28T02:00:00Z',
+    user: { login: 'github-actions[bot]' },
+  };
+
+  it('repairs the newest stale tracker after whole-plan acceptance', async () => {
+    const result = await runLifecycleRepair([accepted, stale]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toEqual([]);
+    expect(result.updated).toHaveLength(1);
+    expect(result.updated[0].comment_id).toBe(20);
+    expect(result.updated[0].body).toContain('- **State:** Activated');
+    expect(result.updated[0].body).toContain('- **Activation:** ✅ Done');
+    expect(result.updated[0].body).toContain('- **Last command:** `/squad activate`');
+    expect(result.updated[0].body).toContain(lifecycleEnvelope);
+  });
+
+  it('does nothing when the newest tracker is already terminal', async () => {
+    const terminal = {
+      ...stale,
+      body: stale.body
+        .replace('**State:** Planned', '**State:** Activated\n**Activation:** ✅ Done')
+        .replace('**Last command:** `/squad plan`', '**Last command:** `/squad activate`'),
+    };
+    const result = await runLifecycleRepair([accepted, terminal]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(result.info).toContain(
+      'The newest lifecycle tracker already records terminal activation.',
+    );
+  });
+
+  it('does not trust a user-authored acceptance artifact', async () => {
+    const result = await runLifecycleRepair([
+      { ...accepted, user: { login: 'untrusted-user' } },
+      stale,
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(result.info).toContain(
+      'No trusted whole-plan acceptance artifact; lifecycle repair is not applicable.',
+    );
   });
 });

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -420,6 +420,16 @@ describe('#1916: lifecycle comment updates use a deterministic safe-output job',
     expect(workflow).toContain('call `upsert_lifecycle_state` once');
     expect(workflow).toContain('updates the newest trusted tracker or creates the first one');
   });
+
+  it('repairs terminal state deterministically when an idempotent rerun omits the upsert', () => {
+    expect(shared).toContain('repair_activated_lifecycle:');
+    expect(shared).toContain(
+      "!contains(needs.agent.outputs.output_types, 'upsert_lifecycle_state')",
+    );
+    expect(shared).toContain("github.event.comment.body == '/squad activate'");
+    expect(shared).toContain('envelope?.squad_artifact === "plan-accepted"');
+    expect(shared).toContain('name: Repair terminal lifecycle after idempotent activation');
+  });
 });
 
 describe('gh-aw: router concurrency guard (#1730)', () => {
@@ -1285,6 +1295,18 @@ describe('gh-aw: compiled workflow shell input security contract', () => {
     );
     expect(compiled).toContain('name: Upsert Squad lifecycle state');
     expect(compiled).toContain('comment_id: current.id');
+  }, 20000);
+
+  it('compiles the deterministic terminal lifecycle repair job (#1928)', () => {
+    const compiled = lockText();
+    expect(compiled).toContain('  repair_activated_lifecycle:');
+    expect(compiled).toMatch(
+      /repair_activated_lifecycle:[\s\S]*?needs:[\s\S]*?- safe_outputs/,
+    );
+    expect(compiled).toContain('name: Repair terminal lifecycle after idempotent activation');
+    expect(compiled).toContain(
+      "!contains(needs.agent.outputs.output_types, 'upsert_lifecycle_state')",
+    );
   }, 20000);
 
   it('preserves the standalone release selection in the compiled install step (#1884)', () => {
@@ -2589,7 +2611,7 @@ describe('gh-aw: shared bootstrap health-before-dispatch contract (#1605)', () =
   });
 
   it('step ordering after activation checkout: init → health → upload', () => {
-    const activationStepsStart = sharedContent.search(/jobs:\s*\n\s+activation:\s*\n\s+steps:/);
+    const activationStepsStart = sharedContent.search(/^  activation:\s*\n\s+steps:/m);
     expect(
       activationStepsStart,
       'jobs.activation.steps must exist in the shared bootstrap',
@@ -2665,11 +2687,11 @@ describe('gh-aw: activation roster guard counts only data rows (#1605)', () => {
     expect(
       sharedContent,
       'jobs.activation.steps runs after the generated activation checkout',
-    ).toMatch(/jobs:\s*\n\s+activation:\s*\n\s+steps:/);
+    ).toMatch(/^  activation:\s*\n\s+steps:/m);
     expect(
       sharedContent,
       'pre-steps run before the generated activation checkout and cannot inspect committed state',
-    ).not.toMatch(/jobs:\s*\n\s+activation:\s*\n\s+pre-steps:/);
+    ).not.toMatch(/^  activation:\s*\n\s+pre-steps:/m);
   });
 
   function initStepScript(): string {

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -181,6 +181,137 @@ safe-outputs:
               }
 
 jobs:
+  repair_activated_lifecycle:
+    name: Repair terminal Squad lifecycle
+    needs:
+      - agent
+      - detection
+      - safe_outputs
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.agent.result == 'success' &&
+        needs.detection.result == 'success' &&
+        needs.safe_outputs.result == 'success' &&
+        !contains(needs.agent.outputs.output_types, 'upsert_lifecycle_state') &&
+        github.event_name == 'issue_comment' &&
+        (github.event.comment.body == '/squad activate' ||
+         github.event.comment.body == '/squad plan accept')
+      }}
+    runs-on: ubuntu-slim
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Repair terminal lifecycle after idempotent activation
+        uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          SQUAD_COMMAND: ${{ github.event.comment.body }}
+        with:
+          script: |
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const command = String(process.env.SQUAD_COMMAND || "").trim();
+            if (
+              !Number.isInteger(issueNumber) ||
+              issueNumber <= 0 ||
+              !["/squad activate", "/squad plan accept"].includes(command)
+            ) {
+              core.setFailed("A valid whole-plan activation command and issue number are required.");
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const trusted = comments.filter(
+              (comment) => comment.user?.login === "github-actions[bot]",
+            );
+            const envelopeFor = (comment) => {
+              const matches = String(comment.body || "").matchAll(
+                /Structured data:\s*```json\s*([\s\S]*?)```/gi,
+              );
+              let envelope = null;
+              for (const match of matches) {
+                try {
+                  envelope = JSON.parse(match[1]);
+                } catch (error) {
+                  if (!(error instanceof SyntaxError)) throw error;
+                }
+              }
+              return envelope;
+            };
+            const artifacts = trusted.map((comment) => ({
+              comment,
+              envelope: envelopeFor(comment),
+            }));
+            const accepted = artifacts.some(
+              ({ envelope }) =>
+                envelope?.squad_artifact === "plan-accepted" &&
+                envelope?.schema_version === "1" &&
+                envelope?.origin_issue === issueNumber &&
+                Array.isArray(envelope?.phases) &&
+                envelope.phases.length === 0,
+            );
+            if (!accepted) {
+              core.info("No trusted whole-plan acceptance artifact; lifecycle repair is not applicable.");
+              return;
+            }
+
+            const lifecycle = artifacts
+              .filter(
+                ({ envelope }) =>
+                  envelope?.squad_artifact === "lifecycle-state" &&
+                  envelope?.schema_version === "1" &&
+                  envelope?.origin_issue === issueNumber,
+              )
+              .sort(({ comment: left }, { comment: right }) =>
+                String(left.created_at).localeCompare(String(right.created_at)),
+              )
+              .at(-1)?.comment;
+            const lifecycleBody = String(lifecycle?.body || "");
+            const terminal =
+              /^(?:[-*]\s+)?\*\*(?:Current state|State):\*\*\s+Activated\s*$/im.test(lifecycleBody) &&
+              /^(?:[-*]\s+)?\*\*Activation:\*\*\s+✅\s+Done\s*$/im.test(lifecycleBody) &&
+              /^(?:[-*]\s+)?\*\*Last command:\*\*\s+`\/squad (?:activate|plan accept)`\s*$/im.test(lifecycleBody);
+            if (terminal) {
+              core.info("The newest lifecycle tracker already records terminal activation.");
+              return;
+            }
+
+            const body = [
+              `## 🧭 Squad Lifecycle State — Issue #${issueNumber}`,
+              "",
+              "- **State:** Activated",
+              "- **Plan:** ✅ Done",
+              "- **Activation:** ✅ Done",
+              `- **Last command:** \`${command}\``,
+              "- **Next action:** Track progress on the created task issues; no further planning action is required.",
+            ].join("\n");
+            const data = JSON.stringify({
+              squad_artifact: "lifecycle-state",
+              schema_version: "1",
+              origin_issue: issueNumber,
+              phases: [],
+            });
+            const finalBody = `${body}\n\nStructured data:\n\n\`\`\`json\n${data}\n\`\`\``;
+
+            if (lifecycle) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: lifecycle.id,
+                body: finalBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issueNumber,
+                body: finalBody,
+              });
+            }
+
   activation:
     steps:
       - name: Mint Squad GitHub App token


### PR DESCRIPTION
## Summary
- add a deterministic post-safe-output repair job for idempotent whole-plan activation reruns
- run only after successful agent, detection, and safe-output jobs when no lifecycle upsert was emitted
- require an exact activation command and a trusted bot-authored `plan-accepted` artifact for the triggering issue
- update the newest trusted lifecycle tracker in place, or create the first only when missing
- no-op when terminal state is already consistent

## Reproduction
Both consumer reruns remained task- and acceptance-idempotent but ignored the prompt-level lifecycle repair requirement:
- https://github.com/octodemo/squad-gh-aw-e2e-20260827-02/actions/runs/33138127543
- https://github.com/octodemo/squad-gh-aw-e2e-20260827-02/actions/runs/33139169271

In each run `upsert_lifecycle_state` was skipped and tracker `5446690088` remained Planned. The second run used the explicit whole-plan prompt contract from merged PR #1929, proving model instructions alone are not a reliable repair mechanism.

## Validation
- 258 targeted GH-AW tests passed
- targeted ESLint passed
- build passed with `SKIP_BUILD_BUMP=1`
- gh-aw v0.86.2 strict compilation is covered by the compiled-workflow test

## Security review
The new job uses the same scoped `issues: write` / `pull-requests: write` permissions as the existing lifecycle writer. It runs only for exact `/squad activate` or `/squad plan accept` issue comments after successful detection and safe outputs, and only when the agent omitted its normal upsert. It ignores agent-authored lifecycle content, trusts only `github-actions[bot]` artifacts with exact schema/version/origin fields, and writes only to the triggering issue's newest trusted tracker. No secrets, dependencies, or action families were added.

Closes #1928