### PR TITLE
fix: refresh stale squad.agent.md greeting version on re-init

### DIFF
--- a/.changeset/fix-reinit-stale-version-greeting.md
+++ b/.changeset/fix-reinit-stale-version-greeting.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+Fix `squad init` re-run on an existing project leaving the `squad.agent.md` first-response greeting (`` `Squad v...` ``) stamped with a stale version even though the HTML comment marker and Identity `Version:` line were correctly refreshed. The greeting regex previously only matched the unresolved `{version}` placeholder, so once a real version had been stamped once, later re-stamps could no longer update it. Both `stampVersion` (squad-cli) and `stampVersionInContent` (squad-sdk) now also match an already-resolved `` `Squad vX.Y.Z` `` literal, making all three version locations idempotently updatable on every re-init or upgrade.

--- a/packages/squad-cli/src/cli/core/version.ts
+++ b/packages/squad-cli/src/cli/core/version.ts
@@ -38,8 +38,10 @@ export function stampVersion(filePath: string, version: string): void {
   content = content.replace(/<!-- version: [^>]+ -->/m, `<!-- version: ${version} -->`);
   // Replace version in the Identity section's Version line
   content = content.replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+(?:\.\d+)?)?/m, `- **Version:** ${version}`);
-  // Replace {version} placeholder in the greeting instruction so it's unambiguous
-  content = content.replace(/`Squad v\{version\}`/g, `\`Squad v${version}\``);
+  // Replace the greeting instruction's version literal so it's unambiguous.
+  // Matches both the unresolved `{version}` placeholder and an already-resolved
+  // semver (e.g. from a prior stamp) so re-running this idempotently refreshes it.
+  content = content.replace(/`Squad v[^`]*`/g, `\`Squad v${version}\``);
   storage.writeSync(filePath, content);
 }
 

--- a/packages/squad-sdk/src/config/init.ts
+++ b/packages/squad-sdk/src/config/init.ts
@@ -631,9 +631,11 @@ function stampVersionInContent(content: string, version: string): string {
     /- \*\*Version:\*\* [0-9.]+(?:-[a-z]+(?:\.\d+)?)?/m,
     `- **Version:** ${version}`
   );
-  // Greeting placeholder: `Squad v{version}`
+  // Greeting placeholder: `Squad v{version}` — also matches an already-resolved
+  // semver (e.g. `Squad v0.11.0`) from a prior stamp so this is idempotent when
+  // re-run against a file that already went through stampVersionInContent.
   content = content.replace(
-    /`Squad v\{version\}`/g,
+    /`Squad v[^`]*`/g,
     `\`Squad v${version}\``
   );
   return content;

--- a/test/cli/init.test.ts
+++ b/test/cli/init.test.ts
@@ -4,13 +4,13 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdir, rm, readdir, readFile } from 'fs/promises';
+import { mkdir, rm, readdir, readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { randomBytes } from 'crypto';
 import { runInit } from '@bradygaster/squad-cli/core/init';
-import { getPackageVersion } from '@bradygaster/squad-cli/core/version';
+import { getPackageVersion, stampVersion } from '@bradygaster/squad-cli/core/version';
 
 const TEST_ROOT = join(tmpdir(), `.test-cli-init-${randomBytes(4).toString('hex')}`);
 const TEST_HOME = join(tmpdir(), `.test-cli-init-home-${randomBytes(4).toString('hex')}`);
@@ -65,6 +65,64 @@ describe('CLI: init command', () => {
     // {version} placeholder must be replaced
     expect(content).not.toContain('`Squad v{version}`');
     expect(content).toContain(`Squad v${currentVersion}`);
+  });
+
+  it('stampVersion should refresh an already-resolved greeting literal, not just the {version} placeholder (regression)', async () => {
+    // The greeting regex used to only match the unresolved `Squad v{version}`
+    // placeholder, so a file that already had a resolved (stale) literal from a
+    // prior stamp stayed stuck on the old version forever.
+    const agentPath = join(TEST_ROOT, 'squad.agent.md');
+    const staleVersion = '0.9.0';
+    const currentVersion = getPackageVersion();
+    const before = [
+      `<!-- version: ${staleVersion} -->`,
+      '',
+      `- **Version:** ${staleVersion}. Include it as \`Squad v${staleVersion}\` in your first response.`,
+    ].join('\n');
+    await writeFile(agentPath, before, 'utf-8');
+
+    stampVersion(agentPath, currentVersion);
+    const after = await readFile(agentPath, 'utf-8');
+
+    expect(after).toContain(`<!-- version: ${currentVersion} -->`);
+    expect(after).toContain(`- **Version:** ${currentVersion}`);
+    expect(after).toContain(`\`Squad v${currentVersion}\``);
+    expect(after).not.toContain(staleVersion);
+  });
+
+  it('re-running init against an existing project should refresh a stale resolved version everywhere, including the greeting literal (re-init regression)', async () => {
+    // First init creates squad.agent.md with the current version stamped
+    // everywhere. Simulate what a real "installed a while ago" repo looks
+    // like: all three version locations still show an older resolved
+    // version (not the unresolved {version} placeholder).
+    await runInit(TEST_ROOT);
+
+    const agentPath = join(TEST_ROOT, '.github', 'agents', 'squad.agent.md');
+    const currentVersion = getPackageVersion();
+    const staleVersion = '0.9.0';
+    const escapedCurrent = currentVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    let content = await readFile(agentPath, 'utf-8');
+    content = content
+      .replace(/<!-- version: [^>]+ -->/, `<!-- version: ${staleVersion} -->`)
+      .replace(/- \*\*Version:\*\* [0-9.]+(?:-[a-z]+(?:\.\d+)?)?/, `- **Version:** ${staleVersion}`)
+      .replace(new RegExp('`Squad v' + escapedCurrent + '`'), `\`Squad v${staleVersion}\``);
+    await writeFile(agentPath, content, 'utf-8');
+
+    // Sanity check: the stale literal is actually present before rerunning init.
+    const beforeRerun = await readFile(agentPath, 'utf-8');
+    expect(beforeRerun).toContain(`\`Squad v${staleVersion}\``);
+
+    // Re-init the existing project. squad.agent.md already exists, so init's
+    // template-copy step is skipped (skipExisting=true) — only the trailing
+    // "ensure version is fully stamped" step in runInit touches this file.
+    await runInit(TEST_ROOT);
+
+    const afterRerun = await readFile(agentPath, 'utf-8');
+    expect(afterRerun).toContain(`<!-- version: ${currentVersion} -->`);
+    expect(afterRerun).toContain(`- **Version:** ${currentVersion}`);
+    expect(afterRerun).toContain(`\`Squad v${currentVersion}\``);
+    expect(afterRerun).not.toContain(staleVersion);
   });
 
   it('should create .squad/ directory structure', async () => {


### PR DESCRIPTION
### What
Fixes `squad.agent.md`'s first-response greeting literal (backtick-quoted `` `Squad v...` ``) staying stamped with a stale version when `squad init` is re-run against an already-initialized project, even though the HTML comment marker (`<!-- version: ... -->`) and the Identity `- **Version:**` line are correctly refreshed on the same re-run.

### Why
`squad init` always calls `stampVersion()` on an existing `squad.agent.md` after `sdkInitSquad()` returns, regardless of `skipExisting`, to "ensure the version is fully stamped". `stampVersion` (in `packages/squad-cli/src/cli/core/version.ts`) and its SDK counterpart `stampVersionInContent` (in `packages/squad-sdk/src/config/init.ts`, used when generating a fresh `squad.agent.md` from the template) each replace three version locations. The first two regexes (`<!-- version: ... -->` and `- **Version:** ...`) are written permissively and are idempotent — they match any prior value, resolved or not. The third regex, however, only matched the unresolved `` `Squad v{version}` `` placeholder token. Once a real version had been stamped once, the placeholder text no longer existed in the file, so every subsequent re-stamp silently left the greeting literal on whatever version it was last set to.

Not affected: `squad upgrade` fully rewrites `squad.agent.md` from the template (which always contains the unresolved placeholder) before stamping, so the placeholder is always present there — the regression is specific to the re-init / `skipExisting=true` path.

### How
Widened the third regex in both `stampVersion` and `stampVersionInContent` from matching only `` `Squad v\{version\}` `` to matching `` `Squad v[^`]*` `` — i.e. anything between `` `Squad v `` and the closing backtick. This still matches the unresolved placeholder, and now also matches an already-resolved semver (with or without a prerelease suffix), making the replacement idempotent regardless of the file's current state. Both implementations were kept in sync per existing convention (each package has its own copy of the stamping logic).

Added regression coverage in `test/cli/init.test.ts`:
- A direct unit test that seeds a stale resolved `` `Squad v0.9.0` `` literal (plus stale marker/Version line) and asserts `stampVersion()` refreshes all three locations.
- A full re-init integration test: `runInit()` once, mutate the resulting `squad.agent.md` to simulate an older installed version in all three locations (not the `{version}` placeholder), `runInit()` again against the same project (hits the `skipExisting=true` / existing-file path), and assert every version location — including the greeting literal — now matches the current version.

### PR Readiness Checklist

#### Branch & Commit
- [x] Branch created from `dev` (`upstream/dev`, not `main`)
- [x] Branch is up to date with `dev`
- [x] PR is in draft mode (by request)
- [x] Commit history is clean (single commit)

#### Build & Test
- [x] `npm run build -w packages/squad-cli` passes
- [ ] `npm run build -w packages/squad-sdk` — **fails on `upstream/dev` baseline**, unrelated to this change (see Waivers)
- [x] Targeted tests pass: `npx vitest run test/cli/init.test.ts` (18/18, including 2 new regression tests)
- [x] Adjacent suite passes: `test/cli/upgrade.test.ts`, `test/cli/init-upgrade-parity.test.ts`, `test/init-sdk.test.ts`, `test/init.test.ts`, `test/init-scaffolding.test.ts` (all pass in isolation; see Waivers for a flaky test under full-suite parallel load)
- [ ] `npm test` (full suite) — **not run to completion**; see Waivers
- [ ] `npm run lint` — **fails on `upstream/dev` baseline**, unrelated to this change (see Waivers)
- [x] `npm run lint:eslint` on changed files — 0 errors (63 pre-existing `n/no-sync` warnings in `init.ts`, untouched by this diff)

#### Changeset
- [x] Changeset added via manual `.changeset/fix-reinit-stale-version-greeting.md` (patch, both `@bradygaster/squad-cli` and `@bradygaster/squad-sdk`)

#### Docs
- [x] N/A — no user-facing/docs change, internal stamping-logic bugfix

#### Exports
- [x] N/A — no new modules, no public API change

---

### Breaking Changes
None.

### Waivers
- **Waived: `npm run build` (squad-sdk) / `npm run lint`** — both fail identically on a clean `upstream/dev` checkout (verified by stashing this PR's changes and re-running) with 6 pre-existing TypeScript errors in `packages/squad-sdk/src/adapter/client.ts` (`RuntimeConnection` not exported by `@github/copilot-sdk`, `CopilotClientOptions.connection`, `ModelBilling.tokenPrices`, `CopilotClient.onLifecycle`, etc.). This file is untouched by this PR. Requesting a maintainer confirm this is known baseline debt (`skip-changelog`/reviewer waiver as appropriate — not requesting `skip-changelog` since a changeset is included).
- **Waived: full `npm test` run** — running the complete suite locally (`npx vitest run`, ~6400 tests, no path filter) produced widespread, unrelated failures across dozens of test files with no relation to this diff (e.g. `test/storage-provider.test.ts`, `test/session-adapter.test.ts`, `test/scripts/check-shebang-eol.test.ts`), consistent with local resource contention under full parallelism rather than a real regression. Also observed: at least one test in this run (apparently a self-upgrade/dogfooding test) wrote to this checkout's own `.squad/config.json` and `.github/agents/squad.agent.md`; both were reverted before committing and are **not** part of this PR's diff. Given the risk of further side effects against this real checkout, I did not force a full run to completion. All targeted and directly-adjacent suites (see above) pass. Requesting CI be the source of truth for the full-suite gate on this PR.
- **Waived: `test/init-scaffolding.test.ts` intermittent failure under combined load** — `no-remote resilience (#579) > initSquad/runInit succeeds in a git repo with no remote` and a `doctor` sub-test flip between pass/fail depending on what else is running concurrently; the full file passes 26/26 in isolation on two separate runs. Not caused by this change (no code in this diff is exercised by that test).

Do not link/close #1589 — related area but a different bug.