### PR TITLE
fix(gh-aw): stabilize fast-path activation contracts

### DIFF
--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -327,6 +327,30 @@ describe('#1916: deterministic lifecycle safe output', () => {
     '- **Last command:** `/squad activate`',
     '- **Next action:** Track progress on the 5 created task issues; no further planning action required.',
   ].join('\n');
+  const terminalTableBody = [
+    '## Planning Lifecycle',
+    '',
+    '| Phase | Status | Artifact | Updated |',
+    '|-------|--------|----------|---------|',
+    '| Activated | ✅ Done | 5 task issues created under #5 | 2026-08-28 |',
+    '',
+    '**Current state:** Activated',
+    '**Last command:** `/squad activate` by @octocat',
+    '**Next action:** None — activation is terminal.',
+  ].join('\n');
+  const terminalProgressBody = [
+    '## Squad Planning Lifecycle',
+    '',
+    '**State:** Activated',
+    '',
+    '**Progress**',
+    '- Research: ✅ Done',
+    '- Plan: ✅ Done',
+    '- Activation: ✅ Done',
+    '',
+    '**Last command:** `/squad activate`',
+    '**Next action:** Plan is fully activated — 6 task issues created under #5.',
+  ].join('\n');
 
   it('creates the first tracker with the fixed structured envelope', async () => {
     const result = await runLifecycleUpsert([
@@ -442,6 +466,19 @@ describe('#1916: deterministic lifecycle safe output', () => {
     expect(result.failures).toEqual([]);
     expect(result.created).toHaveLength(1);
     expect(result.created[0].body).toContain(terminalBody);
+  });
+
+  it.each([
+    ['progress-table activation with command attribution', terminalTableBody],
+    ['plain progress-list activation', terminalProgressBody],
+  ])('accepts live terminal presentation: %s', async (_name, liveBody) => {
+    const result = await runLifecycleUpsert([
+      { type: 'upsert_lifecycle_state', body: liveBody },
+    ]);
+
+    expect(result.failures).toEqual([]);
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0].body).toContain(liveBody);
   });
 
   it('rejects non-command next actions for nonterminal states', async () => {

--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -264,6 +264,14 @@ describe('#1903: fast-path planning binds certified roster owners end to end', (
     expect(accept).toMatch(/Do not\s+create an additional epic, summary, root, or phase issue/i);
   });
 
+  it('resolves fast-plan hierarchy only from explicit phase headings', () => {
+    expect(plan).toMatch(/single `### Phase 1` heading makes the plan phased/i);
+    expect(plan).toMatch(/flat plan MUST use one[\s\S]*no `### Phase \{N\}` headings/i);
+    expect(accept).toMatch(/Determine hierarchy only from the latest plan artifact's headings/i);
+    expect(accept).toMatch(/Any heading[\s\S]*`### Phase \{N\}` makes the plan explicitly phased/i);
+    expect(accept).toMatch(/Do not infer hierarchy from prose, task\s+count, dependency shape, or personal preference/i);
+  });
+
   it('preserves every declared dependency through the safe-output capability', () => {
     expect(accept).toMatch(/Copy every frozen `Depends On` value into the created issue body/i);
     expect(accept).toMatch(/Do not\s+infer, drop, or reorder dependencies/i);

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -269,10 +269,13 @@ safe-outputs:
               const hasState = /^(?:[-*]\s+)?\*\*(?:Current state|State):\*\*\s+\S+/im.test(body);
               const hasLastCommand = /^(?:[-*]\s+)?\*\*Last command:\*\*\s+`\/squad\b[^`]*`/im.test(body);
               const hasNextCommand = /^(?:[-*]\s+)?\*\*Next (?:action|command|recommended):\*\*\s+`\/squad\b[^`]*`/im.test(body);
+              const hasActivationDone =
+                /^(?:[-*]\s+)?(?:\*\*)?Activation:(?:\*\*)?\s+✅\s+Done\b/im.test(body) ||
+                /^\|\s*Activat(?:ion|ed)\s*\|\s*✅\s+Done\s*\|/im.test(body);
               const hasTerminalState =
                 /^(?:[-*]\s+)?\*\*(?:Current state|State):\*\*\s+Activated\s*$/im.test(body) &&
-                /^(?:[-*]\s+)?\*\*Activation:\*\*\s+✅\s+Done\s*$/im.test(body) &&
-                /^(?:[-*]\s+)?\*\*Last command:\*\*\s+`\/squad (?:activate|plan accept)`\s*$/im.test(body) &&
+                hasActivationDone &&
+                /^(?:[-*]\s+)?\*\*Last command:\*\*\s+`\/squad (?:activate|plan accept)(?: phase \d+)?`(?:\s+.*)?$/im.test(body) &&
                 /^(?:[-*]\s+)?\*\*Next (?:action|command|recommended):\*\*\s+\S.+$/im.test(body);
               const hasNextAction = hasNextCommand || hasTerminalState;
               if (!hasLifecycleHeading || !hasState || !hasLastCommand || !hasNextAction) {

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1178,6 +1178,12 @@ the envelope only through `data` so gh-aw appends it exactly once.
 
 Structure: `## 📋 Squad Plan — {Title}` → reference line → Phase tables (# | Title | Owner | Size | Depends On) → Details per item (Scope, Acceptance criteria, Notes) → Dependency Graph → Execution Notes → Next Steps (`/squad activate` preferred, `/squad activate phase 1`, `/squad plan revise`, `/squad plan`; `/squad plan accept` remains a supported legacy alias).
 
+Choose the hierarchy explicitly. A phased plan MUST place every work-item table
+under a heading matching `### Phase {N}` (optional title text may follow). Even a
+single `### Phase 1` heading makes the plan phased. A flat plan MUST use one
+work-item table with no `### Phase {N}` headings. Do not use phase headings as
+visual decoration on a plan intended to stay flat.
+
 Re-check every `Owner` against the Step 1 certified set before posting. If any
 value is absent, re-resolve it to a certified active member and repeat the check;
 do not post until every row passes. Copy each row's `Depends On` value unchanged
@@ -1239,14 +1245,20 @@ Resolve which planning path this issue is on, in this order:
    hint. Out of order → stop with the sequential hint.
 5. Filter items: by phase if set, by unaccepted if prior phases exist, all if fresh.
 6. If no items remain after filter: stop.
+7. Determine hierarchy only from the latest plan artifact's headings. Any heading
+   matching `### Phase {N}` makes the plan explicitly phased, including a lone
+   `### Phase 1`; every accepted row must remain in its declared phase. With no
+   matching heading, the plan is flat. Do not infer hierarchy from prose, task
+   count, dependency shape, or personal preference.
 
 ##### Step 2: Create Sub-Issues — Hierarchical
 
-The origin issue is always the root. If the plan has explicit phases, create one
-phase issue per accepted phase under the origin issue, then create that phase's
-task issues under its phase issue. For a flat plan, create exactly one issue per
-accepted work-item row and set every task's parent to the origin issue. Do not
-create an additional epic, summary, root, or phase issue for a flat plan.
+The origin issue is always the root. Apply Step 1a's heading rule exactly. If the
+plan has explicit `### Phase {N}` headings, create one phase issue per accepted
+phase under the origin issue, then create that phase's task issues under its phase
+issue; never flatten it. For a flat plan, create exactly one issue per accepted
+work-item row and set every task's parent to the origin issue.
+Do not create an additional epic, summary, root, or phase issue for a flat plan.
 
 Before any `create-issue` call, run Team Guard Step TG-2 and validate every
 accepted plan row. Freeze a binding for each task number containing that row's
@@ -1299,7 +1311,8 @@ Call `upsert_lifecycle_state` once with the complete lifecycle body.
   point next to the next unactivated phase.
 - Full or last phase: set Plan = `✅ Done`, Activation = `✅ Done`, state =
   Activated, and the last command to the invoked `/squad activate` or legacy
-  alias. This is terminal, so do not invent another next action.
+  alias. This is terminal. Set Next action to explicit terminal prose such as
+  `None — activation is complete`; do not invent another slash command.
 
 ## skill: `squad-plan-revise`
 ---


### PR DESCRIPTION
## Summary

- accept semantically valid terminal lifecycle presentations produced by live `/squad activate` runs
- define phase hierarchy from explicit `### Phase N` headings so fast-path activation does not flatten phased plans nondeterministically
- clarify terminal next-action guidance and cover the reproduced output shapes

## Consumer evidence

A six-stream activation cohort across three private consumers created every planned issue and acceptance artifact. Three runs then failed only at lifecycle-state validation, leaving the original trackers stale despite successful activation. The same cohort also interpreted equivalent phase headings inconsistently across streams.

No consumer identities or private run URLs are included here.

## Validation

- 427 GH-AW tests pass
- all four workflows compile with `gh aw v0.86.2 --strict`

Closes #1938
