### PR TITLE
fix(gh-aw): accept activate lifecycle rows

### DIFF
--- a/test/gh-aw-lifecycle-upsert.test.ts
+++ b/test/gh-aw-lifecycle-upsert.test.ts
@@ -351,6 +351,19 @@ describe('#1916: deterministic lifecycle safe output', () => {
     '**Last command:** `/squad activate`',
     '**Next action:** Plan is fully activated — 6 task issues created under #5.',
   ].join('\n');
+  const terminalActivateTableBody = [
+    '## 🧭 Squad Lifecycle — Issue #32',
+    '',
+    '**State:** Activated',
+    '**Last command:** `/squad activate`',
+    '**Next action:** None — activation is complete',
+    '',
+    '| Stage | Status |',
+    '|-------|--------|',
+    '| Research | ✅ Done |',
+    '| Plan | ✅ Done |',
+    '| Activate | ✅ Done |',
+  ].join('\n');
 
   it('creates the first tracker with the fixed structured envelope', async () => {
     const result = await runLifecycleUpsert([
@@ -471,6 +484,7 @@ describe('#1916: deterministic lifecycle safe output', () => {
   it.each([
     ['progress-table activation with command attribution', terminalTableBody],
     ['plain progress-list activation', terminalProgressBody],
+    ['activate-stage table row', terminalActivateTableBody],
   ])('accepts live terminal presentation: %s', async (_name, liveBody) => {
     const result = await runLifecycleUpsert([
       { type: 'upsert_lifecycle_state', body: liveBody },

--- a/workflows/shared/squad.md
+++ b/workflows/shared/squad.md
@@ -271,7 +271,7 @@ safe-outputs:
               const hasNextCommand = /^(?:[-*]\s+)?\*\*Next (?:action|command|recommended):\*\*\s+`\/squad\b[^`]*`/im.test(body);
               const hasActivationDone =
                 /^(?:[-*]\s+)?(?:\*\*)?Activation:(?:\*\*)?\s+✅\s+Done\b/im.test(body) ||
-                /^\|\s*Activat(?:ion|ed)\s*\|\s*✅\s+Done\s*\|/im.test(body);
+                /^\|\s*Activat(?:e|ion|ed)\s*\|\s*✅\s+Done\s*\|/im.test(body);
               const hasTerminalState =
                 /^(?:[-*]\s+)?\*\*(?:Current state|State):\*\*\s+Activated\s*$/im.test(body) &&
                 hasActivationDone &&


### PR DESCRIPTION
## Summary

- accept `Activate` alongside `Activation` and `Activated` in terminal lifecycle progress tables
- add the exact live activation output shape as a regression test
- preserve the existing terminal-state, trusted-metadata, and edit-in-place contracts

Closes #1940

## Validation

- 428 GH-AW tests passed
- all four Squad workflows strict-compiled in an installed consumer layout
- no dependency, permission, secret, action, or network-policy changes

## Security review

The change only broadens one anchored lifecycle-label matcher from `Activation|Activated` to `Activate|Activation|Activated`. It adds no actions, secrets, permissions, network access, dependencies, input-controlled execution, or credential handling.