### PR TITLE
fix(gh-aw): auto-provision squad labels during plan activate

### DIFF
--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -173,7 +173,7 @@ jobs:
         # than skipping — a skipped gate is indistinguishable from no gate. This
         # includes the shell input security contract gate (#1834) and the compile
         # contract (#1732).
-        run: gh extension install --pin v0.86.2 github/gh-aw
+        run: gh extension install --pin v0.87.10 github/gh-aw
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Build
@@ -694,8 +694,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
 
-      - name: Install gh-aw v0.86.2 (pinned)
-        run: gh extension install --pin v0.86.2 github/gh-aw
+      - name: Install gh-aw v0.87.10 (pinned)
+        run: gh extension install --pin v0.87.10 github/gh-aw
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/docs/src/content/docs/guide/gh-aw.md
+++ b/docs/src/content/docs/guide/gh-aw.md
@@ -1168,7 +1168,7 @@ gh aw compile --strict
 ```
 
 Confirm all four source files and generated locks reference `SQUAD_SHA`, review
-the workflow diff, then commit them together. With gh-aw v0.86.2, do not use
+the workflow diff, then commit them together. With gh-aw v0.87.10, do not use
 `gh aw update` for this immutable-pin flow: its stored source branch and cooldown
 can leave the installed sources at a different revision than the SHA you intend.
 

--- a/test/gh-aw-activation-label-provisioning.test.ts
+++ b/test/gh-aw-activation-label-provisioning.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Fresh-repo `squad`/`squad:{agent}` label provisioning for `/squad plan activate` (#1955).
+ *
+ * `workflows/squad.md` promised `squad` and `squad:{agent}` labels on every issue the
+ * activation flow creates, but the workflow only declared `issues: read` and a
+ * `create-issue` safe-output — it never declared a way to create a label that does not
+ * already exist. GitHub's REST API silently drops label names that are not already
+ * present in the target repository when they're passed to `POST /issues`, so a
+ * consumer's very first activation on a brand-new repo (zero pre-existing labels)
+ * created every issue with none of the labels the docs promised. The old prose named
+ * this honestly as a "prerequisite gap" instead of fixing it.
+ *
+ * The fix is gh-aw's `add-labels` safe output with `create-if-missing: true`: it creates
+ * any label in its `allowed` list that the target repository is missing, then applies it
+ * via an add-only GraphQL mutation. This suite locks in:
+ *   - the frontmatter no longer describes label creation as an unconfigured gap
+ *   - Steps 2b/2c call `add_labels` immediately after each verified `create-issue` result
+ *   - the roster-binding/correspondence/non-roster rules `gh-aw-agent-binding-
+ *     correspondence.test.ts` already locks in are untouched by this change
+ *   - the compiled workflow actually wires `create_if_missing: true` into the add_labels
+ *     safe-output handler config, so this isn't just unenforced prose
+ *
+ * Out of scope (per #1955's delegated task boundaries): running the E4 live end-to-end
+ * test, and the `squad-plan-accept` fast-path's own separate create-issue/label logic
+ * (only reachable when a flat `plan` artifact exists with no `program`/`implementation`
+ * artifacts — see workflows/squad.md's `squad-plan-accept` skill).
+ */
+
+import { afterAll, describe, it, expect } from 'vitest';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const WORKFLOWS_DIR = join(process.cwd(), 'workflows');
+const SQUAD_WORKFLOW = join(WORKFLOWS_DIR, 'squad.md');
+const TEST_WORKSPACES_DIR = join(process.cwd(), '.test-workspaces-label-provisioning');
+
+afterAll(() => {
+  rmSync(TEST_WORKSPACES_DIR, { recursive: true, force: true });
+});
+
+/** Read a text file with line endings normalized to LF (Windows checkouts materialize CRLF). */
+function readText(filePath: string): string {
+  return readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+}
+
+const workflow = readText(SQUAD_WORKFLOW);
+
+/** Whitespace-collapsed view for prose assertions that may span wrapped lines. */
+const prose = workflow.replace(/\s+/g, ' ');
+
+/** Isolate the `squad-plan-activate` skill body — the only in-scope command for #1955. */
+const ACTIVATE_START = workflow.indexOf("## skill: `squad-plan-activate`");
+const ACTIVATE_END = workflow.indexOf("## end skill: `squad-plan-activate`");
+expect(ACTIVATE_START, '"## skill: `squad-plan-activate`" is missing from workflows/squad.md').toBeGreaterThan(-1);
+expect(ACTIVATE_END, '"## end skill: `squad-plan-activate`" is missing from workflows/squad.md').toBeGreaterThan(ACTIVATE_START);
+const activateSkill = workflow.slice(ACTIVATE_START, ACTIVATE_END);
+const activateProse = activateSkill.replace(/\s+/g, ' ');
+
+describe('gh-aw: fresh-repo label provisioning in squad-plan-activate (#1955)', () => {
+  it('declares add-labels with create-if-missing in frontmatter, not a create-label safe-output', () => {
+    // gh-aw has no `create-label` safe-output primitive; `add-labels` with
+    // `create-if-missing: true` is the only supported mechanism. A regression here
+    // (e.g. someone inventing `create-label`) would fail this assertion first.
+    expect(workflow).toContain('add-labels:');
+    expect(workflow).toContain('create-if-missing: true');
+    expect(workflow).not.toContain('create-label:');
+  });
+
+  it('reframes the old "prerequisite gap" as solved, not still open', () => {
+    // The phrase survives as a deliberate callback ("... is never a prerequisite gap"),
+    // but the old admission that it was an unconfigured limitation must be gone.
+    expect(
+      /never a prerequisite gap/i.test(activateProse),
+      'The prose must state that a fresh repository with missing labels is no longer a ' +
+        'prerequisite gap now that add-labels/create-if-missing is declared.',
+    ).toBe(true);
+
+    expect(
+      /not configured in this workflow/i.test(activateProse),
+      'The old "not configured in this workflow" admission must be removed along with ' +
+        'the gap it described.',
+    ).toBe(false);
+  });
+
+  it('documents that add-labels auto-provisions squad labels on a fresh repository', () => {
+    expect(
+      /`add-labels`.*`create-if-missing`.*auto-creates/is.test(activateSkill) ||
+        /create-if-missing.*creates any label/is.test(activateSkill),
+      'The Label Pre-flight section must explain that add-labels/create-if-missing ' +
+        'auto-provisions squad/squad:{agent} labels, replacing the removed gap language.',
+    ).toBe(true);
+
+    expect(
+      /fresh repository/i.test(activateProse),
+      'The provisioning explanation should name the fresh-repository case #1955 reported.',
+    ).toBe(true);
+  });
+
+  it("explains why create-issue's own labels field cannot provision missing labels", () => {
+    expect(
+      /silently drops? label/i.test(activateProse),
+      "The prose must state that create-issue's labels field cannot create missing " +
+        'labels — GitHub silently drops names that do not already exist — so a reader ' +
+        "does not reintroduce reliance on create-issue's labels field alone.",
+    ).toBe(true);
+  });
+
+  it('calls add_labels immediately after create-issue for epics (2b)', () => {
+    const epicAt = activateSkill.indexOf('**2b. Create Epic Issues:**');
+    const taskAt = activateSkill.indexOf('**2c. Create Task Issues:**');
+    expect(epicAt, '"**2b. Create Epic Issues:**" is missing').toBeGreaterThan(-1);
+    expect(taskAt, '"**2c. Create Task Issues:**" is missing').toBeGreaterThan(epicAt);
+
+    const epicSection = activateSkill.slice(epicAt, taskAt);
+    expect(
+      /add_labels/i.test(epicSection),
+      'Step 2b must call add_labels on the epic issue after create-issue returns.',
+    ).toBe(true);
+    expect(
+      /verified/i.test(epicSection) && /add_labels/i.test(epicSection),
+      'The add_labels call must target the verified (real, returned) issue number, not a predicted one.',
+    ).toBe(true);
+  });
+
+  it('calls add_labels immediately after create-issue for tasks (2c), inside the atomic contract', () => {
+    const taskAt = activateSkill.indexOf('**2c. Create Task Issues:**');
+    const selfValidationAt = activateSkill.indexOf('**2d. Self-Validation:**');
+    expect(taskAt, '"**2c. Create Task Issues:**" is missing').toBeGreaterThan(-1);
+    expect(selfValidationAt, '"**2d. Self-Validation:**" is missing').toBeGreaterThan(taskAt);
+
+    const taskSection = activateSkill.slice(taskAt, selfValidationAt);
+    expect(
+      /add_labels/i.test(taskSection),
+      'Step 2c must call add_labels on the task issue after create-issue returns.',
+    ).toBe(true);
+
+    const atomicAt = taskSection.indexOf('ATOMIC CONTRACT');
+    expect(atomicAt, '"ATOMIC CONTRACT" block is missing from Step 2c').toBeGreaterThan(-1);
+    const atomicLine = taskSection.slice(atomicAt, atomicAt + 400);
+    expect(
+      /add_labels/i.test(atomicLine),
+      'The ATOMIC CONTRACT (one compose → one create-issue call → one verify) must be ' +
+        'extended to include the add_labels call, so the model cannot buffer multiple ' +
+        'tasks before labeling them.',
+    ).toBe(true);
+  });
+
+  it('never calls add_labels before create-issue has returned and been verified', () => {
+    expect(
+      /never call `add_labels` before/i.test(activateProse),
+      'The prose must explicitly forbid calling add_labels before create-issue has ' +
+        'returned a real issue number — there is nothing to target yet.',
+    ).toBe(true);
+  });
+
+  it('preserves the roster-binding correspondence rules unchanged (#1859, #1860)', () => {
+    // This is a narrow smoke check; gh-aw-agent-binding-correspondence.test.ts is the
+    // authoritative lock for these rules. This test only guards against this change
+    // having silently damaged them while rewriting the surrounding label prose.
+    expect(activateProse).toMatch(/own\s+`Agent`\s+cell/i);
+    expect(activateProse).toMatch(/never inherit the parent epic/i);
+    expect(activateProse).toMatch(/carry the previous task/i);
+    expect(activateProse).toMatch(/two or more/i);
+    expect(activateProse).toMatch(/never\s+choose\s+one\s+of\s+several/i);
+    expect(activateProse).toMatch(/simultaneously certified and wrong/i);
+    expect(activateProse).toMatch(/Non-roster agent values` heading is \*\*required\*\*/i);
+  });
+
+  it('keeps rerun idempotency: reapplying labels on a rerun is a documented no-op', () => {
+    expect(
+      /re-applying an already-present label on a rerun is a no-op/i.test(activateProse),
+      'Rerun idempotency must be explicit: title-match dedup already skips recreating ' +
+        'issues, and add_labels must be safe to call again for issues that already carry ' +
+        'the label (add-only GraphQL merge semantics).',
+    ).toBe(true);
+    // Pre-existing idempotent-rerun contract (Step 2d) must remain intact.
+    expect(activateProse).toMatch(/Re-runs are idempotent via title match/i);
+  });
+
+  it('does not touch the separate squad-plan-accept fast-path label logic (out of scope)', () => {
+    const acceptStart = workflow.indexOf('## skill: `squad-plan-accept`');
+    expect(acceptStart, '"## skill: `squad-plan-accept`" is missing from workflows/squad.md').toBeGreaterThan(-1);
+    // squad-plan-accept has no "## end skill" marker of its own; its body runs until the
+    // next "## skill:" heading (squad-plan-revise).
+    const acceptEnd = workflow.indexOf('## skill: `squad-plan-revise`');
+    expect(acceptEnd, '"## skill: `squad-plan-revise`" is missing from workflows/squad.md').toBeGreaterThan(acceptStart);
+
+    const acceptSkill = workflow.slice(acceptStart, acceptEnd);
+    // #1955 is scoped to squad-plan-activate only; squad-plan-accept's own
+    // create-issue/label fast path (reachable only for a flat plan with no
+    // program/implementation artifacts) is intentionally unmodified here.
+    expect(acceptSkill).not.toContain('add_labels');
+    expect(acceptSkill).not.toContain('create-if-missing');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compiled-artifact verification
+// ---------------------------------------------------------------------------
+//
+// The assertions above lock the prose contract. This section proves the prose is
+// backed by a real, compilable safe-output: `gh aw compile --strict` must wire
+// `create_if_missing: true` into the add_labels handler config, and the add_labels
+// tool must be exposed to the agent. Fails closed (never skips) per this repo's
+// #1833/#1834 convention: an unmeasured contract is indistinguishable from a
+// violated one.
+
+const GH_AW_INSTALL_HINT =
+  '`gh aw` is required to compile the workflow this gate inspects. Install it with ' +
+  '`gh extension install github/gh-aw` (matches .github/workflows/squad-ci.yml). This ' +
+  'gate fails closed rather than skipping: an unmeasured contract is indistinguishable ' +
+  'from a violated one (#1834).';
+
+describe('gh-aw: add-labels compiles into the real safe-output handler config (#1955)', () => {
+  let compiledLock: string | null = null;
+
+  function lockText(): string {
+    if (compiledLock !== null) return compiledLock;
+
+    const versionProbe = spawnSync('gh', ['aw', '--version'], { encoding: 'utf8' });
+    if (versionProbe.status !== 0) {
+      throw new Error(`gh aw --version failed. ${GH_AW_INSTALL_HINT}`);
+    }
+
+    mkdirSync(TEST_WORKSPACES_DIR, { recursive: true });
+    const workspace = mkdtempSync(join(TEST_WORKSPACES_DIR, 'add-labels-'));
+    execFileSync('git', ['init', '--quiet'], { cwd: workspace });
+    // gh-aw's dispatch-workflow validation resolves cross-workflow references against
+    // a `.github/workflows/` directory located relative to the compiled file. This repo
+    // ships the gh-aw *source* from a top-level `workflows/` dir; downstream consumers
+    // install it into `.github/workflows/` via `gh aw add`. Mirror that real deployment
+    // layout, matching .github/workflows/squad-ci.yml's own compile gate.
+    cpSync(WORKFLOWS_DIR, join(workspace, '.github', 'workflows'), { recursive: true });
+    execFileSync('gh', ['aw', 'compile', '.github/workflows/squad.md', '--strict', '--approve'], {
+      cwd: workspace,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+
+    const lockPath = join(workspace, '.github', 'workflows', 'squad.lock.yml');
+    if (!existsSync(lockPath)) {
+      throw new Error(
+        `gh aw compile produced no squad.lock.yml — the compiled artifact this gate ` +
+          `inspects is absent, so the contract is unmeasured. ${GH_AW_INSTALL_HINT}`,
+      );
+    }
+    compiledLock = readText(lockPath);
+    return compiledLock;
+  }
+
+  it('strict-compiles with add-labels declared', () => {
+    expect(lockText().length).toBeGreaterThan(0);
+  });
+
+  it('wires create_if_missing: true and the allowed squad label patterns into the handler config', () => {
+    // gh-aw v0.87.x (this fix's required pin bump) emits this JSON config only
+    // embedded inside a double-quoted YAML env var value, with every `"`
+    // backslash-escaped. De-escape before matching so this holds regardless of a
+    // given compiler version's quoting choice.
+    const compiled = lockText().replace(/\\"/g, '"');
+    expect(compiled).toContain('"add_labels"');
+    expect(compiled).toMatch(/"add_labels":\{[^}]*"create_if_missing":true/);
+    expect(compiled).toMatch(/"add_labels":\{[^}]*"allowed":\["squad","squad:\*"\]/);
+  });
+
+  it('exposes add_labels as a tool the agent can call, alongside create_issue', () => {
+    const compiled = lockText();
+    expect(compiled).toMatch(/"tools":\[[^\]]*"add_labels"[^\]]*\]/);
+    expect(compiled).toMatch(/"tools":\[[^\]]*"create_issue"[^\]]*\]/);
+  });
+
+  it("does not broaden the main agent job's permissions — writes stay in the safe-output job", () => {
+    const compiled = lockText();
+    const agentJobAt = compiled.indexOf('\n  agent:\n');
+    const safeOutputsJobAt = compiled.indexOf('\n  safe_outputs:\n');
+    expect(agentJobAt, '"agent:" job is missing from the compiled lock file').toBeGreaterThan(-1);
+    expect(safeOutputsJobAt, '"safe_outputs:" job is missing from the compiled lock file').toBeGreaterThan(agentJobAt);
+
+    const agentJob = compiled.slice(agentJobAt, safeOutputsJobAt);
+    // The agent job's own permissions block (the first "permissions:" after the job
+    // name) must remain issues: read — write access lives only in the safe_outputs job.
+    const permsMatch = agentJob.match(/permissions:\n((?:\s{6}\S.*\n)+)/);
+    expect(permsMatch, 'agent job permissions block not found').not.toBeNull();
+    const permsBlock = permsMatch ? permsMatch[1] : '';
+    expect(permsBlock).toContain('issues: read');
+    expect(permsBlock).not.toContain('issues: write');
+  });
+});

--- a/test/gh-aw-activation-label-provisioning.test.ts
+++ b/test/gh-aw-activation-label-provisioning.test.ts
@@ -232,7 +232,7 @@ describe('gh-aw: add-labels compiles into the real safe-output handler config (#
     // install it into `.github/workflows/` via `gh aw add`. Mirror that real deployment
     // layout, matching .github/workflows/squad-ci.yml's own compile gate.
     cpSync(WORKFLOWS_DIR, join(workspace, '.github', 'workflows'), { recursive: true });
-    execFileSync('gh', ['aw', 'compile', '.github/workflows/squad.md', '--strict', '--approve'], {
+    execFileSync('gh', ['aw', 'compile', '.github/workflows/squad.md', '--strict', '--approve', '--no-check-update'], {
       cwd: workspace,
       encoding: 'utf8',
       stdio: 'pipe',

--- a/test/gh-aw-deps-routing.test.ts
+++ b/test/gh-aw-deps-routing.test.ts
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractSafeOutputsConfigJson } from './helpers/gh-aw-lock.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const WAVE_1_BASENAMES = new Set([
@@ -126,22 +127,9 @@ function compileSafeOutputs(workflowId: string): Record<string, Record<string, u
   );
 
   const compiled = readFileSync(resolve(workflowDir, `${workflowId}.lock.yml`), 'utf8');
-  const lines = compiled.split(/\r?\n/);
-  const configStart = lines.findIndex(
-    line => line.includes('/safeoutputs/config.json') && line.includes('<<'),
-  );
-  const delimiter = lines[configStart]?.match(/<< '([^']+)'/)?.[1];
-  const configEnd = delimiter
-    ? lines.findIndex((line, index) => index > configStart && line.trim() === delimiter)
-    : -1;
-
-  expect(configStart, `${workflowId} must compile safe-output config`).toBeGreaterThanOrEqual(0);
-  expect(delimiter, `${workflowId} safe-output delimiter must be present`).toBeDefined();
-  expect(configEnd, `${workflowId} safe-output config must terminate`).toBeGreaterThan(configStart);
-  return JSON.parse(lines.slice(configStart + 1, configEnd).join('\n')) as Record<
-    string,
-    Record<string, unknown>
-  >;
+  const jsonText = extractSafeOutputsConfigJson(compiled);
+  expect(jsonText, `${workflowId} must compile a parseable safe-output config`).toBeDefined();
+  return JSON.parse(jsonText!) as Record<string, Record<string, unknown>>;
 }
 
 describe('gh-aw dependency dispatcher routing (#1748 S3)', () => {

--- a/test/gh-aw-deps-worker-workflow.test.ts
+++ b/test/gh-aw-deps-worker-workflow.test.ts
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, matchesGlob, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractSafeOutputsConfigJson } from './helpers/gh-aw-lock.js';
 
 // #1748 slice S2: `squad-deps-worker.md` gains Wave 1 `protected-files.exclude`
 // entries. The Wave 1 basenames (npm/yarn/pnpm + NuGet CPM + Go) are excluded
@@ -95,21 +96,10 @@ function compileWorker(workflowId: string): Record<string, unknown> {
   );
 
   const compiled = readFileSync(resolve(workflowDir, `${workflowId}.lock.yml`), 'utf8');
-  const lines = compiled.split(/\r?\n/);
-  const configStart = lines.findIndex(line => line.includes('/safeoutputs/config.json') && line.includes('<<'));
-  const delimiter = lines[configStart]?.match(/<< '([^']+)'/)?.[1];
-  const configEnd = delimiter
-    ? lines.findIndex((line, index) => index > configStart && line.trim() === delimiter)
-    : -1;
+  const jsonText = extractSafeOutputsConfigJson(compiled);
+  expect(jsonText, `compiled ${workflowId} must write a parseable safe-output config`).toBeDefined();
 
-  expect(configStart, `compiled ${workflowId} must write the safe-output config`).toBeGreaterThanOrEqual(0);
-  expect(delimiter, 'safe-output config must use a parseable heredoc delimiter').toBeDefined();
-  expect(configEnd, 'safe-output config heredoc must be terminated').toBeGreaterThan(configStart);
-
-  const safeOutputs = JSON.parse(lines.slice(configStart + 1, configEnd).join('\n')) as Record<
-    string,
-    Record<string, unknown>
-  >;
+  const safeOutputs = JSON.parse(jsonText!) as Record<string, Record<string, unknown>>;
   return safeOutputs.create_pull_request;
 }
 
@@ -509,17 +499,9 @@ describe('gh-aw squad-deps-worker S2: Wave 1 protected-files.exclude (#1748)', (
           resolve(workflowDir, 'squad-implement-worker.lock.yml'),
           'utf8',
         );
-        const lines = compiled.split(/\r?\n/);
-        const configStart = lines.findIndex(
-          line => line.includes('/safeoutputs/config.json') && line.includes('<<'),
-        );
-        const delimiter = lines[configStart]?.match(/<< '([^']+)'/)?.[1];
-        const configEnd = delimiter
-          ? lines.findIndex((line, idx) => idx > configStart && line.trim() === delimiter)
-          : -1;
-        const safeOutputs = JSON.parse(
-          lines.slice(configStart + 1, configEnd).join('\n'),
-        ) as Record<string, Record<string, unknown>>;
+        const jsonText = extractSafeOutputsConfigJson(compiled);
+        expect(jsonText, 'mutated squad-implement-worker must compile a parseable safe-output config').toBeDefined();
+        const safeOutputs = JSON.parse(jsonText!) as Record<string, Record<string, unknown>>;
         const compiledProtectedFiles = (
           safeOutputs.create_pull_request?.protected_files ?? []
         ) as string[];

--- a/test/gh-aw-implement-workflow.test.ts
+++ b/test/gh-aw-implement-workflow.test.ts
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractSafeOutputsConfigJson } from './helpers/gh-aw-lock.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -90,21 +91,9 @@ function compiledWorkerSafeOutputs(): Record<string, Record<string, unknown>> {
   );
 
   const compiled = readFileSync(resolve(workflowDir, 'squad-implement-worker.lock.yml'), 'utf8');
-  const lines = compiled.split(/\r?\n/);
-  const configStart = lines.findIndex(line => line.includes('/safeoutputs/config.json') && line.includes('<<'));
-  const delimiter = lines[configStart]?.match(/<< '([^']+)'/)?.[1];
-  const configEnd = delimiter
-    ? lines.findIndex((line, index) => index > configStart && line.trim() === delimiter)
-    : -1;
-
-  expect(configStart, 'compiled worker must write the safe-output config').toBeGreaterThanOrEqual(0);
-  expect(delimiter, 'safe-output config must use a parseable heredoc delimiter').toBeDefined();
-  expect(configEnd, 'safe-output config heredoc must be terminated').toBeGreaterThan(configStart);
-
-  return JSON.parse(lines.slice(configStart + 1, configEnd).join('\n')) as Record<
-    string,
-    Record<string, unknown>
-  >;
+  const jsonText = extractSafeOutputsConfigJson(compiled);
+  expect(jsonText, 'compiled worker must write a parseable safe-output config').toBeDefined();
+  return JSON.parse(jsonText!) as Record<string, Record<string, unknown>>;
 }
 
 describe('gh-aw implement workflows', () => {

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -389,6 +389,18 @@ describe('gh-aw: safe-output configuration', () => {
     expect(ci, 'create-issue block must exist').toBeDefined();
     expect(ci['max'], 'create-issue max must be 75 — do not reduce below this').toBe(75);
   });
+
+  it('add-labels exists and can auto-provision squad labels on a fresh repo (#1955)', () => {
+    const al = safeOutputs['add-labels'];
+    expect(al, 'add-labels block must exist').toBeDefined();
+    expect(al['create-if-missing'], 'add-labels must set create-if-missing so a fresh repo with no squad labels does not silently drop them').toBe(true);
+    expect(al['allowed']).toEqual(['squad', 'squad:*']);
+    expect(al['issues'], 'add-labels must be allowed to target issues').toBe(true);
+    expect(al['target'], 'add-labels must target created issues, not only the triggering one').toBe('*');
+    // One add_labels call per created issue; must cover the largest possible
+    // create-issue run (max 75) with headroom, never less.
+    expect(al['max'] as number).toBeGreaterThanOrEqual(safeOutputs['create-issue']['max'] as number);
+  });
 });
 
 describe('#1916: lifecycle comment updates use a deterministic safe-output job', () => {
@@ -1276,10 +1288,16 @@ describe('gh-aw: compiled workflow shell input security contract', () => {
   // but can exceed the 5s vitest default under full-suite parallel contention.
   it('strict-compiles and preserves prompt/config behavior', () => {
     const compiled = lockText();
-    expect(compiled).toContain('"auto_close_issue":false');
-    expect(compiled).toContain('"data_enabled":true');
-    expect(compiled).toContain('"required":["origin_issue","phases","schema_version","squad_artifact"]');
-    expect(compiled).toContain('"enum":["research","plan","plan-accepted"');
+    // gh-aw v0.87.x (bumped from v0.86.2 for #1955's add-labels/create-if-missing
+    // support) now emits this JSON config only embedded inside a double-quoted YAML
+    // env var value, so every `"` is backslash-escaped (`\"key\":value`) rather than
+    // appearing as bare JSON. De-escape before matching so this assertion holds
+    // regardless of which quoting style a given compiler version chooses.
+    const unescaped = compiled.replace(/\\"/g, '"');
+    expect(unescaped).toContain('"auto_close_issue":false');
+    expect(unescaped).toContain('"data_enabled":true');
+    expect(unescaped).toContain('"required":["origin_issue","phases","schema_version","squad_artifact"]');
+    expect(unescaped).toContain('"enum":["research","plan","plan-accepted"');
     // gh-aw records runtime-import paths relative to the repo root, so with the
     // real `.github/workflows/` deployment layout these are prefixed accordingly.
     expect(compiled).toContain('{{#runtime-import .github/workflows/shared/squad-planning-ontology.md}}');
@@ -1932,23 +1950,44 @@ describe('gh-aw: Plan Activate hardening behaviors', () => {
 
   it('includes label pre-flight step before issue creation', () => {
     expect(content).toContain('Label Pre-flight');
-    expect(content).toMatch(/squad.*label.*exist|label.*squad.*exist/i);
+    const preflight = (content.match(/##### Label Pre-flight\n([\s\S]*?)(?=\n#####|\n####)/)?.[1] ?? '').replace(
+      /\s+/g,
+      ' '
+    );
+    expect(preflight).toMatch(/squad.*label.*exist|label.*squad.*exist/i);
   });
 
-  it('label pre-flight does not claim impossible label creation', () => {
-    // Workflow has issues: read and no create-label safe-output; must not claim it can create labels
+  it('label pre-flight grounds any label-creation claim in the add-labels safe output (#1955)', () => {
+    // Forward-port note (#1955): the workflow used to have no way to create a missing
+    // label at all, so any claim of "it creates labels" would have been a hallucinated
+    // capability. That gap is now closed by a real `add-labels` safe output with
+    // `create-if-missing: true` — the claim is legitimate, but it must be attributed to
+    // that declared mechanism, not to bare `issues: write` permission or vague
+    // "safe-output permissions handle the write" hand-waving with no named mechanism.
     const preflight = content.match(/##### Label Pre-flight\n([\s\S]*?)(?=\n#####|\n####)/)?.[1] ?? '';
-    expect(preflight).not.toMatch(/create them|safe-output permissions handle the write|no additional token scope/i);
+    expect(preflight, 'Label Pre-flight section must exist').not.toBe('');
+    expect(preflight).not.toMatch(/safe-output permissions handle the write|no additional token scope/i);
+    expect(preflight).toMatch(/add-labels|add_labels/);
+    expect(preflight).toMatch(/create-if-missing/);
   });
 
-  it('label pre-flight reports missing labels as prerequisite gap', () => {
-    expect(content).toMatch(/prerequisite gap|prerequisite/i);
-    expect(content).toMatch(/issues: write/i);
-    expect(content).toMatch(/create-label.*safe-output|safe-output.*create-label/i);
+  it('label pre-flight declares add-labels/create-if-missing instead of an unconfigured gap (#1955)', () => {
+    // Forward-port note (#1955): this used to assert the OPPOSITE — that missing labels
+    // were reported as an unconfigured "prerequisite gap" requiring a nonexistent
+    // `create-label` safe-output. That was the defect #1955 fixes: gh-aw's real
+    // mechanism is `add-labels` with `create-if-missing: true`, declared in frontmatter.
+    expect(content).toContain('add-labels:');
+    expect(content).toContain('create-if-missing: true');
+    expect(content).not.toContain('create-label:');
+    expect(content).not.toMatch(/create-label.*safe-output|safe-output.*create-label/i);
   });
 
-  it('label pre-flight continues activation and omits unavailable labels with report', () => {
-    expect(content).toMatch(/unavailable labels are omitted and reported|omitted and reported/i);
+  it('label pre-flight auto-provisions missing labels instead of omitting them (#1955)', () => {
+    // Forward-port note (#1955): this used to assert labels that don't yet exist are
+    // "omitted and reported, not silently applied" — the exact fresh-repo defect #1955
+    // reports. The fix auto-creates them via create-if-missing instead of omitting them.
+    expect(content).not.toMatch(/unavailable labels are omitted and reported/i);
+    expect(content).toMatch(/auto-creates|auto-provision/i);
   });
 
   it('includes transient failure handling with single retry', () => {

--- a/test/gh-aw-review-workflow.test.ts
+++ b/test/gh-aw-review-workflow.test.ts
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractSafeOutputsConfigJson } from './helpers/gh-aw-lock.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const REVIEWER = read('workflows/squad-review.md');
@@ -128,23 +129,12 @@ function compileReviewer(): CompiledContract {
   );
 
   const lock = readFileSync(resolve(workflowDir, 'squad-review.lock.yml'), 'utf8').replace(/\r\n/g, '\n');
-  const lines = lock.split('\n');
-  const configStart = lines.findIndex(line => line.includes('/safeoutputs/config.json') && line.includes('<<'));
-  const delimiter = lines[configStart]?.match(/<< '([^']+)'/)?.[1];
-  const configEnd = delimiter
-    ? lines.findIndex((line, index) => index > configStart && line.trim() === delimiter)
-    : -1;
-
-  expect(configStart, 'compiled reviewer must write safe-output config').toBeGreaterThanOrEqual(0);
-  expect(delimiter, 'safe-output config must use a parseable heredoc').toBeDefined();
-  expect(configEnd, 'safe-output config heredoc must terminate').toBeGreaterThan(configStart);
+  const jsonText = extractSafeOutputsConfigJson(lock);
+  expect(jsonText, 'compiled reviewer must write a parseable safe-output config').toBeDefined();
 
   return {
     lock,
-    safeOutputs: JSON.parse(lines.slice(configStart + 1, configEnd).join('\n')) as Record<
-      string,
-      Record<string, unknown>
-    >,
+    safeOutputs: JSON.parse(jsonText!) as Record<string, Record<string, unknown>>,
   };
 }
 

--- a/test/helpers/gh-aw-lock.ts
+++ b/test/helpers/gh-aw-lock.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared helper for extracting the JSON-encoded safe-outputs config from a
+ * compiled gh-aw `.lock.yml` file.
+ *
+ * gh-aw v0.86.x wrote this config as a bash heredoc redirected to
+ * `safeoutputs/config.json` (`cat <<'EOF' > .../config.json ... EOF`). gh-aw
+ * v0.87.x (required for #1955's `add-labels`/`create-if-missing` support)
+ * instead emits it as a single-line, JSON-escaped YAML env var
+ * (`GH_AW_SAFE_OUTPUTS_CONFIG: "{\"key\":...}"`). This helper supports both
+ * shapes so tests track the compiler's actual output rather than one
+ * specific serialization strategy, and keep working across future
+ * gh-aw version bumps that may reintroduce either style.
+ */
+export function extractSafeOutputsConfigJson(compiledLockYml: string): string | undefined {
+  const lines = compiledLockYml.split(/\r?\n/);
+
+  const envVarLine = lines.find(line => line.includes('GH_AW_SAFE_OUTPUTS_CONFIG:'));
+  if (envVarLine) {
+    const match = envVarLine.match(/GH_AW_SAFE_OUTPUTS_CONFIG:\s*"(.*)"\s*$/);
+    if (match) return match[1].replace(/\\"/g, '"');
+  }
+
+  const configStart = lines.findIndex(
+    line => line.includes('/safeoutputs/config.json') && line.includes('<<'),
+  );
+  if (configStart === -1) return undefined;
+  const delimiter = lines[configStart]?.match(/<< '([^']+)'/)?.[1];
+  if (!delimiter) return undefined;
+  const configEnd = lines.findIndex(
+    (line, index) => index > configStart && line.trim() === delimiter,
+  );
+  if (configEnd <= configStart) return undefined;
+  return lines.slice(configStart + 1, configEnd).join('\n');
+}

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -105,6 +105,13 @@ safe-outputs:
   create-issue:
     labels: [squad]
     max: 75
+  add-labels:
+    allowed: [squad, "squad:*"]
+    create-if-missing: true
+    issues: true
+    pull-requests: false
+    target: "*"
+    max: 80
   add-comment:
     max: 20
     target: "*"
@@ -1772,7 +1779,23 @@ Count expected issues before starting. If total > 50: recommend phased activatio
    name the value and the issue it applied to. Omitting the heading while omitting the label
    reports a clean run that did not happen.
 
-Then verify labels `squad` and each roster-bound `squad:{agent}` exist. If missing, record them in the activation summary as a prerequisite gap (label creation requires `issues: write` + `create-label` safe-output — not configured in this workflow). Continue activation — `create-issue` will apply any existing labels normally; unavailable labels are omitted and reported, not silently applied.
+**Label provisioning.** The `add-labels` safe output (`allowed: [squad, "squad:*"]`,
+`create-if-missing: true`) auto-creates `squad` and any `squad:{agent}` label the first
+time this run needs it — a fresh repository with zero Squad labels requires no manual
+provisioning and is never a prerequisite gap. `create-issue`'s own `labels:` field cannot
+do this: GitHub silently drops label names that do not already exist in the target
+repository instead of creating them, which is the behavior that previously produced the
+"prerequisite gap" reported here. Do not rely on `create-issue`'s `labels:` field alone
+to land a label on a fresh repository.
+
+Immediately after each `create-issue` call in Steps 2b/2c returns its real issue number,
+call `add_labels` targeting that number with exactly the label set Steps 4-8 above
+computed for that issue — `squad` alone, or `squad` plus the one `squad:{agent}` label
+the correspondence rule (Step 7) certified. `create-if-missing` creates any label that
+does not yet exist before applying it; re-applying an already-present label on a rerun is
+a no-op, so this is safe under the Step 1 idempotent-rerun path. Never call `add_labels`
+before the matching `create-issue` call has returned and been verified — there is no
+issue number to target yet.
 
 ##### Transient Failure Handling
 
@@ -1794,14 +1817,15 @@ Root → Epics → Tasks. Phase-specific: filter to matching phase heading.
 - Body: outcome, stories, epic-level acceptance criteria, context (parent, initiative, milestone, deps)
 - Parent: sub-issue of root intent issue
 - Milestone: assigned
+- Label application: once `create-issue` returns and the epic's issue number is verified, call `add_labels` on that number with this epic's computed label set (see Label Pre-flight). `create-if-missing` provisions `squad`/`squad:{agent}` on a fresh repository automatically.
 
 **⚠️ DO NOT STOP after epics. Tasks MUST follow immediately.**
 
 **2c. Create Task Issues:** `create-issue` per task in dependency order.
 
 > **⚠️ ATOMIC CONTRACT — strictly one task at a time:**
-> For each task: compose ONLY that task's body → call `create-issue` immediately → verify the returned issue number → then move to the next task.
-> **DO NOT** compose or buffer multiple task bodies before making calls. One compose → one call → one verify, repeated per task.
+> For each task: compose ONLY that task's body → call `create-issue` immediately → verify the returned issue number → call `add_labels` on that verified number with the task's computed label set → then move to the next task.
+> **DO NOT** compose or buffer multiple task bodies before making calls. One compose → one call → one verify → one label-application call, repeated per task.
 
 - Title: task title
 - Labels: `squad` (0075ca), `squad:{agent}` (e4e669) where `{agent}` is **this task's own `Agent` cell**, lowercased — read from the implementation-plan row whose `#` matches this task. Map `@copilot` to `squad:copilot`. Never inherit the parent epic's agent, and never carry the previous task's value forward: re-read the `Agent` cell for every task, because consecutive tasks under one epic routinely have different agents. No `size:*` labels unless policy says so.
@@ -1809,10 +1833,14 @@ Root → Epics → Tasks. Phase-specific: filter to matching phase heading.
 - Parent: sub-issue of EPIC (not root)
 - Milestone: same as parent epic
 - Size: Project field if available, else body line
+- Label application: same as epics — call `add_labels` on the verified task issue number with this task's computed label set (see Label Pre-flight). `create-if-missing` provisions `squad`/`squad:{agent}` on a fresh repository automatically.
 
 **2d. Self-Validation:** Compare created/recognized task count vs expected (use the plan's declared total — not the safe-output cap). If created count is below expected: call `report_incomplete` immediately with `created={N}`, `expected={M}`, and the last verified issue number — never noop. Post: `N of M issues created so far — rerun the identical activation command to continue.` Re-runs are idempotent via title match. Never surface the `create-issue` or `add-comment` safe-output caps as the reason for a partial run.
 
-Labels must have descriptions and intentional colors.
+Labels must have descriptions and intentional colors when they already exist in the
+repository. A label auto-provisioned by `add-labels`'s `create-if-missing` on a fresh
+repository instead receives gh-aw's deterministic color and an empty description — that
+is expected, not a failure, and must not be reported as one.
 
 ##### Step 3: Native Dependency Edges
 


### PR DESCRIPTION
Closes #1955

## Problem
`/squad plan activate` silently skipped applying `squad` and `squad:{agent}` labels to issues on a fresh consumer repository when those labels didn't already exist, reporting a "prerequisite gap" instead of creating them. The workflow/docs promised labeled issues that never showed up.

## Fix — `workflows/squad.md`, `squad-plan-activate` skill only
- Added a `safe-outputs.add-labels` block: `allowed: [squad, "squad:*"]`, `create-if-missing: true`, `max: 80`, `target: "*"` — using gh-aw's supported primitive (no invented `create-label` primitive).
- Rewrote the Label Pre-flight prose and Step 2b/2c bullets so the main (read-only) agent still computes per-task roster labels and the `@copilot`/multi-owner/non-roster mapping exactly as before, but now emits them through `add-labels` for auto-provisioning instead of silently omitting missing labels.
- Extended the ATOMIC CONTRACT + added a label-color honesty line so reporting reflects labels actually applied (including any auto-created via `create-if-missing`) — rerun idempotency and honest reporting preserved.
- All writes remain in safe-output jobs; the main activation agent stays read-only. No permissions broadened beyond what `add-labels` requires.

**Sequencing verified**: declaring `add-labels` does *not* retroactively label issues created earlier in the same run by `create-issue`. Confirmed via manual `gh aw compile` in a scratch workspace, and the skill was written so label application is its own step after issue creation, using the created issue number.

## Version bump (required)
`create-if-missing` on `add-labels` requires gh-aw ≥ v0.87.6; this repo was pinned to v0.86.2, which silently ignores the field. Bumped the pin to **v0.87.10** in `.github/workflows/squad-ci.yml` (2 places) and `docs/src/content/docs/guide/gh-aw.md`.

## Test fallout from the version bump (directly related, no behavior change to other workflows)
gh-aw v0.87.10 changed how compiled lock files serialize the safe-outputs config (both `GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG` used by `squad.md`, and `GH_AW_SAFE_OUTPUTS_CONFIG` used by every other workflow) to an escaped-JSON YAML string.

- Added `test/helpers/gh-aw-lock.ts` — shared `extractSafeOutputsConfigJson()` helper supporting both old (heredoc) and new (escaped env var) formats.
- Rewired `test/gh-aw-deps-routing.test.ts`, `test/gh-aw-deps-worker-workflow.test.ts`, `test/gh-aw-implement-workflow.test.ts`, `test/gh-aw-review-workflow.test.ts` to use it instead of duplicated heredoc-only extraction (test plumbing only, no production behavior touched).
- Updated 3 pre-existing tests in `test/gh-aw-quality.test.ts` that had encoded the old "prerequisite gap" omission as expected behavior, plus one de-escaping fix.
- Added `test/gh-aw-activation-label-provisioning.test.ts` — new dedicated test asserting the prose contract and real compiled-lock wiring of `add_labels`/`create_if_missing`, and that the agent job's permissions remain read-only.

## Verification
- `npx vitest run` across the 6 directly affected test files: **247/247 passed**.
- Full `npm test`: only the same 8 pre-existing, unrelated "externalized state" failures remain (confirmed identical on unmodified HEAD via `git stash`) — no gh-aw regressions.
- `npm run build` succeeds (its version-bump/CRLF template side effects reverted so they don't pollute this diff).
- Manual `gh aw compile --strict --no-check-update --approve` succeeds for all 4 workflows with only pre-existing warnings, no errors.
- No changeset required — this PR touches no `packages/squad-cli/src/` or `packages/squad-sdk/src/` files.

## Known limitation (explicitly out of scope per #1955)
The parallel `squad-plan-accept` fast-path issue-creation logic is unchanged — separate code path, not covered by this fix.