### PR TITLE
fix(gh-aw): normalize unlabeled lifecycle metadata

### DIFF
--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -1127,23 +1127,50 @@ reviews.
 
 ## Upgrading
 
-To update your compiled workflow after pulling upstream changes:
+Pin upgrades to one immutable 40-character Squad commit SHA. A bare `gh aw add`
+does not refresh files that are already installed, so use `--force`:
 
 ```bash
+SQUAD_SHA="<40-character-commit-sha>"
+
 gh aw add \
-  bradygaster/squad/workflows/squad.md@dev \
-  bradygaster/squad/workflows/squad-implement-worker.md@dev \
-  bradygaster/squad/workflows/squad-deps-worker.md@dev \
-  bradygaster/squad/workflows/squad-review.md@dev
+  bradygaster/squad/workflows/squad.md@${SQUAD_SHA} \
+  bradygaster/squad/workflows/squad-implement-worker.md@${SQUAD_SHA} \
+  bradygaster/squad/workflows/squad-deps-worker.md@${SQUAD_SHA} \
+  bradygaster/squad/workflows/squad-review.md@${SQUAD_SHA} \
+  --force
 ```
 
-This re-compiles the workflow from source. If you have local customizations in your compiled `.github/workflows/squad-*.lock.yml`, they will be overwritten — keep customizations in the source `.md` files instead.
+`--force` overwrites the installed source files. Save any local source
+customizations first, then reapply them before the final compile. Never customize
+generated `.lock.yml` files.
 
-For manual recompilation of all workflows:
+Existing local imports are not guaranteed to refresh with the top-level files.
+Fetch every Squad shared import at the same SHA:
 
 ```bash
+mkdir -p .github/workflows/shared
+
+curl --fail --silent --show-error --location \
+  "https://raw.githubusercontent.com/bradygaster/squad/${SQUAD_SHA}/workflows/shared/squad.md" \
+  --output .github/workflows/shared/squad.md
+curl --fail --silent --show-error --location \
+  "https://raw.githubusercontent.com/bradygaster/squad/${SQUAD_SHA}/workflows/shared/squad-cast-validator.md" \
+  --output .github/workflows/shared/squad-cast-validator.md
+curl --fail --silent --show-error --location \
+  "https://raw.githubusercontent.com/bradygaster/squad/${SQUAD_SHA}/workflows/shared/squad-planning-ontology.md" \
+  --output .github/workflows/shared/squad-planning-ontology.md
+curl --fail --silent --show-error --location \
+  "https://raw.githubusercontent.com/bradygaster/squad/${SQUAD_SHA}/workflows/shared/squad-planning-policy.md" \
+  --output .github/workflows/shared/squad-planning-policy.md
+
 gh aw compile --strict
 ```
+
+Confirm all four source files and generated locks reference `SQUAD_SHA`, review
+the workflow diff, then commit them together. With gh-aw v0.86.2, do not use
+`gh aw update` for this immutable-pin flow: its stored source branch and cooldown
+can leave the installed sources at a different revision than the SHA you intend.
 
 ---
 

--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -234,6 +234,36 @@ describe('#1916: deterministic lifecycle safe output', () => {
     expect(result.created[0].body).not.toContain('"origin_issue":999');
   });
 
+  it('replaces an unlabeled trailing lifecycle envelope with the trusted envelope', async () => {
+    const result = await runLifecycleUpsert([
+      {
+        type: 'upsert_lifecycle_state',
+        body: `${legacyBody}\n\n\`\`\`json\n{"squad_artifact":"lifecycle-state","origin_issue":999}\n\`\`\``,
+      },
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].body).toContain(legacyBody);
+    expect((result.created[0].body as string).match(/Structured data:/g)).toHaveLength(1);
+    expect(result.created[0].body).toContain(
+      '{"squad_artifact":"lifecycle-state","schema_version":"1","origin_issue":5,"phases":[]}',
+    );
+    expect(result.created[0].body).not.toContain('"origin_issue":999');
+  });
+
+  it('rejects lifecycle metadata that is not the trailing JSON fence', async () => {
+    const result = await runLifecycleUpsert([
+      {
+        type: 'upsert_lifecycle_state',
+        body: `${legacyBody}\n\n\`\`\`json\n{"squad_artifact":"lifecycle-state","origin_issue":999}\n\`\`\`\n\nUnexpected trailing text.`,
+      },
+    ]);
+
+    expect(result.failures).toEqual(['Lifecycle body must omit structured data.']);
+    expect(result.created).toEqual([]);
+  });
+
   it('accepts issue-specific lifecycle presentation headings', async () => {
     const result = await runLifecycleUpsert([
       { type: 'upsert_lifecycle_state', body: issueHeadingBody },

--- a/test/gh-aw-review-workflow.test.ts
+++ b/test/gh-aw-review-workflow.test.ts
@@ -77,7 +77,7 @@ function provenanceRows(workflow: string): string[] {
 function installOrders(markdown: string): string[][] {
   const uncommented = markdown.replace(/^#\s?/gm, '');
   return [...uncommented.matchAll(/gh aw add \\\n((?:\s+bradygaster\/squad\/workflows\/[^\n]+\n?)+)/g)]
-    .map(block => [...block[1].matchAll(/bradygaster\/squad\/workflows\/([^@\s\\]+\.md)@dev/g)]
+    .map(block => [...block[1].matchAll(/bradygaster\/squad\/workflows\/([^@\s\\]+\.md)@(?:dev|\$\{SQUAD_SHA\})/g)]
       .map(match => match[1]));
 }
 

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -117,9 +117,14 @@ safe-outputs:
                 core.setFailed("Lifecycle body exceeds 50,000 characters.");
                 return;
               }
-              const body = rawBody
-                .replace(/\n+Structured data:\s*\n+```json\s*[\s\S]*?```\s*$/i, "")
-                .trim();
+              const marker = '"squad_artifact":"lifecycle-state"';
+              const trailingMetadata = rawBody.match(
+                /\n+(?:Structured data:\s*\n+)?```json\s*(\{(?:(?!```)[\s\S])*?\})\s*```\s*$/i,
+              );
+              const body = trailingMetadata &&
+                trailingMetadata[1].replace(/\s/g, "").includes(marker)
+                ? rawBody.slice(0, trailingMetadata.index).trim()
+                : rawBody;
               const firstLine = body.split(/\r?\n/, 1)[0];
               const hasLifecycleHeading =
                 /^##\s+/.test(firstLine) &&
@@ -155,7 +160,6 @@ safe-outputs:
                 issue_number: issueNumber,
                 per_page: 100,
               });
-              const marker = '"squad_artifact":"lifecycle-state"';
               const matches = comments
                 .filter((comment) =>
                   comment.user?.login === "github-actions[bot]" &&


### PR DESCRIPTION
Closes #1933

## What changed

- normalize one trailing lifecycle-state JSON fence whether or not the model includes the `Structured data:` label
- continue rejecting lifecycle metadata embedded elsewhere in the human-readable body
- replace agent-supplied origin metadata with the writer's trusted fixed envelope

## Reproduction

Two research commands ran concurrently on separate intents in one clean consumer. One posted valid research, then failed lifecycle upsert because the model emitted an unlabeled trailing lifecycle envelope. The issue received no lifecycle tracker even though the completion comment reported success.

## Validation

- targeted lifecycle and GH-AW quality tests
- targeted ESLint
- gh-aw v0.86.2 strict compilation: 4/4 succeeded with only the documented slash-command/bot warning