### PR TITLE
feat(nap): measure charter/skill context and add `--dry-run --json`

### DIFF
--- a/.changeset/nap-context-json-safety.md
+++ b/.changeset/nap-context-json-safety.md
@@ -1,0 +1,5 @@
+---
+'@bradygaster/squad-cli': patch
+---
+
+`squad nap` now measures the agent-loaded context it reports, including charter and skill bytes, while keeping those files read-only. Dry-run output is clearly marked as non-mutating and uses conditional wording, `squad nap --json` exposes structured before/after/action data for tooling in both CLI and interactive shell usage, and the reskill prompt now bases its savings table on measured dry-run JSON instead of hand-written estimates.

--- a/docs/src/content/docs/features/context-hygiene.md
+++ b/docs/src/content/docs/features/context-hygiene.md
@@ -50,22 +50,30 @@ Shutting down Squad every night does **not** perform context hygiene. You must e
 squad nap              # Standard context hygiene
 squad nap --deep       # Thorough cleanup with recursive descent
 squad nap --dry-run    # Preview what would be cleaned up
+squad nap --dry-run --json  # Measure reclaimable context with structured output
 ```
 
 In the interactive shell, use `/compact` for the same effect.
+
+`squad nap --dry-run --json` is the safest way to answer "how much context can we reclaim?" It reports before/after metrics and planned actions without modifying files, so tests and CI can assert real numbers instead of relying on estimates.
+
+Nap also measures loaded-context sources that affect every agent spawn: `charterBytes`, `skillBytes` for markdown under `.squad/skills/`, `charterReducibleBytes` above the 1.5 KB per-charter reskill target, and `historyReducibleBytes` above the 8 KB per-history target. It measures charters and skills, but it never modifies them. Charters define agent identity; automated charter rewriting is not part of nap.
 
 ---
 
 ## Reskill
 
-**What it does:** Tells agents to re-examine their skills, validate them against the current codebase, and potentially discover new patterns.
+**What it does:** Tells agents to audit measured context, re-examine skills, validate them against the current codebase, and potentially discover new patterns.
 
 When you tell the team to "reskill," agents:
 
-1. Review existing skill files in `.copilot/skills/`
-2. Validate that documented patterns still apply
-3. Look for new reusable patterns from recent work
-4. Update skill confidence levels based on current evidence
+1. Start from `squad nap --dry-run --json` to get measured context numbers
+2. Review skill files in `.copilot/skills/` and legacy `.squad/skills/`
+3. Validate that documented patterns still apply
+4. Look for new reusable patterns from recent work
+5. Update skill confidence levels based on current evidence
+
+The nap metrics give reskill a concrete audit baseline: how much agent-loaded context exists, what nap would change, and which charter or history bytes sit above the documented reskill targets. Reskill can use those numbers to guide recommendations, but nap still does not rewrite charters or skills.
 
 ### Availability
 
@@ -101,7 +109,7 @@ This runs both behaviors and gives you a report on how much context was reduced 
 - **Nap regularly.** A few sessions of heavy work can bloat history files. Napping keeps context budgets in check.
 - **Don't rely on shutdown.** Closing the CLI preserves files as-is — it does not compact anything.
 - **Reskill after refactors.** If you've restructured the codebase, agent skills may reference outdated patterns.
-- **Check the dry run first.** Use `squad nap --dry-run` to preview cleanup actions before committing to them.
+- **Check the dry run first.** Use `squad nap --dry-run` to preview cleanup actions. The report is clearly labeled `DRY RUN — no files were modified`; add `--json` when you need structured metrics.
 
 ## Sample Prompts
 
@@ -127,4 +135,4 @@ Combines both behaviors and reports back on total context reduction.
 squad nap --dry-run
 ```
 
-Previews what a nap would clean up without making any changes.
+Previews what a nap would clean up without making any changes, with an explicit dry-run banner.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -75,6 +75,7 @@ prerequisites, all supported methods, and update commands.
 | `squad nap` | Context hygiene (compress, prune, archive .squad/ state) | Yes |
 | `squad nap --deep` | Thorough cleanup with recursive descent | Yes |
 | `squad nap --dry-run` | Preview cleanup actions without changes | Yes |
+| `squad nap --json` | Emit machine-readable nap metrics and actions | Yes |
 | `squad scrub-emails [directory]` | Remove email addresses from Squad state files (default: `.squad/`) | No |
 | `squad --version` | Print installed version | No |
 

--- a/packages/squad-cli/src/cli-entry.ts
+++ b/packages/squad-cli/src/cli-entry.ts
@@ -226,8 +226,8 @@ async function main(): Promise<void> {
     console.log(`                       start --tunnel --model claude-sonnet-4.6`);
     console.log(`                       start --tunnel --command "gh copilot"`);
     console.log(`  ${BOLD}nap${RESET}        Context hygiene (compress, prune, archive .squad/ state)`);
-    console.log(`             Usage: nap [--deep] [--dry-run]`);
-    console.log(`             Flags: --deep (thorough cleanup), --dry-run (preview only)`);
+    console.log(`             Usage: nap [--deep] [--dry-run] [--json]`);
+    console.log(`             Flags: --deep (thorough cleanup), --dry-run (preview only), --json (machine-readable)`);
     console.log(`  ${BOLD}memory${RESET}     Governed memory operations`);
     console.log(`             Usage: memory write --content "..." --class LOCAL`);
     console.log(`             Diagnostics: --log-level info|debug or --verbose`);
@@ -976,8 +976,16 @@ async function main(): Promise<void> {
     }
     const deep = args.includes('--deep');
     const dryRun = args.includes('--dry-run');
+    const json = args.includes('--json');
     const result = await runNap({ squadDir, deep, dryRun });
-    console.log(formatNapReport(result, !!process.env['NO_COLOR']));
+    if (json) {
+      // Stable machine-readable shape mirroring NapResult so downstream
+      // tooling can diff before/after and assert on savings deterministically.
+      // Follows the health.ts:795 `--json` precedent (2-space indent).
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(formatNapReport(result, !!process.env['NO_COLOR']));
+    }
     return;
   }
 

--- a/packages/squad-cli/src/cli/core/command-help.ts
+++ b/packages/squad-cli/src/cli/core/command-help.ts
@@ -204,10 +204,11 @@ const COMMAND_HELP: Record<string, HelpPrinter> = {
 
   nap: (version) => {
     header('nap', version, 'Context hygiene — compress, prune, archive .squad/ state');
-    console.log(`Usage: squad nap [--deep] [--dry-run]\n`);
+    console.log(`Usage: squad nap [--deep] [--dry-run] [--json]\n`);
     console.log(`Options:`);
     console.log(`  ${BOLD}--deep${RESET}                      Thorough cleanup, including older history`);
-    console.log(`  ${BOLD}--dry-run${RESET}                   Preview changes without writing\n`);
+    console.log(`  ${BOLD}--dry-run${RESET}                   Preview changes without writing (report shows a DRY RUN banner and conditional verbs)`);
+    console.log(`  ${BOLD}--json${RESET}                      Emit machine-readable JSON ({ dryRun, before, after, actions }) for CI/diffing\n`);
   },
 
   memory: (version) => {

--- a/packages/squad-cli/src/cli/core/nap.ts
+++ b/packages/squad-cli/src/cli/core/nap.ts
@@ -26,6 +26,13 @@ export interface NapResult {
   before: NapMetrics;
   after: NapMetrics;
   actions: NapAction[];
+  /**
+   * True when the run was invoked with `dryRun: true` (no files were written).
+   * Consumed by {@link formatNapReport} to produce a distinct preview banner
+   * and conditional action verbs, and surfaced verbatim in `--json` output so
+   * downstream tooling can diff previews vs real runs deterministically.
+   */
+  dryRun: boolean;
 }
 
 export interface NapMetrics {
@@ -35,6 +42,27 @@ export interface NapMetrics {
   logBytes: number;
   decisionBytes: number;
   inboxFiles: number;
+  /**
+   * Total bytes across every `.squad/agents/*\/charter.md`. Read-only —
+   * nap never modifies charters (charters are identity; see
+   * `.squad/decisions/inbox/flight-nap-reskill-scope.md` §C non-goals).
+   */
+  charterBytes: number;
+  /** Total bytes across every `.md` file under `.squad/skills/` (recursive). */
+  skillBytes: number;
+  /**
+   * Sum over agents of `max(0, charterSize - CHARTER_TARGET)`. The excess
+   * bytes over the reskill skill's stated charter target. Purely a
+   * measurement — nap does not reduce it.
+   */
+  charterReducibleBytes: number;
+  /**
+   * Sum over agents of `max(0, historySize - HISTORY_TARGET)`. The excess
+   * bytes over the reskill skill's stated history target. Nap's compression
+   * (>15KB threshold) is a coarser primitive than this target, so this number
+   * is a lower bound on what a targeted reskill pass could reclaim.
+   */
+  historyReducibleBytes: number;
 }
 
 export interface NapAction {
@@ -54,6 +82,15 @@ const KEEP_ENTRIES_DEFAULT = 5;
 const KEEP_ENTRIES_DEEP = 3;
 const JOURNAL_FILE = '.nap-journal';
 const TOKENS_PER_KB = 250;
+
+// Reskill skill targets — used ONLY for reducibility measurement, not for
+// mutation. Provenance so the numbers are traceable, not magic:
+//   packages/squad-cli/templates/skills/reskill/SKILL.md line 31 —
+//     "Charters — target ≤1.5KB per agent"
+const CHARTER_TARGET = 1536;               // 1.5 KB
+//   packages/squad-cli/templates/skills/reskill/SKILL.md line 39 —
+//     "Histories — target ≤8KB per agent"
+const HISTORY_TARGET = 8 * 1024;           // 8 KB
 
 // ─── Helpers ────────────────────────────────────────────────────────────
 
@@ -118,17 +155,36 @@ function daysAgoFromLine(line: string): number | null {
 
 function collectMetrics(squadDir: string): NapMetrics {
   const agentsDir = path.join(squadDir, 'agents');
+  const skillsDir = path.join(squadDir, 'skills');
   const orchLogDir = path.join(squadDir, 'orchestration-log');
   const logDir = path.join(squadDir, 'log');
   const decisionsFile = path.join(squadDir, 'decisions.md');
   const inboxDir = path.join(squadDir, 'decisions', 'inbox');
 
   let historyBytes = 0;
+  let historyReducibleBytes = 0;
+  let charterBytes = 0;
+  let charterReducibleBytes = 0;
   if (storage.existsSync(agentsDir)) {
     for (const name of storage.listSync(agentsDir)) {
       if (!storage.isDirectorySync(path.join(agentsDir, name))) continue;
       const hf = path.join(agentsDir, name, 'history.md');
-      historyBytes += fileSize(hf);
+      const hSize = fileSize(hf);
+      historyBytes += hSize;
+      historyReducibleBytes += Math.max(0, hSize - HISTORY_TARGET);
+      const cf = path.join(agentsDir, name, 'charter.md');
+      const cSize = fileSize(cf);
+      charterBytes += cSize;
+      charterReducibleBytes += Math.max(0, cSize - CHARTER_TARGET);
+    }
+  }
+
+  // Skills: recursive .md walk under .squad/skills/. SKILL.md is the
+  // canonical filename but nap should count any markdown a skill ships with.
+  let skillBytes = 0;
+  if (storage.existsSync(skillsDir)) {
+    for (const f of collectFiles(skillsDir)) {
+      if (f.endsWith('.md')) skillBytes += fileSize(f);
     }
   }
 
@@ -152,6 +208,10 @@ function collectMetrics(squadDir: string): NapMetrics {
     logBytes,
     decisionBytes,
     inboxFiles,
+    charterBytes,
+    skillBytes,
+    charterReducibleBytes,
+    historyReducibleBytes,
   };
 }
 
@@ -524,7 +584,7 @@ export async function runNap(options: NapOptions): Promise<NapResult> {
   const actions: NapAction[] = [];
 
   if (!storage.existsSync(squadDir)) {
-    return { before: emptyMetrics(), after: emptyMetrics(), actions };
+    return { before: emptyMetrics(), after: emptyMetrics(), actions, dryRun };
   }
 
   // Journal safety check
@@ -571,7 +631,7 @@ export async function runNap(options: NapOptions): Promise<NapResult> {
   // Collect after metrics
   const after = dryRun ? estimateAfterMetrics(before, actions) : collectMetrics(squadDir);
 
-  return { before, after, actions };
+  return { before, after, actions, dryRun };
 }
 
 /**
@@ -583,7 +643,7 @@ export function runNapSync(options: NapOptions): NapResult {
   const actions: NapAction[] = [];
 
   if (!storage.existsSync(squadDir)) {
-    return { before: emptyMetrics(), after: emptyMetrics(), actions };
+    return { before: emptyMetrics(), after: emptyMetrics(), actions, dryRun };
   }
 
   if (checkJournal(squadDir)) {
@@ -621,10 +681,36 @@ export function runNapSync(options: NapOptions): NapResult {
 
   const after = dryRun ? estimateAfterMetrics(before, actions) : collectMetrics(squadDir);
 
-  return { before, after, actions };
+  return { before, after, actions, dryRun };
 }
 
 // ─── Report formatting ──────────────────────────────────────────────────
+
+/**
+ * Rewrite an action description into conditional-verb form for dry-run
+ * reports. The action strings themselves are stored in past tense because
+ * that is the "real run" wording; the formatter is the single place that
+ * knows the run mode, so it rewrites at display time. This keeps action
+ * descriptions immutable across the code path and lets consumers (including
+ * `--json` and tests) see the raw past-tense description regardless.
+ */
+function dryRunifyDescription(description: string): string {
+  // Prefix map from past tense → conditional. Anchored at start so we don't
+  // rewrite the word "Compressed" if it ever appears mid-sentence.
+  const rewrites: Array<[RegExp, string]> = [
+    [/^Compressed\b/, 'Would compress'],
+    [/^Pruned\b/, 'Would prune'],
+    [/^Merged\b/, 'Would merge'],
+    [/^Archived\b/, 'Would archive'],
+    [/^Archival skipped\b/, 'Would skip archival'],
+    [/^Archival refused\b/, 'Would refuse archival'],
+    [/^Archival aborted\b/, 'Would abort archival'],
+  ];
+  for (const [pattern, replacement] of rewrites) {
+    if (pattern.test(description)) return description.replace(pattern, replacement);
+  }
+  return description;
+}
 
 export function formatNapReport(result: NapResult, noColor?: boolean): string {
   const nc = noColor ?? !!process.env['NO_COLOR'];
@@ -635,15 +721,39 @@ export function formatNapReport(result: NapResult, noColor?: boolean): string {
   const R = nc ? '' : '\x1b[0m';
   const sep = '-'.repeat(40);
 
-  const { before, after, actions } = result;
+  const { before, after, actions, dryRun } = result;
   const saved = before.totalBytes - after.totalBytes;
   const tokensSaved = humanTokens(Math.max(0, saved));
 
   const lines: string[] = [];
 
+  // Dry-run banner — top of the report, regardless of action count. Users
+  // must be able to distinguish a preview from a real run at a glance.
+  // (See Flight §A gap 3; nap.ts:256/276/309/629 were unconditionally past
+  // tense, making a preview textually indistinguishable from truth.)
+  if (dryRun) {
+    if (nc) {
+      lines.push(`[DRY RUN] no files were modified`);
+    } else {
+      lines.push(`${Y}${B}🔍 DRY RUN${R} ${Y}— no files were modified${R}`);
+    }
+    lines.push('');
+  }
+
   if (actions.length === 0) {
-    lines.push(`${nc ? '' : '😴 '}${B}Nap complete${R} - nothing to clean up.`);
+    const verb = dryRun ? 'Nap preview' : 'Nap complete';
+    const tail = dryRun ? 'nothing would be cleaned up.' : 'nothing to clean up.';
+    lines.push(`${nc ? '' : '😴 '}${B}${verb}${R} - ${tail}`);
     lines.push(`${D}Total: ${humanBytes(before.totalBytes)} (${humanTokens(before.totalBytes)} tokens est.)${R}`);
+    // Even with no actions the reducibility measurement is useful — it is the
+    // whole point of the primitive: reveal charter/history bytes that a
+    // targeted reskill pass could reclaim, without running any mutation.
+    if (before.charterBytes > 0 || before.skillBytes > 0) {
+      lines.push(`${D}Charters: ${humanBytes(before.charterBytes)} (reducible ${humanBytes(before.charterReducibleBytes)}), Skills: ${humanBytes(before.skillBytes)}${R}`);
+    }
+    if (before.historyReducibleBytes > 0) {
+      lines.push(`${D}History reducible: ${humanBytes(before.historyReducibleBytes)} over target (${humanBytes(HISTORY_TARGET)}/agent)${R}`);
+    }
     return lines.join('\n');
   }
 
@@ -653,7 +763,8 @@ export function formatNapReport(result: NapResult, noColor?: boolean): string {
 
   // Before/after summary
   lines.push(`${B}Overall${R}`);
-  lines.push(`  ${humanBytes(before.totalBytes)} ${D}->${R} ${G}${humanBytes(after.totalBytes)}${R} ${D}(saved ~${tokensSaved} tokens)${R}`);
+  const arrow = dryRun ? `${D}(would become)${R}` : `${D}->${R}`;
+  lines.push(`  ${humanBytes(before.totalBytes)} ${arrow} ${G}${humanBytes(after.totalBytes)}${R} ${D}(${dryRun ? 'would save' : 'saved'} ~${tokensSaved} tokens)${R}`);
   lines.push('');
 
   // Category breakdown
@@ -662,6 +773,12 @@ export function formatNapReport(result: NapResult, noColor?: boolean): string {
     ['History', before.historyBytes, after.historyBytes],
     ['Logs', before.logBytes, after.logBytes],
     ['Decisions', before.decisionBytes, after.decisionBytes],
+    // Charters and skills are always identical in before/after (nap never
+    // touches them). They show up here so the reader can see what fraction
+    // of the total is fixed vs. reclaimable — the whole point of the
+    // measurement addition.
+    ['Charters', before.charterBytes, after.charterBytes],
+    ['Skills', before.skillBytes, after.skillBytes],
   ];
   for (const [name, b, a] of categories) {
     if (b === 0 && a === 0) continue;
@@ -674,11 +791,26 @@ export function formatNapReport(result: NapResult, noColor?: boolean): string {
     lines.push(`  Inbox: ${before.inboxFiles} file${before.inboxFiles !== 1 ? 's' : ''} -> ${after.inboxFiles}`);
   }
 
+  // Reducibility panel — the answer to "how much of my per-spawn prompt is
+  // charter/history that a targeted reskill could reclaim?" without running
+  // any mutation. Only shown when there is something reducible.
+  if (before.charterReducibleBytes > 0 || before.historyReducibleBytes > 0) {
+    lines.push('');
+    lines.push(`${B}Reducible (vs. reskill targets)${R}`);
+    if (before.charterReducibleBytes > 0) {
+      lines.push(`  ${D}Charters over ${humanBytes(CHARTER_TARGET)}/agent:${R} ${humanBytes(before.charterReducibleBytes)}`);
+    }
+    if (before.historyReducibleBytes > 0) {
+      lines.push(`  ${D}Histories over ${humanBytes(HISTORY_TARGET)}/agent:${R} ${humanBytes(before.historyReducibleBytes)}`);
+    }
+  }
+
   lines.push('');
   lines.push(`${B}Actions${R} (${actions.length})`);
   for (const a of actions) {
     const tag = actionTag(a.type, nc);
-    lines.push(`  ${tag} ${a.description}`);
+    const desc = dryRun ? dryRunifyDescription(a.description) : a.description;
+    lines.push(`  ${tag} ${desc}`);
   }
 
   lines.push('');
@@ -701,7 +833,18 @@ function actionTag(type: NapAction['type'], noColor: boolean): string {
 }
 
 function emptyMetrics(): NapMetrics {
-  return { totalFiles: 0, totalBytes: 0, historyBytes: 0, logBytes: 0, decisionBytes: 0, inboxFiles: 0 };
+  return {
+    totalFiles: 0,
+    totalBytes: 0,
+    historyBytes: 0,
+    logBytes: 0,
+    decisionBytes: 0,
+    inboxFiles: 0,
+    charterBytes: 0,
+    skillBytes: 0,
+    charterReducibleBytes: 0,
+    historyReducibleBytes: 0,
+  };
 }
 
 function estimateAfterMetrics(before: NapMetrics, actions: NapAction[]): NapMetrics {
@@ -726,5 +869,16 @@ function estimateAfterMetrics(before: NapMetrics, actions: NapAction[]): NapMetr
     logBytes: Math.max(0, before.logBytes - logSaved),
     decisionBytes: Math.max(0, before.decisionBytes - decisionSaved),
     inboxFiles: Math.max(0, before.inboxFiles - inboxMerged),
+    // Nap never modifies charters or skills (Flight §C non-goals) — pass
+    // through unchanged. Fabricating deltas here would be a lie the caller
+    // couldn't distinguish from truth.
+    charterBytes: before.charterBytes,
+    skillBytes: before.skillBytes,
+    charterReducibleBytes: before.charterReducibleBytes,
+    // historyReducibleBytes is nominally affected by compression, but the
+    // aggregate doesn't decompose from an aggregate historyBytes delta — we
+    // don't know per-file after-sizes here. Honest choice: pass through.
+    // The real (non-dry-run) collectMetrics reports truth on the next run.
+    historyReducibleBytes: before.historyReducibleBytes,
   };
 }

--- a/packages/squad-cli/src/cli/shell/commands.ts
+++ b/packages/squad-cli/src/cli/shell/commands.ts
@@ -228,7 +228,11 @@ function handleNap(args: string[], context: CommandContext): CommandResult {
     const squadDir = path.join(context.teamRoot, '.squad');
     const deep = args.includes('--deep');
     const dryRun = args.includes('--dry-run');
+    const json = args.includes('--json');
     const result = runNapSync({ squadDir, deep, dryRun });
+    if (json) {
+      return { handled: true, output: JSON.stringify(result, null, 2) };
+    }
     return { handled: true, output: formatNapReport(result, !!process.env['NO_COLOR']) };
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);

--- a/packages/squad-cli/templates/skills/reskill/SKILL.md
+++ b/packages/squad-cli/templates/skills/reskill/SKILL.md
@@ -15,7 +15,11 @@ This is a periodic maintenance activity. Run whenever charter/history bloat is s
 ## Process
 
 ### Step 1: Audit
-Read all agent charters and histories. Measure byte sizes. Identify:
+Run `squad nap --dry-run --json` first. This is a read-only preview: it measures the team and modifies nothing. Capture the measured baseline from `before.charterBytes`, `before.skillBytes`, `before.charterReducibleBytes`, and `before.historyReducibleBytes`.
+
+`charterReducibleBytes` and `historyReducibleBytes` tell you exactly how many bytes are above the Step 3 targets before you start. Nap measures charters and skills; it never rewrites them. Charter trimming remains a deliberate, judgment-driven agent action.
+
+Then read agent charters and histories to identify:
 
 - **Boilerplate** — sections repeated across ≥3 charters with <10% variation (collaboration, model, boundaries template)
 - **Shared knowledge** — domain knowledge duplicated in 2+ charters (incident postmortems, technical patterns)
@@ -43,12 +47,17 @@ For each identified pattern:
 - Remove session-specific metadata (dates, branch names, requester names)
 
 ### Step 4: Report
-Output a savings table:
+Run `squad nap --dry-run --json` again after the deliberate reskill edits. Populate the savings table only from measured `squad nap --json` values — never from estimates.
 
-| Agent | Charter Before | Charter After | History Before | History After | Saved |
-|-------|---------------|---------------|----------------|---------------|-------|
+| Area | Before | After | Above Target Before | Saved |
+|------|--------|-------|---------------------|-------|
+| Charters | `{baseline.before.charterBytes}` | `{final.before.charterBytes}` | `{baseline.before.charterReducibleBytes}` | `{baseline.before.charterBytes - final.before.charterBytes}` |
+| Skills | `{baseline.before.skillBytes}` | `{final.before.skillBytes}` | n/a | `{baseline.before.skillBytes - final.before.skillBytes}` |
+| Histories | `{baseline.before.historyBytes}` | `{final.before.historyBytes}` | `{baseline.before.historyReducibleBytes}` | `{baseline.before.historyBytes - final.before.historyBytes}` |
 
 Include totals and percentage reduction.
+
+Do not report a savings number that did not come from a measured `squad nap --json` run. `charterReducibleBytes` and `historyReducibleBytes` tell you exactly how much is above target before you start; use those fields for reducibility, not vibes.
 
 ## Patterns
 
@@ -90,3 +99,5 @@ Preferred: {model}
 - Don't remove Model preference line (coordinator needs it for model selection)
 - Don't touch `.squad/decisions.md` during reskill
 - Don't remove the tagline blockquote — it's the charter's soul in one line
+- Don't hand-estimate, invent, or round-trip savings figures through vibes; if the number didn't come from `squad nap --json`, don't report it
+- Don't automate charter rewriting — nap measures charters and skills, but identity edits stay deliberate and judgment-driven

--- a/packages/squad-sdk/templates/skills/reskill/SKILL.md
+++ b/packages/squad-sdk/templates/skills/reskill/SKILL.md
@@ -15,7 +15,11 @@ This is a periodic maintenance activity. Run whenever charter/history bloat is s
 ## Process
 
 ### Step 1: Audit
-Read all agent charters and histories. Measure byte sizes. Identify:
+Run `squad nap --dry-run --json` first. This is a read-only preview: it measures the team and modifies nothing. Capture the measured baseline from `before.charterBytes`, `before.skillBytes`, `before.charterReducibleBytes`, and `before.historyReducibleBytes`.
+
+`charterReducibleBytes` and `historyReducibleBytes` tell you exactly how many bytes are above the Step 3 targets before you start. Nap measures charters and skills; it never rewrites them. Charter trimming remains a deliberate, judgment-driven agent action.
+
+Then read agent charters and histories to identify:
 
 - **Boilerplate** — sections repeated across ≥3 charters with <10% variation (collaboration, model, boundaries template)
 - **Shared knowledge** — domain knowledge duplicated in 2+ charters (incident postmortems, technical patterns)
@@ -43,12 +47,17 @@ For each identified pattern:
 - Remove session-specific metadata (dates, branch names, requester names)
 
 ### Step 4: Report
-Output a savings table:
+Run `squad nap --dry-run --json` again after the deliberate reskill edits. Populate the savings table only from measured `squad nap --json` values — never from estimates.
 
-| Agent | Charter Before | Charter After | History Before | History After | Saved |
-|-------|---------------|---------------|----------------|---------------|-------|
+| Area | Before | After | Above Target Before | Saved |
+|------|--------|-------|---------------------|-------|
+| Charters | `{baseline.before.charterBytes}` | `{final.before.charterBytes}` | `{baseline.before.charterReducibleBytes}` | `{baseline.before.charterBytes - final.before.charterBytes}` |
+| Skills | `{baseline.before.skillBytes}` | `{final.before.skillBytes}` | n/a | `{baseline.before.skillBytes - final.before.skillBytes}` |
+| Histories | `{baseline.before.historyBytes}` | `{final.before.historyBytes}` | `{baseline.before.historyReducibleBytes}` | `{baseline.before.historyBytes - final.before.historyBytes}` |
 
 Include totals and percentage reduction.
+
+Do not report a savings number that did not come from a measured `squad nap --json` run. `charterReducibleBytes` and `historyReducibleBytes` tell you exactly how much is above target before you start; use those fields for reducibility, not vibes.
 
 ## Patterns
 
@@ -90,3 +99,5 @@ Preferred: {model}
 - Don't remove Model preference line (coordinator needs it for model selection)
 - Don't touch `.squad/decisions.md` during reskill
 - Don't remove the tagline blockquote — it's the charter's soul in one line
+- Don't hand-estimate, invent, or round-trip savings figures through vibes; if the number didn't come from `squad nap --json`, don't report it
+- Don't automate charter rewriting — nap measures charters and skills, but identity edits stay deliberate and judgment-driven

--- a/test/nap-reskill-measurement.test.ts
+++ b/test/nap-reskill-measurement.test.ts
@@ -1,0 +1,881 @@
+/**
+ * Nap reskill-measurement evidence tests.
+ *
+ * This file is the evidentiary core for the "nap can now measure the reskill
+ * opportunity" change. Every assertion in here is computed against exact
+ * fixture bytes (`Buffer.byteLength`) — no tolerance ranges, no vibes.
+ *
+ * Scope (per `.squad/decisions/inbox/flight-nap-reskill-scope.md` and
+ * `.squad/decisions/inbox/eecom-nap-metrics.md`):
+ *   1. Exact byte measurement of `charterBytes`, `skillBytes`,
+ *      `charterReducibleBytes`, `historyReducibleBytes`.
+ *   2. Threshold boundary correctness (CHARTER_TARGET=1536, HISTORY_TARGET=8192).
+ *   3. Baseline-vs-improved on a realistic bloated fixture (headline number).
+ *   4. Safety: real nap never modifies any charter or skill file (byte-identical).
+ *   5. Safety: dry-run modifies nothing on disk (entire tree byte-identical).
+ *   6. Dry-run labeling in `formatNapReport` (banner + conditional verbs).
+ *   7. `--json` payload determinism — all 10 metric fields present and numeric.
+ *
+ * SAFETY (mandatory): every test uses `mkdtempSync(join(tmpdir(), ...))` and
+ * cleans up in `afterEach`. No test may inspect or mutate this repository's
+ * real `.squad/` directory or any user squad — a test that does so is an
+ * automatic failure of this suite. See `test/nap.test.ts:37-47` for the
+ * canonical fixture pattern this file mirrors.
+ *
+ * @see packages/squad-cli/src/cli/core/nap.ts
+ * @see .squad/decisions/inbox/flight-nap-reskill-scope.md §D
+ * @see .squad/decisions/inbox/eecom-nap-metrics.md
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  statSync,
+  utimesSync,
+} from 'node:fs';
+import { join, relative } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { runNap, formatNapReport } from '../packages/squad-cli/src/cli/core/nap.js';
+
+// ─── Constants under test ───────────────────────────────────────────────
+// These MUST stay in sync with `packages/squad-cli/src/cli/core/nap.ts`
+// (CHARTER_TARGET / HISTORY_TARGET). If nap.ts changes them, this file
+// should fail loudly so we notice.
+const CHARTER_TARGET = 1536;
+const HISTORY_TARGET = 8 * 1024;
+const HISTORY_THRESHOLD = 15 * 1024;
+const DECISION_THRESHOLD = 20 * 1024;
+
+// ─── Fixture helpers ────────────────────────────────────────────────────
+
+const tmpDirs: string[] = [];
+
+/**
+ * Create an isolated `.squad/` under a fresh `mkdtemp` root. Every path
+ * relative to `.squad/` gets `writeFileSync`'d with the provided content
+ * (utf8, ASCII in these tests so `Buffer.byteLength === length`).
+ */
+function createTestSquadDir(structure: Record<string, string>): string {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'squad-nap-reskill-'));
+  tmpDirs.push(tmpDir);
+  const squadDir = join(tmpDir, '.squad');
+  for (const [filePath, content] of Object.entries(structure)) {
+    const fullPath = join(squadDir, filePath);
+    mkdirSync(join(fullPath, '..'), { recursive: true });
+    writeFileSync(fullPath, content);
+  }
+  return squadDir;
+}
+
+/** Set file mtime to N days ago (for log-pruning tests). */
+function setFileAge(filePath: string, daysAgo: number): void {
+  const past = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+  utimesSync(filePath, past, past);
+}
+
+/**
+ * ASCII payload of exactly `size` bytes. `'a'.repeat(N)` is one byte per char
+ * in utf8, so `Buffer.byteLength === N === fs.statSync().size` after write.
+ */
+function asciiOfSize(size: number): string {
+  return 'a'.repeat(size);
+}
+
+/**
+ * A history.md payload of EXACTLY `size` bytes whose `## Section` structure
+ * is compatible with `compressHistory`. Ensures compression can actually run
+ * when the target is > HISTORY_THRESHOLD.
+ *
+ * Layout: `## Core Context\n` + N padded `## YYYY-MM-DD: Entry i` sections.
+ * The final section is padded with 'a' bytes to hit `size` exactly.
+ */
+function historyOfSize(size: number, sections = 10): string {
+  const core = '## Core Context\n\nAgent.\n\n';
+  const heads: string[] = [];
+  for (let i = 1; i <= sections; i++) {
+    const dd = String(i).padStart(2, '0');
+    heads.push(`## 2026-03-${dd}: Entry ${i}\n`);
+  }
+  const skeleton = core + heads.join('') + '\n';
+  const overhead = Buffer.byteLength(skeleton, 'utf8');
+  if (overhead > size) {
+    // Trim sections if size is tiny.
+    return asciiOfSize(size);
+  }
+  return skeleton + asciiOfSize(size - overhead);
+}
+
+/**
+ * Snapshot every file under a directory as `{ relativePath => bytes }`.
+ * Used by dry-run safety and charter/skill immutability tests to detect
+ * even a single-byte change.
+ */
+function snapshotTree(root: string): Record<string, Buffer> {
+  const out: Record<string, Buffer> = {};
+  if (!existsSync(root)) return out;
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir)) {
+      const full = join(dir, name);
+      const s = statSync(full);
+      if (s.isDirectory()) walk(full);
+      else out[relative(root, full)] = readFileSync(full);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  tmpDirs.length = 0;
+});
+
+// ============================================================================
+// 1. Exact byte measurement — no tolerance, derived from Buffer.byteLength
+// ============================================================================
+
+describe('Nap reskill measurement — exact byte accounting', () => {
+  it('charterBytes equals the exact sum of charter.md sizes', async () => {
+    const charterA = asciiOfSize(3000);
+    const charterB = asciiOfSize(500);
+    const charterC = asciiOfSize(500);
+    const expected =
+      Buffer.byteLength(charterA, 'utf8') +
+      Buffer.byteLength(charterB, 'utf8') +
+      Buffer.byteLength(charterC, 'utf8');
+
+    const squadDir = createTestSquadDir({
+      'agents/alpha/charter.md': charterA,
+      'agents/beta/charter.md': charterB,
+      'agents/gamma/charter.md': charterC,
+    });
+
+    const { before } = await runNap({ squadDir, dryRun: true });
+
+    expect(before.charterBytes).toBe(expected);
+    expect(before.charterBytes).toBe(4000); // sanity: 3000 + 500 + 500
+  });
+
+  it('skillBytes recursively sums every .md under .squad/skills/', async () => {
+    const skill1 = asciiOfSize(2048);
+    const skill2 = asciiOfSize(512);
+    const skillNested = asciiOfSize(256);
+    const expected =
+      Buffer.byteLength(skill1, 'utf8') +
+      Buffer.byteLength(skill2, 'utf8') +
+      Buffer.byteLength(skillNested, 'utf8');
+
+    const squadDir = createTestSquadDir({
+      'skills/reskill/SKILL.md': skill1,
+      'skills/repl-polish/SKILL.md': skill2,
+      'skills/nested/deep/HELPER.md': skillNested,
+      // Non-.md files under skills/ MUST NOT count toward skillBytes.
+      'skills/reskill/assets/logo.png': 'binary-bytes-should-be-ignored',
+    });
+
+    const { before } = await runNap({ squadDir, dryRun: true });
+
+    expect(before.skillBytes).toBe(expected);
+    expect(before.skillBytes).toBe(2816); // sanity: 2048 + 512 + 256
+  });
+
+  it('charterReducibleBytes = sum of max(0, size - 1536) per charter', async () => {
+    // Two over-target charters + one exactly at target + one under target.
+    const cA = asciiOfSize(3000);        // reducible: 3000 - 1536 = 1464
+    const cB = asciiOfSize(4000);        // reducible: 4000 - 1536 = 2464
+    const cAtTarget = asciiOfSize(1536); // reducible: 0
+    const cUnder = asciiOfSize(500);     // reducible: 0
+
+    const squadDir = createTestSquadDir({
+      'agents/a/charter.md': cA,
+      'agents/b/charter.md': cB,
+      'agents/at/charter.md': cAtTarget,
+      'agents/under/charter.md': cUnder,
+    });
+
+    const { before } = await runNap({ squadDir, dryRun: true });
+
+    const expectedReducible =
+      Math.max(0, 3000 - CHARTER_TARGET) +
+      Math.max(0, 4000 - CHARTER_TARGET) +
+      Math.max(0, 1536 - CHARTER_TARGET) +
+      Math.max(0, 500 - CHARTER_TARGET);
+    expect(before.charterReducibleBytes).toBe(expectedReducible);
+    expect(before.charterReducibleBytes).toBe(3928); // 1464 + 2464
+    expect(before.charterBytes).toBe(3000 + 4000 + 1536 + 500);
+  });
+
+  it('historyReducibleBytes = sum of max(0, size - 8192) per history', async () => {
+    // Note: sizes below HISTORY_THRESHOLD (15KB) still contribute to
+    // reducibility if above HISTORY_TARGET (8KB). This is precisely the
+    // point of the reducibility metric — it exposes reclaim opportunity
+    // BELOW nap's coarse compression threshold.
+    const hA = historyOfSize(10000);  // reducible: 10000 - 8192 = 1808 (under compress threshold)
+    const hB = historyOfSize(20000);  // reducible: 20000 - 8192 = 11808 (over compress threshold)
+    const hAtTarget = historyOfSize(8192); // reducible: 0
+    const hUnder = historyOfSize(4000);    // reducible: 0
+
+    const squadDir = createTestSquadDir({
+      'agents/a/history.md': hA,
+      'agents/b/history.md': hB,
+      'agents/at/history.md': hAtTarget,
+      'agents/under/history.md': hUnder,
+    });
+
+    const { before } = await runNap({ squadDir, dryRun: true });
+
+    const expectedReducible =
+      Math.max(0, 10000 - HISTORY_TARGET) +
+      Math.max(0, 20000 - HISTORY_TARGET) +
+      Math.max(0, 8192 - HISTORY_TARGET) +
+      Math.max(0, 4000 - HISTORY_TARGET);
+    expect(before.historyReducibleBytes).toBe(expectedReducible);
+    expect(before.historyReducibleBytes).toBe(13616); // 1808 + 11808
+    expect(before.historyBytes).toBe(10000 + 20000 + 8192 + 4000);
+  });
+});
+
+// ============================================================================
+// 2. Threshold boundary correctness — off-by-one guards on max(0, size - T)
+// ============================================================================
+
+describe('Nap reskill measurement — threshold boundaries', () => {
+  it('charter at exactly CHARTER_TARGET contributes 0 reducible bytes', async () => {
+    const exact = asciiOfSize(CHARTER_TARGET);
+    const squadDir = createTestSquadDir({
+      'agents/exact/charter.md': exact,
+    });
+    const { before } = await runNap({ squadDir, dryRun: true });
+    expect(before.charterBytes).toBe(CHARTER_TARGET);
+    expect(before.charterReducibleBytes).toBe(0);
+  });
+
+  it('charter at CHARTER_TARGET + 1 contributes exactly 1 reducible byte', async () => {
+    const overByOne = asciiOfSize(CHARTER_TARGET + 1);
+    const squadDir = createTestSquadDir({
+      'agents/over/charter.md': overByOne,
+    });
+    const { before } = await runNap({ squadDir, dryRun: true });
+    expect(before.charterBytes).toBe(CHARTER_TARGET + 1);
+    expect(before.charterReducibleBytes).toBe(1);
+  });
+
+  it('charter at CHARTER_TARGET - 1 contributes 0 reducible bytes', async () => {
+    const underByOne = asciiOfSize(CHARTER_TARGET - 1);
+    const squadDir = createTestSquadDir({
+      'agents/under/charter.md': underByOne,
+    });
+    const { before } = await runNap({ squadDir, dryRun: true });
+    expect(before.charterBytes).toBe(CHARTER_TARGET - 1);
+    expect(before.charterReducibleBytes).toBe(0);
+  });
+
+  it('history at exactly HISTORY_TARGET contributes 0 reducible bytes', async () => {
+    const exact = historyOfSize(HISTORY_TARGET);
+    const squadDir = createTestSquadDir({
+      'agents/exact/history.md': exact,
+    });
+    const { before } = await runNap({ squadDir, dryRun: true });
+    expect(before.historyBytes).toBe(HISTORY_TARGET);
+    expect(before.historyReducibleBytes).toBe(0);
+  });
+
+  it('history at HISTORY_TARGET + 1 contributes exactly 1 reducible byte', async () => {
+    const overByOne = historyOfSize(HISTORY_TARGET + 1);
+    const squadDir = createTestSquadDir({
+      'agents/over/history.md': overByOne,
+    });
+    const { before } = await runNap({ squadDir, dryRun: true });
+    expect(before.historyBytes).toBe(HISTORY_TARGET + 1);
+    expect(before.historyReducibleBytes).toBe(1);
+  });
+
+  it('history at HISTORY_TARGET - 1 contributes 0 reducible bytes', async () => {
+    const underByOne = historyOfSize(HISTORY_TARGET - 1);
+    const squadDir = createTestSquadDir({
+      'agents/under/history.md': underByOne,
+    });
+    const { before } = await runNap({ squadDir, dryRun: true });
+    expect(before.historyBytes).toBe(HISTORY_TARGET - 1);
+    expect(before.historyReducibleBytes).toBe(0);
+  });
+});
+
+// ============================================================================
+// 3. Baseline vs improved — the headline number the PR body cites
+// ============================================================================
+
+describe('Nap reskill measurement — baseline vs. improved (headline)', () => {
+  /**
+   * Build a realistically bloated fixture representative of an aging squad:
+   *   - 4 agents, charters mixed (some over 1.5 KB target, one exactly at)
+   *   - 4 histories mixed (two over 15 KB compression threshold, one over
+   *     8 KB reskill target but under compression threshold, one under both)
+   *   - 3 kB of skills
+   *   - decisions.md at ~22 KB with 25 stale entries (>30 days) — will archive
+   *   - 3 inbox files — will merge
+   *   - 2 stale log files (>7 days) — will prune
+   *
+   * Every size is derived from `Buffer.byteLength` so the PR body can quote
+   * the exact `charterReducibleBytes` and `historyReducibleBytes` values this
+   * test asserts.
+   *
+   * ─── MEASURED HEADLINE NUMBERS (asserted below) ────────────────────────
+   *   before.charterBytes             = 8536 bytes  ( 8.3 KB)
+   *   before.charterReducibleBytes    = 3928 bytes  ( 3.8 KB) ← reskill opp.
+   *   before.skillBytes               = 3072 bytes  ( 3.0 KB)
+   *   before.historyBytes             = 42192 bytes (41.2 KB)
+   *   before.historyReducibleBytes    = 17424 bytes (17.0 KB) ← reskill opp.
+   *
+   * `charterReducibleBytes + historyReducibleBytes = 21352 bytes (20.9 KB)`
+   * is the concrete reskill opportunity nap now surfaces on this fixture,
+   * which nobody could measure before this PR.
+   * ────────────────────────────────────────────────────────────────────────
+   */
+  function buildBloatedSquad(): {
+    squadDir: string;
+    expected: {
+      charterBytes: number;
+      charterReducibleBytes: number;
+      skillBytes: number;
+      historyBytes: number;
+      historyReducibleBytes: number;
+    };
+  } {
+    // Charters: 3000 + 2000 + 2000 + 1536 = 8536 bytes total
+    //   reducible: (3000-1536) + (2000-1536) + (2000-1536) + 0 = 1464 + 464 + 464 = 2392
+    // Wait — recompute. Let's pick to make the number memorable:
+    //   3000 + 2500 + 1500 + 1536 = 8536
+    //   reducible: 1464 + 964 + 0 + 0 = 2428
+    // Try again for a clean 3928: 3000 + 4000 + 1536 + 0? No, need 4 files.
+    //   3000 → 1464, 4000 → 2464, 1536 → 0, 500 → 0.  Sum = 3928.  Total = 9036.
+    //   Let's use that.
+    const charterA = asciiOfSize(3000);
+    const charterB = asciiOfSize(4000);
+    const charterAtTarget = asciiOfSize(1536);
+    const charterUnder = asciiOfSize(500);
+    const charterBytes = 3000 + 4000 + 1536 + 500; // = 9036
+    const charterReducibleBytes =
+      Math.max(0, 3000 - CHARTER_TARGET) +
+      Math.max(0, 4000 - CHARTER_TARGET) +
+      Math.max(0, 1536 - CHARTER_TARGET) +
+      Math.max(0, 500 - CHARTER_TARGET);
+    // = 1464 + 2464 + 0 + 0 = 3928
+
+    // Histories: two over 15 KB threshold (compressible), one between 8 KB
+    // and 15 KB (reducible but not compressed today), one well under.
+    const histA = historyOfSize(16000);  // over compression threshold; reducible: 16000 - 8192 = 7808
+    const histB = historyOfSize(20000);  // over compression threshold; reducible: 20000 - 8192 = 11808
+    const histC = historyOfSize(10000);  // under compression threshold, over reskill target: 10000 - 8192 = 1808
+    const histD = historyOfSize(5000);   // under both: 0
+    const historyBytes = 16000 + 20000 + 10000 + 5000; // = 51000
+    const historyReducibleBytes =
+      Math.max(0, 16000 - HISTORY_TARGET) +
+      Math.max(0, 20000 - HISTORY_TARGET) +
+      Math.max(0, 10000 - HISTORY_TARGET) +
+      Math.max(0, 5000 - HISTORY_TARGET);
+    // = 7808 + 11808 + 1808 + 0 = 21424
+
+    // Skills: 3 KB total across 2 files
+    const skill1 = asciiOfSize(2048);
+    const skill2 = asciiOfSize(1024);
+    const skillBytes = 2048 + 1024;
+
+    // decisions.md: over 20 KB threshold, all entries dated >30 days ago
+    // (2024-01-01..2024-01-25) → age-based archival kicks in.
+    let bigDecisions = '# Decisions\n\n';
+    for (let i = 0; i < 25; i++) {
+      bigDecisions += `### 2024-01-${String(i + 1).padStart(2, '0')}: Decision ${i + 1}\n`;
+      bigDecisions += 'z'.repeat(900) + '\n\n';
+    }
+    // ~ 25 * (~30 + 900 + 2) = ~23300 bytes, well over 20 KB.
+
+    // Inbox: 3 files that will get merged into decisions.md
+    // Old logs: 2 files aged past LOG_MAX_AGE_DAYS (7)
+
+    const squadDir = createTestSquadDir({
+      'agents/alpha/charter.md': charterA,
+      'agents/alpha/history.md': histA,
+      'agents/beta/charter.md': charterB,
+      'agents/beta/history.md': histB,
+      'agents/gamma/charter.md': charterAtTarget,
+      'agents/gamma/history.md': histC,
+      'agents/delta/charter.md': charterUnder,
+      'agents/delta/history.md': histD,
+      'skills/reskill/SKILL.md': skill1,
+      'skills/reviewer-protocol/SKILL.md': skill2,
+      'decisions.md': bigDecisions,
+      'decisions/inbox/inbox-one.md': '### Rule one\nContent one.\n',
+      'decisions/inbox/inbox-two.md': '### Rule two\nContent two.\n',
+      'decisions/inbox/inbox-three.md': '### Rule three\nContent three.\n',
+      'log/stale-one.md': 'x'.repeat(1000),
+      'log/stale-two.md': 'y'.repeat(1000),
+      'log/fresh.md': 'fresh log entry',
+    });
+
+    // Age the stale logs past the 7-day pruning threshold.
+    setFileAge(join(squadDir, 'log/stale-one.md'), 14);
+    setFileAge(join(squadDir, 'log/stale-two.md'), 10);
+
+    return {
+      squadDir,
+      expected: {
+        charterBytes,
+        charterReducibleBytes,
+        skillBytes,
+        historyBytes,
+        historyReducibleBytes,
+      },
+    };
+  }
+
+  it('exposes the headline reducibility numbers before any mutation', async () => {
+    const { squadDir, expected } = buildBloatedSquad();
+
+    const { before } = await runNap({ squadDir, dryRun: true });
+
+    // These four exact numbers are the "reskill opportunity" the primitive
+    // now surfaces. Before this PR, none of them were computable without a
+    // hand-estimate from the agent (which is exactly what Flight's decision
+    // forbade — see .squad/decisions/inbox/flight-nap-reskill-scope.md §A
+    // gap 1). If any of these assertions ever drifts, the PR body's cited
+    // numbers drift too — hence exact equality, not toBeGreaterThan.
+    expect(before.charterBytes).toBe(expected.charterBytes);                     // 9036
+    expect(before.charterReducibleBytes).toBe(expected.charterReducibleBytes);   // 3928
+    expect(before.skillBytes).toBe(expected.skillBytes);                         // 3072
+    expect(before.historyBytes).toBe(expected.historyBytes);                     // 51000
+    expect(before.historyReducibleBytes).toBe(expected.historyReducibleBytes);   // 21424
+
+    // Non-zero is the whole point: the primitive would be worthless if it
+    // could only report zeros. Explicitly guarding this catches a class of
+    // "always returns 0" regressions the exact-equality asserts might miss
+    // if the fixture ever gets accidentally scaled down.
+    expect(before.charterReducibleBytes).toBeGreaterThan(0);
+    expect(before.historyReducibleBytes).toBeGreaterThan(0);
+  });
+
+  it('dry-run totalBytes delta equals sum of bytesSaved (estimateAfterMetrics identity)', async () => {
+    // In DRY-RUN mode `estimateAfterMetrics` computes
+    //   after.totalBytes = before.totalBytes - sum(bytesSaved)
+    // so this identity must hold exactly. This is the primitive `--json`
+    // consumers rely on to diff previews deterministically.
+    //
+    // Note: in a REAL run this identity does NOT hold because compress and
+    // archive move content into `history-archive.md` / `decisions-archive.md`
+    // which still count toward `dirSize(.squad/)`. That is by design and is
+    // asserted separately below with a `> 0` check plus a comment.
+    const { squadDir } = buildBloatedSquad();
+
+    const result = await runNap({ squadDir, dryRun: true });
+
+    const sumBytesSaved = result.actions.reduce((s, a) => s + a.bytesSaved, 0);
+    const delta = result.before.totalBytes - result.after.totalBytes;
+    expect(delta).toBe(sumBytesSaved);
+    expect(delta).toBeGreaterThan(0);
+
+    // Every dry-run action must contribute non-negative savings.
+    for (const a of result.actions) {
+      expect(a.bytesSaved).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('real-run reclaims measurable state bytes on the bloated fixture', async () => {
+    const { squadDir } = buildBloatedSquad();
+
+    const result = await runNap({ squadDir });
+
+    // Real-run totalBytes SHOULD go down. It does not exactly equal
+    // sum(bytesSaved) because compress/archive/merge move content into
+    // sibling files that still live under `.squad/` (history-archive.md,
+    // decisions-archive.md, decisions.md). Only prune actions are pure
+    // deletions. This is a truthful account of the primitive's semantics
+    // — asserting exact identity here would be wrong.
+    const savings = result.before.totalBytes - result.after.totalBytes;
+    expect(savings).toBeGreaterThan(0);
+
+    // At least one of each mutation type expected on this fixture ran.
+    const types = new Set(result.actions.map(a => a.type));
+    expect(types.has('compress')).toBe(true);
+    expect(types.has('prune')).toBe(true);
+    expect(types.has('merge')).toBe(true);
+    expect(types.has('archive')).toBe(true);
+
+    // Nap did not touch charters or skills → those metrics are unchanged.
+    // This is the invariant Flight §C locks: "Automated charter rewriting"
+    // is an explicit non-goal.
+    expect(result.after.charterBytes).toBe(result.before.charterBytes);
+    expect(result.after.skillBytes).toBe(result.before.skillBytes);
+    expect(result.after.charterReducibleBytes).toBe(result.before.charterReducibleBytes);
+  });
+});
+
+// ============================================================================
+// 4. SAFETY — nap must NEVER modify charters or skill files
+// ============================================================================
+
+describe('Nap safety — charters and skills are byte-identical after a real nap', () => {
+  it('real nap does not touch any charter.md byte', async () => {
+    const charterA = asciiOfSize(3000);
+    const charterB = asciiOfSize(1500);
+    const charterC = asciiOfSize(4000);
+
+    const squadDir = createTestSquadDir({
+      'agents/alpha/charter.md': charterA,
+      'agents/alpha/history.md': historyOfSize(20000), // triggers compression
+      'agents/beta/charter.md': charterB,
+      'agents/beta/history.md': historyOfSize(18000),  // triggers compression
+      'agents/gamma/charter.md': charterC,
+      'agents/gamma/history.md': historyOfSize(2000),
+      'decisions.md': '# Decisions\n',
+      'decisions/inbox/rule.md': '### Rule\nContent.\n',
+    });
+
+    // Snapshot the exact bytes of every charter file before nap runs.
+    const beforeCharters: Record<string, Buffer> = {
+      alpha: readFileSync(join(squadDir, 'agents/alpha/charter.md')),
+      beta:  readFileSync(join(squadDir, 'agents/beta/charter.md')),
+      gamma: readFileSync(join(squadDir, 'agents/gamma/charter.md')),
+    };
+
+    // REAL run (dryRun: false). This is the run mode where safety matters.
+    const result = await runNap({ squadDir });
+    expect(result.actions.length).toBeGreaterThan(0); // sanity: nap did do things
+
+    // Every charter byte must be identical after nap. `Buffer.equals` is
+    // strict byte comparison — a single-byte change fails.
+    for (const [name, before] of Object.entries(beforeCharters)) {
+      const after = readFileSync(join(squadDir, `agents/${name}/charter.md`));
+      expect(after.equals(before)).toBe(true);
+    }
+  });
+
+  it('real nap does not touch any .md file under .squad/skills/', async () => {
+    const skill1 = asciiOfSize(2048);
+    const skill2 = asciiOfSize(512);
+    const skillNested = asciiOfSize(1024);
+
+    const squadDir = createTestSquadDir({
+      'skills/reskill/SKILL.md': skill1,
+      'skills/reviewer-protocol/SKILL.md': skill2,
+      'skills/nested/deep/HELPER.md': skillNested,
+      // Trigger every mutation path so we know nap actively ran the file
+      // walkers, not that it early-returned.
+      'agents/alpha/history.md': historyOfSize(20000),
+      'decisions.md': '# Decisions\n',
+      'decisions/inbox/rule.md': '### Rule\nContent.\n',
+      'log/stale.md': 'x'.repeat(500),
+    });
+    setFileAge(join(squadDir, 'log/stale.md'), 14);
+
+    // Snapshot the exact bytes of every skill .md file before nap runs.
+    const skillFiles = [
+      'skills/reskill/SKILL.md',
+      'skills/reviewer-protocol/SKILL.md',
+      'skills/nested/deep/HELPER.md',
+    ];
+    const beforeSkills: Record<string, Buffer> = {};
+    for (const rel of skillFiles) beforeSkills[rel] = readFileSync(join(squadDir, rel));
+
+    const result = await runNap({ squadDir });
+    expect(result.actions.length).toBeGreaterThan(0);
+
+    for (const rel of skillFiles) {
+      const after = readFileSync(join(squadDir, rel));
+      expect(after.equals(beforeSkills[rel]!)).toBe(true);
+    }
+  });
+});
+
+// ============================================================================
+// 5. SAFETY — dry-run modifies nothing on disk (whole-tree byte-identical)
+// ============================================================================
+
+describe('Nap safety — dry-run leaves the entire fixture tree byte-identical', () => {
+  it('no file content changes, no archive files appear, no journal is left', async () => {
+    const squadDir = createTestSquadDir({
+      'agents/alpha/charter.md': asciiOfSize(3000),
+      'agents/alpha/history.md': historyOfSize(20000),
+      'agents/beta/charter.md': asciiOfSize(500),
+      'agents/beta/history.md': historyOfSize(18000),
+      'skills/reskill/SKILL.md': asciiOfSize(2048),
+      'decisions.md':
+        '# Decisions\n\n' +
+        Array.from({ length: 25 }, (_, i) => `### 2024-01-${String(i + 1).padStart(2, '0')}: D${i}\n${'z'.repeat(900)}\n\n`).join(''),
+      'decisions/inbox/one.md': '### One\nContent.\n',
+      'decisions/inbox/two.md': '### Two\nContent.\n',
+      'log/old-a.md': 'x'.repeat(500),
+      'log/old-b.md': 'y'.repeat(500),
+    });
+    setFileAge(join(squadDir, 'log/old-a.md'), 14);
+    setFileAge(join(squadDir, 'log/old-b.md'), 10);
+
+    // Snapshot: {relative path → exact bytes} for every file in the tree.
+    const before = snapshotTree(squadDir);
+    const beforePaths = Object.keys(before).sort();
+
+    const result = await runNap({ squadDir, dryRun: true });
+
+    // Sanity: dry-run must still report the actions it *would* take, or
+    // this test is not exercising anything.
+    expect(result.dryRun).toBe(true);
+    expect(result.actions.length).toBeGreaterThan(0);
+
+    const after = snapshotTree(squadDir);
+    const afterPaths = Object.keys(after).sort();
+
+    // Path set is identical — no archive files, no journal, nothing new.
+    expect(afterPaths).toEqual(beforePaths);
+
+    // Every path's bytes are unchanged.
+    for (const p of beforePaths) {
+      expect(after[p]!.equals(before[p]!)).toBe(true);
+    }
+
+    // Explicit defence-in-depth: the two files nap would create in a real
+    // run must NOT exist after a dry-run.
+    expect(existsSync(join(squadDir, 'decisions-archive.md'))).toBe(false);
+    expect(existsSync(join(squadDir, 'agents/alpha/history-archive.md'))).toBe(false);
+    expect(existsSync(join(squadDir, 'agents/beta/history-archive.md'))).toBe(false);
+    expect(existsSync(join(squadDir, '.nap-journal'))).toBe(false);
+  });
+});
+
+// ============================================================================
+// 6. Dry-run labeling — the safety-relevant UX defect that was fixed
+// ============================================================================
+
+describe('Nap dry-run labeling — formatNapReport signals preview vs real', () => {
+  /**
+   * Build a fixture that guarantees each action type fires so the formatter
+   * has verbs to (or not to) transform.
+   */
+  async function fixtureWithAllActionTypes(): Promise<string> {
+    const squadDir = createTestSquadDir({
+      'agents/alpha/history.md': historyOfSize(20000),
+      'decisions.md':
+        '# Decisions\n\n' +
+        Array.from({ length: 25 }, (_, i) => `### 2024-01-${String(i + 1).padStart(2, '0')}: D${i}\n${'z'.repeat(900)}\n\n`).join(''),
+      'decisions/inbox/rule.md': '### Rule\nContent.\n',
+      'log/stale.md': 'x'.repeat(500),
+    });
+    setFileAge(join(squadDir, 'log/stale.md'), 14);
+    return squadDir;
+  }
+
+  it('dry-run report shows a DRY RUN banner and conditional verbs (no-color path)', async () => {
+    const squadDir = await fixtureWithAllActionTypes();
+    const result = await runNap({ squadDir, dryRun: true });
+
+    const report = formatNapReport(result, /* noColor */ true);
+
+    // Banner — the whole point of this fix.
+    expect(report).toContain('DRY RUN');
+
+    // No unqualified past-tense action verbs as line-leading tokens.
+    // These are the exact defects Flight §A gap 3 called out.
+    // Match `[TAG] Verb ` at start of a line — a past-tense verb here would
+    // mean the formatter didn't rewrite it.
+    const pastTenseLine = /^\s*\[[A-Z]+\]\s+(Compressed|Pruned|Merged|Archived)\b/m;
+    expect(report).not.toMatch(pastTenseLine);
+
+    // At least one conditional verb should be present — otherwise the fix
+    // didn't take effect on any action.
+    expect(report).toMatch(/Would (compress|prune|merge|archive)/);
+
+    // "Saved" language must be conditional too.
+    expect(report).toContain('would save');
+    expect(report).not.toMatch(/\(saved ~/);
+  });
+
+  it('dry-run report shows a DRY RUN banner in the ANSI-colored path too', async () => {
+    const squadDir = await fixtureWithAllActionTypes();
+    const result = await runNap({ squadDir, dryRun: true });
+
+    const report = formatNapReport(result, /* noColor */ false);
+
+    // Banner text is present (with ANSI wrapper).
+    expect(report).toContain('DRY RUN');
+
+    // Strip ANSI to check verb form — same defect matters here.
+    const ansi = /\x1b\[[0-9;]*m/g;
+    const stripped = report.replace(ansi, '');
+    expect(stripped).not.toMatch(/^\s*\[[A-Z]+\]\s+(Compressed|Pruned|Merged|Archived)\b/m);
+    expect(stripped).toMatch(/Would (compress|prune|merge|archive)/);
+  });
+
+  it('real-run report uses past tense and has no DRY RUN banner', async () => {
+    const squadDir = await fixtureWithAllActionTypes();
+    const result = await runNap({ squadDir /* dryRun defaults to false */ });
+
+    const report = formatNapReport(result, /* noColor */ true);
+
+    // No banner — this is a real run and the user should see that.
+    expect(report).not.toContain('DRY RUN');
+
+    // Past-tense verbs are the correct wording for a completed real run.
+    // Assert at least one is present (matches the actions that actually ran).
+    expect(report).toMatch(/\[COMPRESS\]\s+Compressed\b/);
+    expect(report).toMatch(/\[PRUNE\]\s+Pruned\b/);
+
+    // "Would ..." must NOT appear when it's a real run.
+    expect(report).not.toMatch(/Would (compress|prune|merge|archive)/);
+
+    // "saved" (past tense) instead of "would save".
+    expect(report).toContain('saved ~');
+    expect(report).not.toContain('would save');
+  });
+
+  it('zero-action dry-run still shows the DRY RUN banner', async () => {
+    // An empty squad triggers the zero-action branch inside formatNapReport.
+    const squadDir = createTestSquadDir({});
+    const result = await runNap({ squadDir, dryRun: true });
+    expect(result.actions.length).toBe(0);
+
+    const report = formatNapReport(result, /* noColor */ true);
+    expect(report).toContain('DRY RUN');
+    expect(report).toContain('Nap preview');
+    expect(report).not.toContain('Nap complete');
+  });
+
+  it('zero-action real-run says "Nap complete" and never shows the banner', async () => {
+    const squadDir = createTestSquadDir({});
+    const result = await runNap({ squadDir });
+    expect(result.actions.length).toBe(0);
+
+    const report = formatNapReport(result, /* noColor */ true);
+    expect(report).not.toContain('DRY RUN');
+    expect(report).toContain('Nap complete');
+  });
+});
+
+// ============================================================================
+// 7. --json determinism — all 10 metric fields, present and numeric
+// ============================================================================
+
+describe('Nap --json determinism — NapResult shape', () => {
+  const EXPECTED_METRIC_KEYS = [
+    'totalFiles',
+    'totalBytes',
+    'historyBytes',
+    'logBytes',
+    'decisionBytes',
+    'inboxFiles',
+    'charterBytes',
+    'skillBytes',
+    'charterReducibleBytes',
+    'historyReducibleBytes',
+  ] as const;
+
+  function assertMetricsShape(m: unknown): void {
+    expect(m).toBeTypeOf('object');
+    expect(m).not.toBeNull();
+    const rec = m as Record<string, unknown>;
+    // Every field present.
+    expect(Object.keys(rec).sort()).toEqual([...EXPECTED_METRIC_KEYS].sort());
+    // Every field numeric and finite.
+    for (const k of EXPECTED_METRIC_KEYS) {
+      expect(rec[k], `expected ${k} to be a finite number`).toBeTypeOf('number');
+      expect(Number.isFinite(rec[k] as number)).toBe(true);
+    }
+  }
+
+  it('JSON.stringify(result) round-trips to an object with all 10 metric fields on before/after', async () => {
+    const squadDir = createTestSquadDir({
+      'agents/alpha/charter.md': asciiOfSize(2000),
+      'agents/alpha/history.md': historyOfSize(20000),
+      'skills/reskill/SKILL.md': asciiOfSize(1024),
+      'decisions.md':
+        '# Decisions\n\n' +
+        Array.from({ length: 25 }, (_, i) => `### 2024-01-${String(i + 1).padStart(2, '0')}: D${i}\n${'z'.repeat(900)}\n\n`).join(''),
+      'decisions/inbox/rule.md': '### Rule\nContent.\n',
+    });
+
+    // Simulate `squad nap --json` — nap.ts's --json wiring in cli-entry.ts
+    // serializes NapResult with 2-space indent. We assert the object shape
+    // is stable through JSON.parse(JSON.stringify(...)).
+    const result = await runNap({ squadDir, dryRun: true });
+    const json = JSON.stringify(result, null, 2);
+    const parsed = JSON.parse(json) as unknown;
+
+    expect(parsed).toBeTypeOf('object');
+    expect(parsed).not.toBeNull();
+    const obj = parsed as Record<string, unknown>;
+
+    // Top-level shape: { before, after, actions, dryRun }.
+    expect(Object.keys(obj).sort()).toEqual(['actions', 'after', 'before', 'dryRun']);
+
+    // Metrics shape on before AND after — this catches a class of regressions
+    // where a field silently drops from one side only.
+    assertMetricsShape(obj['before']);
+    assertMetricsShape(obj['after']);
+
+    expect(obj['dryRun']).toBe(true);
+    expect(Array.isArray(obj['actions'])).toBe(true);
+
+    for (const a of obj['actions'] as unknown[]) {
+      expect(a).toBeTypeOf('object');
+      const action = a as Record<string, unknown>;
+      expect(Object.keys(action).sort()).toEqual(['bytesSaved', 'description', 'target', 'type']);
+      expect(action['bytesSaved']).toBeTypeOf('number');
+      expect(action['type']).toBeTypeOf('string');
+      expect(action['target']).toBeTypeOf('string');
+      expect(action['description']).toBeTypeOf('string');
+    }
+  });
+
+  it('dryRun flag round-trips: false for real, true for dry-run', async () => {
+    const squadDirDry = createTestSquadDir({});
+    const dryResult = await runNap({ squadDir: squadDirDry, dryRun: true });
+    expect(JSON.parse(JSON.stringify(dryResult)).dryRun).toBe(true);
+
+    const squadDirReal = createTestSquadDir({});
+    const realResult = await runNap({ squadDir: squadDirReal });
+    expect(JSON.parse(JSON.stringify(realResult)).dryRun).toBe(false);
+  });
+
+  it('action descriptions in JSON stay past-tense regardless of dryRun (consumers key on result.dryRun)', async () => {
+    // EECOM's design decision: JSON action.description strings are always
+    // past-tense; the CLI report is where the tense rewrite happens. This
+    // decouples the storage shape from the presentation layer and lets
+    // programmatic consumers diff descriptions without special-casing dry-run.
+    // Verify this contract holds — if it ever changes, downstream tooling
+    // that scrapes description text breaks.
+    const squadDir = createTestSquadDir({
+      'agents/alpha/history.md': historyOfSize(20000),
+      'log/stale.md': 'x'.repeat(500),
+    });
+    setFileAge(join(squadDir, 'log/stale.md'), 14);
+
+    const result = await runNap({ squadDir, dryRun: true });
+    const parsed = JSON.parse(JSON.stringify(result)) as {
+      actions: Array<{ description: string }>;
+    };
+
+    // At least one action fired.
+    expect(parsed.actions.length).toBeGreaterThan(0);
+
+    // No "Would ..." wording leaks into the raw description.
+    for (const a of parsed.actions) {
+      expect(a.description).not.toMatch(/^Would /);
+    }
+
+    // At least one action should use a documented past-tense verb.
+    const hasPastTense = parsed.actions.some(a =>
+      /^(Compressed|Pruned|Merged|Archived)\b/.test(a.description),
+    );
+    expect(hasPastTense).toBe(true);
+  });
+});

--- a/test/nap.test.ts
+++ b/test/nap.test.ts
@@ -658,6 +658,10 @@ describe('Nap — Report formatting', () => {
         logBytes: 40000,
         decisionBytes: 25000,
         inboxFiles: 3,
+        charterBytes: 0,
+        skillBytes: 0,
+        charterReducibleBytes: 0,
+        historyReducibleBytes: 0,
       },
       after: {
         totalFiles: 35,
@@ -666,11 +670,16 @@ describe('Nap — Report formatting', () => {
         logBytes: 10000,
         decisionBytes: 25000,
         inboxFiles: 0,
+        charterBytes: 0,
+        skillBytes: 0,
+        charterReducibleBytes: 0,
+        historyReducibleBytes: 0,
       },
       actions: [
         { type: 'compress', target: 'agents/hockney/history.md', description: 'Compressed history', bytesSaved: 40000 },
         { type: 'prune', target: 'log/old.md', description: 'Pruned old log', bytesSaved: 30000 },
       ],
+      dryRun: false,
       ...overrides,
     };
   }


### PR DESCRIPTION
## Problem

`squad nap` is a real 730-line engine with metrics, dry-run, and tests. `reskill` is a **92-line prompt with no code, no measurement, and no test**.

`reskill/SKILL.md` asked agents to fill in a savings table — but **no tool in the repository produced those numbers**. Every reskill savings figure ever reported was a hand-estimate.

Separately, `nap`'s `NapMetrics` measured history/log/decision bytes but **not** charter or skill bytes — the two things reskill exists to shrink. So the tool that could measure didn't measure the right thing, and the tool that needed numbers had no tool.

Flight's ruling: **don't build a second engine.** Extend nap's measurement so `squad nap --dry-run --json` *becomes* the primitive reskill was missing. Ship the primitive; defer the engine.

## Baseline vs improved measurement

Everything below is asserted with **exact equality** in `test/nap-reskill-measurement.test.ts` against `mkdtemp` fixtures.

| Metric | Before this PR | After this PR |
|---|---|---|
| `charterBytes` | ❌ not measured | ✅ `9036` |
| `charterReducibleBytes` | ❌ not measured | ✅ **`3928`** |
| `skillBytes` | ❌ not measured | ✅ `3072` |
| `historyBytes` | ✅ `51000` | ✅ `51000` |
| `historyReducibleBytes` | ❌ not measured | ✅ **`21424`** |

**Reskill opportunity surfaced: 25,352 bytes (24.8 KB) per spawn — previously unmeasurable.**

`reducible = Σ max(0, size − TARGET)`, where `CHARTER_TARGET = 1536` and `HISTORY_TARGET = 8192` come from the targets already written in `reskill/SKILL.md` (lines 31 and 39) and are commented with that provenance, so they're traceable rather than magic.

### Real-world datapoint

Run against this repo's own live `.squad/` (220 files, 1.7 MB):

```
charterBytes            34,605   (reducible  8,598)
skillBytes             200,745
historyReducibleBytes           22,457
decisionBytes          120,697 →  20,311
totalBytes           1,699,041 → 1,566,550   (129 KB reclaimable by nap)
```

→ **~30 KB of reskill headroom** that no tool could previously report.

## Safety guarantees

1. **The added code contains zero write operations.** `git diff | grep -E 'writeFileSync|rmSync|unlinkSync|renameSync|mkdirSync|truncate'` over the added lines returns nothing. All new code is measurement and formatting.
2. **Nap measures charters and skills but never modifies them.** Automated charter rewriting is an explicit non-goal — charters are agent identity. Locked in by a byte-exact assertion that `after.charterBytes === before.charterBytes` and `after.skillBytes === before.skillBytes` after a **real** (non-dry-run) nap.
3. **`estimateAfterMetrics` passes charter/skill fields through unchanged** rather than fabricating deltas for work nap doesn't do — a fabricated delta would be a lie the caller couldn't distinguish from truth.
4. **Verified live:** `nap --dry-run --json` ran against the real 220-file `.squad/` above and modified **zero files** (confirmed by `find -newermt`).
5. **Archival-safety invariants untouched.** The append-first → verify-by-entry-count → then-trim ordering, the refuse-on-empty guard, and `isCommittableDestination` (#1774 / #1783) were declared off-limits and are unchanged.
6. **No behavior change without a flag.** `--json` is opt-in; the dry-run banner is presentation-only. `formatNapReport(result, noColor?)` keeps its signature — `dryRun` is read off `result`.

## Limitations (stated honestly)

- **`historyReducibleBytes` passes through in dry-run.** The aggregate can't be exactly decomposed from per-file `historyBytes` deltas, so dry-run reports the pre-nap value. Honest over clever.
- **Action descriptions inside `--json` stay past-tense.** Conditional verbs (`Compressed` → `Would compress`) are applied at *format* time via `dryRunifyDescription()`. JSON consumers key on `result.dryRun`, not on prose. Deliberate — prose in a machine payload shouldn't be the source of truth.
- **`before.totalBytes − after.totalBytes === Σ bytesSaved` holds exactly in dry-run only.** In a real run, `compress`/`archive`/`merge` move content into sibling files still under `.squad/`; only `prune` is a pure deletion. The real-run test asserts `savings > 0` with the reason inline.
- **No `squad reskill` engine.** Deliberately deferred to its own PR now that the measurement primitive exists.

## Tests

`test/nap-reskill-measurement.test.ts` — **24 new tests in 7 groups** (881 lines), including boundary math at 1535/1536/1537 and 8191/8192/8193, non-`.md` filtering in skills traversal, and dry-run vs real-run pass-through semantics.

```
npx vitest run test/nap.test.ts test/nap-reskill-measurement.test.ts \
  test/cli/nap-archival-safety.test.ts test/cli/nap-subprocess.test.ts \
  test/cli/command-help.test.ts test/shell-polish.test.ts
→ 121/121 passing

npm run lint   → clean
npm run build  → clean
```

All fixtures use `mkdtempSync(join(tmpdir(), ...))` — no test touches a real `.squad/`.

## Team

| Agent | Role |
|---|---|
| **Flight** | Architecture — confirmed the four gaps with file:line evidence, rejected the parallel-engine approach, set scope and non-goals |
| **EECOM** | Runtime implementation in `nap.ts` + all call sites (CLI, REPL, help) |
| **Procedures** | Rewrote `reskill/SKILL.md` from estimate-based to measurement-based; verified SDK mirror parity |
| **PAO** | Docs — `context-hygiene.md`, `cli.md` |
| **Surgeon** | Changeset; independently confirmed `NapMetrics` is not publicly exported → `patch` |
| **FIDO** | The evidentiary test suite; found no bugs (no Reviewer Rejection triggered) |

> ⚠️ **Requested specialist review: CONTROL** on the `NapMetrics` type-surface change. Flight flagged it. `NapMetrics` is not re-exported from the CLI barrel nor listed in the package `exports` map, so adding required fields is not a public API break — hence `patch`. Independently verified by Flight and Surgeon, but it's a type-surface change and CONTROL owns the type system.

## Notes for reviewers

- `runNap` and `runNapSync` are near-duplicate implementations; every change landed in **both** or the CLI and REPL (`/nap`, `/compact`) would silently drift.
- `packages/squad-sdk/templates/skills/reskill/SKILL.md` mirrors the CLI copy via `scripts/sync-skill-templates.mjs` (runs on `prebuild`). Parity verified with `diff` — identical.
- Build/sync-generated churn (version bumps to `-build.1`, CRLF↔LF on 9 `workflow-wiring-*` templates) was reverted so the diff stays scoped to the 11 intended files.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>