### PR TITLE
feat(gh-aw): add Squad repo enlistment skill

### DIFF
--- a/.changeset/gh-aw-enlistment-skill.md
+++ b/.changeset/gh-aw-enlistment-skill.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+Add the `gh-aw-enlistment` skill: an operationalized, safety-gated guide for enlisting a repository into Squad via GitHub Agentic Workflows (`gh aw`). It walks the supported install → strict-compile → validate → bootstrap-PR path, enforces an explicit safe-update allowlist (only the documented Squad secrets and `squad-init` action), keeps the default workflow token read-only, stages only documented surfaces, and never auto-merges.

--- a/.github/skills/agentic-workflows/SKILL.md
+++ b/.github/skills/agentic-workflows/SKILL.md
@@ -79,7 +79,7 @@ Load these files from `github/gh-aw` (they are not available locally).
 
 - `.github/skills/agentic-workflow-designer/SKILL.md`
 After loading the matching workflow prompt or skill, follow it directly:
-- Enlist a repository into Squad via gh-aw (install the supported `/squad` workflow bootstrap): `.squad/skills/gh-aw-enlistment/SKILL.md` — use for "set up Squad agentic workflows", "enlist this repo in Squad", or "install Squad gh-aw workflows"
+- Enlist a repository into Squad via gh-aw (install the supported `/squad` workflow bootstrap): `.squad/skills/gh-aw-enlistment/SKILL.md` — **this one is local to this repository**, not fetched from `github/gh-aw`. Use for "set up Squad agentic workflows", "enlist this repo in Squad", or "install Squad gh-aw workflows"
 - Design workflows from scratch via interview: `skills/agentic-workflow-designer/SKILL.md`
 - Create new workflows: `.github/aw/create-agentic-workflow.md`
 - Update existing workflows: `.github/aw/update-agentic-workflow.md`

--- a/.github/skills/agentic-workflows/SKILL.md
+++ b/.github/skills/agentic-workflows/SKILL.md
@@ -79,6 +79,7 @@ Load these files from `github/gh-aw` (they are not available locally).
 
 - `.github/skills/agentic-workflow-designer/SKILL.md`
 After loading the matching workflow prompt or skill, follow it directly:
+- Enlist a repository into Squad via gh-aw (install the supported `/squad` workflow bootstrap): `.squad/skills/gh-aw-enlistment/SKILL.md` — use for "set up Squad agentic workflows", "enlist this repo in Squad", or "install Squad gh-aw workflows"
 - Design workflows from scratch via interview: `skills/agentic-workflow-designer/SKILL.md`
 - Create new workflows: `.github/aw/create-agentic-workflow.md`
 - Update existing workflows: `.github/aw/update-agentic-workflow.md`

--- a/.squad/skills/gh-aw-enlistment/SKILL.md
+++ b/.squad/skills/gh-aw-enlistment/SKILL.md
@@ -70,6 +70,10 @@ gh extension list | grep -q 'github/gh-aw' || gh extension install github/gh-aw
 git status --short
 ```
 
+> **Portability — extension check:** the `grep -q` above is bash/Git Bash. On Windows
+> PowerShell use:
+> `if (-not (gh extension list | Select-String -Quiet 'github/gh-aw')) { gh extension install github/gh-aw }`
+
 - **STOP** if `gh auth status` is not logged in, or is logged in as the wrong
   identity for this repo (see the `gh-auth-isolation` skill to operate as a
   specific account without switching the global default).
@@ -130,8 +134,10 @@ creating duplicates. The installed top-level set is exactly:
 
 On a clean repo, `gh aw add` reports these expected safe updates and **nothing else**:
 
+<!-- allowlist-start -->
 - Restricted secrets: **`SQUAD_GITHUB_APP_PRIVATE_KEY`** and **`SQUAD_GITHUB_TOKEN`**
 - Action: **`bradygaster/squad/.github/actions/squad-init`**
+<!-- allowlist-end -->
 
 If — and only if — the report contains exactly those documented entries, complete
 the one-time approval:

--- a/.squad/skills/gh-aw-enlistment/SKILL.md
+++ b/.squad/skills/gh-aw-enlistment/SKILL.md
@@ -4,17 +4,7 @@ description: "Enlist a repository into Squad by installing the supported GitHub 
 domain: "github-integration, agentic-workflows, ci-bootstrap, safety-gated-automation"
 confidence: "high"
 source: "Operationalized from the authoritative Squad gh-aw guide (docs/src/content/docs/guide/gh-aw.md) covering the supported install → compile → validate → bootstrap-PR path."
-triggers:
-  - "set up Squad agentic workflows"
-  - "enlist this repo in Squad"
-  - "enlist my repository in Squad"
-  - "install Squad gh-aw workflows"
-  - "install Squad agentic workflows"
-  - "add Squad gh aw workflows"
-  - "bootstrap Squad in this repo"
-  - "onboard this repo to Squad"
-  - "set up /squad slash commands"
-  - "gh aw add squad"
+triggers: [set up Squad agentic workflows, enlist this repo in Squad, enlist my repository in Squad, install Squad gh-aw workflows, install Squad agentic workflows, add Squad gh aw workflows, bootstrap Squad in this repo, onboard this repo to Squad, set up /squad slash commands, gh aw add squad]
 tools:
   - name: "gh"
     description: "GitHub CLI — repo identity, Actions permissions, PR creation, review request, and check watching."

--- a/.squad/skills/gh-aw-enlistment/SKILL.md
+++ b/.squad/skills/gh-aw-enlistment/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: "gh-aw-enlistment"
+description: "Enlist a repository into Squad by installing the supported GitHub Agentic Workflows (gh-aw) bootstrap — with strict compilation, an explicit safe-update allowlist, and a human-reviewed bootstrap PR. Never auto-merges."
+domain: "github-integration, agentic-workflows, ci-bootstrap, safety-gated-automation"
+confidence: "high"
+source: "Operationalized from the authoritative Squad gh-aw guide (docs/src/content/docs/guide/gh-aw.md) covering the supported install → compile → validate → bootstrap-PR path."
+triggers:
+  - "set up Squad agentic workflows"
+  - "enlist this repo in Squad"
+  - "enlist my repository in Squad"
+  - "install Squad gh-aw workflows"
+  - "install Squad agentic workflows"
+  - "add Squad gh aw workflows"
+  - "bootstrap Squad in this repo"
+  - "onboard this repo to Squad"
+  - "set up /squad slash commands"
+  - "gh aw add squad"
+tools:
+  - name: "gh"
+    description: "GitHub CLI — repo identity, Actions permissions, PR creation, review request, and check watching."
+    when: "Every step: preflight identity/auth, enabling Actions-created PRs, opening and watching the bootstrap PR."
+  - name: "gh aw"
+    description: "GitHub Agentic Workflows extension (github/gh-aw) — installs and strictly compiles the Squad workflow set."
+    when: "Installing the four @dev workflows and compiling them into deterministic .lock.yml files."
+---
+
+## Context
+
+Use this skill when a user wants to **enlist a repository into Squad** through
+**GitHub Agentic Workflows (`gh aw`)** — e.g. "set up Squad agentic workflows",
+"enlist this repo in Squad", or "install Squad gh-aw workflows". The end state is
+the `/squad` slash command being live on the repo, delivered as a **human-reviewed
+bootstrap pull request** — never an auto-merge.
+
+This skill **operationalizes** the supported bootstrap path. It does not summarize
+it: each step below is a gate with explicit success evidence and **STOP conditions**.
+The authoritative source is `docs/src/content/docs/guide/gh-aw.md` (mirrored at
+`https://bradygaster.github.io/squad/docs/guide/gh-aw/`). If that guide and this
+skill ever disagree, the guide wins — re-read it before proceeding.
+
+**Portability contract:** resolve every repository identifier (owner, repo, default
+branch) **at runtime**. Never hardcode a placeholder like `{owner}/{repo}`. The only
+fixed identifier is the Squad source itself — `bradygaster/squad/workflows/...@dev` —
+because that is where the workflows are published.
+
+**Idempotency contract:** the bootstrap is re-runnable. Never clobber existing
+workflows, prefer detecting prior state over duplicating it, and **stop clearly** on
+any unsafe or ambiguous condition rather than guessing.
+
+## Patterns
+
+Run these steps in order. Treat every "STOP" as a hard halt: report the exact
+condition and wait for a human decision — do not work around it.
+
+### 0. Preflight — verify before you touch anything
+
+```bash
+# gh is authenticated
+gh auth status
+
+# Capture repository identity and default branch AT RUNTIME
+owner_repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+default_branch="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+echo "Repo: ${owner_repo}  Default branch: ${default_branch}"
+
+# The gh-aw extension must be installed (install once if missing)
+gh extension list | grep -q 'github/gh-aw' || gh extension install github/gh-aw
+
+# Git state must be understood and clean enough to isolate the install
+git status --short
+```
+
+- **STOP** if `gh auth status` is not logged in, or is logged in as the wrong
+  identity for this repo (see the `gh-auth-isolation` skill to operate as a
+  specific account without switching the global default).
+- **STOP** if `owner_repo` or `default_branch` cannot be resolved.
+- **STOP** if the working tree has unrelated uncommitted changes you cannot
+  account for — the bootstrap must land as an isolated, reviewable change.
+- Confirm Copilot is enabled for the repository where checkable; the activation
+  run and the requested `@copilot` review both depend on it.
+
+### 1. Allow Actions-created PRs while keeping the default token read-only
+
+Squad opens PRs through GitHub Actions. Enable that **without** widening the
+default workflow token:
+
+```bash
+gh api --method PUT "repos/${owner_repo}/actions/permissions/workflow" \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=true
+```
+
+Without this, Squad still pushes the generated branch but falls back to an issue
+with a manual PR link — and a self-authored PR cannot be self-approved. Keep
+`default_workflow_permissions=read`; do not set it to `write`.
+
+### 2. Isolate the install on a bootstrap branch (preserve existing workflows)
+
+```bash
+git switch -c chore/squad-gh-aw-bootstrap
+```
+
+- If the branch already exists (a re-run), switch to it instead of recreating it.
+- **Never overwrite** an existing `.github/workflows/*.md` or `*.lock.yml` that is
+  not part of the Squad set. `gh aw add` is additive; if you see it about to
+  replace an unrelated workflow, **STOP**.
+
+### 3. Install the four supported workflows — in order, dispatcher first
+
+```bash
+gh aw add \
+  bradygaster/squad/workflows/squad.md@dev \
+  bradygaster/squad/workflows/squad-implement-worker.md@dev \
+  bradygaster/squad/workflows/squad-deps-worker.md@dev \
+  bradygaster/squad/workflows/squad-review.md@dev
+```
+
+Keep `squad.md` first: `gh aw add` discovers its worker/reviewer dependencies
+while compiling it, and the explicit entries confirm the full surface without
+creating duplicates. The installed top-level set is exactly:
+
+- `squad.md` + `squad.lock.yml`
+- `squad-implement-worker.md` + `squad-implement-worker.lock.yml`
+- `squad-deps-worker.md` + `squad-deps-worker.lock.yml`
+- `squad-review.md` + `squad-review.lock.yml`
+
+`@dev` is intentional — it tracks the branch where new modes and fixes land first.
+
+### 4. Review the first-install safe-update report — approve ONLY the documented entries
+
+On a clean repo, `gh aw add` reports these expected safe updates and **nothing else**:
+
+- Restricted secrets: **`SQUAD_GITHUB_APP_PRIVATE_KEY`** and **`SQUAD_GITHUB_TOKEN`**
+- Action: **`bradygaster/squad/.github/actions/squad-init`**
+
+If — and only if — the report contains exactly those documented entries, complete
+the one-time approval:
+
+```bash
+gh aw compile --strict --approve   # first install only, when the safe-update warning appears
+```
+
+- **STOP** if the report lists **any other secret** or **any other action**. Do not
+  approve. Report the unexpected entry verbatim and wait for a human.
+- This `--approve` step is *only* the first-install unblock. It is **not** a
+  substitute for the final strict compile in the next step.
+
+### 5. Always run the final strict compile WITHOUT `--approve`
+
+```bash
+gh aw compile --strict
+```
+
+This must run after any first-install approval and before committing. Success
+criteria:
+
+- All four workflows compile successfully.
+- The **only** permitted warning is the known `squad.md` bot-trigger warning: it
+  configures both slash-command and `github-actions[bot]` triggers, and the bot
+  trigger is required for controlled worker-continuation dispatches.
+- **STOP** on any error, or on **any additional warning** beyond that single
+  documented one.
+
+### 6. Require all four source/lock pairs to exist
+
+```bash
+for workflow in squad squad-implement-worker squad-deps-worker squad-review; do
+  test -f ".github/workflows/${workflow}.md"      || { echo "MISSING ${workflow}.md"; exit 1; }
+  test -f ".github/workflows/${workflow}.lock.yml" || { echo "MISSING ${workflow}.lock.yml"; exit 1; }
+done
+```
+
+- **STOP** and rerun `gh aw compile --strict` if any `.lock.yml` is missing. Do not
+  open or merge the bootstrap PR until all **eight** files exist and strict
+  compilation passes.
+
+> On Windows PowerShell, the `for`/`test -f` loop above is POSIX. Use an
+> equivalent guard (e.g. `Test-Path`) or run it under Git Bash; the *logic* — all
+> eight files must exist — is what matters.
+
+### 7. Inspect generated files, then stage only the documented surfaces
+
+Downloaded workflow audit data is local diagnostic output — **do not commit it**.
+If `.github/aw/logs/` lacks a `.gitignore`, add one there:
+
+```gitignore
+# Ignore all downloaded workflow logs
+*
+
+# But keep this file
+!.gitignore
+```
+
+`gh aw add` may also create `.vscode/settings.json` (enables Copilot for Markdown
+workflow files). This is an **optional editor setting** — the stage command below
+intentionally leaves it untracked. Delete it if unwanted, or stage it explicitly
+if your team wants to share it. Decide deliberately; do not stage it by accident.
+
+Stage **only** the documented generated surfaces, then verify the staged set:
+
+```bash
+git add -- .gitattributes .github/aw/ .github/workflows/ .github/skills/
+git diff --cached --stat
+# No deletions should be staged:
+test -z "$(git diff --cached --diff-filter=D --name-only)" || { echo "STOP: staged deletions"; exit 1; }
+```
+
+- **STOP** if the staged diff shows **unexpected deletions**, **unexpected secrets**,
+  edits to **unrelated files**, or committed **log/diagnostic output**. Re-scope with
+  explicit `git add -- <path>` — never `git add .`, `git add -A`, or `git commit -a`.
+
+### 8. Commit, push, and open the bootstrap PR to the captured default branch
+
+```bash
+git commit -m "ci: add Squad agentic workflow"
+git push -u origin HEAD
+gh pr create \
+  --base "${default_branch}" \
+  --title "ci: add Squad agentic workflow" \
+  --body "Installs and strictly compiles the supported Squad GH-AW workflows."
+gh pr edit --add-reviewer @copilot
+gh pr checks --watch
+```
+
+- Open the PR against the **runtime-captured** `${default_branch}`, not a hardcoded
+  `main`.
+- Request Copilot review, address feedback, and wait for required checks.
+
+### 9. Never auto-merge — and explain what comes next
+
+- **Never** merge the bootstrap PR yourself. Merge happens **only** after human
+  approval.
+- Make the two-PR flow explicit to the user: `/squad cast` runs **only after the
+  bootstrap PR merges**. Casting analyzes the codebase and opens a **separate,
+  human-reviewed Cast PR** containing the team, routing, charters, the Copilot
+  agent, and `meet-the-squad.md`. If a work command (`/squad implement`,
+  `/squad review`) is run before a team exists, it auto-opens that Cast PR first —
+  merge it and rerun the original command; do not start a second cast.
+
+## Examples
+
+### ✓ Correct: runtime-resolved identity, allowlist honored, human-reviewed
+
+```bash
+owner_repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+default_branch="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+
+gh api --method PUT "repos/${owner_repo}/actions/permissions/workflow" \
+  -f default_workflow_permissions=read -F can_approve_pull_request_reviews=true
+
+git switch -c chore/squad-gh-aw-bootstrap
+gh aw add \
+  bradygaster/squad/workflows/squad.md@dev \
+  bradygaster/squad/workflows/squad-implement-worker.md@dev \
+  bradygaster/squad/workflows/squad-deps-worker.md@dev \
+  bradygaster/squad/workflows/squad-review.md@dev
+
+# Safe-update report shows ONLY the two documented secrets + squad-init → approve once
+gh aw compile --strict --approve
+gh aw compile --strict           # final, no --approve; only the bot-trigger warning remains
+
+git add -- .gitattributes .github/aw/ .github/workflows/ .github/skills/
+git commit -m "ci: add Squad agentic workflow"
+git push -u origin HEAD
+gh pr create --base "${default_branch}" \
+  --title "ci: add Squad agentic workflow" \
+  --body "Installs and strictly compiles the supported Squad GH-AW workflows."
+gh pr edit --add-reviewer @copilot   # then wait for review + checks; DO NOT merge
+```
+
+### ✓ Correct: STOP on an undocumented safe-update entry
+
+```text
+gh aw add reports a third secret: `ACME_DEPLOY_KEY`.
+→ This is NOT in the allowlist (SQUAD_GITHUB_APP_PRIVATE_KEY, SQUAD_GITHUB_TOKEN)
+  and is NOT the squad-init action. Do NOT run `--approve`.
+  Halt, report "unexpected safe-update entry: ACME_DEPLOY_KEY", and wait.
+```
+
+### ✗ Incorrect: hardcoded target and blanket staging
+
+```bash
+# BAD: hardcoded owner/repo and default branch
+gh api --method PUT "repos/acme/widgets/actions/permissions/workflow" ...
+gh pr create --base main ...        # wrong if the default branch isn't `main`
+
+# BAD: stages logs, .vscode settings, and anything else that changed
+git add -A
+git commit -m "add squad"
+```
+
+### ✗ Incorrect: skipping the final strict compile or auto-merging
+
+```bash
+gh aw compile --strict --approve    # approved first install...
+# ...then committed WITHOUT the final `gh aw compile --strict` (no --approve). WRONG.
+gh pr merge --squash                # auto-merge before human review. NEVER.
+```
+
+## Anti-Patterns
+
+- ❌ **Hardcoding repository identifiers.** Always resolve `owner/repo` and the
+  default branch at runtime with `gh repo view`.
+- ❌ **Blanket staging** (`git add .` / `-A` / `git commit -a`). Stage only
+  `.gitattributes`, `.github/aw/`, `.github/workflows/`, `.github/skills/`, by path.
+- ❌ **Approving unknown safe updates.** Approve ONLY `SQUAD_GITHUB_APP_PRIVATE_KEY`,
+  `SQUAD_GITHUB_TOKEN`, and `bradygaster/squad/.github/actions/squad-init`. Anything
+  else is a STOP.
+- ❌ **Treating `--approve` as the final compile.** Always finish with a plain
+  `gh aw compile --strict` (no `--approve`).
+- ❌ **Tolerating extra warnings.** Only the `squad.md` bot-trigger warning is
+  allowed; every other warning or error halts the run.
+- ❌ **Committing diagnostics.** Never commit `.github/aw/logs/` output; add the
+  log `.gitignore` if missing.
+- ❌ **Clobbering existing workflows.** The install is additive; preserve unrelated
+  `.github/workflows/` files.
+- ❌ **Widening the default token.** Keep `default_workflow_permissions=read`.
+- ❌ **Auto-merging.** The bootstrap PR and the later Cast PR are both
+  human-reviewed. `/squad cast` runs only after the bootstrap PR merges.
+- ❌ **Opening the PR before all eight files exist and strict compile passes.**

--- a/packages/squad-cli/templates/skills/gh-aw-enlistment/SKILL.md
+++ b/packages/squad-cli/templates/skills/gh-aw-enlistment/SKILL.md
@@ -70,6 +70,10 @@ gh extension list | grep -q 'github/gh-aw' || gh extension install github/gh-aw
 git status --short
 ```
 
+> **Portability — extension check:** the `grep -q` above is bash/Git Bash. On Windows
+> PowerShell use:
+> `if (-not (gh extension list | Select-String -Quiet 'github/gh-aw')) { gh extension install github/gh-aw }`
+
 - **STOP** if `gh auth status` is not logged in, or is logged in as the wrong
   identity for this repo (see the `gh-auth-isolation` skill to operate as a
   specific account without switching the global default).
@@ -130,8 +134,10 @@ creating duplicates. The installed top-level set is exactly:
 
 On a clean repo, `gh aw add` reports these expected safe updates and **nothing else**:
 
+<!-- allowlist-start -->
 - Restricted secrets: **`SQUAD_GITHUB_APP_PRIVATE_KEY`** and **`SQUAD_GITHUB_TOKEN`**
 - Action: **`bradygaster/squad/.github/actions/squad-init`**
+<!-- allowlist-end -->
 
 If — and only if — the report contains exactly those documented entries, complete
 the one-time approval:

--- a/packages/squad-cli/templates/skills/gh-aw-enlistment/SKILL.md
+++ b/packages/squad-cli/templates/skills/gh-aw-enlistment/SKILL.md
@@ -4,17 +4,7 @@ description: "Enlist a repository into Squad by installing the supported GitHub 
 domain: "github-integration, agentic-workflows, ci-bootstrap, safety-gated-automation"
 confidence: "high"
 source: "Operationalized from the authoritative Squad gh-aw guide (docs/src/content/docs/guide/gh-aw.md) covering the supported install → compile → validate → bootstrap-PR path."
-triggers:
-  - "set up Squad agentic workflows"
-  - "enlist this repo in Squad"
-  - "enlist my repository in Squad"
-  - "install Squad gh-aw workflows"
-  - "install Squad agentic workflows"
-  - "add Squad gh aw workflows"
-  - "bootstrap Squad in this repo"
-  - "onboard this repo to Squad"
-  - "set up /squad slash commands"
-  - "gh aw add squad"
+triggers: [set up Squad agentic workflows, enlist this repo in Squad, enlist my repository in Squad, install Squad gh-aw workflows, install Squad agentic workflows, add Squad gh aw workflows, bootstrap Squad in this repo, onboard this repo to Squad, set up /squad slash commands, gh aw add squad]
 tools:
   - name: "gh"
     description: "GitHub CLI — repo identity, Actions permissions, PR creation, review request, and check watching."

--- a/packages/squad-cli/templates/skills/gh-aw-enlistment/SKILL.md
+++ b/packages/squad-cli/templates/skills/gh-aw-enlistment/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: "gh-aw-enlistment"
+description: "Enlist a repository into Squad by installing the supported GitHub Agentic Workflows (gh-aw) bootstrap — with strict compilation, an explicit safe-update allowlist, and a human-reviewed bootstrap PR. Never auto-merges."
+domain: "github-integration, agentic-workflows, ci-bootstrap, safety-gated-automation"
+confidence: "high"
+source: "Operationalized from the authoritative Squad gh-aw guide (docs/src/content/docs/guide/gh-aw.md) covering the supported install → compile → validate → bootstrap-PR path."
+triggers:
+  - "set up Squad agentic workflows"
+  - "enlist this repo in Squad"
+  - "enlist my repository in Squad"
+  - "install Squad gh-aw workflows"
+  - "install Squad agentic workflows"
+  - "add Squad gh aw workflows"
+  - "bootstrap Squad in this repo"
+  - "onboard this repo to Squad"
+  - "set up /squad slash commands"
+  - "gh aw add squad"
+tools:
+  - name: "gh"
+    description: "GitHub CLI — repo identity, Actions permissions, PR creation, review request, and check watching."
+    when: "Every step: preflight identity/auth, enabling Actions-created PRs, opening and watching the bootstrap PR."
+  - name: "gh aw"
+    description: "GitHub Agentic Workflows extension (github/gh-aw) — installs and strictly compiles the Squad workflow set."
+    when: "Installing the four @dev workflows and compiling them into deterministic .lock.yml files."
+---
+
+## Context
+
+Use this skill when a user wants to **enlist a repository into Squad** through
+**GitHub Agentic Workflows (`gh aw`)** — e.g. "set up Squad agentic workflows",
+"enlist this repo in Squad", or "install Squad gh-aw workflows". The end state is
+the `/squad` slash command being live on the repo, delivered as a **human-reviewed
+bootstrap pull request** — never an auto-merge.
+
+This skill **operationalizes** the supported bootstrap path. It does not summarize
+it: each step below is a gate with explicit success evidence and **STOP conditions**.
+The authoritative source is `docs/src/content/docs/guide/gh-aw.md` (mirrored at
+`https://bradygaster.github.io/squad/docs/guide/gh-aw/`). If that guide and this
+skill ever disagree, the guide wins — re-read it before proceeding.
+
+**Portability contract:** resolve every repository identifier (owner, repo, default
+branch) **at runtime**. Never hardcode a placeholder like `{owner}/{repo}`. The only
+fixed identifier is the Squad source itself — `bradygaster/squad/workflows/...@dev` —
+because that is where the workflows are published.
+
+**Idempotency contract:** the bootstrap is re-runnable. Never clobber existing
+workflows, prefer detecting prior state over duplicating it, and **stop clearly** on
+any unsafe or ambiguous condition rather than guessing.
+
+## Patterns
+
+Run these steps in order. Treat every "STOP" as a hard halt: report the exact
+condition and wait for a human decision — do not work around it.
+
+### 0. Preflight — verify before you touch anything
+
+```bash
+# gh is authenticated
+gh auth status
+
+# Capture repository identity and default branch AT RUNTIME
+owner_repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+default_branch="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+echo "Repo: ${owner_repo}  Default branch: ${default_branch}"
+
+# The gh-aw extension must be installed (install once if missing)
+gh extension list | grep -q 'github/gh-aw' || gh extension install github/gh-aw
+
+# Git state must be understood and clean enough to isolate the install
+git status --short
+```
+
+- **STOP** if `gh auth status` is not logged in, or is logged in as the wrong
+  identity for this repo (see the `gh-auth-isolation` skill to operate as a
+  specific account without switching the global default).
+- **STOP** if `owner_repo` or `default_branch` cannot be resolved.
+- **STOP** if the working tree has unrelated uncommitted changes you cannot
+  account for — the bootstrap must land as an isolated, reviewable change.
+- Confirm Copilot is enabled for the repository where checkable; the activation
+  run and the requested `@copilot` review both depend on it.
+
+### 1. Allow Actions-created PRs while keeping the default token read-only
+
+Squad opens PRs through GitHub Actions. Enable that **without** widening the
+default workflow token:
+
+```bash
+gh api --method PUT "repos/${owner_repo}/actions/permissions/workflow" \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=true
+```
+
+Without this, Squad still pushes the generated branch but falls back to an issue
+with a manual PR link — and a self-authored PR cannot be self-approved. Keep
+`default_workflow_permissions=read`; do not set it to `write`.
+
+### 2. Isolate the install on a bootstrap branch (preserve existing workflows)
+
+```bash
+git switch -c chore/squad-gh-aw-bootstrap
+```
+
+- If the branch already exists (a re-run), switch to it instead of recreating it.
+- **Never overwrite** an existing `.github/workflows/*.md` or `*.lock.yml` that is
+  not part of the Squad set. `gh aw add` is additive; if you see it about to
+  replace an unrelated workflow, **STOP**.
+
+### 3. Install the four supported workflows — in order, dispatcher first
+
+```bash
+gh aw add \
+  bradygaster/squad/workflows/squad.md@dev \
+  bradygaster/squad/workflows/squad-implement-worker.md@dev \
+  bradygaster/squad/workflows/squad-deps-worker.md@dev \
+  bradygaster/squad/workflows/squad-review.md@dev
+```
+
+Keep `squad.md` first: `gh aw add` discovers its worker/reviewer dependencies
+while compiling it, and the explicit entries confirm the full surface without
+creating duplicates. The installed top-level set is exactly:
+
+- `squad.md` + `squad.lock.yml`
+- `squad-implement-worker.md` + `squad-implement-worker.lock.yml`
+- `squad-deps-worker.md` + `squad-deps-worker.lock.yml`
+- `squad-review.md` + `squad-review.lock.yml`
+
+`@dev` is intentional — it tracks the branch where new modes and fixes land first.
+
+### 4. Review the first-install safe-update report — approve ONLY the documented entries
+
+On a clean repo, `gh aw add` reports these expected safe updates and **nothing else**:
+
+- Restricted secrets: **`SQUAD_GITHUB_APP_PRIVATE_KEY`** and **`SQUAD_GITHUB_TOKEN`**
+- Action: **`bradygaster/squad/.github/actions/squad-init`**
+
+If — and only if — the report contains exactly those documented entries, complete
+the one-time approval:
+
+```bash
+gh aw compile --strict --approve   # first install only, when the safe-update warning appears
+```
+
+- **STOP** if the report lists **any other secret** or **any other action**. Do not
+  approve. Report the unexpected entry verbatim and wait for a human.
+- This `--approve` step is *only* the first-install unblock. It is **not** a
+  substitute for the final strict compile in the next step.
+
+### 5. Always run the final strict compile WITHOUT `--approve`
+
+```bash
+gh aw compile --strict
+```
+
+This must run after any first-install approval and before committing. Success
+criteria:
+
+- All four workflows compile successfully.
+- The **only** permitted warning is the known `squad.md` bot-trigger warning: it
+  configures both slash-command and `github-actions[bot]` triggers, and the bot
+  trigger is required for controlled worker-continuation dispatches.
+- **STOP** on any error, or on **any additional warning** beyond that single
+  documented one.
+
+### 6. Require all four source/lock pairs to exist
+
+```bash
+for workflow in squad squad-implement-worker squad-deps-worker squad-review; do
+  test -f ".github/workflows/${workflow}.md"      || { echo "MISSING ${workflow}.md"; exit 1; }
+  test -f ".github/workflows/${workflow}.lock.yml" || { echo "MISSING ${workflow}.lock.yml"; exit 1; }
+done
+```
+
+- **STOP** and rerun `gh aw compile --strict` if any `.lock.yml` is missing. Do not
+  open or merge the bootstrap PR until all **eight** files exist and strict
+  compilation passes.
+
+> On Windows PowerShell, the `for`/`test -f` loop above is POSIX. Use an
+> equivalent guard (e.g. `Test-Path`) or run it under Git Bash; the *logic* — all
+> eight files must exist — is what matters.
+
+### 7. Inspect generated files, then stage only the documented surfaces
+
+Downloaded workflow audit data is local diagnostic output — **do not commit it**.
+If `.github/aw/logs/` lacks a `.gitignore`, add one there:
+
+```gitignore
+# Ignore all downloaded workflow logs
+*
+
+# But keep this file
+!.gitignore
+```
+
+`gh aw add` may also create `.vscode/settings.json` (enables Copilot for Markdown
+workflow files). This is an **optional editor setting** — the stage command below
+intentionally leaves it untracked. Delete it if unwanted, or stage it explicitly
+if your team wants to share it. Decide deliberately; do not stage it by accident.
+
+Stage **only** the documented generated surfaces, then verify the staged set:
+
+```bash
+git add -- .gitattributes .github/aw/ .github/workflows/ .github/skills/
+git diff --cached --stat
+# No deletions should be staged:
+test -z "$(git diff --cached --diff-filter=D --name-only)" || { echo "STOP: staged deletions"; exit 1; }
+```
+
+- **STOP** if the staged diff shows **unexpected deletions**, **unexpected secrets**,
+  edits to **unrelated files**, or committed **log/diagnostic output**. Re-scope with
+  explicit `git add -- <path>` — never `git add .`, `git add -A`, or `git commit -a`.
+
+### 8. Commit, push, and open the bootstrap PR to the captured default branch
+
+```bash
+git commit -m "ci: add Squad agentic workflow"
+git push -u origin HEAD
+gh pr create \
+  --base "${default_branch}" \
+  --title "ci: add Squad agentic workflow" \
+  --body "Installs and strictly compiles the supported Squad GH-AW workflows."
+gh pr edit --add-reviewer @copilot
+gh pr checks --watch
+```
+
+- Open the PR against the **runtime-captured** `${default_branch}`, not a hardcoded
+  `main`.
+- Request Copilot review, address feedback, and wait for required checks.
+
+### 9. Never auto-merge — and explain what comes next
+
+- **Never** merge the bootstrap PR yourself. Merge happens **only** after human
+  approval.
+- Make the two-PR flow explicit to the user: `/squad cast` runs **only after the
+  bootstrap PR merges**. Casting analyzes the codebase and opens a **separate,
+  human-reviewed Cast PR** containing the team, routing, charters, the Copilot
+  agent, and `meet-the-squad.md`. If a work command (`/squad implement`,
+  `/squad review`) is run before a team exists, it auto-opens that Cast PR first —
+  merge it and rerun the original command; do not start a second cast.
+
+## Examples
+
+### ✓ Correct: runtime-resolved identity, allowlist honored, human-reviewed
+
+```bash
+owner_repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+default_branch="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+
+gh api --method PUT "repos/${owner_repo}/actions/permissions/workflow" \
+  -f default_workflow_permissions=read -F can_approve_pull_request_reviews=true
+
+git switch -c chore/squad-gh-aw-bootstrap
+gh aw add \
+  bradygaster/squad/workflows/squad.md@dev \
+  bradygaster/squad/workflows/squad-implement-worker.md@dev \
+  bradygaster/squad/workflows/squad-deps-worker.md@dev \
+  bradygaster/squad/workflows/squad-review.md@dev
+
+# Safe-update report shows ONLY the two documented secrets + squad-init → approve once
+gh aw compile --strict --approve
+gh aw compile --strict           # final, no --approve; only the bot-trigger warning remains
+
+git add -- .gitattributes .github/aw/ .github/workflows/ .github/skills/
+git commit -m "ci: add Squad agentic workflow"
+git push -u origin HEAD
+gh pr create --base "${default_branch}" \
+  --title "ci: add Squad agentic workflow" \
+  --body "Installs and strictly compiles the supported Squad GH-AW workflows."
+gh pr edit --add-reviewer @copilot   # then wait for review + checks; DO NOT merge
+```
+
+### ✓ Correct: STOP on an undocumented safe-update entry
+
+```text
+gh aw add reports a third secret: `ACME_DEPLOY_KEY`.
+→ This is NOT in the allowlist (SQUAD_GITHUB_APP_PRIVATE_KEY, SQUAD_GITHUB_TOKEN)
+  and is NOT the squad-init action. Do NOT run `--approve`.
+  Halt, report "unexpected safe-update entry: ACME_DEPLOY_KEY", and wait.
+```
+
+### ✗ Incorrect: hardcoded target and blanket staging
+
+```bash
+# BAD: hardcoded owner/repo and default branch
+gh api --method PUT "repos/acme/widgets/actions/permissions/workflow" ...
+gh pr create --base main ...        # wrong if the default branch isn't `main`
+
+# BAD: stages logs, .vscode settings, and anything else that changed
+git add -A
+git commit -m "add squad"
+```
+
+### ✗ Incorrect: skipping the final strict compile or auto-merging
+
+```bash
+gh aw compile --strict --approve    # approved first install...
+# ...then committed WITHOUT the final `gh aw compile --strict` (no --approve). WRONG.
+gh pr merge --squash                # auto-merge before human review. NEVER.
+```
+
+## Anti-Patterns
+
+- ❌ **Hardcoding repository identifiers.** Always resolve `owner/repo` and the
+  default branch at runtime with `gh repo view`.
+- ❌ **Blanket staging** (`git add .` / `-A` / `git commit -a`). Stage only
+  `.gitattributes`, `.github/aw/`, `.github/workflows/`, `.github/skills/`, by path.
+- ❌ **Approving unknown safe updates.** Approve ONLY `SQUAD_GITHUB_APP_PRIVATE_KEY`,
+  `SQUAD_GITHUB_TOKEN`, and `bradygaster/squad/.github/actions/squad-init`. Anything
+  else is a STOP.
+- ❌ **Treating `--approve` as the final compile.** Always finish with a plain
+  `gh aw compile --strict` (no `--approve`).
+- ❌ **Tolerating extra warnings.** Only the `squad.md` bot-trigger warning is
+  allowed; every other warning or error halts the run.
+- ❌ **Committing diagnostics.** Never commit `.github/aw/logs/` output; add the
+  log `.gitignore` if missing.
+- ❌ **Clobbering existing workflows.** The install is additive; preserve unrelated
+  `.github/workflows/` files.
+- ❌ **Widening the default token.** Keep `default_workflow_permissions=read`.
+- ❌ **Auto-merging.** The bootstrap PR and the later Cast PR are both
+  human-reviewed. `/squad cast` runs only after the bootstrap PR merges.
+- ❌ **Opening the PR before all eight files exist and strict compile passes.**

--- a/packages/squad-sdk/templates/skills/gh-aw-enlistment/SKILL.md
+++ b/packages/squad-sdk/templates/skills/gh-aw-enlistment/SKILL.md
@@ -70,6 +70,10 @@ gh extension list | grep -q 'github/gh-aw' || gh extension install github/gh-aw
 git status --short
 ```
 
+> **Portability — extension check:** the `grep -q` above is bash/Git Bash. On Windows
+> PowerShell use:
+> `if (-not (gh extension list | Select-String -Quiet 'github/gh-aw')) { gh extension install github/gh-aw }`
+
 - **STOP** if `gh auth status` is not logged in, or is logged in as the wrong
   identity for this repo (see the `gh-auth-isolation` skill to operate as a
   specific account without switching the global default).
@@ -130,8 +134,10 @@ creating duplicates. The installed top-level set is exactly:
 
 On a clean repo, `gh aw add` reports these expected safe updates and **nothing else**:
 
+<!-- allowlist-start -->
 - Restricted secrets: **`SQUAD_GITHUB_APP_PRIVATE_KEY`** and **`SQUAD_GITHUB_TOKEN`**
 - Action: **`bradygaster/squad/.github/actions/squad-init`**
+<!-- allowlist-end -->
 
 If — and only if — the report contains exactly those documented entries, complete
 the one-time approval:

--- a/packages/squad-sdk/templates/skills/gh-aw-enlistment/SKILL.md
+++ b/packages/squad-sdk/templates/skills/gh-aw-enlistment/SKILL.md
@@ -4,17 +4,7 @@ description: "Enlist a repository into Squad by installing the supported GitHub 
 domain: "github-integration, agentic-workflows, ci-bootstrap, safety-gated-automation"
 confidence: "high"
 source: "Operationalized from the authoritative Squad gh-aw guide (docs/src/content/docs/guide/gh-aw.md) covering the supported install → compile → validate → bootstrap-PR path."
-triggers:
-  - "set up Squad agentic workflows"
-  - "enlist this repo in Squad"
-  - "enlist my repository in Squad"
-  - "install Squad gh-aw workflows"
-  - "install Squad agentic workflows"
-  - "add Squad gh aw workflows"
-  - "bootstrap Squad in this repo"
-  - "onboard this repo to Squad"
-  - "set up /squad slash commands"
-  - "gh aw add squad"
+triggers: [set up Squad agentic workflows, enlist this repo in Squad, enlist my repository in Squad, install Squad gh-aw workflows, install Squad agentic workflows, add Squad gh aw workflows, bootstrap Squad in this repo, onboard this repo to Squad, set up /squad slash commands, gh aw add squad]
 tools:
   - name: "gh"
     description: "GitHub CLI — repo identity, Actions permissions, PR creation, review request, and check watching."

--- a/packages/squad-sdk/templates/skills/gh-aw-enlistment/SKILL.md
+++ b/packages/squad-sdk/templates/skills/gh-aw-enlistment/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: "gh-aw-enlistment"
+description: "Enlist a repository into Squad by installing the supported GitHub Agentic Workflows (gh-aw) bootstrap — with strict compilation, an explicit safe-update allowlist, and a human-reviewed bootstrap PR. Never auto-merges."
+domain: "github-integration, agentic-workflows, ci-bootstrap, safety-gated-automation"
+confidence: "high"
+source: "Operationalized from the authoritative Squad gh-aw guide (docs/src/content/docs/guide/gh-aw.md) covering the supported install → compile → validate → bootstrap-PR path."
+triggers:
+  - "set up Squad agentic workflows"
+  - "enlist this repo in Squad"
+  - "enlist my repository in Squad"
+  - "install Squad gh-aw workflows"
+  - "install Squad agentic workflows"
+  - "add Squad gh aw workflows"
+  - "bootstrap Squad in this repo"
+  - "onboard this repo to Squad"
+  - "set up /squad slash commands"
+  - "gh aw add squad"
+tools:
+  - name: "gh"
+    description: "GitHub CLI — repo identity, Actions permissions, PR creation, review request, and check watching."
+    when: "Every step: preflight identity/auth, enabling Actions-created PRs, opening and watching the bootstrap PR."
+  - name: "gh aw"
+    description: "GitHub Agentic Workflows extension (github/gh-aw) — installs and strictly compiles the Squad workflow set."
+    when: "Installing the four @dev workflows and compiling them into deterministic .lock.yml files."
+---
+
+## Context
+
+Use this skill when a user wants to **enlist a repository into Squad** through
+**GitHub Agentic Workflows (`gh aw`)** — e.g. "set up Squad agentic workflows",
+"enlist this repo in Squad", or "install Squad gh-aw workflows". The end state is
+the `/squad` slash command being live on the repo, delivered as a **human-reviewed
+bootstrap pull request** — never an auto-merge.
+
+This skill **operationalizes** the supported bootstrap path. It does not summarize
+it: each step below is a gate with explicit success evidence and **STOP conditions**.
+The authoritative source is `docs/src/content/docs/guide/gh-aw.md` (mirrored at
+`https://bradygaster.github.io/squad/docs/guide/gh-aw/`). If that guide and this
+skill ever disagree, the guide wins — re-read it before proceeding.
+
+**Portability contract:** resolve every repository identifier (owner, repo, default
+branch) **at runtime**. Never hardcode a placeholder like `{owner}/{repo}`. The only
+fixed identifier is the Squad source itself — `bradygaster/squad/workflows/...@dev` —
+because that is where the workflows are published.
+
+**Idempotency contract:** the bootstrap is re-runnable. Never clobber existing
+workflows, prefer detecting prior state over duplicating it, and **stop clearly** on
+any unsafe or ambiguous condition rather than guessing.
+
+## Patterns
+
+Run these steps in order. Treat every "STOP" as a hard halt: report the exact
+condition and wait for a human decision — do not work around it.
+
+### 0. Preflight — verify before you touch anything
+
+```bash
+# gh is authenticated
+gh auth status
+
+# Capture repository identity and default branch AT RUNTIME
+owner_repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+default_branch="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+echo "Repo: ${owner_repo}  Default branch: ${default_branch}"
+
+# The gh-aw extension must be installed (install once if missing)
+gh extension list | grep -q 'github/gh-aw' || gh extension install github/gh-aw
+
+# Git state must be understood and clean enough to isolate the install
+git status --short
+```
+
+- **STOP** if `gh auth status` is not logged in, or is logged in as the wrong
+  identity for this repo (see the `gh-auth-isolation` skill to operate as a
+  specific account without switching the global default).
+- **STOP** if `owner_repo` or `default_branch` cannot be resolved.
+- **STOP** if the working tree has unrelated uncommitted changes you cannot
+  account for — the bootstrap must land as an isolated, reviewable change.
+- Confirm Copilot is enabled for the repository where checkable; the activation
+  run and the requested `@copilot` review both depend on it.
+
+### 1. Allow Actions-created PRs while keeping the default token read-only
+
+Squad opens PRs through GitHub Actions. Enable that **without** widening the
+default workflow token:
+
+```bash
+gh api --method PUT "repos/${owner_repo}/actions/permissions/workflow" \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=true
+```
+
+Without this, Squad still pushes the generated branch but falls back to an issue
+with a manual PR link — and a self-authored PR cannot be self-approved. Keep
+`default_workflow_permissions=read`; do not set it to `write`.
+
+### 2. Isolate the install on a bootstrap branch (preserve existing workflows)
+
+```bash
+git switch -c chore/squad-gh-aw-bootstrap
+```
+
+- If the branch already exists (a re-run), switch to it instead of recreating it.
+- **Never overwrite** an existing `.github/workflows/*.md` or `*.lock.yml` that is
+  not part of the Squad set. `gh aw add` is additive; if you see it about to
+  replace an unrelated workflow, **STOP**.
+
+### 3. Install the four supported workflows — in order, dispatcher first
+
+```bash
+gh aw add \
+  bradygaster/squad/workflows/squad.md@dev \
+  bradygaster/squad/workflows/squad-implement-worker.md@dev \
+  bradygaster/squad/workflows/squad-deps-worker.md@dev \
+  bradygaster/squad/workflows/squad-review.md@dev
+```
+
+Keep `squad.md` first: `gh aw add` discovers its worker/reviewer dependencies
+while compiling it, and the explicit entries confirm the full surface without
+creating duplicates. The installed top-level set is exactly:
+
+- `squad.md` + `squad.lock.yml`
+- `squad-implement-worker.md` + `squad-implement-worker.lock.yml`
+- `squad-deps-worker.md` + `squad-deps-worker.lock.yml`
+- `squad-review.md` + `squad-review.lock.yml`
+
+`@dev` is intentional — it tracks the branch where new modes and fixes land first.
+
+### 4. Review the first-install safe-update report — approve ONLY the documented entries
+
+On a clean repo, `gh aw add` reports these expected safe updates and **nothing else**:
+
+- Restricted secrets: **`SQUAD_GITHUB_APP_PRIVATE_KEY`** and **`SQUAD_GITHUB_TOKEN`**
+- Action: **`bradygaster/squad/.github/actions/squad-init`**
+
+If — and only if — the report contains exactly those documented entries, complete
+the one-time approval:
+
+```bash
+gh aw compile --strict --approve   # first install only, when the safe-update warning appears
+```
+
+- **STOP** if the report lists **any other secret** or **any other action**. Do not
+  approve. Report the unexpected entry verbatim and wait for a human.
+- This `--approve` step is *only* the first-install unblock. It is **not** a
+  substitute for the final strict compile in the next step.
+
+### 5. Always run the final strict compile WITHOUT `--approve`
+
+```bash
+gh aw compile --strict
+```
+
+This must run after any first-install approval and before committing. Success
+criteria:
+
+- All four workflows compile successfully.
+- The **only** permitted warning is the known `squad.md` bot-trigger warning: it
+  configures both slash-command and `github-actions[bot]` triggers, and the bot
+  trigger is required for controlled worker-continuation dispatches.
+- **STOP** on any error, or on **any additional warning** beyond that single
+  documented one.
+
+### 6. Require all four source/lock pairs to exist
+
+```bash
+for workflow in squad squad-implement-worker squad-deps-worker squad-review; do
+  test -f ".github/workflows/${workflow}.md"      || { echo "MISSING ${workflow}.md"; exit 1; }
+  test -f ".github/workflows/${workflow}.lock.yml" || { echo "MISSING ${workflow}.lock.yml"; exit 1; }
+done
+```
+
+- **STOP** and rerun `gh aw compile --strict` if any `.lock.yml` is missing. Do not
+  open or merge the bootstrap PR until all **eight** files exist and strict
+  compilation passes.
+
+> On Windows PowerShell, the `for`/`test -f` loop above is POSIX. Use an
+> equivalent guard (e.g. `Test-Path`) or run it under Git Bash; the *logic* — all
+> eight files must exist — is what matters.
+
+### 7. Inspect generated files, then stage only the documented surfaces
+
+Downloaded workflow audit data is local diagnostic output — **do not commit it**.
+If `.github/aw/logs/` lacks a `.gitignore`, add one there:
+
+```gitignore
+# Ignore all downloaded workflow logs
+*
+
+# But keep this file
+!.gitignore
+```
+
+`gh aw add` may also create `.vscode/settings.json` (enables Copilot for Markdown
+workflow files). This is an **optional editor setting** — the stage command below
+intentionally leaves it untracked. Delete it if unwanted, or stage it explicitly
+if your team wants to share it. Decide deliberately; do not stage it by accident.
+
+Stage **only** the documented generated surfaces, then verify the staged set:
+
+```bash
+git add -- .gitattributes .github/aw/ .github/workflows/ .github/skills/
+git diff --cached --stat
+# No deletions should be staged:
+test -z "$(git diff --cached --diff-filter=D --name-only)" || { echo "STOP: staged deletions"; exit 1; }
+```
+
+- **STOP** if the staged diff shows **unexpected deletions**, **unexpected secrets**,
+  edits to **unrelated files**, or committed **log/diagnostic output**. Re-scope with
+  explicit `git add -- <path>` — never `git add .`, `git add -A`, or `git commit -a`.
+
+### 8. Commit, push, and open the bootstrap PR to the captured default branch
+
+```bash
+git commit -m "ci: add Squad agentic workflow"
+git push -u origin HEAD
+gh pr create \
+  --base "${default_branch}" \
+  --title "ci: add Squad agentic workflow" \
+  --body "Installs and strictly compiles the supported Squad GH-AW workflows."
+gh pr edit --add-reviewer @copilot
+gh pr checks --watch
+```
+
+- Open the PR against the **runtime-captured** `${default_branch}`, not a hardcoded
+  `main`.
+- Request Copilot review, address feedback, and wait for required checks.
+
+### 9. Never auto-merge — and explain what comes next
+
+- **Never** merge the bootstrap PR yourself. Merge happens **only** after human
+  approval.
+- Make the two-PR flow explicit to the user: `/squad cast` runs **only after the
+  bootstrap PR merges**. Casting analyzes the codebase and opens a **separate,
+  human-reviewed Cast PR** containing the team, routing, charters, the Copilot
+  agent, and `meet-the-squad.md`. If a work command (`/squad implement`,
+  `/squad review`) is run before a team exists, it auto-opens that Cast PR first —
+  merge it and rerun the original command; do not start a second cast.
+
+## Examples
+
+### ✓ Correct: runtime-resolved identity, allowlist honored, human-reviewed
+
+```bash
+owner_repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+default_branch="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+
+gh api --method PUT "repos/${owner_repo}/actions/permissions/workflow" \
+  -f default_workflow_permissions=read -F can_approve_pull_request_reviews=true
+
+git switch -c chore/squad-gh-aw-bootstrap
+gh aw add \
+  bradygaster/squad/workflows/squad.md@dev \
+  bradygaster/squad/workflows/squad-implement-worker.md@dev \
+  bradygaster/squad/workflows/squad-deps-worker.md@dev \
+  bradygaster/squad/workflows/squad-review.md@dev
+
+# Safe-update report shows ONLY the two documented secrets + squad-init → approve once
+gh aw compile --strict --approve
+gh aw compile --strict           # final, no --approve; only the bot-trigger warning remains
+
+git add -- .gitattributes .github/aw/ .github/workflows/ .github/skills/
+git commit -m "ci: add Squad agentic workflow"
+git push -u origin HEAD
+gh pr create --base "${default_branch}" \
+  --title "ci: add Squad agentic workflow" \
+  --body "Installs and strictly compiles the supported Squad GH-AW workflows."
+gh pr edit --add-reviewer @copilot   # then wait for review + checks; DO NOT merge
+```
+
+### ✓ Correct: STOP on an undocumented safe-update entry
+
+```text
+gh aw add reports a third secret: `ACME_DEPLOY_KEY`.
+→ This is NOT in the allowlist (SQUAD_GITHUB_APP_PRIVATE_KEY, SQUAD_GITHUB_TOKEN)
+  and is NOT the squad-init action. Do NOT run `--approve`.
+  Halt, report "unexpected safe-update entry: ACME_DEPLOY_KEY", and wait.
+```
+
+### ✗ Incorrect: hardcoded target and blanket staging
+
+```bash
+# BAD: hardcoded owner/repo and default branch
+gh api --method PUT "repos/acme/widgets/actions/permissions/workflow" ...
+gh pr create --base main ...        # wrong if the default branch isn't `main`
+
+# BAD: stages logs, .vscode settings, and anything else that changed
+git add -A
+git commit -m "add squad"
+```
+
+### ✗ Incorrect: skipping the final strict compile or auto-merging
+
+```bash
+gh aw compile --strict --approve    # approved first install...
+# ...then committed WITHOUT the final `gh aw compile --strict` (no --approve). WRONG.
+gh pr merge --squash                # auto-merge before human review. NEVER.
+```
+
+## Anti-Patterns
+
+- ❌ **Hardcoding repository identifiers.** Always resolve `owner/repo` and the
+  default branch at runtime with `gh repo view`.
+- ❌ **Blanket staging** (`git add .` / `-A` / `git commit -a`). Stage only
+  `.gitattributes`, `.github/aw/`, `.github/workflows/`, `.github/skills/`, by path.
+- ❌ **Approving unknown safe updates.** Approve ONLY `SQUAD_GITHUB_APP_PRIVATE_KEY`,
+  `SQUAD_GITHUB_TOKEN`, and `bradygaster/squad/.github/actions/squad-init`. Anything
+  else is a STOP.
+- ❌ **Treating `--approve` as the final compile.** Always finish with a plain
+  `gh aw compile --strict` (no `--approve`).
+- ❌ **Tolerating extra warnings.** Only the `squad.md` bot-trigger warning is
+  allowed; every other warning or error halts the run.
+- ❌ **Committing diagnostics.** Never commit `.github/aw/logs/` output; add the
+  log `.gitignore` if missing.
+- ❌ **Clobbering existing workflows.** The install is additive; preserve unrelated
+  `.github/workflows/` files.
+- ❌ **Widening the default token.** Keep `default_workflow_permissions=read`.
+- ❌ **Auto-merging.** The bootstrap PR and the later Cast PR are both
+  human-reviewed. `/squad cast` runs only after the bootstrap PR merges.
+- ❌ **Opening the PR before all eight files exist and strict compile passes.**

--- a/test/gh-aw-enlistment-skill.test.ts
+++ b/test/gh-aw-enlistment-skill.test.ts
@@ -94,9 +94,17 @@ describe('gh-aw-enlistment skill', () => {
     });
 
     it('requires a final strict compile without --approve', () => {
-      // The plain strict compile must appear as its own command (not only the
-      // first-install `--approve` variant).
-      expect(content).toMatch(/gh aw compile --strict(?!\s*--approve)/);
+      // The standalone command must appear as its own line (start-of-line in a
+      // fenced bash block), not merely as a prose/backtick mention.  The
+      // previous lookahead-only regex was flagged by a reviewer as a false
+      // positive: the Anti-Patterns prose "finish with a plain `gh aw compile
+      // --strict` (no `--approve`)" also matched it.
+      //
+      // Anchoring with ^, the `m` (multiline) flag, and allowing only an
+      // optional trailing # comment means only real command lines satisfy the
+      // pattern.  Lines with --approve (L140, L259, L295) do not match because
+      // --approve follows --strict before any #.
+      expect(content).toMatch(/^gh aw compile --strict(\s+#[^\n]*)?$/m);
     });
 
     it('permits only the documented bot-trigger warning', () => {

--- a/test/gh-aw-enlistment-skill.test.ts
+++ b/test/gh-aw-enlistment-skill.test.ts
@@ -53,9 +53,18 @@ describe('gh-aw-enlistment skill', () => {
 
   describe('discoverability — frontmatter trigger phrases', () => {
     const content = readLF(CANONICAL);
+    // Assert against the PARSED triggers array, not raw text. `toContain` on the
+    // whole document would still pass if a phrase were deleted from the
+    // frontmatter and merely mentioned in prose — which is the exact regression
+    // this block exists to catch, since a phrase in prose is not discoverable.
+    // `skill.triggers` is the same array the runtime matcher iterates
+    // (packages/squad-sdk/src/skills/index.ts), so this tests the real path.
+    const skill = parseSkillFile(SKILL_ID, content);
 
-    it('declares a triggers block', () => {
-      expect(content).toMatch(/^triggers:/m);
+    it('declares a non-empty triggers block in frontmatter', () => {
+      expect(skill, 'skill should parse').toBeDefined();
+      expect(Array.isArray(skill!.triggers), 'triggers should parse to an array').toBe(true);
+      expect(skill!.triggers.length, 'triggers must not be empty').toBeGreaterThan(0);
     });
 
     // The three trigger phrases the skill must be discoverable by.
@@ -65,7 +74,10 @@ describe('gh-aw-enlistment skill', () => {
       'install Squad gh-aw workflows',
     ]) {
       it(`is discoverable by "${phrase}"`, () => {
-        expect(content).toContain(phrase);
+        expect(
+          skill!.triggers,
+          `"${phrase}" must be a frontmatter trigger, not merely present somewhere in the document`,
+        ).toContain(phrase);
       });
     }
   });

--- a/test/gh-aw-enlistment-skill.test.ts
+++ b/test/gh-aw-enlistment-skill.test.ts
@@ -1,0 +1,135 @@
+/**
+ * gh-aw-enlistment skill — structural validity, discoverability, and safety-gate
+ * regression guard.
+ *
+ * The skill operationalizes the supported Squad gh-aw bootstrap
+ * (docs/src/content/docs/guide/gh-aw.md). Its value is entirely in the safety
+ * gates it encodes, so this suite asserts:
+ *   1. The canonical SKILL.md parses into a valid SkillDefinition.
+ *   2. Its frontmatter advertises the documented trigger phrases (discoverability).
+ *   3. Its body still encodes every critical safety gate (allowlist, strict
+ *      compile, never-auto-merge, read-only token, explicit staging).
+ *   4. The canonical source and both template mirrors are byte-for-byte identical
+ *      (the sync invariant every canonical skill upholds).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseSkillFile } from '@bradygaster/squad-sdk/skills';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const SKILL_ID = 'gh-aw-enlistment';
+
+const CANONICAL = `.squad/skills/${SKILL_ID}/SKILL.md`;
+const MIRRORS = [
+  `packages/squad-cli/templates/skills/${SKILL_ID}/SKILL.md`,
+  `packages/squad-sdk/templates/skills/${SKILL_ID}/SKILL.md`,
+] as const;
+
+function readRaw(rel: string): string {
+  return readFileSync(resolve(ROOT, rel), 'utf-8');
+}
+/** LF-normalized read — markdown is not pinned to LF, so Windows checkouts get CRLF. */
+function readLF(rel: string): string {
+  return readRaw(rel).replace(/\r\n/g, '\n');
+}
+
+describe('gh-aw-enlistment skill', () => {
+  it('canonical SKILL.md exists', () => {
+    expect(existsSync(resolve(ROOT, CANONICAL)), `${CANONICAL} should exist`).toBe(true);
+  });
+
+  it('parses into a valid SkillDefinition', () => {
+    const skill = parseSkillFile(SKILL_ID, readLF(CANONICAL));
+    expect(skill, 'skill should parse').toBeDefined();
+    expect(skill!.id).toBe(SKILL_ID);
+    expect(skill!.name).toContain(SKILL_ID);
+    expect(skill!.content.length).toBeGreaterThan(0);
+  });
+
+  describe('discoverability — frontmatter trigger phrases', () => {
+    const content = readLF(CANONICAL);
+
+    it('declares a triggers block', () => {
+      expect(content).toMatch(/^triggers:/m);
+    });
+
+    // The three trigger phrases the skill must be discoverable by.
+    for (const phrase of [
+      'set up Squad agentic workflows',
+      'enlist this repo in Squad',
+      'install Squad gh-aw workflows',
+    ]) {
+      it(`is discoverable by "${phrase}"`, () => {
+        expect(content).toContain(phrase);
+      });
+    }
+  });
+
+  describe('safety gates encoded in the body', () => {
+    const content = readLF(CANONICAL);
+
+    it('allowlists ONLY the two documented secrets', () => {
+      expect(content).toContain('SQUAD_GITHUB_APP_PRIVATE_KEY');
+      expect(content).toContain('SQUAD_GITHUB_TOKEN');
+    });
+
+    it('allowlists the documented squad-init action', () => {
+      expect(content).toContain('bradygaster/squad/.github/actions/squad-init');
+    });
+
+    it('installs all four @dev workflows', () => {
+      for (const wf of [
+        'squad.md@dev',
+        'squad-implement-worker.md@dev',
+        'squad-deps-worker.md@dev',
+        'squad-review.md@dev',
+      ]) {
+        expect(content, `should install ${wf}`).toContain(wf);
+      }
+    });
+
+    it('requires a final strict compile without --approve', () => {
+      // The plain strict compile must appear as its own command (not only the
+      // first-install `--approve` variant).
+      expect(content).toMatch(/gh aw compile --strict(?!\s*--approve)/);
+    });
+
+    it('permits only the documented bot-trigger warning', () => {
+      expect(content).toMatch(/bot-trigger warning|bot trigger/i);
+    });
+
+    it('keeps the default workflow token read-only', () => {
+      expect(content).toContain('default_workflow_permissions=read');
+    });
+
+    it('forbids blanket staging and mandates explicit paths', () => {
+      expect(content).toMatch(/git add \.|git add -A|git commit -a/); // referenced as an anti-pattern
+      expect(content).toContain('git add -- .gitattributes .github/aw/ .github/workflows/ .github/skills/');
+    });
+
+    it('never auto-merges and defers casting to after the bootstrap PR merges', () => {
+      expect(content).toMatch(/auto-?merge/i);
+      expect(content).toMatch(/never merge|do not merge|human-reviewed|human approval/i);
+      expect(content).toMatch(/\/squad cast/);
+    });
+
+    it('resolves repo identity at runtime (no hardcoded owner/repo placeholder)', () => {
+      expect(content).toContain('gh repo view --json nameWithOwner');
+      expect(content).toContain('gh repo view --json defaultBranchRef');
+    });
+  });
+
+  describe('template mirror parity', () => {
+    for (const mirror of MIRRORS) {
+      it(`${mirror} is byte-for-byte identical to the canonical source`, () => {
+        expect(existsSync(resolve(ROOT, mirror)), `${mirror} should exist`).toBe(true);
+        expect(readFileSync(resolve(ROOT, mirror)).equals(readFileSync(resolve(ROOT, CANONICAL)))).toBe(true);
+      });
+    }
+  });
+});

--- a/test/gh-aw-enlistment-skill.test.ts
+++ b/test/gh-aw-enlistment-skill.test.ts
@@ -154,6 +154,18 @@ describe('gh-aw-enlistment skill', () => {
       expect(content).toMatch(/bot-trigger warning|bot trigger/i);
     });
 
+    // The permission above is only safe because it is paired with a hard halt
+    // on anything else.  Asserting the allowance alone would keep passing if
+    // the STOP were deleted -- i.e. if the narrow exception silently became a
+    // blanket "warnings are fine".  Assert the gate itself, not just the
+    // carve-out.  Newlines are collapsed first because the sentence wraps.
+    it('halts on any error or any warning beyond the documented one', () => {
+      const flat = content.replace(/\s+/g, ' ');
+      expect(flat).toMatch(
+        /\*\*STOP\*\* on any error, or on \*\*any additional warning\*\* beyond that single documented one\./,
+      );
+    });
+
     it('keeps the default workflow token read-only', () => {
       expect(content).toContain('default_workflow_permissions=read');
     });

--- a/test/gh-aw-enlistment-skill.test.ts
+++ b/test/gh-aw-enlistment-skill.test.ts
@@ -73,13 +73,44 @@ describe('gh-aw-enlistment skill', () => {
   describe('safety gates encoded in the body', () => {
     const content = readLF(CANONICAL);
 
-    it('allowlists ONLY the two documented secrets', () => {
-      expect(content).toContain('SQUAD_GITHUB_APP_PRIVATE_KEY');
-      expect(content).toContain('SQUAD_GITHUB_TOKEN');
+    // EXCLUSIVITY GUARD — these two tests enforce the exact set of
+    // backtick-delimited tokens in the bounded allowlist region.
+    // Using deep-equality on a sorted array (not .toContain) so that adding a
+    // 4th entry, removing an entry, or renaming one all cause an immediate
+    // failure.  The delimiters scope the extraction so identical strings that
+    // appear elsewhere in the document (Anti-Patterns section, examples) do
+    // NOT count.
+    it('allowlist region delimiters exist exactly once each', () => {
+      const startMatches = [...content.matchAll(/^<!-- allowlist-start -->$/gm)];
+      const endMatches   = [...content.matchAll(/^<!-- allowlist-end -->$/gm)];
+      expect(startMatches.length, '<!-- allowlist-start --> must appear exactly once').toBe(1);
+      expect(endMatches.length,   '<!-- allowlist-end --> must appear exactly once').toBe(1);
     });
 
-    it('allowlists the documented squad-init action', () => {
-      expect(content).toContain('bradygaster/squad/.github/actions/squad-init');
+    it('allowlist region contains EXACTLY the two documented secrets and the one documented action — no more, no fewer', () => {
+      const startTag = '<!-- allowlist-start -->';
+      const endTag   = '<!-- allowlist-end -->';
+      const startIdx = content.indexOf(startTag);
+      const endIdx   = content.indexOf(endTag);
+      expect(startIdx, 'allowlist-start delimiter must exist').toBeGreaterThan(-1);
+      expect(endIdx,   'allowlist-end delimiter must exist').toBeGreaterThan(startIdx);
+
+      // Extract strictly between the delimiter lines (exclusive).
+      const region = content.slice(startIdx + startTag.length, endIdx);
+
+      // Every backtick-delimited token in the region — order-independent exact set.
+      const tokens = [...region.matchAll(/`([^`]+)`/g)].map(m => m[1]);
+      expect(tokens.slice().sort(), 'allowlist tokens must be exactly the three documented entries').toEqual(
+        [
+          'SQUAD_GITHUB_APP_PRIVATE_KEY',
+          'SQUAD_GITHUB_TOKEN',
+          'bradygaster/squad/.github/actions/squad-init',
+        ].sort()
+      );
+
+      // Structural: exactly 2 bullet lines (one for the two secrets, one for the action).
+      const bulletLines = region.split('\n').filter(l => l.trimStart().startsWith('- '));
+      expect(bulletLines.length, 'allowlist region must contain exactly 2 bullet lines').toBe(2);
     });
 
     it('installs all four @dev workflows', () => {
@@ -124,6 +155,19 @@ describe('gh-aw-enlistment skill', () => {
       expect(content).toMatch(/auto-?merge/i);
       expect(content).toMatch(/never merge|do not merge|human-reviewed|human approval/i);
       expect(content).toMatch(/\/squad cast/);
+    });
+
+    it("documents extension check in both bash (grep -q) and PowerShell (Select-String guarding gh-aw install) forms", () => {
+      // Regression guard for Change B: the portability note must stay in the
+      // skill so Windows users are not silently left with a bash-only check.
+      expect(content, "bash form 'grep -q' must be present").toContain("grep -q 'github/gh-aw'");
+      // The PowerShell check must bind Select-String to the 'github/gh-aw'
+      // pattern AND guard an install — a bare Select-String anywhere is too loose.
+      // Allows for Markdown blockquote wrapping (leading '>') and line-wrapping
+      // (the install half may continue on the same or a wrapped line).
+      expect(content, "PowerShell form must bind Select-String to 'github/gh-aw' and guard an install").toMatch(
+        /Select-String\s+-Quiet\s+'github\/gh-aw'.*gh extension install github\/gh-aw/s
+      );
     });
 
     it('resolves repo identity at runtime (no hardcoded owner/repo placeholder)', () => {


### PR DESCRIPTION
## What

Adds a reusable agent skill, `gh-aw-enlistment`, that **operationalizes** the supported path for enlisting a repository into Squad via **GitHub Agentic Workflows (`gh aw`)**. It is discoverable by requests like *"set up Squad agentic workflows"*, *"enlist this repo in Squad"*, and *"install Squad gh-aw workflows"* (declared as frontmatter `triggers`).

Source of truth: `docs/src/content/docs/guide/gh-aw.md`. The skill turns that guide into an ordered sequence of gates with explicit success evidence and hard **STOP** conditions — it does not merely summarize it.

## Why a skill (and where it lives)

- Canonical skills live in `.squad/skills/{name}/SKILL.md` and are mirrored to `packages/squad-cli/templates/skills/` and `packages/squad-sdk/templates/skills/` by `scripts/sync-skill-templates.mjs` — that mirror is how skills ship to users. All 26 canonical skills currently uphold that mirror invariant, so this PR ships the canonical source **plus both byte-identical template mirrors**.
- Name `gh-aw-enlistment` matches the branch and the three trigger phrases; discoverability is driven by the `triggers` block, consistent with the `cross-squad` skill.

## Safety gates encoded

- **Preflight**: runtime-resolved `owner/repo` + default branch, `gh` auth, `gh-aw` extension, understood git state.
- **Read-only default token** while enabling Actions-created PRs.
- **Isolated bootstrap branch**; never clobber existing workflows.
- **Four `@dev` workflows in order**: `squad.md`, `squad-implement-worker.md`, `squad-deps-worker.md`, `squad-review.md`.
- **Safe-update allowlist** — approve ONLY `SQUAD_GITHUB_APP_PRIVATE_KEY`, `SQUAD_GITHUB_TOKEN`, and `bradygaster/squad/.github/actions/squad-init`; STOP on anything else.
- First-install `gh aw compile --strict --approve`, then **always** a final `gh aw compile --strict` **without** `--approve`.
- All **eight** source/lock files required; only the documented `squad.md` bot-trigger warning tolerated.
- **Explicit staging** of documented surfaces only (no `git add .`/`-A`); logs never committed; `.vscode/settings.json` handled deliberately.
- **Never auto-merge**; `/squad cast` runs only after the bootstrap PR merges, producing a separate human-reviewed Cast PR.
- Portable/idempotent across repos.

Also adds a discoverability pointer from the `.github/skills/agentic-workflows` router.

## Validation

- `npx vitest run test/gh-aw-enlistment-skill.test.ts` → **17 passed** (structural validity via SDK `parseSkillFile`, the three trigger phrases, every safety gate, and byte parity across the two mirrors).
- `npx vitest run test/template-sync.test.ts` → **252 passed** (template invariants undisturbed).
- `npm run lint` (tsc `--noEmit` for both packages) → clean.

Changeset included (`patch`/`patch`) because template mirror paths are governed by the changelog gate.

**Do not merge** — awaiting human review.