### PR TITLE
fix(gh-aw): accept bold research sections

### DIFF
--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -202,10 +202,11 @@ describe('#1935: deterministic research artifact safe output', () => {
     '### Acceptance framing',
     '- R1',
   ].join('\n');
+  const boldSectionBody = body.replace(/^### (.+)$/gm, '**$1**');
 
-  it('creates the first research artifact with the fixed structured envelope', async () => {
+  it('accepts bold section labels and creates the fixed structured envelope', async () => {
     const result = await runResearchUpsert([
-      { type: 'upsert_research_artifact', body },
+      { type: 'upsert_research_artifact', body: boldSectionBody },
     ]);
 
     expect(result.failures).toEqual([]);
@@ -213,7 +214,7 @@ describe('#1935: deterministic research artifact safe output', () => {
     expect(result.deleted).toEqual([]);
     expect(result.created).toHaveLength(1);
     expect(result.created[0].issue_number).toBe(5);
-    expect(result.created[0].body).toContain(body);
+    expect(result.created[0].body).toContain(boldSectionBody);
     expect(result.created[0].body).toContain(
       '{"squad_artifact":"research","schema_version":"1","origin_issue":5,"phases":[]}',
     );

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -134,9 +134,13 @@ safe-outputs:
                 "Open decisions",
                 "Acceptance framing",
               ];
-              const hasRequiredSections = requiredSections.every((section) =>
-                new RegExp(`^#{2,6}\\s+${section}\\s*$`, "im").test(body),
-              );
+              const hasRequiredSections = requiredSections.every((section) => {
+                const label = section.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                return new RegExp(
+                  `^(?:#{2,6}\\s+${label}|\\*\\*${label}\\*\\*)\\s*$`,
+                  "im",
+                ).test(body);
+              });
               if (!/^##\s+.*\bSquad Research\b/i.test(firstLine) || !hasRequiredSections) {
                 core.setFailed("Research body must include an H2 Squad Research heading and every required section.");
                 return;


### PR DESCRIPTION
## Summary

- accept required research sections expressed as either Markdown headings or bold labels
- cover the exact bold-label shape emitted during live consumer validation
- preserve all deterministic upsert, trusted-envelope, and duplicate-convergence behavior

Closes #1935

## Validation

- targeted research/lifecycle writer tests pass
- all four workflows compile strictly with gh-aw v0.86.2; only the documented slash-command plus bot warning remains
- live failure changed no research artifacts and the lifecycle tracker still updated in place

## Security review

This follow-up only broadens validation of constant section labels. It does not change permissions, API targets, comment matching, deletion scope, secrets, dependencies, or actions.