### PR TITLE
fix(workflows): target activation labels via gh-aw temporary IDs

### DIFF
--- a/test/gh-aw-activation-label-provisioning.test.ts
+++ b/test/gh-aw-activation-label-provisioning.test.ts
@@ -146,11 +146,28 @@ describe('gh-aw: fresh-repo label provisioning in squad-plan-activate (#1955)', 
     ).toBe(true);
   });
 
-  it('never calls add_labels before create-issue has returned and been verified', () => {
+  it('forbids the invalid "wait for a returned real issue number" contract (#1962)', () => {
+    // The original version of this rule told the model to wait until create-issue
+    // "returned and been verified" before calling add_labels. gh-aw never returns a real
+    // issue number to the agent — creation is deferred to the safe-output job — so that
+    // instruction was unsatisfiable and is exactly the defect #1962 corrects. The prose
+    // must now say the opposite: do not wait, because no number arrives.
     expect(
       /never call `add_labels` before/i.test(activateProse),
-      'The prose must explicitly forbid calling add_labels before create-issue has ' +
-        'returned a real issue number — there is nothing to target yet.',
+      'The old "never call add_labels before create-issue has returned a real issue ' +
+        'number" rule must be gone — it encoded the invalid assumption #1962 fixes.',
+    ).toBe(false);
+
+    expect(
+      /do not wait for a returned issue number/i.test(activateProse),
+      'The prose must explicitly tell the model NOT to wait for a returned issue ' +
+        'number, since gh-aw never provides one during the run.',
+    ).toBe(true);
+
+    expect(
+      /does \*\*not\*\* return a real GitHub issue number/i.test(activateProse),
+      'The Hallucination Guard must state plainly that create-issue does not return a ' +
+        'real issue number during the run.',
     ).toBe(true);
   });
 

--- a/test/gh-aw-activation-temporary-ids.test.ts
+++ b/test/gh-aw-activation-temporary-ids.test.ts
@@ -1,0 +1,279 @@
+/**
+ * gh-aw temporary-ID targeting for `/squad plan activate` (#1962, parent #1957).
+ *
+ * The activation prose previously told the model to read a real GitHub issue number back
+ * from each `create-issue` call and then target `add_labels` at it. gh-aw never does that:
+ * issue creation is deferred to the post-agent safe-output job, so the agent only ever
+ * receives a success acknowledgement. Every downstream operation that depended on a
+ * "returned" number was therefore either blocked forever or satisfied by a hallucinated
+ * number — and an `add_labels` call with no resolvable `item_number` silently falls back to
+ * labelling the *triggering intent issue*.
+ *
+ * gh-aw's supported linkage is `temporary_id`: `create_issue` mints one, and
+ * `add_labels.item_number`, `create_issue.parent`, and `create_issue.blocked_by` accept it.
+ * The safe-output job resolves temporary IDs to real issue numbers after the agent exits.
+ *
+ * Verified against the pinned gh-aw v0.87.10 (.github/workflows/squad-ci.yml):
+ *   - `create_issue.temporary_id` — optional string, pattern `^#?aw_[A-Za-z0-9_]{3,12}$`
+ *   - `add_labels.item_number`    — number | string, `^(\d+|#?aw_[A-Za-z0-9_]{3,12})$`
+ *   - `require-temporary-id: true` under `safe-outputs.create-issue` compiles to
+ *     `"require_temporary_id":true` plus `required_field_additions.create_issue`
+ *
+ * This suite locks the corrected contract. It is deliberately narrow: the broad activation
+ * behavioral suite is #1960, the `/squad activate` fast path is #1959, and the activation
+ * reporting redesign is #1963.
+ */
+
+import { afterAll, describe, it, expect } from 'vitest';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const WORKFLOWS_DIR = join(process.cwd(), 'workflows');
+const SQUAD_WORKFLOW = join(WORKFLOWS_DIR, 'squad.md');
+const TEST_WORKSPACES_DIR = join(process.cwd(), '.test-workspaces-temporary-ids');
+
+afterAll(() => {
+  rmSync(TEST_WORKSPACES_DIR, { recursive: true, force: true });
+});
+
+/** Read a text file with line endings normalized to LF (Windows checkouts materialize CRLF). */
+function readText(filePath: string): string {
+  return readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+}
+
+const workflow = readText(SQUAD_WORKFLOW);
+
+const ACTIVATE_START = workflow.indexOf('## skill: `squad-plan-activate`');
+const ACTIVATE_END = workflow.indexOf('## end skill: `squad-plan-activate`');
+expect(ACTIVATE_START, '"## skill: `squad-plan-activate`" is missing from workflows/squad.md').toBeGreaterThan(-1);
+expect(ACTIVATE_END, '"## end skill: `squad-plan-activate`" is missing from workflows/squad.md').toBeGreaterThan(
+  ACTIVATE_START,
+);
+const activateSkill = workflow.slice(ACTIVATE_START, ACTIVATE_END);
+
+/** Whitespace-collapsed view for prose assertions that may span wrapped lines. */
+const activateProse = activateSkill.replace(/\s+/g, ' ');
+
+/** Isolate a `**{marker}**` step body, running to the next bold step heading. */
+function stepBody(marker: string): string {
+  const start = activateSkill.indexOf(marker);
+  expect(start, `"${marker}" is missing from the squad-plan-activate skill`).toBeGreaterThan(-1);
+  const rest = activateSkill.slice(start + marker.length);
+  const nextStep = rest.search(/\n\*\*\d[a-z]?\./);
+  return (nextStep === -1 ? rest : rest.slice(0, nextStep)).replace(/\s+/g, ' ');
+}
+
+describe('gh-aw: temporary-ID targeting in squad-plan-activate (#1962)', () => {
+  it('requires a temporary_id on every create-issue via frontmatter', () => {
+    // Without this, a create_issue call that forgets its temporary_id still succeeds and
+    // the matching add_labels has nothing resolvable to target. The flag makes the
+    // omission a hard rejection instead of a silent mis-label.
+    const frontmatterEnd = workflow.indexOf('\n---', 4);
+    expect(frontmatterEnd, 'workflows/squad.md frontmatter is unterminated').toBeGreaterThan(0);
+    const frontmatter = workflow.slice(0, frontmatterEnd);
+
+    const createIssueAt = frontmatter.indexOf('create-issue:');
+    expect(createIssueAt, '`create-issue:` is missing from the safe-outputs frontmatter').toBeGreaterThan(-1);
+
+    expect(
+      frontmatter.slice(createIssueAt),
+      '`require-temporary-id: true` must be declared under safe-outputs.create-issue.',
+    ).toMatch(/create-issue:[\s\S]*?require-temporary-id: true/);
+  });
+
+  it('documents the exact gh-aw temporary-ID format, not an invented one', () => {
+    // A value outside gh-aw's pattern is rejected at the MCP tool layer, so the prose has
+    // to carry the real pattern rather than a plausible-looking approximation.
+    expect(
+      activateProse,
+      'The prose must cite gh-aw\'s actual temporary_id pattern.',
+    ).toContain('^#?aw_[A-Za-z0-9_]{3,12}$');
+  });
+
+  it('mints deterministic temporary IDs derived from the plan, never invented ones', () => {
+    expect(activateProse).toMatch(/#aw_epic\{K\}/);
+    expect(activateProse).toMatch(/#aw_task\{N\}/);
+    expect(
+      /derive, never invent/i.test(activateProse),
+      'The minting scheme must be derived from the plan\'s own identifiers so a rerun ' +
+        'produces the same IDs and two items can never collide.',
+    ).toBe(true);
+  });
+
+  it('makes temporary-ID uniqueness the prompt\'s responsibility', () => {
+    // Verified in gh-aw v0.87.10: a duplicate temporary_id is NOT rejected. The
+    // temporaryIdMap set() silently overwrites, so the last create_issue using a value
+    // owns it and every earlier reference resolves to the wrong issue. gh-aw emits no
+    // warning for this on create_issue, so the prompt must enforce it.
+    expect(
+      /uniqueness is your responsibility/i.test(activateProse),
+      'The prose must state that gh-aw does not enforce temporary-ID uniqueness.',
+    ).toBe(true);
+    expect(
+      /does not reject a duplicate `temporary_id`/i.test(activateProse),
+      'The prose must name the concrete failure mode: duplicates are silently accepted.',
+    ).toBe(true);
+  });
+
+  it('mandates an explicit add_labels item_number and names the silent-fallback hazard', () => {
+    // This is the actual production defect: an add_labels with no item_number does not
+    // error — it labels the triggering intent issue, branding the user's own request.
+    expect(
+      /every `add_labels` call MUST pass `item_number`/i.test(activateProse),
+      'Explicit item_number targeting must be mandatory, not implied.',
+    ).toBe(true);
+    expect(
+      /triggering intent issue/i.test(activateProse),
+      'The prose must name what an omitted item_number silently hits.',
+    ).toBe(true);
+  });
+
+  it('targets add_labels at the create-issue call\'s temporary_id', () => {
+    expect(
+      /`item_number` set to that call's `temporary_id`/i.test(activateProse),
+      'add_labels must be wired to the minting create-issue call\'s temporary_id.',
+    ).toBe(true);
+  });
+
+  it('never waits for, predicts, or reads back an issue number for issues it created', () => {
+    expect(
+      /does \*\*not\*\* return a real GitHub issue number/i.test(activateProse),
+      'The Hallucination Guard must state plainly that create-issue returns no number.',
+    ).toBe(true);
+    expect(
+      /never predict, infer, or "read back" a number/i.test(activateProse),
+      'Predicting or inferring a created issue\'s number must be explicitly forbidden.',
+    ).toBe(true);
+    expect(
+      /do not wait for a returned issue number/i.test(activateProse),
+      'The prose must tell the model not to block on a number that never arrives.',
+    ).toBe(true);
+  });
+
+  it('still uses real, verified numbers for pre-existing and reused issues', () => {
+    // Temporary IDs only map issues THIS run created. An idempotent rerun or a
+    // dedup-by-title match has a genuine number and must use it.
+    expect(
+      /has a real, verified number: target it by that number, not a temporary ID/i.test(activateProse),
+      'Reused/pre-existing issues must be targeted by their verified real number.',
+    ).toBe(true);
+  });
+
+  it('declares a temporary ID in both the epic (2b) and task (2c) creation steps', () => {
+    for (const marker of ['**2b. Create Epic Issues:**', '**2c. Create Task Issues:**']) {
+      expect(stepBody(marker), `${marker} must declare a Temporary ID field`).toMatch(/- Temporary ID:/);
+    }
+  });
+
+  it('passes the epic\'s temporary ID as each task\'s parent', () => {
+    // The epic does not exist yet when the task create-issue is emitted, so `parent`
+    // cannot be a real number. gh-aw resolves a temporary ID here.
+    expect(stepBody('**2c. Create Task Issues:**')).toMatch(/#aw_epic\{K\}/);
+  });
+
+  it('uses the triggering issue\'s own real number as the epic parent', () => {
+    // The one place a real number IS correct: the intent issue that triggered the run
+    // already exists and its number is independently known.
+    expect(stepBody('**2b. Create Epic Issues:**')).toMatch(/triggering issue/i);
+  });
+
+  it('expresses native dependency edges with temporary IDs on create-issue', () => {
+    // blocked_by must be declared on the create_issue call itself (gh-aw's topological
+    // sort only inspects create_issue.blocked_by), not patched in afterwards with a
+    // number the agent does not have.
+    const start = activateSkill.indexOf('##### Step 3: Native Dependency Edges');
+    expect(start, '"##### Step 3: Native Dependency Edges" is missing').toBeGreaterThan(-1);
+    const rest = activateSkill.slice(start);
+    const nextHeading = rest.slice(1).search(/\n#{1,5} /);
+    const stepThree = (nextHeading === -1 ? rest : rest.slice(0, nextHeading + 1)).replace(/\s+/g, ' ');
+
+    expect(stepThree).toMatch(/blocked_by/);
+    expect(stepThree).toMatch(/#aw_task\{N\}/);
+    expect(
+      /on the `create-issue` call itself/i.test(stepThree),
+      'blocked_by must be declared on the create-issue call, not applied afterwards.',
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compiled-artifact verification
+// ---------------------------------------------------------------------------
+//
+// The prose assertions above are only a contract if gh-aw actually compiles the
+// requirement into the safe-output handler config. Fails closed (never skips) per this
+// repo's #1833/#1834 convention: an unmeasured contract is indistinguishable from a
+// violated one.
+
+const GH_AW_INSTALL_HINT =
+  '`gh aw` is required to compile the workflow this gate inspects. Install it with ' +
+  '`gh extension install --pin v0.87.10 github/gh-aw` (matches .github/workflows/squad-ci.yml). ' +
+  'This gate fails closed rather than skipping: an unmeasured contract is ' +
+  'indistinguishable from a violated one (#1834).';
+
+describe('gh-aw: require-temporary-id compiles into the real safe-output config (#1962)', () => {
+  let compiledLock: string | null = null;
+
+  function lockText(): string {
+    if (compiledLock !== null) return compiledLock;
+
+    const versionProbe = spawnSync('gh', ['aw', '--version'], { encoding: 'utf8' });
+    if (versionProbe.status !== 0) {
+      throw new Error(`gh aw --version failed. ${GH_AW_INSTALL_HINT}`);
+    }
+
+    mkdirSync(TEST_WORKSPACES_DIR, { recursive: true });
+    const workspace = mkdtempSync(join(TEST_WORKSPACES_DIR, 'temp-ids-'));
+    execFileSync('git', ['init', '--quiet'], { cwd: workspace });
+    // This repo ships the gh-aw *source* from a top-level `workflows/` dir; downstream
+    // consumers install it into `.github/workflows/` via `gh aw add`. Mirror that real
+    // deployment layout, matching .github/workflows/squad-ci.yml's own compile gate.
+    cpSync(WORKFLOWS_DIR, join(workspace, '.github', 'workflows'), { recursive: true });
+    execFileSync('gh', ['aw', 'compile', '.github/workflows/squad.md', '--strict', '--approve', '--no-check-update'], {
+      cwd: workspace,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+
+    const lockPath = join(workspace, '.github', 'workflows', 'squad.lock.yml');
+    if (!existsSync(lockPath)) {
+      throw new Error(
+        `gh aw compile produced no squad.lock.yml — the compiled artifact this gate ` +
+          `inspects is absent, so the contract is unmeasured. ${GH_AW_INSTALL_HINT}`,
+      );
+    }
+    compiledLock = readText(lockPath);
+    return compiledLock;
+  }
+
+  it('strict-compiles with require-temporary-id declared', () => {
+    expect(lockText().length).toBeGreaterThan(0);
+  });
+
+  it('wires require_temporary_id: true into the create_issue handler config', () => {
+    // gh-aw embeds this JSON inside a double-quoted YAML env value with every `"`
+    // backslash-escaped. De-escape before matching so this holds regardless of a given
+    // compiler version's quoting choice.
+    const compiled = lockText().replace(/\\"/g, '"');
+    expect(compiled).toMatch(/"create_issue":\{[^}]*"require_temporary_id":true/);
+  });
+
+  it('adds temporary_id to create_issue\'s required fields', () => {
+    // gh-aw emits this block pretty-printed across multiple lines, so match with
+    // whitespace tolerance rather than assuming compact JSON.
+    const compiled = lockText().replace(/\\"/g, '"');
+    expect(compiled).toMatch(
+      /"required_field_additions":\s*\{\s*"create_issue":\s*\[\s*"temporary_id"\s*\]/,
+    );
+  });
+
+  it('tells the agent, in its own tool constraints, that temporary_id is required', () => {
+    // The prompt-side constraint string is what the model actually reads at runtime;
+    // without it the enforcement is a silent rejection the agent cannot anticipate.
+    // De-escaping reintroduces quotes inside the value (`Labels ["squad"]`), so match
+    // with a bounded lazy span rather than a quote-delimited one.
+    const compiled = lockText().replace(/\\"/g, '"');
+    expect(compiled).toMatch(/"create_issue":\s*"\s*CONSTRAINTS:[\s\S]{0,300}?temporary_id is required/);
+  });
+});

--- a/test/gh-aw-activation-temporary-ids.test.ts
+++ b/test/gh-aw-activation-temporary-ids.test.ts
@@ -247,6 +247,32 @@ describe('gh-aw: temporary-ID targeting in squad-plan-activate (#1962)', () => {
       'blocked_by must be declared on the create-issue call, not applied afterwards.',
     ).toBe(true);
   });
+
+  it('names the 2d self-validation count with one consistent term', () => {
+    // The reviewer flagged a mixed-terminology hazard: comparing a "requested/recognized"
+    // count but then reporting it as `created={N}` left {N} undefined. One term, defined
+    // once, and both report_incomplete parameters bound explicitly to it.
+    //
+    // 2d is the last bold step, so bound the slice at the next heading too — otherwise it
+    // swallows Step 4, whose separate "created/recognized" binding wording belongs to #1963.
+    const marker = '**2d. Self-Validation:**';
+    const start = activateSkill.indexOf(marker);
+    expect(start, `"${marker}" is missing`).toBeGreaterThan(-1);
+    const rest = activateSkill.slice(start + marker.length);
+    const end = rest.search(/\n#{1,5} |\n\*\*\d[a-z]?\./);
+    const body = (end === -1 ? rest : rest.slice(0, end)).replace(/\s+/g, ' ');
+
+    expect(body, '2d must define the counted quantity once, as the created count').toMatch(
+      /\*\*created count\*\* is the number of `create-issue` calls this run emitted/i,
+    );
+    // Nothing may reintroduce a competing noun for the same quantity.
+    expect(body, '2d must not mix in a second term for the same count').not.toMatch(
+      /requested\/recognized|created\/recognized|requested count|recognized count/i,
+    );
+    // Both parameters must state what they carry, so {N} and {M} are unambiguous.
+    expect(body).toMatch(/`created=\{N\}` set to that created count/);
+    expect(body).toMatch(/`expected=\{M\}` set to the declared total/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/gh-aw-activation-temporary-ids.test.ts
+++ b/test/gh-aw-activation-temporary-ids.test.ts
@@ -172,6 +172,58 @@ describe('gh-aw: temporary-ID targeting in squad-plan-activate (#1962)', () => {
     expect(stepBody('**2c. Create Task Issues:**')).toMatch(/#aw_epic\{K\}/);
   });
 
+  it('uses a verified real number when 2b reused a deduped prior-phase epic', () => {
+    // 2b dedups epics by title against prior phases. A reused epic was never minted in
+    // this run, so it has no entry in gh-aw's temporary-ID map — passing `#aw_epic{K}`
+    // for it would be an unresolvable parent reference. The prose must carve this out
+    // instead of applying the temporary ID unconditionally.
+    const parentLine = stepBody('**2c. Create Task Issues:**');
+
+    expect(
+      /minted this epic in this run/i.test(parentLine),
+      'Task parent targeting must condition the temporary ID on the epic having been ' +
+        'minted in this run.',
+    ).toBe(true);
+
+    expect(
+      /matched a pre-existing epic by title[\s\S]*?verified real number/i.test(parentLine),
+      'A dedup-by-title/prior-phase epic match must be targeted by its verified real ' +
+        'number, not a temporary ID this run never minted.',
+    ).toBe(true);
+
+    expect(
+      /never pass a temporary ID that was not minted this run/i.test(parentLine),
+      'The prose must forbid passing a temporary ID that was not minted this run.',
+    ).toBe(true);
+  });
+
+  it('never leaves an unresolved temporary ID in the sub-issue fallback body reference', () => {
+    // gh-aw leaves an `#aw_…` reference it cannot resolve in the body VERBATIM, so a
+    // reused/pre-existing parent written as a temporary ID would ship a literal
+    // "#aw_epic3" string to the user. The fallback must branch on provenance.
+    const start = workflow.indexOf('##### Sub-issue Fallback');
+    expect(start, '"##### Sub-issue Fallback" is missing').toBeGreaterThan(-1);
+    const rest = workflow.slice(start);
+    const nextHeading = rest.slice(1).search(/\n#{1,5} /);
+    const fallback = (nextHeading === -1 ? rest : rest.slice(0, nextHeading + 1)).replace(/\s+/g, ' ');
+
+    expect(
+      /if that parent was minted this run/i.test(fallback),
+      'The fallback must use a temporary ID only for a parent minted in this run.',
+    ).toBe(true);
+
+    expect(
+      /pre-existing or was matched by dedup[\s\S]*?verified real number/i.test(fallback),
+      'A pre-existing or deduped parent must be written as its verified real number.',
+    ).toBe(true);
+
+    expect(
+      /leaves an unresolved `#aw_…` reference in the body verbatim/i.test(fallback),
+      'The prose must state WHY: an unresolved temporary ID is not stripped, so it ' +
+        'would ship to the user as a meaningless literal.',
+    ).toBe(true);
+  });
+
   it('uses the triggering issue\'s own real number as the epic parent', () => {
     // The one place a real number IS correct: the intent issue that triggered the run
     // already exists and its number is independently known.

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -105,6 +105,7 @@ safe-outputs:
   create-issue:
     labels: [squad]
     max: 75
+    require-temporary-id: true
   add-labels:
     allowed: [squad, "squad:*"]
     create-if-missing: true
@@ -1275,9 +1276,10 @@ substitute, re-route, or fall back to another identity during acceptance.
 
 For each work item, `create-issue`:
 - Title: work item title
+- Temporary ID: `temporary_id` is **required** on every `create-issue` call in this workflow (`require-temporary-id: true`), so mint a unique one per item: `#aw_ph{N}` for a phase issue and `#aw_wi{N}` for a work item, where `{N}` is that row's plan number with non-alphanumeric characters replaced by `_`. It must match `^#?aw_[A-Za-z0-9_]{3,12}$` and must not repeat within this run — gh-aw does not reject a duplicate, it silently lets the last writer own the mapping.
 - Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`) where `{owner}` is the frozen row `Owner` lowercased. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster.
 - Body: scope, acceptance criteria, context (parent, phase, size, depends on, owner), notes, footer
-- Parent: phase issue (hierarchical) or root (flat)
+- Parent: phase issue (hierarchical) or root (flat). For a phase issue created in this run, pass its `#aw_ph{N}` temporary ID — `create-issue` resolves it. The flat-plan root is the triggering issue's own real number. Never guess a number for an issue this run created.
 - Size: set Project field if available, else body `**Size:**` line
 
 Copy every frozen `Depends On` value into the created issue body. Cross-phase
@@ -1736,7 +1738,39 @@ description: Activate an accepted plan by creating the epic and task issues on G
 
 ##### Hallucination Guard
 
-After EVERY `create-issue` call: verify returned issue number, stop on failure, NEVER predict issue numbers.
+`create-issue` does **not** return a real GitHub issue number during this run — gh-aw defers
+creation to the safe-output job, so the agent sees only a success acknowledgement. NEVER
+predict, infer, or "read back" a number for an issue this run created, and never wait for
+one. Use a real number only when verified independently: a pre-existing issue matched by
+title, the triggering issue, or one recorded in a prior run's artifact.
+
+##### Temporary-ID Contract
+
+Every `create-issue` call MUST carry a `temporary_id`, and every operation pointing back at
+that issue MUST reuse the identical value. `require-temporary-id: true` enforces the first
+half — a call without one is rejected. The second half is yours.
+
+**Form.** Matches `^#?aw_[A-Za-z0-9_]{3,12}$`. Write the canonical `#aw_…` form. Dots,
+hyphens, spaces, and `:` are illegal.
+
+**Minting — derive, never invent.** Epic: `#aw_epic{K}`, `{K}` = the epic's 1-based position
+in the accepted plan. Task: `#aw_task{N}`, `{N}` = that task's own `#` cell with every
+character outside `A-Za-z0-9` replaced by `_` (`2.3` → `#aw_task2_3`). If a derived ID
+exceeds 12 characters after `aw_`, drop the `epic`/`task` word (`#aw_e{K}` / `#aw_t{N}`)
+rather than truncating the number — two items must never collapse onto one ID.
+
+**Uniqueness is your responsibility.** gh-aw does not reject a duplicate `temporary_id`; it
+silently lets the last `create-issue` using it own the mapping, so every later reference
+lands on the wrong issue. Confirm each ID is unused before calling. Epics and tasks share one
+namespace, hence the distinct prefixes.
+
+**Explicit targeting is mandatory.** Every `add_labels` call MUST pass `item_number`. Omitting
+it does not fail — it silently labels the **triggering intent issue**, branding the user's own
+request with an activated item's owner label.
+
+**Existing and reused issues.** An issue recognized by Step 1's idempotent-rerun path or a
+dedup-by-title match has a real, verified number: target it by that number, not a temporary
+ID, which only maps issues this run created.
 
 ##### Output Budget Awareness
 
@@ -1788,14 +1822,16 @@ repository instead of creating them, which is the behavior that previously produ
 "prerequisite gap" reported here. Do not rely on `create-issue`'s `labels:` field alone
 to land a label on a fresh repository.
 
-Immediately after each `create-issue` call in Steps 2b/2c returns its real issue number,
-call `add_labels` targeting that number with exactly the label set Steps 4-8 above
-computed for that issue — `squad` alone, or `squad` plus the one `squad:{agent}` label
-the correspondence rule (Step 7) certified. `create-if-missing` creates any label that
-does not yet exist before applying it; re-applying an already-present label on a rerun is
-a no-op, so this is safe under the Step 1 idempotent-rerun path. Never call `add_labels`
-before the matching `create-issue` call has returned and been verified — there is no
-issue number to target yet.
+In the same turn as each `create-issue` call in Steps 2b/2c, call `add_labels` with
+`item_number` set to that call's `temporary_id` and exactly the label set Steps 4-8 computed
+for that issue — `squad` alone, or `squad` plus the one `squad:{agent}` label the
+correspondence rule (Step 7) certified. Do not wait for a returned issue number; none
+arrives. gh-aw resolves `add_labels` after the `create-issue` that minted the ID, so
+`create-issue` first and `add_labels` immediately after is the supported order.
+`create-if-missing` creates any label that does not yet exist before applying it;
+re-applying an already-present label on a rerun is a no-op, so this is safe under the Step 1
+idempotent-rerun path. Never emit `add_labels` for an item whose `create-issue` call was not
+made in this run, and never reuse another item's temporary ID.
 
 ##### Transient Failure Handling
 
@@ -1803,7 +1839,7 @@ On `5xx` response from `create-issue`: wait briefly and retry once. On second fa
 
 ##### Sub-issue Fallback
 
-When setting a `parent` sub-issue relationship returns `404` or `422` (feature disabled or repo plan): degrade gracefully — record the intended parent as a body reference (`Parent: #{issue_number}`), then continue. Never fail activation over sub-issue API unavailability.
+When setting a `parent` sub-issue relationship returns `404` or `422` (feature disabled or repo plan): degrade gracefully — record the intended parent as a body reference, then continue. Write it as the parent's temporary ID (`Parent: #aw_epic{K}`); gh-aw rewrites an `#aw_…` reference in an issue body to the real `#{number}`, so no number is predicted. Use a literal `Parent: #{issue_number}` only for a pre-existing, verified parent. Never fail activation over sub-issue API unavailability.
 
 ##### Step 2: Create Issues — Full Hierarchy
 
@@ -1813,29 +1849,31 @@ Root → Epics → Tasks. Phase-specific: filter to matching phase heading.
 
 **2b. Create Epic Issues:** `create-issue` per epic (dedup by title `[Epic] {name}` if already exists from prior phase).
 - Title: `[Epic] {name}`
+- Temporary ID: `temporary_id: "#aw_epic{K}"` per the Temporary-ID Contract, where `{K}` is this epic's 1-based position in the accepted plan. Required — the call is rejected without it.
 - Labels: `squad` (0075ca), `squad:{agent}` (e4e669) where `{agent}` is **derived from this epic's own tasks**: collect the `Agent` values of every implementation-plan row whose `Epic` cell names this epic. Exactly one distinct roster value → mint `squad:{that agent}`; exactly `@copilot` → mint `squad:copilot`. Two or more → multi-owner epic: apply only `squad` and record it under `Non-roster agent values`. Never mint a single agent label for a multi-owner epic, and never choose one of several.
 - Body: outcome, stories, epic-level acceptance criteria, context (parent, initiative, milestone, deps)
-- Parent: sub-issue of root intent issue
+- Parent: sub-issue of root intent issue — the triggering issue's own real number, which is known independently of this run's creations
 - Milestone: assigned
-- Label application: once `create-issue` returns and the epic's issue number is verified, call `add_labels` on that number with this epic's computed label set (see Label Pre-flight). `create-if-missing` provisions `squad`/`squad:{agent}` on a fresh repository automatically.
+- Label application: in the same turn as this `create-issue` call, call `add_labels` with `item_number` set to this epic's `#aw_epic{K}` temporary ID and this epic's computed label set (see Label Pre-flight). A dedup-by-title match instead targets that existing issue's verified real number. `create-if-missing` provisions `squad`/`squad:{agent}` on a fresh repository automatically.
 
 **⚠️ DO NOT STOP after epics. Tasks MUST follow immediately.**
 
 **2c. Create Task Issues:** `create-issue` per task in dependency order.
 
 > **⚠️ ATOMIC CONTRACT — strictly one task at a time:**
-> For each task: compose ONLY that task's body → call `create-issue` immediately → verify the returned issue number → call `add_labels` on that verified number with the task's computed label set → then move to the next task.
-> **DO NOT** compose or buffer multiple task bodies before making calls. One compose → one call → one verify → one label-application call, repeated per task.
+> For each task: compose ONLY that task's body → call `create-issue` immediately, carrying that task's `temporary_id` → call `add_labels` with `item_number` set to that same temporary ID and the task's computed label set → then move to the next task.
+> **DO NOT** compose or buffer multiple task bodies before making calls. One compose → one `create-issue` call → one `add_labels` call, repeated per task. Do not pause for a returned issue number between the two calls; none is returned.
 
 - Title: task title
+- Temporary ID: `temporary_id: "#aw_task{N}"` per the Temporary-ID Contract, where `{N}` is this task's own `#` cell with non-alphanumeric characters replaced by `_`. Required, and unique across every epic and task in this run.
 - Labels: `squad` (0075ca), `squad:{agent}` (e4e669) where `{agent}` is **this task's own `Agent` cell**, lowercased — read from the implementation-plan row whose `#` matches this task. Map `@copilot` to `squad:copilot`. Never inherit the parent epic's agent, and never carry the previous task's value forward: re-read the `Agent` cell for every task, because consecutive tasks under one epic routinely have different agents. No `size:*` labels unless policy says so.
 - Body: one sentence describing scope; 1-2 acceptance criteria; one compact context line (parent epic, size, deps)
-- Parent: sub-issue of EPIC (not root)
+- Parent: sub-issue of EPIC (not root) — pass the epic's `#aw_epic{K}` temporary ID, which `create-issue`'s `parent` field accepts. Never guess the epic's real number.
 - Milestone: same as parent epic
 - Size: Project field if available, else body line
-- Label application: same as epics — call `add_labels` on the verified task issue number with this task's computed label set (see Label Pre-flight). `create-if-missing` provisions `squad`/`squad:{agent}` on a fresh repository automatically.
+- Label application: same as epics — call `add_labels` with `item_number` set to this task's temporary ID and the task's computed label set (see Label Pre-flight). `create-if-missing` provisions `squad`/`squad:{agent}` on a fresh repository automatically.
 
-**2d. Self-Validation:** Compare created/recognized task count vs expected (use the plan's declared total — not the safe-output cap). If created count is below expected: call `report_incomplete` immediately with `created={N}`, `expected={M}`, and the last verified issue number — never noop. Post: `N of M issues created so far — rerun the identical activation command to continue.` Re-runs are idempotent via title match. Never surface the `create-issue` or `add-comment` safe-output caps as the reason for a partial run.
+**2d. Self-Validation:** Compare requested/recognized task count vs expected (use the plan's declared total — not the safe-output cap). If the requested count is below expected: call `report_incomplete` immediately with `created={N}`, `expected={M}`, and the last task's temporary ID — never noop, and never substitute a guessed issue number. Post: `N of M issues created so far — rerun the identical activation command to continue.` Re-runs are idempotent via title match. Never surface the `create-issue` or `add-comment` safe-output caps as the reason for a partial run.
 
 Labels must have descriptions and intentional colors when they already exist in the
 repository. A label auto-provisioned by `add-labels`'s `create-if-missing` on a fresh
@@ -1844,7 +1882,11 @@ is expected, not a failure, and must not be reported as one.
 
 ##### Step 3: Native Dependency Edges
 
-Add `blockedBy` via API for tasks and epics. Graceful fallback. Never fail activation over edge creation.
+Declare `blocked_by` on the `create-issue` call itself, passing the blocking item's
+temporary ID (`#aw_task{N}` / `#aw_epic{K}`) — `blocked_by` resolves temporary IDs, so this
+needs no real issue number. Use a verified real number only for a dependency on a
+pre-existing issue. Never call a write API with a guessed number to add an edge. Graceful
+fallback to a body reference. Never fail activation over edge creation.
 
 ##### Step 4: Post Activation Record
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1761,8 +1761,7 @@ rather than truncating the number.
 
 **Uniqueness is your responsibility.** gh-aw does not reject a duplicate `temporary_id`; it
 silently lets the last `create-issue` using it own the mapping, so every later reference
-lands on the wrong issue. Confirm each ID is unused before calling. Epics and tasks share one
-namespace, hence the distinct prefixes.
+lands on the wrong issue. Confirm each ID is unused; epics and tasks share one namespace.
 
 **Explicit targeting is mandatory.** Every `add_labels` call MUST pass `item_number`. Omitting
 it does not fail — it silently labels the **triggering intent issue**, branding the user's own
@@ -1867,12 +1866,12 @@ Root → Epics → Tasks. Phase-specific: filter to matching phase heading.
 - Temporary ID: `temporary_id: "#aw_task{N}"` per the Temporary-ID Contract. Required, and unique across every epic and task in this run.
 - Labels: `squad` (0075ca), `squad:{agent}` (e4e669) where `{agent}` is **this task's own `Agent` cell**, lowercased — read from the implementation-plan row whose `#` matches this task. Map `@copilot` to `squad:copilot`. Never inherit the parent epic's agent, and never carry the previous task's value forward: re-read the `Agent` cell for every task, because consecutive tasks under one epic routinely have different agents. No `size:*` labels unless policy says so.
 - Body: one sentence describing scope; 1-2 acceptance criteria; one compact context line (parent epic, size, deps)
-- Parent: sub-issue of EPIC (not root). If 2b minted this epic in this run, pass its `#aw_epic{K}` temporary ID, which `create-issue`'s `parent` field accepts. If 2b instead matched a pre-existing epic by title (a prior phase created it), that epic has no temporary ID in this run — pass its verified real number. Never guess the epic's real number, and never pass a temporary ID that was not minted this run.
+- Parent: sub-issue of EPIC (not root). If 2b minted this epic in this run, pass its `#aw_epic{K}` temporary ID, which `create-issue`'s `parent` field accepts. If 2b instead matched a pre-existing epic by title, that epic has no temporary ID in this run — pass its verified real number. Never guess the epic's real number, and never pass a temporary ID that was not minted this run.
 - Milestone: same as parent epic
 - Size: Project field if available, else body line
 - Label application: same as epics — call `add_labels` with `item_number` set to this task's temporary ID and the task's computed label set (see Label Pre-flight). `create-if-missing` provisions `squad`/`squad:{agent}` on a fresh repository automatically.
 
-**2d. Self-Validation:** Compare requested/recognized task count vs expected (use the plan's declared total — not the safe-output cap). If the requested count is below expected: call `report_incomplete` immediately with `created={N}`, `expected={M}`, and the last task's temporary ID — never noop, and never substitute a guessed issue number. Post: `N of M issues created so far — rerun the identical activation command to continue.` Re-runs are idempotent via title match. Never surface the `create-issue` or `add-comment` safe-output caps as the reason for a partial run.
+**2d. Self-Validation:** The **created count** is the number of `create-issue` calls this run emitted. Compare it against the plan's declared total (not the safe-output cap). If it is lower: call `report_incomplete` immediately with `created={N}` set to that created count, `expected={M}` set to the declared total, and the last task's temporary ID — never noop, and never substitute a guessed issue number. Post: `N of M issues created so far — rerun the identical activation command to continue.` Re-runs are idempotent via title match. Never surface the `create-issue` or `add-comment` safe-output caps as the reason for a partial run.
 
 Labels must have descriptions and intentional colors when they already exist in the
 repository. A label auto-provisioned by `add-labels`'s `create-if-missing` on a fresh

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1276,7 +1276,7 @@ substitute, re-route, or fall back to another identity during acceptance.
 
 For each work item, `create-issue`:
 - Title: work item title
-- Temporary ID: `temporary_id` is **required** on every `create-issue` call in this workflow (`require-temporary-id: true`), so mint a unique one per item: `#aw_ph{N}` for a phase issue and `#aw_wi{N}` for a work item, where `{N}` is that row's plan number with non-alphanumeric characters replaced by `_`. It must match `^#?aw_[A-Za-z0-9_]{3,12}$` and must not repeat within this run — gh-aw does not reject a duplicate, it silently lets the last writer own the mapping.
+- Temporary ID: `temporary_id` is required on every `create-issue` call (`require-temporary-id: true`). Mint one per item: `#aw_ph{N}` for a phase issue and `#aw_wi{N}` for a work item, where `{N}` is that row's plan number with non-alphanumeric characters replaced by `_`. Must match `^#?aw_[A-Za-z0-9_]{3,12}$` and be unique in this run — gh-aw silently lets a duplicate's last writer own the mapping.
 - Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`) where `{owner}` is the frozen row `Owner` lowercased. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster.
 - Body: scope, acceptance criteria, context (parent, phase, size, depends on, owner), notes, footer
 - Parent: phase issue (hierarchical) or root (flat). For a phase issue created in this run, pass its `#aw_ph{N}` temporary ID — `create-issue` resolves it. The flat-plan root is the triggering issue's own real number. Never guess a number for an issue this run created.
@@ -1757,7 +1757,7 @@ hyphens, spaces, and `:` are illegal.
 in the accepted plan. Task: `#aw_task{N}`, `{N}` = that task's own `#` cell with every
 character outside `A-Za-z0-9` replaced by `_` (`2.3` → `#aw_task2_3`). If a derived ID
 exceeds 12 characters after `aw_`, drop the `epic`/`task` word (`#aw_e{K}` / `#aw_t{N}`)
-rather than truncating the number — two items must never collapse onto one ID.
+rather than truncating the number.
 
 **Uniqueness is your responsibility.** gh-aw does not reject a duplicate `temporary_id`; it
 silently lets the last `create-issue` using it own the mapping, so every later reference
@@ -1826,12 +1826,11 @@ In the same turn as each `create-issue` call in Steps 2b/2c, call `add_labels` w
 `item_number` set to that call's `temporary_id` and exactly the label set Steps 4-8 computed
 for that issue — `squad` alone, or `squad` plus the one `squad:{agent}` label the
 correspondence rule (Step 7) certified. Do not wait for a returned issue number; none
-arrives. gh-aw resolves `add_labels` after the `create-issue` that minted the ID, so
-`create-issue` first and `add_labels` immediately after is the supported order.
-`create-if-missing` creates any label that does not yet exist before applying it;
-re-applying an already-present label on a rerun is a no-op, so this is safe under the Step 1
-idempotent-rerun path. Never emit `add_labels` for an item whose `create-issue` call was not
-made in this run, and never reuse another item's temporary ID.
+arrives. gh-aw resolves `add_labels` after the `create-issue` that minted the ID, so that
+order is the supported one. `create-if-missing` creates any label that does not yet exist
+before applying it; re-applying an already-present label on a rerun is a no-op, so this is
+safe under the Step 1 idempotent-rerun path. Never emit `add_labels` for an item whose
+`create-issue` call was not made in this run.
 
 ##### Transient Failure Handling
 
@@ -1839,7 +1838,7 @@ On `5xx` response from `create-issue`: wait briefly and retry once. On second fa
 
 ##### Sub-issue Fallback
 
-When setting a `parent` sub-issue relationship returns `404` or `422` (feature disabled or repo plan): degrade gracefully — record the intended parent as a body reference, then continue. Write it as the parent's temporary ID (`Parent: #aw_epic{K}`); gh-aw rewrites an `#aw_…` reference in an issue body to the real `#{number}`, so no number is predicted. Use a literal `Parent: #{issue_number}` only for a pre-existing, verified parent. Never fail activation over sub-issue API unavailability.
+When setting a `parent` sub-issue relationship returns `404` or `422` (feature disabled or repo plan): degrade gracefully — record the intended parent as a body reference, then continue. If that parent was minted this run, write its temporary ID (`Parent: #aw_epic{K}`); gh-aw rewrites an `#aw_…` body reference to the real `#{number}`, so no number is predicted. If the parent is pre-existing or was matched by dedup, write its verified real number (`Parent: #{issue_number}`) — gh-aw leaves an unresolved `#aw_…` reference in the body verbatim, so a temporary ID it never minted would ship as a meaningless literal. Never fail activation over sub-issue API unavailability.
 
 ##### Step 2: Create Issues — Full Hierarchy
 
@@ -1849,7 +1848,7 @@ Root → Epics → Tasks. Phase-specific: filter to matching phase heading.
 
 **2b. Create Epic Issues:** `create-issue` per epic (dedup by title `[Epic] {name}` if already exists from prior phase).
 - Title: `[Epic] {name}`
-- Temporary ID: `temporary_id: "#aw_epic{K}"` per the Temporary-ID Contract, where `{K}` is this epic's 1-based position in the accepted plan. Required — the call is rejected without it.
+- Temporary ID: `temporary_id: "#aw_epic{K}"` per the Temporary-ID Contract. Required — the call is rejected without it.
 - Labels: `squad` (0075ca), `squad:{agent}` (e4e669) where `{agent}` is **derived from this epic's own tasks**: collect the `Agent` values of every implementation-plan row whose `Epic` cell names this epic. Exactly one distinct roster value → mint `squad:{that agent}`; exactly `@copilot` → mint `squad:copilot`. Two or more → multi-owner epic: apply only `squad` and record it under `Non-roster agent values`. Never mint a single agent label for a multi-owner epic, and never choose one of several.
 - Body: outcome, stories, epic-level acceptance criteria, context (parent, initiative, milestone, deps)
 - Parent: sub-issue of root intent issue — the triggering issue's own real number, which is known independently of this run's creations
@@ -1865,10 +1864,10 @@ Root → Epics → Tasks. Phase-specific: filter to matching phase heading.
 > **DO NOT** compose or buffer multiple task bodies before making calls. One compose → one `create-issue` call → one `add_labels` call, repeated per task. Do not pause for a returned issue number between the two calls; none is returned.
 
 - Title: task title
-- Temporary ID: `temporary_id: "#aw_task{N}"` per the Temporary-ID Contract, where `{N}` is this task's own `#` cell with non-alphanumeric characters replaced by `_`. Required, and unique across every epic and task in this run.
+- Temporary ID: `temporary_id: "#aw_task{N}"` per the Temporary-ID Contract. Required, and unique across every epic and task in this run.
 - Labels: `squad` (0075ca), `squad:{agent}` (e4e669) where `{agent}` is **this task's own `Agent` cell**, lowercased — read from the implementation-plan row whose `#` matches this task. Map `@copilot` to `squad:copilot`. Never inherit the parent epic's agent, and never carry the previous task's value forward: re-read the `Agent` cell for every task, because consecutive tasks under one epic routinely have different agents. No `size:*` labels unless policy says so.
 - Body: one sentence describing scope; 1-2 acceptance criteria; one compact context line (parent epic, size, deps)
-- Parent: sub-issue of EPIC (not root) — pass the epic's `#aw_epic{K}` temporary ID, which `create-issue`'s `parent` field accepts. Never guess the epic's real number.
+- Parent: sub-issue of EPIC (not root). If 2b minted this epic in this run, pass its `#aw_epic{K}` temporary ID, which `create-issue`'s `parent` field accepts. If 2b instead matched a pre-existing epic by title (a prior phase created it), that epic has no temporary ID in this run — pass its verified real number. Never guess the epic's real number, and never pass a temporary ID that was not minted this run.
 - Milestone: same as parent epic
 - Size: Project field if available, else body line
 - Label application: same as epics — call `add_labels` with `item_number` set to this task's temporary ID and the task's computed label set (see Label Pre-flight). `create-if-missing` provisions `squad`/`squad:{agent}` on a fresh repository automatically.
@@ -1883,10 +1882,10 @@ is expected, not a failure, and must not be reported as one.
 ##### Step 3: Native Dependency Edges
 
 Declare `blocked_by` on the `create-issue` call itself, passing the blocking item's
-temporary ID (`#aw_task{N}` / `#aw_epic{K}`) — `blocked_by` resolves temporary IDs, so this
-needs no real issue number. Use a verified real number only for a dependency on a
-pre-existing issue. Never call a write API with a guessed number to add an edge. Graceful
-fallback to a body reference. Never fail activation over edge creation.
+temporary ID (`#aw_task{N}` / `#aw_epic{K}`) — `blocked_by` resolves temporary IDs. Use a
+verified real number only for a dependency on a pre-existing issue. Never call a write API
+with a guessed number to add an edge. Graceful fallback to a body reference. Never fail
+activation over edge creation.
 
 ##### Step 4: Post Activation Record
 


### PR DESCRIPTION
Closes #1962
Parent #1957

Working as **Procedures** (Prompt Engineer) — issue carries `squad:procedures`.

## Problem

The `/squad plan activate` prose instructed the model to read a real GitHub issue number back from each `create-issue` call, then target `add_labels` at that number:

> After EVERY `create-issue` call: verify returned issue number, stop on failure, NEVER predict issue numbers.

gh-aw **never returns an issue number to the agent.** Issue creation is deferred to the post-agent safe-output job, so the agent only ever receives a success acknowledgement. The instruction was therefore unsatisfiable, and it left two failure modes:

1. The model either stalls waiting for a number that never arrives, or invents one.
2. An `add_labels` call whose `item_number` cannot be resolved **does not error** — it silently applies the labels to the **triggering intent issue**, branding the user's own request with an activated item's owner label.

## Fix

Switched the full activation path to gh-aw's supported `temporary_id` linkage.

| Area | Before | After |
|---|---|---|
| Frontmatter | `create-issue` accepted calls without a temp ID | `require-temporary-id: true` — a call without one is rejected |
| Hallucination Guard | "verify returned issue number" | States plainly that no number is returned; forbids predicting, inferring, or waiting |
| `add_labels` | targeted a "verified" real number | `item_number` = the minting `create-issue` call's `temporary_id`; a dedup-matched epic uses its verified real number |
| Task `parent` | implied the epic's real number | epic's `#aw_epic{K}` when minted this run; **verified real number when 2b reused a deduped prior-phase epic** |
| Dependency edges (Step 3) | `blockedBy` via write API with a real number | `blocked_by` declared on the `create-issue` call, using temporary IDs |
| Sub-issue fallback body ref | literal `Parent: #{issue_number}` | `Parent: #aw_epic{K}` when minted this run; **verified real number otherwise** |
| 2d `report_incomplete` | "last verified issue number" | last task's temporary ID |

New **Temporary-ID Contract** section covers:

- **Form** — the real gh-aw pattern `^#?aw_[A-Za-z0-9_]{3,12}$`.
- **Minting — derive, never invent** — `#aw_epic{K}` (1-based epic position), `#aw_task{N}` (task's own `#` cell, non-alphanumerics → `_`, so `2.3` → `#aw_task2_3`). Overflow drops the `epic`/`task` word rather than truncating the number.
- **Uniqueness is the prompt's responsibility** — verified: gh-aw does **not** reject a duplicate `temporary_id`; `temporaryIdMap.set()` silently overwrites, so the last writer owns the mapping and earlier references resolve to the wrong issue. No warning is emitted.
- **Explicit targeting is mandatory** — names the silent-fallback hazard above.
- **Existing and reused issues** — targeted only by verified real numbers, since temporary IDs map only issues this run created.

### Reused/deduped epics (review finding, fixed)

Step 2b dedups epics by title against prior phases. A reused epic was **never minted in this run**, so it has no entry in gh-aw's temporary-ID map — passing `#aw_epic{K}` for it would be an unresolvable reference. Both places that reference an epic now branch on provenance:

- **Step 2c `parent`** — temporary ID only when 2b minted the epic this run; verified real number for a dedup-by-title/prior-phase match. The prose also explicitly forbids passing a temporary ID that was not minted this run.
- **Sub-issue Fallback body reference** — same carve-out, and it matters more here: gh-aw leaves an unresolved `#aw_…` body reference **verbatim** rather than stripping it, so a temporary ID it never minted would ship to the user as a literal `#aw_epic3`.

Preserved unchanged: roster correspondence (per-task `Agent` cell, never inherited from the epic or carried forward), base `squad`, `@copilot` → `squad:copilot`, multi-owner epic behavior, non-roster recording, and origin-issue safety.

## Contract verification (pinned gh-aw v0.87.10)

Checked against the binary's embedded schema and upstream source, not assumed:

- `create_issue.temporary_id` — optional string, `^#?aw_[A-Za-z0-9_]{3,12}$`
- `add_labels.item_number` — `number | string`, `^(\d+|#?aw_[A-Za-z0-9_]{3,12})$`
- `create_issue.parent` / `create_issue.blocked_by` — accept temporary IDs
- `require-temporary-id: true` compiles to `"require_temporary_id":true`, `required_field_additions.create_issue: ["temporary_id"]`, and the agent-facing constraint string `temporary_id is required.`
- Ordering is safe: the topological sort inspects `create_issue.blocked_by`; an `add_labels` hitting an unresolved temp ID returns `deferred` and gets one retry pass — so `create-issue` then `add_labels` is the supported order.
- `replaceTemporaryIdReferences()` leaves an **unresolved** `#aw_…` body reference intact — the basis for the fallback carve-out above.

## ⚠️ Two things reviewers should confirm

**1. `require-temporary-id` is workflow-global, not per-skill.**

It is enforced in `safe_outputs_handlers.cjs` at the MCP tool layer from the single `config.create_issue` block. `workflows/squad.md` has a second `create_issue` caller — the `squad-plan-accept` fast path (#1959's scope) — whose calls would be rejected outright once the flag is on. I enabled the flag (an explicit #1962 success criterion) **plus** the smallest possible compliance edit to the fast path: mint a temporary ID and use it for `parent`. I deliberately did **not** add `add_labels` or `create-if-missing` there — that remains #1959, and an existing test asserts their absence in that region (still passing).

**2. The `Activation bindings:` JSON block still references real issue numbers — and cannot be fixed here.**

`replaceTemporaryIdReferences()` replaces an `#aw_task1` token with `` `#${number}` `` — the `#` is **retained** for same-repo refs. Embedding `#aw_` refs in that JSON code block would emit `"issue": #42`, which is invalid JSON. There is no substitution form that yields a bare number. Per the instruction to report rather than invent a workaround, I left the block unchanged and am flagging it as a **blocker/decision for #1963** rather than papering over it. This means #1962's "no operation relies on an inferred issue number" is satisfied for every *targeting* operation but not yet for that *reporting* block.

Viable avenue for #1963: gh-aw exposes the resolved map as `steps.process_safe_outputs.outputs.temporary_id_map` (JSON `{ "aw_id": {"repo":..., "number":N} }`) and as artifact `/tmp/gh-aw/temporary-id-map.json`.

## Validation

- **Strict compile:** all 4 workflows (`squad`, `squad-implement-worker`, `squad-review`, `squad-deps-worker`) compile with `--strict`, all 4 lock files emitted, `FAILED=0`. Remaining warnings are pre-existing on `dev` (concurrency discriminator, slash_command+bots).
- **Targeted tests:** `296 passed` across `gh-aw-activation-temporary-ids`, `gh-aw-activation-label-provisioning`, `gh-aw-agent-binding-correspondence`, `gh-aw-activate-roster-binding`, `gh-aw-plan-lifecycle`, `gh-aw-quality`.
- **Build:** `npm run build` passes.
- **Full suite:** `8127 passed`. The 12 failures in `cli-packaging-smoke` / `acceptance` / external-state CLI tests are **pre-existing** — reproduced identically on the baseline with my changes stashed.

## Test changes

**Updated** `test/gh-aw-activation-label-provisioning.test.ts` — one test asserted the prose must contain "never call `add_labels` before [create-issue] has returned a real issue number". That sentence encoded the exact invalid premise this issue corrects, so the test now asserts the inverse contract (the old rule is gone; the prose tells the model not to wait; create-issue returns no number).

**Added** `test/gh-aw-activation-temporary-ids.test.ts` (18 tests) — narrowly scoped to #1962: temporary-ID declaration on every activation `create-issue`, the documented gh-aw pattern, deterministic minting, the uniqueness mandate, mandatory explicit `item_number`, `add_labels` → `temporary_id` wiring, no-prediction rules, real numbers for reused issues, 2b/2c temp-ID fields, epic-as-parent, **reused-epic parent targeting**, **sub-issue fallback provenance branching**, `blocked_by` on `create-issue`, plus compiled-lock assertions that `require_temporary_id` actually reaches the handler config. Fails closed on a missing `gh aw` per the repo's #1834 convention.

Prose was tightened to stay under the existing 160 KB source-growth guard rather than raising it.

## Out of scope (untouched)

`/squad activate` fast-path provisioning (#1959, beyond the minimal compliance edit above), activation reporting redesign (#1963), capacity safeguards (#1961), broad behavioral suite (#1960), E4 (#1958), checker distribution.

No changeset: no `packages/*/src/` or `templates/` changes, so the `changelog-gate` path regex does not match.

> **Note:** #1964 conflicts at Step 2d. Not merged or rebased into this branch — the parent coordinator is sequencing integration.