### PR TITLE
fix(gh-aw): upsert research artifacts

### DIFF
--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -34,6 +34,10 @@ function lifecycleScript(): string {
   return scriptForStep('Upsert Squad lifecycle state');
 }
 
+function researchScript(): string {
+  return scriptForStep('Upsert Squad research artifact');
+}
+
 function lifecycleRepairScript(): string {
   return scriptForStep('Repair terminal lifecycle after idempotent activation');
 }
@@ -87,6 +91,50 @@ async function runLifecycleUpsert(items: unknown[], comments: Comment[] = []) {
   return { created, updated, failures };
 }
 
+async function runResearchUpsert(items: unknown[], comments: Comment[] = []) {
+  const directory = mkdtempSync(join(tmpdir(), 'squad-research-'));
+  tempDirectories.push(directory);
+  const outputPath = join(directory, 'agent-output.json');
+  writeFileSync(outputPath, JSON.stringify({ items }));
+
+  const created: Array<Record<string, unknown>> = [];
+  const updated: Array<Record<string, unknown>> = [];
+  const deleted: Array<Record<string, unknown>> = [];
+  const failures: string[] = [];
+  const github = {
+    paginate: async () => comments,
+    rest: {
+      issues: {
+        listComments: () => undefined,
+        createComment: async (params: Record<string, unknown>) => created.push(params),
+        updateComment: async (params: Record<string, unknown>) => updated.push(params),
+        deleteComment: async (params: Record<string, unknown>) => deleted.push(params),
+      },
+    },
+  };
+  const context = { repo: { owner: 'octodemo', repo: 'consumer' } };
+  const previousOutput = process.env.GH_AW_AGENT_OUTPUT;
+  const previousIssue = process.env.ISSUE_NUMBER;
+  process.env.GH_AW_AGENT_OUTPUT = outputPath;
+  process.env.ISSUE_NUMBER = '5';
+
+  try {
+    const compiled = compileFunction(
+      `return (async () => {\n${researchScript()}\n})();`,
+      ['github', 'context', 'core'],
+      { importModuleDynamically: vmConstants.USE_MAIN_CONTEXT_DEFAULT_LOADER },
+    ) as (...args: unknown[]) => Promise<unknown>;
+    await compiled(github, context, { setFailed: (message: string) => failures.push(message) });
+  } finally {
+    if (previousOutput === undefined) delete process.env.GH_AW_AGENT_OUTPUT;
+    else process.env.GH_AW_AGENT_OUTPUT = previousOutput;
+    if (previousIssue === undefined) delete process.env.ISSUE_NUMBER;
+    else process.env.ISSUE_NUMBER = previousIssue;
+  }
+
+  return { created, updated, deleted, failures };
+}
+
 async function runLifecycleRepair(
   comments: Comment[],
   command = '/squad activate',
@@ -129,6 +177,117 @@ async function runLifecycleRepair(
 
   return { created, updated, failures, info };
 }
+
+describe('#1935: deterministic research artifact safe output', () => {
+  const body = [
+    '## 🔬 Squad Research — Example',
+    '',
+    '### Goals',
+    '- Goal',
+    '',
+    '### Non-goals',
+    '- Non-goal',
+    '',
+    '### Evidence table',
+    '| Rn | Finding | Risk | Complexity | Citation |',
+    '| --- | --- | --- | --- | --- |',
+    '| R1 | Finding | 🟢 | S | src/example.ts:1 |',
+    '',
+    '### Load-bearing assumptions',
+    '- R1',
+    '',
+    '### Open decisions',
+    '- Decision',
+    '',
+    '### Acceptance framing',
+    '- R1',
+  ].join('\n');
+
+  it('creates the first research artifact with the fixed structured envelope', async () => {
+    const result = await runResearchUpsert([
+      { type: 'upsert_research_artifact', body },
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(result.deleted).toEqual([]);
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].issue_number).toBe(5);
+    expect(result.created[0].body).toContain(body);
+    expect(result.created[0].body).toContain(
+      '{"squad_artifact":"research","schema_version":"1","origin_issue":5,"phases":[]}',
+    );
+  });
+
+  it('updates the newest trusted research artifact and removes older duplicates', async () => {
+    const artifact = (originIssue: number) => [
+      'Research',
+      '',
+      '```json',
+      JSON.stringify({
+        squad_artifact: 'research',
+        schema_version: '1',
+        origin_issue: originIssue,
+        phases: [],
+      }),
+      '```',
+    ].join('\n');
+    const result = await runResearchUpsert(
+      [{ type: 'upsert_research_artifact', body }],
+      [
+        {
+          id: 10,
+          body: artifact(5),
+          created_at: '2026-08-27T23:00:00Z',
+          user: { login: 'github-actions[bot]' },
+        },
+        {
+          id: 20,
+          body: artifact(5),
+          created_at: '2026-08-28T00:00:00Z',
+          user: { login: 'github-actions[bot]' },
+        },
+        {
+          id: 30,
+          body: artifact(6),
+          created_at: '2026-08-28T01:00:00Z',
+          user: { login: 'github-actions[bot]' },
+        },
+        {
+          id: 40,
+          body: artifact(5),
+          created_at: '2026-08-28T02:00:00Z',
+          user: { login: 'untrusted-user' },
+        },
+      ],
+    );
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toEqual([]);
+    expect(result.updated).toHaveLength(1);
+    expect(result.updated[0].comment_id).toBe(20);
+    expect(result.deleted).toEqual([
+      expect.objectContaining({ comment_id: 10 }),
+    ]);
+  });
+
+  it('replaces agent-supplied trailing metadata with the trusted envelope', async () => {
+    const result = await runResearchUpsert([
+      {
+        type: 'upsert_research_artifact',
+        body: `${body}\n\n\`\`\`json\n{"squad_artifact":"research","origin_issue":999}\n\`\`\``,
+      },
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toHaveLength(1);
+    expect((result.created[0].body as string).match(/Structured data:/g)).toHaveLength(1);
+    expect(result.created[0].body).toContain(
+      '{"squad_artifact":"research","schema_version":"1","origin_issue":5,"phases":[]}',
+    );
+    expect(result.created[0].body).not.toContain('"origin_issue":999');
+  });
+});
 
 describe('#1916: deterministic lifecycle safe output', () => {
   const body = [

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -73,6 +73,138 @@ ambient-folders:
 
 safe-outputs:
   jobs:
+    upsert-research-artifact:
+      description: Create or replace the single Squad research artifact for this issue.
+      runs-on: ubuntu-slim
+      needs: safe_outputs
+      permissions:
+        issues: write
+        pull-requests: write
+      max: 1
+      output: Research artifact updated.
+      inputs:
+        body:
+          description: Complete research Markdown with an H2 Squad Research heading and all required sections; structured data is normalized by the writer.
+          required: true
+          type: string
+      steps:
+        - name: Upsert Squad research artifact
+          uses: actions/github-script@v9
+          env:
+            ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.issue_number }}
+          with:
+            script: |
+              const { readFileSync } = await import("node:fs");
+              const issueNumber = Number(process.env.ISSUE_NUMBER);
+              if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+                core.setFailed("A valid issue or pull request number is required.");
+                return;
+              }
+
+              const output = JSON.parse(readFileSync(process.env.GH_AW_AGENT_OUTPUT, "utf8"));
+              const items = (output.items || []).filter(
+                (item) => item.type === "upsert_research_artifact",
+              );
+              if (items.length !== 1) {
+                core.setFailed(`Expected exactly one research update, found ${items.length}.`);
+                return;
+              }
+
+              const rawBody = String(items[0].body || "")
+                .replace(/<!--[\s\S]*?-->/g, "")
+                .trim();
+              if (rawBody.length > 50000) {
+                core.setFailed("Research body exceeds 50,000 characters.");
+                return;
+              }
+              const marker = '"squad_artifact":"research"';
+              const trailingMetadata = rawBody.match(
+                /\n+(?:Structured data:\s*\n+)?```json\s*(\{(?:(?!```)[\s\S])*?\})\s*```\s*$/i,
+              );
+              const body = trailingMetadata &&
+                trailingMetadata[1].replace(/\s/g, "").includes(marker)
+                ? rawBody.slice(0, trailingMetadata.index).trim()
+                : rawBody;
+              const firstLine = body.split(/\r?\n/, 1)[0];
+              const requiredSections = [
+                "Goals",
+                "Non-goals",
+                "Evidence table",
+                "Load-bearing assumptions",
+                "Open decisions",
+                "Acceptance framing",
+              ];
+              const hasRequiredSections = requiredSections.every((section) =>
+                new RegExp(`^#{2,6}\\s+${section}\\s*$`, "im").test(body),
+              );
+              if (!/^##\s+.*\bSquad Research\b/i.test(firstLine) || !hasRequiredSections) {
+                core.setFailed("Research body must include an H2 Squad Research heading and every required section.");
+                return;
+              }
+              if (body.includes("Structured data:") || body.replace(/\s/g, "").includes(marker)) {
+                core.setFailed("Research body must omit structured data.");
+                return;
+              }
+
+              const data = JSON.stringify({
+                squad_artifact: "research",
+                schema_version: "1",
+                origin_issue: issueNumber,
+                phases: [],
+              });
+              const finalBody = `${body}\n\nStructured data:\n\n\`\`\`json\n${data}\n\`\`\``;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                ...context.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              const matches = comments
+                .filter((comment) => {
+                  if (comment.user?.login !== "github-actions[bot]") return false;
+                  const blocks = String(comment.body || "").matchAll(
+                    /```json\s*(\{(?:(?!```)[\s\S])*?\})\s*```/gi,
+                  );
+                  for (const block of blocks) {
+                    try {
+                      const candidate = JSON.parse(block[1]);
+                      if (
+                        candidate.squad_artifact === "research" &&
+                        candidate.schema_version === "1" &&
+                        candidate.origin_issue === issueNumber
+                      ) {
+                        return true;
+                      }
+                    } catch {
+                      // Ignore non-JSON fences and continue scanning this comment.
+                    }
+                  }
+                  return false;
+                })
+                .sort((left, right) =>
+                  String(left.created_at).localeCompare(String(right.created_at)),
+                );
+              const current = matches.at(-1);
+
+              if (current) {
+                await github.rest.issues.updateComment({
+                  ...context.repo,
+                  comment_id: current.id,
+                  body: finalBody,
+                });
+                for (const duplicate of matches.slice(0, -1)) {
+                  await github.rest.issues.deleteComment({
+                    ...context.repo,
+                    comment_id: duplicate.id,
+                  });
+                }
+              } else {
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: issueNumber,
+                  body: finalBody,
+                });
+              }
+
     upsert-lifecycle-state:
       description: Update the single Squad planning lifecycle comment for this issue.
       runs-on: ubuntu-slim

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1101,7 +1101,9 @@ Budget-aware breadth-first investigation: architecture mapping, technology audit
 
 ##### Step 3: Post Findings
 
-`add-comment` with `data: {"squad_artifact":"research","schema_version":"1","origin_issue":{issue_number},"phases":[]}`.
+Call `upsert_research_artifact` once with the complete research body. The
+trusted writer supplies the structured envelope and replaces the existing
+bot-authored research artifact for this issue.
 
 Structure: `## 🔬 Squad Research — {Title}` → Summary (2-3 sentences) → **Goals** → **Non-goals** → **Evidence table** (columns `Rn` | Finding | Risk 🟢/🟡/🔴 | Complexity S/M/L/XL | Citation) → **Load-bearing assumptions** → **Open decisions** → **Acceptance framing** → Recommendations (each referencing the `Rn` IDs it rests on) → Next Step (`/squad triage` or `/squad plan`).
 


### PR DESCRIPTION
## Summary

- add a deterministic upsert_research_artifact safe-output writer
- update the newest matching bot-authored research comment instead of appending
- remove older matching duplicates so reruns converge to one artifact
- supply the structured envelope from the trusted writer and reject malformed research bodies
- route /squad research through the new writer

Closes #1935

## Validation

- all 424 GH-AW tests pass
- runtime coverage proves create, update, duplicate convergence, origin isolation, author isolation, and trusted metadata replacement
- all four workflows compile strictly with gh-aw v0.86.2; only the documented Squad slash-command plus bot warning remains
- package build passes

## Security review

No secrets, external dependencies, redirects, or new third-party actions are introduced. The custom job uses the existing actions/github-script@v9 pattern, which gh-aw resolves into the compiled lock, and scopes write permissions to issue/PR comments. Duplicate removal is restricted to github-actions[bot] comments whose parsed JSON envelope exactly matches research, schema version 1, and the triggering issue number; user-authored or cross-origin comments are never modified.