### PR TITLE
fix(workflows): provision labels in the /squad activate fast path

### DIFF
--- a/test/gh-aw-activate-fast-path-label-provisioning.test.ts
+++ b/test/gh-aw-activate-fast-path-label-provisioning.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Fresh-repo label provisioning for the recommended `/squad activate` fast path (#1959).
+ *
+ * Parent: #1957. Depends on #1962 (`gh-aw-activation-temporary-ids.test.ts`), which
+ * established the temporary-ID targeting pattern for the full `/squad plan activate`
+ * path and enabled workflow-global `require-temporary-id: true`.
+ *
+ * `/squad activate` routes to the `squad-plan-accept` skill. When only a flat `plan`
+ * artifact exists (no `program`/`implementation`), it takes its own fast path with its
+ * own `create-issue` calls. #1955 fixed provisioning in `squad-plan-activate` only, and
+ * #1962 added just enough temporary-ID compliance here to survive the new global flag —
+ * so on a fresh repository the fast path still leaned on `create-issue`'s `labels:`
+ * field, which GitHub silently drops for label names that do not already exist.
+ *
+ * This suite locks in the fast path's own copy of the verified pattern:
+ *   - every fast-path `create-issue` still carries a unique temporary ID (#1962's
+ *     compliance edit is preserved, not regressed)
+ *   - `add_labels` is called in the same turn, targeting that call's temporary ID
+ *   - `item_number` is mandatory, with the silent triggering-issue fallback named
+ *   - reused/pre-existing issues are targeted by verified real numbers instead
+ *   - base `squad`, single certified owner, `@copilot`, multi-owner, and non-roster
+ *     behavior stays at parity with `squad-plan-activate`
+ *   - the origin intent issue is never an `add_labels` target
+ *   - reruns stay idempotent
+ *
+ * Out of scope: activation-result reporting redesign (#1963), operation-capacity policy
+ * (#1961), the broad behavioral suite (#1960), checker distribution, and E4 (#1958).
+ */
+
+import { afterAll, describe, it, expect } from 'vitest';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const WORKFLOWS_DIR = join(process.cwd(), 'workflows');
+const SQUAD_WORKFLOW = join(WORKFLOWS_DIR, 'squad.md');
+const TEST_WORKSPACES_DIR = join(process.cwd(), '.test-workspaces-fast-path-labels');
+
+afterAll(() => {
+  rmSync(TEST_WORKSPACES_DIR, { recursive: true, force: true });
+});
+
+/** Read a text file with line endings normalized to LF (Windows checkouts materialize CRLF). */
+function readText(filePath: string): string {
+  return readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+}
+
+const workflow = readText(SQUAD_WORKFLOW);
+
+/**
+ * Isolate the `squad-plan-accept` skill body — the fast path `/squad activate` routes to.
+ * It has no `## end skill:` marker of its own, so its body runs to the next `## skill:`
+ * heading (`squad-plan-revise`).
+ */
+const ACCEPT_START = workflow.indexOf('## skill: `squad-plan-accept`');
+const ACCEPT_END = workflow.indexOf('## skill: `squad-plan-revise`');
+expect(ACCEPT_START, '"## skill: `squad-plan-accept`" is missing from workflows/squad.md').toBeGreaterThan(-1);
+expect(ACCEPT_END, '"## skill: `squad-plan-revise`" is missing from workflows/squad.md').toBeGreaterThan(ACCEPT_START);
+const acceptSkill = workflow.slice(ACCEPT_START, ACCEPT_END);
+
+/** Whitespace-collapsed view for prose assertions that may span wrapped lines. */
+const acceptProse = acceptSkill.replace(/\s+/g, ' ');
+
+/** The `squad-plan-activate` body, used only for path-parity comparisons. */
+const ACTIVATE_START = workflow.indexOf('## skill: `squad-plan-activate`');
+const ACTIVATE_END = workflow.indexOf('## end skill: `squad-plan-activate`');
+expect(ACTIVATE_START, '"## skill: `squad-plan-activate`" is missing from workflows/squad.md').toBeGreaterThan(-1);
+expect(ACTIVATE_END, '"## end skill: `squad-plan-activate`" is missing').toBeGreaterThan(ACTIVATE_START);
+const activateProse = workflow.slice(ACTIVATE_START, ACTIVATE_END).replace(/\s+/g, ' ');
+
+describe('gh-aw: /squad activate fast path provisions labels on a fresh repo (#1959)', () => {
+  it('routes `/squad activate` to squad-plan-accept, so this skill is the fast path', () => {
+    // If routing ever moves, every assertion below is inspecting the wrong skill.
+    expect(workflow).toContain('| `activate` | `squad-plan-accept` |');
+    expect(workflow).toContain('| `/squad activate` | Activate (recommended fast-path) |');
+  });
+
+  it('names the root cause: create-issue labels: cannot create a missing label', () => {
+    expect(
+      /GitHub silently drops label names that do not already exist/i.test(acceptProse),
+      "The fast path must state why create-issue's own labels: field is insufficient — " +
+        'GitHub drops unknown label names on POST /issues rather than creating them. ' +
+        'Without this the model has no reason to make the extra add_labels call.',
+    ).toBe(true);
+    expect(acceptProse).toMatch(/`create-issue`'s (own )?`labels:` field (alone )?cannot/i);
+  });
+
+  it('declares add_labels with create-if-missing as the provisioning mechanism', () => {
+    expect(acceptSkill).toContain('add_labels');
+    expect(acceptSkill).toContain('create-if-missing');
+    expect(acceptProse).toMatch(/`add-labels` safe output \(`allowed: \[squad, "squad:\*"\]`, `create-if-missing: true`\)/);
+    expect(
+      /fresh repository/i.test(acceptProse),
+      'The fresh-repository case is the entire point of #1959 and must be named explicitly.',
+    ).toBe(true);
+  });
+
+  it('calls add_labels in the same turn as each create-issue call', () => {
+    expect(acceptProse).toMatch(/In the same turn as each `create-issue` call in Step 2, call `add_labels`/i);
+    // The per-item bullet must carry the instruction too, not just the section prose,
+    // so a model reading only the create-issue recipe still emits the label call.
+    const labelApplication = acceptSkill.match(/^- Label application:.*$/m)?.[0] ?? '';
+    expect(labelApplication, 'Step 2 needs a per-item "Label application:" bullet').not.toBe('');
+    expect(labelApplication).toContain('add_labels');
+    expect(labelApplication).toContain('item_number');
+  });
+});
+
+describe('#1959: fast-path add_labels targets an explicit, verified item', () => {
+  it('targets the minting create-issue call\'s own temporary ID', () => {
+    expect(acceptProse).toMatch(
+      /`item_number` — that same `create-issue` call's `temporary_id` \(`#aw_ph\{N\}` for a phase issue, `#aw_wi\{N\}` for a work item\)/i,
+    );
+    const labelApplication = acceptSkill.match(/^- Label application:.*$/m)?.[0] ?? '';
+    expect(labelApplication).toMatch(/`item_number` set to this item's own temporary ID/i);
+  });
+
+  it('preserves #1962\'s minimal temp-ID compliance on every fast-path create-issue', () => {
+    // Regression guard: #1962 enabled workflow-global require-temporary-id: true, which
+    // rejects any create-issue call lacking one. #1959 must not weaken that.
+    const tempIdBullet = acceptSkill.match(/^- Temporary ID:.*$/m)?.[0] ?? '';
+    expect(tempIdBullet, 'Step 2 must keep its "Temporary ID:" bullet').not.toBe('');
+    expect(tempIdBullet).toContain('require-temporary-id: true');
+    expect(tempIdBullet).toContain('#aw_ph{N}');
+    expect(tempIdBullet).toContain('#aw_wi{N}');
+    expect(tempIdBullet).toContain('^#?aw_[A-Za-z0-9_]{3,12}$');
+    expect(tempIdBullet).toMatch(/must not repeat within this run/i);
+    // The phase-issue parent linkage from #1962 must still resolve via temporary ID.
+    expect(acceptProse).toMatch(/pass its `#aw_ph\{N\}` temporary ID/i);
+  });
+
+  it('makes item_number mandatory and names the silent triggering-issue fallback', () => {
+    expect(acceptProse).toMatch(/Every `add_labels` call MUST pass `item_number`/);
+    expect(
+      /Omitting it does not fail — it silently applies the labels to the \*\*triggering intent issue\*\*/i.test(
+        acceptProse,
+      ),
+      'The hazard must be stated as a silent mislabel of the user\'s own issue, not a ' +
+        'generic "always pass item_number" — the model needs the consequence to weigh it.',
+    ).toBe(true);
+    // Parity: squad-plan-activate states the identical hazard.
+    expect(activateProse).toMatch(/silently labels the \*\*triggering intent issue\*\*/i);
+  });
+
+  it('forbids borrowing another item\'s temporary ID or labeling an uncreated item', () => {
+    expect(acceptProse).toMatch(/Never reuse another item's temporary ID/i);
+    expect(acceptProse).toMatch(
+      /never emit `add_labels` for an item whose `create-issue` call was not made in this run/i,
+    );
+  });
+
+  it('uses verified real numbers for reused or pre-existing issues', () => {
+    expect(acceptProse).toMatch(
+      /For an issue this run did \*\*not\*\* create — one recognized by Step 1a's idempotency check or matched by title — pass its verified real number instead/i,
+    );
+    expect(acceptProse).toMatch(/a temporary ID maps only issues this run created/i);
+  });
+
+  it('forbids predicting a returned issue number or waiting for one', () => {
+    expect(acceptProse).toMatch(
+      /`create-issue` returns no real issue number during this run, so never predict or infer one and never pause between the two calls waiting for one/i,
+    );
+    expect(acceptProse).toMatch(/`create-issue` first and `add_labels` immediately after is the supported order/i);
+  });
+});
+
+describe('#1959: fast-path label sets stay at parity with squad-plan-activate', () => {
+  it('applies the base squad label to every activated item', () => {
+    expect(acceptProse).toMatch(/Work item: `squad`, plus `squad:\{owner\}`/);
+    expect(acceptProse).toMatch(/Phase issue: `squad`, plus `squad:\{owner\}`/);
+  });
+
+  it('derives the member label from that row\'s own frozen certified Owner', () => {
+    expect(acceptProse).toMatch(
+      /derived from that row's own frozen certified `Owner`, lowercased/i,
+    );
+    expect(acceptProse).toMatch(
+      /never inherit the phase issue's owner or carry the previous row's value forward/i,
+    );
+    // The Step 2 computation bullet must still name its certified binding source.
+    const labelRule = acceptSkill.match(/^- Labels:.*$/m)?.[0] ?? '';
+    expect(labelRule).toMatch(/frozen row `Owner` lowercased/i);
+    expect(labelRule).toMatch(/only from that task's certified binding/i);
+  });
+
+  it('maps @copilot to squad:copilot, matching the full activation path', () => {
+    expect(acceptProse).toMatch(/`@copilot` maps to the existing `squad:copilot` routing label — never `squad:@copilot`/);
+    expect(activateProse).toMatch(/`@copilot` maps to the existing `squad:copilot` routing label — never `squad:@copilot`/);
+    // The pre-mutation roster gate must not treat @copilot as an uncertified value,
+    // or the mapping above would be unreachable.
+    expect(acceptProse).toMatch(/the special value `@copilot` excepted/i);
+  });
+
+  it('gives a multi-owner phase issue only squad, and records the omission', () => {
+    expect(acceptProse).toMatch(
+      /only when every accepted row in that phase names one and the same owner/i,
+    );
+    expect(acceptProse).toMatch(
+      /Two or more distinct owners is a multi-owner phase: apply only `squad`, choose none of them/i,
+    );
+    expect(acceptProse).toMatch(/record it under a `Non-roster agent values` heading/i);
+    // Parity with the epic rule in squad-plan-activate.
+    expect(activateProse).toMatch(/multi-owner epic: apply only `squad`/i);
+  });
+
+  it('keeps the pre-mutation stop as the fast path\'s non-roster contract', () => {
+    // The fast path is stricter than squad-plan-activate here: it refuses to mutate at
+    // all rather than creating an issue with an omitted label. That is preserved, and
+    // it is why no uncertified value can reach add_labels.
+    expect(acceptProse).toMatch(/stop before mutation and require `\/squad plan revise`/i);
+    expect(acceptProse).toMatch(
+      /An `Owner` that is neither a certified roster name nor `@copilot` already stopped this run before mutation/i,
+    );
+    expect(acceptProse).toMatch(/no uncertified value can ever reach `add_labels`/i);
+  });
+
+  it('never targets the triggering intent issue with an owner label', () => {
+    expect(acceptProse).toMatch(
+      /The triggering intent issue is never an `add_labels` target/i,
+    );
+    expect(acceptProse).toMatch(
+      /It is the flat-plan parent, not an activated item, and receives no owner label from this run/i,
+    );
+  });
+
+  it('keeps reruns idempotent', () => {
+    expect(acceptProse).toMatch(
+      /Re-applying an already-present label on a rerun is a no-op under add-only merge semantics/i,
+    );
+    expect(acceptProse).toMatch(/safe under Step 1a's idempotency path/i);
+    // The pre-existing whole-plan idempotency contract must survive untouched.
+    expect(acceptProse).toMatch(/\*\*Whole-plan idempotency:\*\* when `requested_phase` is null/i);
+  });
+
+  it('treats an auto-provisioned label\'s default color as expected, not a failure', () => {
+    expect(acceptProse).toMatch(
+      /auto-provisioned by `create-if-missing` on a fresh repository instead receives gh-aw's deterministic color and an empty description/i,
+    );
+    expect(acceptProse).toMatch(/that is expected, not a failure, and must not be reported as one/i);
+  });
+
+  it('reports labels actually applied, never merely intended', () => {
+    expect(acceptProse).toMatch(
+      /Report only the labels a successful `add_labels` call actually applied; never a label that was skipped, deferred, or merely intended/i,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compiled-artifact verification
+// ---------------------------------------------------------------------------
+//
+// The assertions above lock the prose contract. This section proves the fast path's
+// calls are actually executable: `gh aw compile --strict` must expose add_labels and
+// create_issue as tools, wire create_if_missing into the handler config, and keep
+// #1962's require_temporary_id enforcement on. Fails closed (never skips) per this
+// repo's #1833/#1834 convention: an unmeasured contract is indistinguishable from a
+// violated one.
+
+const GH_AW_INSTALL_HINT =
+  '`gh aw` is required to compile the workflow this gate inspects. Install it with ' +
+  '`gh extension install github/gh-aw` (matches .github/workflows/squad-ci.yml). This ' +
+  'gate fails closed rather than skipping: an unmeasured contract is indistinguishable ' +
+  'from a violated one (#1834).';
+
+describe('gh-aw: the fast path\'s label calls compile and stay enforceable (#1959)', () => {
+  let compiledLock: string | null = null;
+
+  function lockText(): string {
+    if (compiledLock !== null) return compiledLock;
+
+    const versionProbe = spawnSync('gh', ['aw', '--version'], { encoding: 'utf8' });
+    if (versionProbe.status !== 0) {
+      throw new Error(`gh aw --version failed. ${GH_AW_INSTALL_HINT}`);
+    }
+
+    mkdirSync(TEST_WORKSPACES_DIR, { recursive: true });
+    const workspace = mkdtempSync(join(TEST_WORKSPACES_DIR, 'fast-path-labels-'));
+    execFileSync('git', ['init', '--quiet'], { cwd: workspace });
+    // gh-aw's dispatch-workflow validation resolves cross-workflow references against a
+    // `.github/workflows/` directory relative to the compiled file. This repo ships the
+    // gh-aw *source* from a top-level `workflows/` dir; consumers install it into
+    // `.github/workflows/` via `gh aw add`. Mirror that real deployment layout.
+    cpSync(WORKFLOWS_DIR, join(workspace, '.github', 'workflows'), { recursive: true });
+    execFileSync(
+      'gh',
+      ['aw', 'compile', '.github/workflows/squad.md', '--strict', '--approve', '--no-check-update'],
+      { cwd: workspace, encoding: 'utf8', stdio: 'pipe' },
+    );
+
+    const lockPath = join(workspace, '.github', 'workflows', 'squad.lock.yml');
+    if (!existsSync(lockPath)) {
+      throw new Error(
+        'gh aw compile produced no squad.lock.yml — the compiled artifact this gate ' +
+          `inspects is absent, so the contract is unmeasured. ${GH_AW_INSTALL_HINT}`,
+      );
+    }
+    compiledLock = readText(lockPath);
+    return compiledLock;
+  }
+
+  it('strict-compiles the workflow carrying the fast-path label calls', () => {
+    expect(lockText().length).toBeGreaterThan(0);
+  });
+
+  it('keeps add_labels and create_issue callable together, so the fast path can pair them', () => {
+    const compiled = lockText();
+    expect(compiled).toMatch(/"tools":\[[^\]]*"add_labels"[^\]]*\]/);
+    expect(compiled).toMatch(/"tools":\[[^\]]*"create_issue"[^\]]*\]/);
+  });
+
+  it('wires create_if_missing into the handler config the fast path relies on', () => {
+    // gh-aw embeds this JSON config inside a double-quoted YAML env value with every
+    // `"` backslash-escaped. De-escape before matching so this holds across versions.
+    const compiled = lockText().replace(/\\"/g, '"');
+    expect(compiled).toMatch(/"add_labels":\{[^}]*"create_if_missing":true/);
+    expect(compiled).toMatch(/"add_labels":\{[^}]*"allowed":\["squad","squad:\*"\]/);
+  });
+
+  it('keeps #1962\'s require_temporary_id enforcement on for the fast path\'s create_issue calls', () => {
+    // require-temporary-id is workflow-global, enforced at the MCP tool layer from the
+    // single create_issue config block — it covers squad-plan-accept's calls too.
+    const compiled = lockText().replace(/\\"/g, '"');
+    expect(compiled).toMatch(/"create_issue":\{[^}]*"require_temporary_id":true/);
+    expect(compiled).toMatch(/"required_field_additions":\s*\{\s*"create_issue":\s*\[\s*"temporary_id"\s*\]/);
+  });
+
+  it('leaves label writes in the safe-output job, not the agent job', () => {
+    const compiled = lockText();
+    const agentJobAt = compiled.indexOf('\n  agent:\n');
+    const safeOutputsJobAt = compiled.indexOf('\n  safe_outputs:\n');
+    expect(agentJobAt, '"agent:" job is missing from the compiled lock file').toBeGreaterThan(-1);
+    expect(safeOutputsJobAt, '"safe_outputs:" job is missing from the compiled lock file').toBeGreaterThan(agentJobAt);
+
+    const permsMatch = compiled.slice(agentJobAt, safeOutputsJobAt).match(/permissions:\n((?:\s{6}\S.*\n)+)/);
+    expect(permsMatch, 'agent job permissions block not found').not.toBeNull();
+    const permsBlock = permsMatch ? permsMatch[1] : '';
+    expect(permsBlock).toContain('issues: read');
+    expect(permsBlock).not.toContain('issues: write');
+  });
+});

--- a/test/gh-aw-activate-fast-path-label-provisioning.test.ts
+++ b/test/gh-aw-activate-fast-path-label-provisioning.test.ts
@@ -19,7 +19,9 @@
  *   - `item_number` is mandatory, with the silent triggering-issue fallback named
  *   - reused/pre-existing issues are targeted by verified real numbers instead
  *   - base `squad`, single certified owner, `@copilot`, multi-owner, and non-roster
- *     behavior stays at parity with `squad-plan-activate`
+ *     behavior stays at parity with `squad-plan-activate` — including the `@copilot`
+ *     mapping stated in the *primary* Step 2 label computation, not only in the
+ *     provisioning prose, and omit-and-record (not a hard stop) for an uncertified owner
  *   - the origin intent issue is never an `add_labels` target
  *   - reruns stay idempotent
  *
@@ -183,12 +185,27 @@ describe('#1959: fast-path label sets stay at parity with squad-plan-activate', 
     expect(labelRule).toMatch(/only from that task's certified binding/i);
   });
 
-  it('maps @copilot to squad:copilot, matching the full activation path', () => {
+  it('maps @copilot to squad:copilot in the primary label computation itself', () => {
+    // The bug this guards: the Step 2 `- Labels:` bullet is the *primary* computation —
+    // it says "the frozen row `Owner` lowercased", which turns `@copilot` into the
+    // invalid `squad:@copilot`. Stating the mapping only in the provisioning section
+    // below leaves the primary rule wrong, and a model following the bullet literally
+    // still emits the bad label. Assert against the extracted bullet, not the whole
+    // skill, so a correct-elsewhere/wrong-here workflow cannot pass.
+    const labelRule = acceptSkill.match(/^- Labels:.*$/m)?.[0] ?? '';
+    expect(labelRule, 'Step 2 must have a "- Labels:" computation bullet').not.toBe('');
+    expect(
+      /Map `@copilot` to `squad:copilot`/.test(labelRule),
+      'The `- Labels:` bullet must carry the @copilot mapping inline.',
+    ).toBe(true);
+    expect(
+      /never `squad:@copilot`/.test(labelRule),
+      'The `- Labels:` bullet must forbid the lowercased-verbatim form explicitly.',
+    ).toBe(true);
+
+    // Still stated in the provisioning section, and identical to the full path.
     expect(acceptProse).toMatch(/`@copilot` maps to the existing `squad:copilot` routing label — never `squad:@copilot`/);
     expect(activateProse).toMatch(/`@copilot` maps to the existing `squad:copilot` routing label — never `squad:@copilot`/);
-    // The pre-mutation roster gate must not treat @copilot as an uncertified value,
-    // or the mapping above would be unreachable.
-    expect(acceptProse).toMatch(/the special value `@copilot` excepted/i);
   });
 
   it('gives a multi-owner phase issue only squad, and records the omission', () => {
@@ -203,15 +220,60 @@ describe('#1959: fast-path label sets stay at parity with squad-plan-activate', 
     expect(activateProse).toMatch(/multi-owner epic: apply only `squad`/i);
   });
 
-  it('keeps the pre-mutation stop as the fast path\'s non-roster contract', () => {
-    // The fast path is stricter than squad-plan-activate here: it refuses to mutate at
-    // all rather than creating an issue with an omitted label. That is preserved, and
-    // it is why no uncertified value can reach add_labels.
-    expect(acceptProse).toMatch(/stop before mutation and require `\/squad plan revise`/i);
+  it('omits and records a non-roster owner instead of stopping, matching full activation', () => {
+    // #1959 requires parity with squad-plan-activate. The fast path previously stopped
+    // before any mutation on an uncertified Owner; that is now aligned to omit-and-record
+    // so both activation paths behave identically for the same plan.
+    const labelRule = acceptSkill.match(/^- Labels:.*$/m)?.[0] ?? '';
+    expect(
+      /An `Owner` certified by neither route gets `squad` alone: omit the owner label, continue, and record the value under `Non-roster agent values`/.test(
+        labelRule,
+      ),
+      'The primary label computation must carry the omit-and-record rule inline, not ' +
+        'defer it to prose elsewhere in the skill.',
+    ).toBe(true);
+
     expect(acceptProse).toMatch(
-      /An `Owner` that is neither a certified roster name nor `@copilot` already stopped this run before mutation/i,
+      /An individual `Owner` matching no certified active roster name and not `@copilot` does \*\*not\*\* stop the run/i,
     );
-    expect(acceptProse).toMatch(/no uncertified value can ever reach `add_labels`/i);
+    expect(acceptProse).toMatch(
+      /create that issue with the base `squad` label only, omit the owner label, continue, and record the value under `Non-roster agent values`/i,
+    );
+    expect(acceptProse).toMatch(
+      /an uncertified value can reach `add_labels` only as the base `squad` label/i,
+    );
+
+    // The old stop must be gone — a lingering `/squad plan revise` hard stop would
+    // contradict the rule above and reintroduce the divergence.
+    expect(
+      acceptProse,
+      'The pre-mutation stop on an uncertified Owner must be removed, not merely ' +
+        'supplemented — otherwise the fast path still diverges from squad-plan-activate.',
+    ).not.toMatch(/stop before mutation and require `\/squad plan revise`/i);
+
+    // Parity: squad-plan-activate's own omit-and-record rule.
+    expect(activateProse).toMatch(
+      /MUST NOT become a\s+`squad:\{agent\}` label: apply only `squad` for that issue/i,
+    );
+  });
+
+  it('still stops before mutation when the roster itself is unreadable', () => {
+    // ROSTER_UNREADABLE is a different failure: no certified set exists at all, so
+    // omit-and-record has nothing to certify against. squad-plan-activate stops here
+    // too — this is parity, not a leftover of the removed per-owner stop.
+    expect(acceptProse).toMatch(
+      /If TG-2 emitted a `ROSTER_UNREADABLE:` line, stop before mutation and report that named reason/i,
+    );
+    expect(activateProse).toMatch(/If TG-2 emitted a `ROSTER_UNREADABLE:` line, STOP:/);
+  });
+
+  it('requires the Non-roster agent values heading the omissions feed', () => {
+    // The omit-and-record rule is only coherent if the heading it records into is
+    // actually mandated. Without this, "record it" points at nothing.
+    expect(acceptProse).toMatch(
+      /Whenever an accepted `Owner` did not become a `squad:\{owner\}` label — a multi-owner phase issue, or a value certified by neither the roster nor `@copilot` — a `Non-roster agent values` heading is \*\*required\*\* in this summary, naming the value and the issue it applied to/i,
+    );
+    expect(acceptProse).toMatch(/Omitting the label while omitting the heading reports a clean run that did not happen/i);
   });
 
   it('never targets the triggering intent issue with an owner label', () => {

--- a/test/gh-aw-activation-label-provisioning.test.ts
+++ b/test/gh-aw-activation-label-provisioning.test.ts
@@ -23,7 +23,10 @@
  * Out of scope (per #1955's delegated task boundaries): running the E4 live end-to-end
  * test, and the `squad-plan-accept` fast-path's own separate create-issue/label logic
  * (only reachable when a flat `plan` artifact exists with no `program`/`implementation`
- * artifacts — see workflows/squad.md's `squad-plan-accept` skill).
+ * artifacts — see workflows/squad.md's `squad-plan-accept` skill). #1959 subsequently
+ * brought that fast path onto the same pattern; its own contract is locked in
+ * `gh-aw-activate-fast-path-label-provisioning.test.ts`, and the boundary test below now
+ * asserts the parity instead of the former gap.
  */
 
 import { afterAll, describe, it, expect } from 'vitest';
@@ -195,7 +198,7 @@ describe('gh-aw: fresh-repo label provisioning in squad-plan-activate (#1955)', 
     expect(activateProse).toMatch(/Re-runs are idempotent via title match/i);
   });
 
-  it('does not touch the separate squad-plan-accept fast-path label logic (out of scope)', () => {
+  it('extends the same provisioning pattern to the squad-plan-accept fast path (#1959)', () => {
     const acceptStart = workflow.indexOf('## skill: `squad-plan-accept`');
     expect(acceptStart, '"## skill: `squad-plan-accept`" is missing from workflows/squad.md').toBeGreaterThan(-1);
     // squad-plan-accept has no "## end skill" marker of its own; its body runs until the
@@ -204,11 +207,11 @@ describe('gh-aw: fresh-repo label provisioning in squad-plan-activate (#1955)', 
     expect(acceptEnd, '"## skill: `squad-plan-revise`" is missing from workflows/squad.md').toBeGreaterThan(acceptStart);
 
     const acceptSkill = workflow.slice(acceptStart, acceptEnd);
-    // #1955 is scoped to squad-plan-activate only; squad-plan-accept's own
-    // create-issue/label fast path (reachable only for a flat plan with no
-    // program/implementation artifacts) is intentionally unmodified here.
-    expect(acceptSkill).not.toContain('add_labels');
-    expect(acceptSkill).not.toContain('create-if-missing');
+    // #1955 landed provisioning in squad-plan-activate only. #1959 applied the same
+    // add_labels + create-if-missing pattern to the fast path, so the two activation
+    // paths now provision labels identically. Assert the parity rather than the old gap.
+    expect(acceptSkill).toContain('add_labels');
+    expect(acceptSkill).toContain('create-if-missing');
   });
 });
 

--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -876,7 +876,15 @@ describe('gh-aw: prompt budget & planning import regression', () => {
   // "keeps the ambient prompt under 40 KB". The check below is only a source-GROWTH
   // regression guard: it keeps unbounded authoring growth visible without pretending
   // authored bytes are delivered bytes.
-  const SOURCE_GROWTH_BUDGET_KB = 160;
+  //
+  // Raised 160 → 170 KB by #1959. The fast-path label-provisioning contract it adds
+  // lives entirely inside the `squad-plan-accept` inline `## skill:` block, so gh-aw
+  // strips it from the ambient prompt — "keeps the ambient prompt under 40 KB" is
+  // unaffected and still passing, which is exactly the condition the comment above
+  // names as making a raise legitimate. At 160 KB the guard had ~37 bytes of headroom
+  // left after #1962, so it had stopped measuring growth and started blocking any
+  // correct change; 170 KB restores a usable margin without removing the signal.
+  const SOURCE_GROWTH_BUDGET_KB = 170;
   const SOURCE_GROWTH_BUDGET_BYTES = SOURCE_GROWTH_BUDGET_KB * 1024;
 
   it('squad-planning-ontology.md is in the imports list', () => {

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1270,15 +1270,18 @@ Do not create an additional epic, summary, root, or phase issue for a flat plan.
 
 Before any `create-issue` call, run Team Guard Step TG-2 and validate every
 accepted plan row. Freeze a binding for each task number containing that row's
-original `Owner` and `Depends On` values. If any `Owner` does not match a certified
-active roster name — the special value `@copilot` excepted — stop before mutation and
-require `/squad plan revise`; never
-substitute, re-route, or fall back to another identity during acceptance.
+original `Owner` and `Depends On` values. If TG-2 emitted a `ROSTER_UNREADABLE:`
+line, stop before mutation and report that named reason. An individual `Owner`
+matching no certified active roster name and not `@copilot` does **not** stop the
+run — matching `squad-plan-activate`, create that issue with the base `squad` label
+only, omit the owner label, continue, and record the value under
+`Non-roster agent values` (Step 4). Never substitute, re-route, or fall back to
+another identity during acceptance.
 
 For each work item, `create-issue`:
 - Title: work item title
 - Temporary ID: `temporary_id` is **required** on every `create-issue` call in this workflow (`require-temporary-id: true`), so mint a unique one per item: `#aw_ph{N}` for a phase issue and `#aw_wi{N}` for a work item, where `{N}` is that row's plan number with non-alphanumeric characters replaced by `_`. It must match `^#?aw_[A-Za-z0-9_]{3,12}$` and must not repeat within this run — gh-aw does not reject a duplicate, it silently lets the last writer own the mapping.
-- Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`) where `{owner}` is the frozen row `Owner` lowercased. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster. This computes the label set; `add_labels` applies it (see Fast-Path Label Provisioning) — `create-issue`'s `labels:` field alone cannot land it on a fresh repository.
+- Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`) where `{owner}` is the frozen row `Owner` lowercased. Map `@copilot` to `squad:copilot`; never `squad:@copilot` — `@copilot` is the one permitted non-roster value and it is mapped, not lowercased verbatim. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. An `Owner` certified by neither route gets `squad` alone: omit the owner label, continue, and record the value under `Non-roster agent values` (Step 4). On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster. This computes the label set; `add_labels` applies it (see Fast-Path Label Provisioning) — `create-issue`'s `labels:` field alone cannot land it on a fresh repository.
 - Body: scope, acceptance criteria, context (parent, phase, size, depends on, owner), notes, footer
 - Parent: phase issue (hierarchical) or root (flat). For a phase issue created in this run, pass its `#aw_ph{N}` temporary ID — `create-issue` resolves it. The flat-plan root is the triggering issue's own real number. Never guess a number for an issue this run created.
 - Size: set Project field if available, else body `**Size:**` line
@@ -1331,9 +1334,11 @@ supported order.
 - The triggering intent issue is never an `add_labels` target. It is the flat-plan
   parent, not an activated item, and receives no owner label from this run.
 
-An `Owner` that is neither a certified roster name nor `@copilot` already stopped this
-run before mutation (see the Step 2 pre-flight), so no uncertified value can ever
-reach `add_labels`.
+An `Owner` that is neither a certified roster name nor `@copilot` never becomes a
+`squad:{owner}` label: send `squad` alone for that issue and record the value under
+`Non-roster agent values` in the Step 4 summary — the same omit-and-record contract
+`squad-plan-activate` uses, so an uncertified value can reach `add_labels` only as
+the base `squad` label.
 
 Re-applying an already-present label on a rerun is a no-op under add-only merge
 semantics, so this is safe under Step 1a's idempotency path. Labels must have
@@ -1365,6 +1370,12 @@ Report the exact number of created task issues, their actual parent hierarchy,
 and whether dependencies use native edges or the body-reference fallback. Never
 claim an epic, phase issue, sub-issue relationship, or native dependency edge
 that was not created.
+
+Whenever an accepted `Owner` did not become a `squad:{owner}` label — a multi-owner
+phase issue, or a value certified by neither the roster nor `@copilot` — a
+`Non-roster agent values` heading is **required** in this summary, naming the value
+and the issue it applied to. Omitting the label while omitting the heading reports a
+clean run that did not happen.
 
 ##### Step 5: Update Fast-Path Lifecycle
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1271,22 +1271,77 @@ Do not create an additional epic, summary, root, or phase issue for a flat plan.
 Before any `create-issue` call, run Team Guard Step TG-2 and validate every
 accepted plan row. Freeze a binding for each task number containing that row's
 original `Owner` and `Depends On` values. If any `Owner` does not match a certified
-active roster name, stop before mutation and require `/squad plan revise`; never
+active roster name — the special value `@copilot` excepted — stop before mutation and
+require `/squad plan revise`; never
 substitute, re-route, or fall back to another identity during acceptance.
 
 For each work item, `create-issue`:
 - Title: work item title
 - Temporary ID: `temporary_id` is **required** on every `create-issue` call in this workflow (`require-temporary-id: true`), so mint a unique one per item: `#aw_ph{N}` for a phase issue and `#aw_wi{N}` for a work item, where `{N}` is that row's plan number with non-alphanumeric characters replaced by `_`. It must match `^#?aw_[A-Za-z0-9_]{3,12}$` and must not repeat within this run — gh-aw does not reject a duplicate, it silently lets the last writer own the mapping.
-- Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`) where `{owner}` is the frozen row `Owner` lowercased. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster.
+- Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`) where `{owner}` is the frozen row `Owner` lowercased. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster. This computes the label set; `add_labels` applies it (see Fast-Path Label Provisioning) — `create-issue`'s `labels:` field alone cannot land it on a fresh repository.
 - Body: scope, acceptance criteria, context (parent, phase, size, depends on, owner), notes, footer
 - Parent: phase issue (hierarchical) or root (flat). For a phase issue created in this run, pass its `#aw_ph{N}` temporary ID — `create-issue` resolves it. The flat-plan root is the triggering issue's own real number. Never guess a number for an issue this run created.
 - Size: set Project field if available, else body `**Size:**` line
+- Label application: in the same turn as this `create-issue` call, call `add_labels` with `item_number` set to this item's own temporary ID and this item's computed label set (see Fast-Path Label Provisioning). `create-if-missing` provisions `squad`/`squad:{owner}` on a fresh repository automatically.
 
 Copy every frozen `Depends On` value into the created issue body. Cross-phase
 deps: look up real issue numbers from prior acceptance comments without changing
 the declared task dependencies.
 
-Create in dependency order. Labels must have descriptions and colors.
+Create in dependency order.
+
+##### Fast-Path Label Provisioning
+
+`create-issue`'s own `labels:` field cannot provision a label: GitHub silently drops
+label names that do not already exist in the target repository instead of creating
+them, so on a fresh repository every fast-path issue would come out unlabeled. The
+`add-labels` safe output (`allowed: [squad, "squad:*"]`, `create-if-missing: true`) is
+the only operation here that creates a missing label, and it is the same one
+`squad-plan-activate` uses — both activation paths provision labels identically, so
+`/squad activate` needs no manual label setup on a fresh repository.
+
+In the same turn as each `create-issue` call in Step 2, call `add_labels` with:
+
+- `item_number` — that same `create-issue` call's `temporary_id` (`#aw_ph{N}` for a
+  phase issue, `#aw_wi{N}` for a work item). For an issue this run did **not** create
+  — one recognized by Step 1a's idempotency check or matched by title — pass its
+  verified real number instead; a temporary ID maps only issues this run created.
+- `labels` — exactly the set computed below for that one issue, and nothing else.
+
+**Explicit targeting is mandatory.** Every `add_labels` call MUST pass `item_number`.
+Omitting it does not fail — it silently applies the labels to the **triggering intent
+issue**, branding the user's own request with an activated item's owner label. Never
+reuse another item's temporary ID, and never emit `add_labels` for an item whose
+`create-issue` call was not made in this run. `create-issue` returns no real issue
+number during this run, so never predict or infer one and never pause between the two
+calls waiting for one; gh-aw resolves `add_labels` after the `create-issue` that
+minted the ID, so `create-issue` first and `add_labels` immediately after is the
+supported order.
+
+**Label set, per issue:**
+
+- Work item: `squad`, plus `squad:{owner}` derived from that row's own frozen
+  certified `Owner`, lowercased. `@copilot` maps to the existing `squad:copilot`
+  routing label — never `squad:@copilot`. Re-read each row's frozen `Owner`; never
+  inherit the phase issue's owner or carry the previous row's value forward.
+- Phase issue: `squad`, plus `squad:{owner}` only when every accepted row in that
+  phase names one and the same owner. Two or more distinct owners is a multi-owner
+  phase: apply only `squad`, choose none of them, and record it under a
+  `Non-roster agent values` heading in the Step 4 summary.
+- The triggering intent issue is never an `add_labels` target. It is the flat-plan
+  parent, not an activated item, and receives no owner label from this run.
+
+An `Owner` that is neither a certified roster name nor `@copilot` already stopped this
+run before mutation (see the Step 2 pre-flight), so no uncertified value can ever
+reach `add_labels`.
+
+Re-applying an already-present label on a rerun is a no-op under add-only merge
+semantics, so this is safe under Step 1a's idempotency path. Labels must have
+descriptions and intentional colors when they already exist; a label auto-provisioned
+by `create-if-missing` on a fresh repository instead receives gh-aw's deterministic
+color and an empty description — that is expected, not a failure, and must not be
+reported as one. Report only the labels a successful `add_labels` call actually
+applied; never a label that was skipped, deferred, or merely intended.
 
 ##### Step 3: Preserve Dependencies
 


### PR DESCRIPTION
Closes #1959
Parent #1957

Working as **Procedures** (Prompt Engineer) — issue carries `squad:procedures`.

## ⚠️ Stacked PR — merge gate

**Base branch: `bradygaster-plan-activate-temporary-ids` (PR #1965 / #1962), not `dev`.**

#1965 is unmerged and this work builds directly on it — it establishes the temporary-ID contract, enables workflow-global `require-temporary-id: true`, and its `create-if-missing` safe output is the mechanism reused here. **Merge #1965 first**, then this PR's base auto-retargets to `dev`.

> **CI will not run on this PR until #1965 merges and GitHub retargets it to `dev`.** Validation below was run locally against the stacked tree.

## Problem

`/squad activate` routes to `squad-plan-accept`. When only a flat `plan` artifact exists (no `program`/`implementation`), it takes its **own** fast path with its own `create-issue` calls — separate code from `squad-plan-activate`.

#1955 fixed fresh-repo label provisioning in `squad-plan-activate` only. #1962 added just enough temporary-ID compliance to the fast path to survive the new global `require-temporary-id: true` flag, and deliberately stopped there. So the fast path still leaned on `create-issue`'s `labels:` field — and GitHub **silently drops** label names that don't already exist in the target repo instead of creating them.

Net effect: on a fresh repository, the *recommended* activation command produced issues with none of the labels the docs promise, while the legacy long path worked correctly.

## Fix

Applied the same verified pattern to the fast path. New `##### Fast-Path Label Provisioning` section in `squad-plan-accept`, plus a per-item `- Label application:` bullet in Step 2.

| Concern | Behavior |
|---|---|
| Provisioning | `add_labels` (`allowed: [squad, "squad:*"]`, `create-if-missing: true`) — the same safe output `squad-plan-activate` uses. Both paths now provision identically. |
| Targeting | `item_number` = that `create-issue` call's own `temporary_id` (`#aw_ph{N}` phase, `#aw_wi{N}` work item) |
| Reused issues | Verified real number instead — a temp ID maps only issues *this run* created |
| Ordering | `create-issue` first, `add_labels` immediately after; no waiting for a returned number (none is returned) |
| Origin issue | Explicitly never an `add_labels` target |

**Every `add_labels` call must pass `item_number`.** The prose names the consequence, not just the rule: omitting it does not error — gh-aw silently applies the labels to the **triggering intent issue**, branding the user's own request with an activated item's owner label. That's the same hazard `squad-plan-activate` warns about, stated identically.

## Parity with the full activation path

- **Base `squad`** on every activated item.
- **Work item** → `squad:{owner}` from that row's own frozen certified `Owner`, lowercased. Re-read per row; never inherit the phase issue's owner or carry the previous row's value forward.
- **`@copilot`** → `squad:copilot`, never `squad:@copilot` — stated **inline in the primary Step 2 label computation**, not only in the provisioning section (see below).
- **Multi-owner phase issue** → `squad` only, choose none of them, recorded under `Non-roster agent values`.
- **Non-roster owner** → base `squad` only, owner label omitted, run **continues**, value recorded (see below).
- **`ROSTER_UNREADABLE:`** → stop before mutation, report the named reason. Also a stop in `squad-plan-activate`.
- **Idempotency** → re-applying an existing label is a documented no-op under add-only merge semantics, safe under Step 1a's rerun path.

### `@copilot` must be mapped in the primary computation

The Step 2 `- Labels:` bullet is where the label set is actually computed, and it said only "the frozen row `Owner` lowercased" — which turns `@copilot` into the invalid `squad:@copilot`. Stating the mapping only in the provisioning section below left the primary rule wrong; a model following the bullet literally still emits the bad label.

**Map `@copilot` to `squad:copilot`; never `squad:@copilot`** is now inline in that exact bullet. The test extracts that bullet with `/^- Labels:.*$/m` and asserts against it specifically, so a workflow that is correct elsewhere but wrong in the primary computation fails.

### Non-roster: aligned to full activation

#1959 requires non-roster behavior to match the full activation path, so the fast path's pre-mutation stop is **removed**, not preserved. `squad-plan-activate` applies base `squad`, omits the owner label, and continues; the fast path now does the same and records the value under `Non-roster agent values`. Both paths now produce identical results for the same plan.

`ROSTER_UNREADABLE:` still stops before mutation. That is a different failure — no certified set exists at all, so omit-and-record has nothing to certify against — and `squad-plan-activate` stops there too. The distinction is asserted by a dedicated test so the stop can't be mistaken for a leftover of the removed per-owner stop.

Step 4 now **requires** the `Non-roster agent values` heading whenever an accepted `Owner` did not become a `squad:{owner}` label — multi-owner phase or uncertified value — naming the value and the issue it applied to. Without that, "record it" pointed at a heading the fast path never had to emit. This is a heading requirement only, not a summary redesign, so it stays compatible with #1963.

### #1962 compliance preserved

A dedicated regression test asserts the fast path keeps its `Temporary ID:` bullet, `require-temporary-id: true`, both ID forms, the `^#?aw_[A-Za-z0-9_]{3,12}$` pattern, the uniqueness mandate, and the `#aw_ph{N}` parent linkage. A compiled-lock assertion confirms `require_temporary_id` and `required_field_additions.create_issue` still reach the handler config — that flag is workflow-global and covers the fast path's `create_issue` calls too.

## 📌 Source-growth guard raised 160 → 170 KB

`gh-aw-quality.test.ts`'s guard had **~37 bytes** of headroom left after #1962 (163 803 of 163 840). At that margin it had stopped measuring growth and started blocking any correct change on byte count alone — the same failure mode its own comment block documents from #1842.

The raise is legitimate by the criterion that comment names: the new prose lives entirely inside the `squad-plan-accept` inline `## skill:` block, which gh-aw **strips** during setup/interpolation, so it never enters the ambient prompt. The canonical budget — `keeps the ambient prompt under 40 KB` — is unaffected and still passing. I tightened the section first and still could not fit under 160 KB.

## Validation

- **Strict compile:** all 4 workflows (`squad`, `squad-implement-worker`, `squad-review`, `squad-deps-worker`) compile with `--strict --approve`, all 4 lock files emitted, `FAILED=0`. Remaining warnings (concurrency discriminator, `slash_command`+`bots`) are pre-existing and identical on the base branch.
- **Targeted tests:** `485 passed` across all 14 `gh-aw-*` suites.
- **Build:** `npm run build` passes.

## Test changes

**Added** `test/gh-aw-activate-fast-path-label-provisioning.test.ts` (26 tests) — routing sanity (`/squad activate` → `squad-plan-accept`, so the suite can't drift onto the wrong skill), the dropped-label root cause, `add_labels`+`create-if-missing` presence, same-turn pairing at both section and bullet level, temp-ID targeting, #1962 compliance regression guard, mandatory `item_number` + the silent-fallback hazard, no-borrowed-IDs, verified real numbers for reused issues, no-prediction, then per-label-set parity assertions (base `squad`, own-row owner, `@copilot` **asserted against the extracted primary bullet**, multi-owner, non-roster omit-and-record, `ROSTER_UNREADABLE:` stop, the required `Non-roster agent values` heading, origin-issue safety, idempotency, default-color-is-not-a-failure, report-what-applied). Several assert the *same* string against both skills so the two paths can't silently diverge. One asserts the removed `/squad plan revise` stop is **absent**, so it can't be reintroduced alongside the new rule. Compiled-lock section fails closed on a missing `gh aw` per this repo's #1834 convention.

**Updated** `test/gh-aw-activation-label-provisioning.test.ts` — one #1955 boundary test asserted the fast path contained no `add_labels` and no `create-if-missing`, encoding the exact gap #1959 closes. Inverted to assert the parity instead.

**Updated** `test/gh-aw-quality.test.ts` — guard constant and its rationale comment (see above).

## Impact on #1963 (activation reporting)

#1965 flagged that the `Activation bindings:` JSON block still embeds real issue numbers and cannot be fixed there, because `replaceTemporaryIdReferences()` retains the `#`, which would emit invalid JSON. **That constraint is unchanged by this PR** — the fast path's Step 4 posts a `plan-accepted` / `phases-accepted` artifact and does not emit an `Activation bindings:` block at all, so this PR neither worsens nor resolves it.

Three things #1963 should now account for:

1. **Reporting is now two-path.** Any redesign must cover `squad-plan-accept`'s Step 4 summary as well as `squad-plan-activate`'s Step 4 record. Previously the fast path had no label operations worth attributing.
2. **The fast path now has a required heading.** `Non-roster agent values` is mandatory in the fast path's Step 4 whenever a label was omitted. #1963 must either keep that heading or explicitly supersede it — the omit-and-record rule in Step 2 and the provisioning section both reference it by name.
3. **The attribution vocabulary already exists here.** This PR states "Report only the labels a successful `add_labels` call actually applied; never a label that was skipped, deferred, or merely intended." #1963 can build on that rather than introducing a competing contract, but it will need to reconcile the fast path's heading with a mechanism that has no bindings block to hang structured data on.

## Out of scope (untouched)

Activation reporting redesign (#1963), capacity safeguards (#1961), broad behavioral contracts (#1960), E4 (#1958), checker distribution.

No changeset: no `packages/*/src/` changes, so the `changelog-gate` path regex does not match.
