### PR TITLE
Preserve full URLs in Squad research output

### DIFF
--- a/test/gh-aw-quality.test.ts
+++ b/test/gh-aw-quality.test.ts
@@ -326,7 +326,7 @@ describe('gh-aw: safe-output configuration', () => {
 
   it('each safe-output has a max value that is a positive integer ≤ 1000', () => {
     for (const [name, config] of Object.entries(safeOutputs)) {
-      if (name === 'data' || name === 'messages' || name === 'jobs') continue;
+      if (name === 'data' || name === 'messages' || name === 'jobs' || name === 'allowed-domains') continue;
       expect(config.max, `${name} should have a max field`).toBeDefined();
       const max = config.max as number;
       expect(max, `${name}.max should be > 0`).toBeGreaterThan(0);

--- a/test/gh-aw-research-online.test.ts
+++ b/test/gh-aw-research-online.test.ts
@@ -117,6 +117,21 @@ describe('gh-aw: /squad research online-documentation capability', () => {
     expect(researchSkill).toContain('masquerade as one that consulted a source');
   });
 
+  it('preserves full public documentation URLs without weakening general URL sanitization', () => {
+    const safeOutputsMatch = frontmatter.match(
+      /^safe-outputs:\n((?:[ \t].*\n?)*)/m
+    );
+    expect(safeOutputsMatch, 'safe-outputs: block should exist in frontmatter').not.toBeNull();
+    expect(safeOutputsMatch![1]).toMatch(
+      /allowed-domains:\n\s+- learn\.microsoft\.com\n\s+- aspire\.dev/
+    );
+    expect(researchSkill).toMatch(/Preserve\s+each public documentation URL in full/);
+    expect(researchSkill).toContain('do not replace the path with `/redacted`');
+    expect(researchSkill).toMatch(
+      /Never include URL userinfo, credentials, access tokens,[\s\S]*secret-bearing query parameters/
+    );
+  });
+
   it('lists Online sources as a required labeled section of the artifact', () => {
     // The structural contract MUST-contain list includes Online sources. Bound
     // the match to the enumeration SENTENCE (up to its terminating period) so it

--- a/test/gh-aw-research-online.test.ts
+++ b/test/gh-aw-research-online.test.ts
@@ -122,11 +122,18 @@ describe('gh-aw: /squad research online-documentation capability', () => {
       /^safe-outputs:\n((?:[ \t].*\n?)*)/m
     );
     expect(safeOutputsMatch, 'safe-outputs: block should exist in frontmatter').not.toBeNull();
-    expect(safeOutputsMatch![1]).toMatch(
-      /allowed-domains:\n\s+- learn\.microsoft\.com\n\s+- aspire\.dev/
+    const allowedDomainsMatch = safeOutputsMatch![1].match(
+      /^  allowed-domains:\n((?:    - .+\n?)*)/m
     );
+    expect(allowedDomainsMatch, 'safe-outputs.allowed-domains should exist').not.toBeNull();
+    const allowedDomains = allowedDomainsMatch![1]
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.startsWith('- '))
+      .map(line => line.slice(2));
+    expect(allowedDomains).toEqual(['learn.microsoft.com', 'aspire.dev']);
     expect(researchSkill).toMatch(/Preserve\s+each public documentation URL in full/);
-    expect(researchSkill).toContain('do not replace the path with `/redacted`');
+    expect(researchSkill).toMatch(/do not replace the\s+path with `\/redacted`/);
     expect(researchSkill).toMatch(
       /Never include URL userinfo, credentials, access tokens,[\s\S]*secret-bearing query parameters/
     );

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -169,6 +169,9 @@ pre-agent-steps:
       SQUAD_CAST_VALIDATOR_RUNNER
       chmod 500 "$validator_runner"
 safe-outputs:
+  allowed-domains:
+    - learn.microsoft.com
+    - aspire.dev
   messages:
     append-only-comments: true
     run-success: "🤖 [{workflow_name}]({run_url}) finished processing. This completion message does not indicate Cast success. For Cast, only a linked Cast pull request indicates success."
@@ -1464,7 +1467,10 @@ section MUST state exactly one status so a later reader or test can assert on it
 instead of trusting silence:
 
 - `Online sources: consulted` — followed by the list of URLs actually fetched
-  this run (each URL also appears as a citation in the evidence table); or
+  this run (each URL also appears as a citation in the evidence table). Preserve
+  each public documentation URL in full, including its path; do not replace the
+  path with `/redacted`. Never include URL userinfo, credentials, access tokens,
+  or secret-bearing query parameters; omit those sensitive parts instead; or
 - `Online sources: unavailable — <reason>` — when no external documentation was
   fetched, e.g. the network policy disallowed it, no external source was needed,
   or a requested source-of-truth site was unreachable.


### PR DESCRIPTION
### What
Preserves full Microsoft Learn and Aspire documentation URLs in `/squad research` comments instead of rendering their paths as `/redacted`.

### Why
gh-aw safe-output ingestion sanitized URLs whose domains were absent from `safe-outputs.allowed-domains`, so users could not open or verify the sources cited by research results.

### How
Adds only `learn.microsoft.com` and `aspire.dev` to the safe-output domain allowlist while leaving `network.allowed` and general URL sanitization unchanged. The research prompt now requires full public documentation URLs but continues to omit URL userinfo, credentials, tokens, and secret-bearing query parameters. Targeted regression coverage guards both the allowlist and the sensitive-data constraints. Strict gh-aw compilation succeeded and emitted both domains in `GH_AW_ALLOWED_DOMAINS`; focused assertions passed. Full npm validation was blocked by registry `ENOTCONN` errors during dependency restoration.

---

### ⚠️ Quick Check
- [x] If SDK/CLI source files changed: completed the applicable Changeset step below (`npx changeset add` / `.changeset/*.md`, direct `CHANGELOG.md` entry for maintainers, or `skip-changelog` label for no user-facing changes)

### PR Readiness Checklist

> The PR readiness bot will validate these automatically after push.
> Check each item before requesting review. See [CONTRIBUTING.md](../CONTRIBUTING.md) for full details.

#### Branch & Commit
- [x] Branch created from `dev` (not `main`)
- [ ] Branch is up to date with `dev` (`git fetch upstream && git rebase upstream/dev`)
- [x] Verified diff contains only intended changes (`git diff --cached --stat`)
- [x] PR is **not** in draft mode (mark ready when checks pass)
- [x] Commit history is clean (squash fixups before review)

#### Build & Test
- [ ] `npm run build` passes
- [ ] `npm test` passes (all tests green)
- [ ] `npm run lint` passes (type check clean)
- [ ] `npm run lint:eslint` passes
- [ ] For migration PRs (>20 files): include test output summary in PR description

#### Changeset
- [ ] Changeset added via `npx changeset add` (if `packages/squad-sdk/src/` or `packages/squad-cli/src/` changed)
- [ ] Or direct `CHANGELOG.md` entry (maintainers only — write-protected for external contributors)
- [ ] Or `skip-changelog` label applied (if no user-facing changes)

No SDK or CLI source files changed; no changeset is required.

#### Docs
- [ ] README section updated (if new feature/module)
- [ ] Docs feature page (if new user-facing capability)

N/A - this corrects existing workflow output behavior.

#### Exports
- [ ] package.json subpath exports updated (if new module)

N/A - no SDK modules changed.

---

### Breaking Changes
None.

### Waivers
N/A.