### PR TITLE
fix: enforce product and team isolation

### DIFF
--- a/.changeset/recast-label-slugs.md
+++ b/.changeset/recast-label-slugs.md
@@ -3,4 +3,4 @@
 "@bradygaster/squad-sdk": patch
 ---
 
-Keep generated issue-assignment workflows and activation binding checks consistent for multi-word member names, and strengthen product/team isolation validation.
+Keep generated issue-assignment workflows and activation binding checks consistent for multi-word member names, fail closed on colliding member-label slugs, and strengthen product/team isolation validation.

--- a/.changeset/recast-label-slugs.md
+++ b/.changeset/recast-label-slugs.md
@@ -1,0 +1,6 @@
+---
+"@bradygaster/squad-cli": patch
+"@bradygaster/squad-sdk": patch
+---
+
+Keep generated issue-assignment workflows and activation binding checks consistent for multi-word member names, and strengthen product/team isolation validation.

--- a/.copilot/skills/architectural-proposals/SKILL.md
+++ b/.copilot/skills/architectural-proposals/SKILL.md
@@ -86,7 +86,7 @@ When a proposal invalidates existing wave structure:
 **Alternatives:** `blessed`, raw readline  
 **Decision rationale:** Component model enables testable UI. Battle-tested ecosystem.
 
-**Needs sign-off from:** Brady (product direction), Fortier (runtime performance)
+**Needs sign-off from:** Product Lead (product direction), Runtime Reviewer (runtime performance)
 ```
 
 ### Risk Documentation

--- a/.copilot/skills/init-mode/SKILL.md
+++ b/.copilot/skills/init-mode/SKILL.md
@@ -86,10 +86,10 @@ The `union` merge driver keeps all lines from both sides, which is correct for a
 3. Asks: *"Hey {user}, what are you building?"*
 4. User: *"TypeScript CLI tool with GitHub API integration"*
 5. Coordinator runs casting algorithm → selects "The Usual Suspects" universe
-6. Proposes: Keaton (Lead), Verbal (Prompt), Fenster (Backend), Hockney (Tester), Scribe, Ralph
+6. Proposes: Agent Alpha (Lead), Agent Beta (Prompt), Agent Gamma (Backend), Agent Delta (Tester), Scribe, Ralph
 7. Uses `ask_user` with choices → user selects "Yes, cast this team"
 8. Coordinator creates `.squad/` structure, initializes casting state, seeds agents
-9. Says: *"✅ Team cast. Try: 'Keaton, set up the project structure'"*
+9. Says: *"✅ Team cast. Try: 'Agent Alpha, set up the project structure'"*
 
 ## Anti-Patterns
 

--- a/.copilot/skills/model-selection/SKILL.md
+++ b/.copilot/skills/model-selection/SKILL.md
@@ -90,11 +90,11 @@ If you've exhausted the fallback chain and reached the platform default fallback
 When spawning, include the model in your acknowledgment:
 
 ```
-🔧 Fenster (claude-sonnet-5) — refactoring auth module
-🎨 Redfoot (gpt-5.6-sol · vision) — designing color system
+🔧 Agent Alpha (claude-sonnet-5) — refactoring auth module
+🎨 Agent Beta (gpt-5.6-sol · vision) — designing color system
 📋 Scribe (gpt-5.6-luna · fast) — logging session
-⚡ Keaton (gpt-5.6-sol · bumped for architecture) — reviewing proposal
-📝 McManus (gpt-5.6-luna · fast) — updating docs
+⚡ Agent Gamma (gpt-5.6-sol · bumped for architecture) — reviewing proposal
+📝 Agent Delta (gpt-5.6-luna · fast) — updating docs
 ```
 
 Include tier annotation only when the model was bumped or a specialist was chosen. Default-tier spawns just show the model name.
@@ -111,7 +111,7 @@ Include tier annotation only when the model was bumped or a specialist was chose
 - Role: Backend Dev
 - Task: "implement REST endpoints for user management"
 - Layer 3 decision: writing code → `gpt-5.6-terra` (standard tier)
-- Spawn: `🔧 Fenster (gpt-5.6-terra) — implementing user API endpoints`
+- Spawn: `🔧 Agent Alpha (gpt-5.6-terra) — implementing user API endpoints`
 
 **Example 2: User override**
 - User says: "use haiku for everything this session"
@@ -123,7 +123,7 @@ Include tier annotation only when the model was bumped or a specialist was chose
 - Task: "refactor 15 auth-related files to use new token system"
 - Layer 3 base: `gpt-5.6-terra`
 - Task complexity: heavy multi-file refactor → switch to `gpt-5.3-codex`
-- Spawn: `🔧 Fenster (gpt-5.3-codex · code specialist) — refactoring auth to new token system`
+- Spawn: `🔧 Agent Alpha (gpt-5.3-codex · code specialist) — refactoring auth to new token system`
 
 **Example 4: Scribe logging**
 - Role: Scribe

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -178,6 +178,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Build
         run: npm run build
+      - name: Verify product/team isolation
+        run: npm run verify:team-isolation
       - name: Type-check
         run: npm run lint
       - name: Lint source and tests

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -48,6 +48,10 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
             const label = context.payload.label.name;
+            const slugify = value => value
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-|-$/g, '');
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -83,7 +87,7 @@ jobs:
                 }
                 if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
                   const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && cells[0].toLowerCase() === memberName) {
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
                     assignedMember = { name: cells[0], role: cells[1] };
                     break;
                   }

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -51,7 +51,7 @@ jobs:
             const slugify = value => value
               .toLowerCase()
               .replace(/[^a-z0-9]+/g, '-')
-              .replace(/^-|-$/g, '');
+              .replace(/^-+|-+$/g, '');
             const findMemberBySlug = (lines, memberName) => {
               let inMembersTable = false;
               const matches = [];

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -52,6 +52,27 @@ jobs:
               .toLowerCase()
               .replace(/[^a-z0-9]+/g, '-')
               .replace(/^-|-$/g, '');
+            const findMemberBySlug = (lines, memberName) => {
+              let inMembersTable = false;
+              const matches = [];
+              for (const line of lines) {
+                if (line.match(/^##\s+(Members|Team Roster)/i)) {
+                  inMembersTable = true;
+                  continue;
+                }
+                if (inMembersTable && line.startsWith('## ')) break;
+                if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
+                  const cells = line.split('|').map(c => c.trim()).filter(Boolean);
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
+                    matches.push({ name: cells[0], role: cells[1] });
+                  }
+                }
+              }
+              return {
+                member: matches.length === 1 ? matches[0] : null,
+                ambiguous: matches.length > 1,
+              };
+            };
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -76,22 +97,17 @@ jobs:
             if (isCopilotAssignment) {
               assignedMember = { name: '@copilot', role: 'Coding Agent' };
             } else {
-              let inMembersTable = false;
-              for (const line of lines) {
-                if (line.match(/^##\s+(Members|Team Roster)/i)) {
-                  inMembersTable = true;
-                  continue;
-                }
-                if (inMembersTable && line.startsWith('## ')) {
-                  break;
-                }
-                if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
-                  const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
-                    assignedMember = { name: cells[0], role: cells[1] };
-                    break;
-                  }
-                }
+              const match = findMemberBySlug(lines, memberName);
+              assignedMember = match.member;
+              if (match.ambiguous) {
+                core.warning(`Multiple squad members map to label "${label}" — refusing ambiguous assignment`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `⚠️ Multiple squad members map to label \`${label}\`. Rename the colliding members in \`.squad/team.md\` before assigning work.`
+                });
+                return;
               }
             }
 

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -156,7 +156,7 @@ jobs:
               { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' }
             ];
 
-            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''); }
             function assertUniqueMemberSlugs(teamMembers) {
               const memberBySlug = new Map();
               for (const member of teamMembers) {

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -157,6 +157,17 @@ jobs:
             ];
 
             function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+            function assertUniqueMemberSlugs(teamMembers) {
+              const memberBySlug = new Map();
+              for (const member of teamMembers) {
+                const slug = slugify(member.name);
+                if (memberBySlug.has(slug)) {
+                  throw new Error(`Squad member label slug "${slug}" is ambiguous: "${memberBySlug.get(slug)}" and "${member.name}"`);
+                }
+                memberBySlug.set(slug, member.name);
+              }
+            }
+            assertUniqueMemberSlugs(members);
 
             // Ensure the base "squad" triage label exists
             const labels = [

--- a/.squad-templates/skills/model-selection/SKILL.md
+++ b/.squad-templates/skills/model-selection/SKILL.md
@@ -102,8 +102,8 @@ After resolving the model and including it in the spawn template, this skill is 
   "version": 1,
   "defaultModel": "claude-opus-4.6",
   "agentModelOverrides": {
-    "fenster": "claude-sonnet-4.6",
-    "mcmanus": "claude-haiku-4.5"
+    "agent-alpha": "claude-sonnet-4.6",
+    "agent-beta": "claude-haiku-4.5"
   }
 }
 ```

--- a/.squad-templates/workflows/squad-issue-assign.yml
+++ b/.squad-templates/workflows/squad-issue-assign.yml
@@ -26,7 +26,7 @@ jobs:
             const slugify = value => value
               .toLowerCase()
               .replace(/[^a-z0-9]+/g, '-')
-              .replace(/^-|-$/g, '');
+              .replace(/^-+|-+$/g, '');
             const findMemberBySlug = (lines, memberName) => {
               let inMembersTable = false;
               const matches = [];

--- a/.squad-templates/workflows/squad-issue-assign.yml
+++ b/.squad-templates/workflows/squad-issue-assign.yml
@@ -23,6 +23,10 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
             const label = context.payload.label.name;
+            const slugify = value => value
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-|-$/g, '');
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -54,7 +58,7 @@ jobs:
                 }
                 if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
                   const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && cells[0].toLowerCase() === memberName) {
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
                     assignedMember = { name: cells[0], role: cells[1] };
                     break;
                   }

--- a/.squad-templates/workflows/squad-issue-assign.yml
+++ b/.squad-templates/workflows/squad-issue-assign.yml
@@ -27,6 +27,27 @@ jobs:
               .toLowerCase()
               .replace(/[^a-z0-9]+/g, '-')
               .replace(/^-|-$/g, '');
+            const findMemberBySlug = (lines, memberName) => {
+              let inMembersTable = false;
+              const matches = [];
+              for (const line of lines) {
+                if (line.match(/^##\s+(Members|Team Roster)/i)) {
+                  inMembersTable = true;
+                  continue;
+                }
+                if (inMembersTable && line.startsWith('## ')) break;
+                if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
+                  const cells = line.split('|').map(c => c.trim()).filter(Boolean);
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
+                    matches.push({ name: cells[0], role: cells[1] });
+                  }
+                }
+              }
+              return {
+                member: matches.length === 1 ? matches[0] : null,
+                ambiguous: matches.length > 1,
+              };
+            };
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -47,22 +68,17 @@ jobs:
             if (isCopilotAssignment) {
               assignedMember = { name: '@copilot', role: 'Coding Agent' };
             } else {
-              let inMembersTable = false;
-              for (const line of lines) {
-                if (line.match(/^##\s+(Members|Team Roster)/i)) {
-                  inMembersTable = true;
-                  continue;
-                }
-                if (inMembersTable && line.startsWith('## ')) {
-                  break;
-                }
-                if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
-                  const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
-                    assignedMember = { name: cells[0], role: cells[1] };
-                    break;
-                  }
-                }
+              const match = findMemberBySlug(lines, memberName);
+              assignedMember = match.member;
+              if (match.ambiguous) {
+                core.warning(`Multiple squad members map to label "${label}" — refusing ambiguous assignment`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `⚠️ Multiple squad members map to label \`${label}\`. Rename the colliding members in \`.squad/team.md\` before assigning work.`
+                });
+                return;
               }
             }
 

--- a/.squad-templates/workflows/sync-squad-labels.yml
+++ b/.squad-templates/workflows/sync-squad-labels.yml
@@ -153,6 +153,17 @@ jobs:
             ];
 
             function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+            function assertUniqueMemberSlugs(teamMembers) {
+              const memberBySlug = new Map();
+              for (const member of teamMembers) {
+                const slug = slugify(member.name);
+                if (memberBySlug.has(slug)) {
+                  throw new Error(`Squad member label slug "${slug}" is ambiguous: "${memberBySlug.get(slug)}" and "${member.name}"`);
+                }
+                memberBySlug.set(slug, member.name);
+              }
+            }
+            assertUniqueMemberSlugs(members);
 
             // Ensure the base "squad" triage label exists
             const labels = [

--- a/.squad-templates/workflows/sync-squad-labels.yml
+++ b/.squad-templates/workflows/sync-squad-labels.yml
@@ -152,7 +152,7 @@ jobs:
               { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' }
             ];
 
-            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''); }
             function assertUniqueMemberSlugs(teamMembers) {
               const memberBySlug = new Map();
               for (const member of teamMembers) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prebuild": "node scripts/bump-build.mjs",
     "build": "npm run build -w packages/squad-sdk && npm run build -w packages/squad-cli",
     "sync-templates": "node scripts/sync-templates.mjs --sync",
+    "verify:team-isolation": "node scripts/verify-team-isolation.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "bench": "node scripts/run-benchmarks.mjs",

--- a/packages/squad-cli/templates/skills/model-selection/SKILL.md
+++ b/packages/squad-cli/templates/skills/model-selection/SKILL.md
@@ -102,8 +102,8 @@ After resolving the model and including it in the spawn template, this skill is 
   "version": 1,
   "defaultModel": "claude-opus-4.6",
   "agentModelOverrides": {
-    "fenster": "claude-sonnet-4.6",
-    "mcmanus": "claude-haiku-4.5"
+    "agent-alpha": "claude-sonnet-4.6",
+    "agent-beta": "claude-haiku-4.5"
   }
 }
 ```

--- a/packages/squad-cli/templates/workflows/squad-issue-assign.yml
+++ b/packages/squad-cli/templates/workflows/squad-issue-assign.yml
@@ -26,7 +26,7 @@ jobs:
             const slugify = value => value
               .toLowerCase()
               .replace(/[^a-z0-9]+/g, '-')
-              .replace(/^-|-$/g, '');
+              .replace(/^-+|-+$/g, '');
             const findMemberBySlug = (lines, memberName) => {
               let inMembersTable = false;
               const matches = [];

--- a/packages/squad-cli/templates/workflows/squad-issue-assign.yml
+++ b/packages/squad-cli/templates/workflows/squad-issue-assign.yml
@@ -23,6 +23,10 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
             const label = context.payload.label.name;
+            const slugify = value => value
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-|-$/g, '');
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -54,7 +58,7 @@ jobs:
                 }
                 if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
                   const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && cells[0].toLowerCase() === memberName) {
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
                     assignedMember = { name: cells[0], role: cells[1] };
                     break;
                   }

--- a/packages/squad-cli/templates/workflows/squad-issue-assign.yml
+++ b/packages/squad-cli/templates/workflows/squad-issue-assign.yml
@@ -27,6 +27,27 @@ jobs:
               .toLowerCase()
               .replace(/[^a-z0-9]+/g, '-')
               .replace(/^-|-$/g, '');
+            const findMemberBySlug = (lines, memberName) => {
+              let inMembersTable = false;
+              const matches = [];
+              for (const line of lines) {
+                if (line.match(/^##\s+(Members|Team Roster)/i)) {
+                  inMembersTable = true;
+                  continue;
+                }
+                if (inMembersTable && line.startsWith('## ')) break;
+                if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
+                  const cells = line.split('|').map(c => c.trim()).filter(Boolean);
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
+                    matches.push({ name: cells[0], role: cells[1] });
+                  }
+                }
+              }
+              return {
+                member: matches.length === 1 ? matches[0] : null,
+                ambiguous: matches.length > 1,
+              };
+            };
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -47,22 +68,17 @@ jobs:
             if (isCopilotAssignment) {
               assignedMember = { name: '@copilot', role: 'Coding Agent' };
             } else {
-              let inMembersTable = false;
-              for (const line of lines) {
-                if (line.match(/^##\s+(Members|Team Roster)/i)) {
-                  inMembersTable = true;
-                  continue;
-                }
-                if (inMembersTable && line.startsWith('## ')) {
-                  break;
-                }
-                if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
-                  const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
-                    assignedMember = { name: cells[0], role: cells[1] };
-                    break;
-                  }
-                }
+              const match = findMemberBySlug(lines, memberName);
+              assignedMember = match.member;
+              if (match.ambiguous) {
+                core.warning(`Multiple squad members map to label "${label}" — refusing ambiguous assignment`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `⚠️ Multiple squad members map to label \`${label}\`. Rename the colliding members in \`.squad/team.md\` before assigning work.`
+                });
+                return;
               }
             }
 

--- a/packages/squad-cli/templates/workflows/sync-squad-labels.yml
+++ b/packages/squad-cli/templates/workflows/sync-squad-labels.yml
@@ -153,6 +153,17 @@ jobs:
             ];
 
             function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+            function assertUniqueMemberSlugs(teamMembers) {
+              const memberBySlug = new Map();
+              for (const member of teamMembers) {
+                const slug = slugify(member.name);
+                if (memberBySlug.has(slug)) {
+                  throw new Error(`Squad member label slug "${slug}" is ambiguous: "${memberBySlug.get(slug)}" and "${member.name}"`);
+                }
+                memberBySlug.set(slug, member.name);
+              }
+            }
+            assertUniqueMemberSlugs(members);
 
             // Ensure the base "squad" triage label exists
             const labels = [

--- a/packages/squad-cli/templates/workflows/sync-squad-labels.yml
+++ b/packages/squad-cli/templates/workflows/sync-squad-labels.yml
@@ -152,7 +152,7 @@ jobs:
               { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' }
             ];
 
-            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''); }
             function assertUniqueMemberSlugs(teamMembers) {
               const memberBySlug = new Map();
               for (const member of teamMembers) {

--- a/packages/squad-sdk/templates/skills/model-selection/SKILL.md
+++ b/packages/squad-sdk/templates/skills/model-selection/SKILL.md
@@ -102,8 +102,8 @@ After resolving the model and including it in the spawn template, this skill is 
   "version": 1,
   "defaultModel": "claude-opus-4.6",
   "agentModelOverrides": {
-    "fenster": "claude-sonnet-4.6",
-    "mcmanus": "claude-haiku-4.5"
+    "agent-alpha": "claude-sonnet-4.6",
+    "agent-beta": "claude-haiku-4.5"
   }
 }
 ```

--- a/packages/squad-sdk/templates/workflows/squad-issue-assign.yml
+++ b/packages/squad-sdk/templates/workflows/squad-issue-assign.yml
@@ -26,7 +26,7 @@ jobs:
             const slugify = value => value
               .toLowerCase()
               .replace(/[^a-z0-9]+/g, '-')
-              .replace(/^-|-$/g, '');
+              .replace(/^-+|-+$/g, '');
             const findMemberBySlug = (lines, memberName) => {
               let inMembersTable = false;
               const matches = [];

--- a/packages/squad-sdk/templates/workflows/squad-issue-assign.yml
+++ b/packages/squad-sdk/templates/workflows/squad-issue-assign.yml
@@ -23,6 +23,10 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
             const label = context.payload.label.name;
+            const slugify = value => value
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-|-$/g, '');
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -54,7 +58,7 @@ jobs:
                 }
                 if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
                   const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && cells[0].toLowerCase() === memberName) {
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
                     assignedMember = { name: cells[0], role: cells[1] };
                     break;
                   }

--- a/packages/squad-sdk/templates/workflows/squad-issue-assign.yml
+++ b/packages/squad-sdk/templates/workflows/squad-issue-assign.yml
@@ -27,6 +27,27 @@ jobs:
               .toLowerCase()
               .replace(/[^a-z0-9]+/g, '-')
               .replace(/^-|-$/g, '');
+            const findMemberBySlug = (lines, memberName) => {
+              let inMembersTable = false;
+              const matches = [];
+              for (const line of lines) {
+                if (line.match(/^##\s+(Members|Team Roster)/i)) {
+                  inMembersTable = true;
+                  continue;
+                }
+                if (inMembersTable && line.startsWith('## ')) break;
+                if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
+                  const cells = line.split('|').map(c => c.trim()).filter(Boolean);
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
+                    matches.push({ name: cells[0], role: cells[1] });
+                  }
+                }
+              }
+              return {
+                member: matches.length === 1 ? matches[0] : null,
+                ambiguous: matches.length > 1,
+              };
+            };
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -47,22 +68,17 @@ jobs:
             if (isCopilotAssignment) {
               assignedMember = { name: '@copilot', role: 'Coding Agent' };
             } else {
-              let inMembersTable = false;
-              for (const line of lines) {
-                if (line.match(/^##\s+(Members|Team Roster)/i)) {
-                  inMembersTable = true;
-                  continue;
-                }
-                if (inMembersTable && line.startsWith('## ')) {
-                  break;
-                }
-                if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
-                  const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
-                    assignedMember = { name: cells[0], role: cells[1] };
-                    break;
-                  }
-                }
+              const match = findMemberBySlug(lines, memberName);
+              assignedMember = match.member;
+              if (match.ambiguous) {
+                core.warning(`Multiple squad members map to label "${label}" — refusing ambiguous assignment`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `⚠️ Multiple squad members map to label \`${label}\`. Rename the colliding members in \`.squad/team.md\` before assigning work.`
+                });
+                return;
               }
             }
 

--- a/packages/squad-sdk/templates/workflows/sync-squad-labels.yml
+++ b/packages/squad-sdk/templates/workflows/sync-squad-labels.yml
@@ -153,6 +153,17 @@ jobs:
             ];
 
             function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+            function assertUniqueMemberSlugs(teamMembers) {
+              const memberBySlug = new Map();
+              for (const member of teamMembers) {
+                const slug = slugify(member.name);
+                if (memberBySlug.has(slug)) {
+                  throw new Error(`Squad member label slug "${slug}" is ambiguous: "${memberBySlug.get(slug)}" and "${member.name}"`);
+                }
+                memberBySlug.set(slug, member.name);
+              }
+            }
+            assertUniqueMemberSlugs(members);
 
             // Ensure the base "squad" triage label exists
             const labels = [

--- a/packages/squad-sdk/templates/workflows/sync-squad-labels.yml
+++ b/packages/squad-sdk/templates/workflows/sync-squad-labels.yml
@@ -152,7 +152,7 @@ jobs:
               { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' }
             ];
 
-            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''); }
             function assertUniqueMemberSlugs(teamMembers) {
               const memberBySlug = new Map();
               for (const member of teamMembers) {

--- a/scripts/check-agent-binding.mjs
+++ b/scripts/check-agent-binding.mjs
@@ -43,6 +43,10 @@ function normalize(value) {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
+function slugify(value) {
+  return normalize(value).replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
 /**
  * Resolve a binding issue reference to a real issue number.
  *
@@ -219,7 +223,7 @@ export function parseRoster(teamMarkdown) {
 
 function expectedLabel(agent, roster) {
   if (agent === '@copilot') return { label: 'squad:copilot', omission: null };
-  if (roster.has(agent)) return { label: `squad:${agent}`, omission: null };
+  if (roster.has(agent)) return { label: `squad:${slugify(agent)}`, omission: null };
   return { label: null, omission: 'non-roster' };
 }
 

--- a/scripts/check-agent-binding.mjs
+++ b/scripts/check-agent-binding.mjs
@@ -218,6 +218,16 @@ export function parseRoster(teamMarkdown) {
     .map(line => normalize(cells(line)[nameIndex]))
     .filter(Boolean);
   if (names.length === 0) throw new Error('roster Members table has no members');
+
+  const namesBySlug = new Map();
+  for (const name of names) {
+    const slug = slugify(name);
+    const existing = namesBySlug.get(slug);
+    if (existing) {
+      throw new Error(`roster member label slug "${slug}" is ambiguous: "${existing}" and "${name}"`);
+    }
+    namesBySlug.set(slug, name);
+  }
   return new Set(names);
 }
 

--- a/scripts/check-agent-binding.mjs
+++ b/scripts/check-agent-binding.mjs
@@ -44,7 +44,7 @@ function normalize(value) {
 }
 
 function slugify(value) {
-  return normalize(value).replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return normalize(value).replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
 /**

--- a/scripts/verify-team-isolation.mjs
+++ b/scripts/verify-team-isolation.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const NODE_MODULES = join(ROOT, 'node_modules');
+const SYNTHETIC_MARKER = 'QUARTZ_NAVIGATOR_SYNTHETIC_TEAM';
+
+if (!existsSync(NODE_MODULES)) {
+  throw new Error('node_modules is required; restore the locked dependencies before running this check');
+}
+
+function trackedFiles() {
+  return execFileSync('git', ['ls-files', '-z'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  })
+    .split('\0')
+    .filter(Boolean)
+    .filter(file => file !== '.squad' && !file.startsWith('.squad/'));
+}
+
+function trackedTeamFiles() {
+  return execFileSync('git', ['ls-files', '-z', '--', '.squad'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  })
+    .split('\0')
+    .filter(Boolean);
+}
+
+function copyTrackedTree(destination) {
+  for (const file of trackedFiles()) {
+    const source = join(ROOT, file);
+    const target = join(destination, file);
+    mkdirSync(dirname(target), { recursive: true });
+    cpSync(source, target, {
+      dereference: false,
+      preserveTimestamps: true,
+    });
+  }
+  linkDependencies(destination);
+}
+
+function linkDependencies(destination) {
+  const destinationModules = join(destination, 'node_modules');
+  mkdirSync(destinationModules);
+
+  for (const entry of readdirSync(NODE_MODULES, { withFileTypes: true })) {
+    const source = join(NODE_MODULES, entry.name);
+    const target = join(destinationModules, entry.name);
+
+    if (entry.name !== '@bradygaster') {
+      symlinkSync(source, target, entry.isDirectory() ? 'dir' : 'file');
+      continue;
+    }
+
+    mkdirSync(target);
+    for (const scopedEntry of readdirSync(source, { withFileTypes: true })) {
+      const scopedTarget = join(target, scopedEntry.name);
+      if (scopedEntry.name === 'squad-sdk') {
+        symlinkSync(join(destination, 'packages', 'squad-sdk'), scopedTarget, 'dir');
+      } else {
+        symlinkSync(
+          join(source, scopedEntry.name),
+          scopedTarget,
+          scopedEntry.isDirectory() ? 'dir' : 'file',
+        );
+      }
+    }
+  }
+}
+
+function copyLiveTeam(destination) {
+  const files = trackedTeamFiles();
+  for (const file of files) {
+    const source = join(ROOT, file);
+    const target = join(destination, file);
+    mkdirSync(dirname(target), { recursive: true });
+    cpSync(source, target, {
+      dereference: false,
+      preserveTimestamps: true,
+    });
+  }
+  return files.length > 0;
+}
+
+function writeSyntheticTeam(destination) {
+  const teamDir = join(destination, '.squad');
+  mkdirSync(join(teamDir, 'agents', 'quartz-navigator'), { recursive: true });
+  mkdirSync(join(teamDir, 'casting'), { recursive: true });
+  mkdirSync(join(teamDir, 'decisions', 'inbox'), { recursive: true });
+  mkdirSync(join(teamDir, 'templates'), { recursive: true });
+  mkdirSync(join(teamDir, 'skills', 'synthetic-only'), { recursive: true });
+  writeFileSync(
+    join(teamDir, 'team.md'),
+    [
+      '# Synthetic Isolation Team',
+      '',
+      '## Members',
+      '',
+      '| Name | Role | Charter | Status |',
+      '| --- | --- | --- | --- |',
+      '| Quartz Navigator | Lead | `.squad/agents/quartz-navigator/charter.md` | Active |',
+      '| Moss Verifier | Quality | `.squad/agents/moss-verifier/charter.md` | Active |',
+      '',
+      `<!-- ${SYNTHETIC_MARKER} -->`,
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(
+    join(teamDir, 'routing.md'),
+    [
+      '# Synthetic Routing',
+      '',
+      '| Work Type | Agent | Examples |',
+      '| --- | --- | --- |',
+      '| Runtime | Quartz Navigator | adapter, session pool |',
+      '| Quality | Moss Verifier | tests, verification |',
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(
+    join(teamDir, 'agents', 'quartz-navigator', 'charter.md'),
+    `# Quartz Navigator\n\n${SYNTHETIC_MARKER}\n`,
+  );
+  writeFileSync(
+    join(teamDir, 'skills', 'synthetic-only', 'SKILL.md'),
+    `# Synthetic-only skill\n\n${SYNTHETIC_MARKER}\n`,
+  );
+  for (const [path, content] of [
+    ['config.json', `{"marker":"${SYNTHETIC_MARKER}"}`],
+    ['decisions.md', `# Decisions\n\n${SYNTHETIC_MARKER}\n`],
+    ['casting/registry.json', `{"marker":"${SYNTHETIC_MARKER}","agents":[]}`],
+    ['templates/synthetic-only.md', `# Synthetic template\n\n${SYNTHETIC_MARKER}\n`],
+  ]) {
+    writeFileSync(join(teamDir, path), content);
+  }
+}
+
+function run(command, args, cwd) {
+  execFileSync(command, args, {
+    cwd,
+    env: {
+      ...process.env,
+      CI: 'true',
+      SKIP_BUILD_BUMP: '1',
+    },
+    stdio: 'inherit',
+  });
+}
+
+function filesUnder(directory) {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? filesUnder(path) : [path];
+  });
+}
+
+function hashFile(file) {
+  return createHash('sha256').update(readFileSync(file)).digest('hex');
+}
+
+function packageManifest(root, packageDirectory) {
+  const output = execFileSync(
+    'npm',
+    ['pack', '--dry-run', '--json', '--ignore-scripts'],
+    {
+      cwd: join(root, packageDirectory),
+      encoding: 'utf8',
+      env: { ...process.env, CI: 'true' },
+    },
+  );
+  const result = JSON.parse(output);
+  if (!Array.isArray(result) || result.length !== 1 || !Array.isArray(result[0].files)) {
+    throw new Error(`Unexpected npm pack output for ${packageDirectory}`);
+  }
+  return result[0].files
+    .map(({ path }) => {
+      const file = join(root, packageDirectory, path);
+      const stat = lstatSync(file);
+      return {
+        path,
+        mode: stat.mode & 0o777,
+        hash: hashFile(file),
+      };
+    })
+    .sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function buildManifest(root) {
+  run('node', ['scripts/sync-templates.mjs', '--sync'], root);
+  run('npm', ['run', 'build'], root);
+  run(
+    'npm',
+    [
+      'test',
+      '--',
+      'test/recast-identity-neutrality.test.ts',
+      'test/template-extra-classification.test.ts',
+      'test/template-sync.test.ts',
+      'test/cli-packaging-smoke.test.ts',
+    ],
+    root,
+  );
+
+  const packageDirectories = ['packages/squad-sdk', 'packages/squad-cli'];
+  const packages = Object.fromEntries(
+    packageDirectories.map(packageDirectory => [
+      packageDirectory,
+      packageManifest(root, packageDirectory),
+    ]),
+  );
+
+  for (const [packageDirectory, files] of Object.entries(packages)) {
+    const leaked = files
+      .map(file => file.path)
+      .filter(file => file === '.squad' || file.startsWith('.squad/'));
+    if (leaked.length > 0) {
+      throw new Error(`${packageDirectory} package includes team state: ${leaked.join(', ')}`);
+    }
+  }
+
+  const outputRoots = [
+    '.squad-templates',
+    'templates',
+    '.github/agents/squad.agent.md',
+    'packages/squad-sdk/dist',
+    'packages/squad-sdk/templates',
+    'packages/squad-cli/dist',
+    'packages/squad-cli/templates',
+  ];
+  const requiredOutputs = [
+    '.squad-templates',
+    'templates',
+    '.github/agents/squad.agent.md',
+    'packages/squad-sdk/dist/index.js',
+    'packages/squad-sdk/dist/index.d.ts',
+    'packages/squad-sdk/templates',
+    'packages/squad-cli/dist/cli-entry.js',
+    'packages/squad-cli/templates',
+  ];
+  for (const output of requiredOutputs) {
+    if (!existsSync(join(root, output))) {
+      throw new Error(`Expected product output is missing: ${output}`);
+    }
+  }
+
+  const files = outputRoots.flatMap(path => {
+    const absolute = join(root, path);
+    return lstatSync(absolute).isDirectory() ? filesUnder(absolute) : [absolute];
+  });
+
+  const hashes = Object.fromEntries(
+    files
+      .map(file => [relative(root, file), hashFile(file)])
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+
+  for (const file of files) {
+    if (readFileSync(file).includes(Buffer.from(SYNTHETIC_MARKER))) {
+      throw new Error(`Synthetic team content leaked into product output: ${relative(root, file)}`);
+    }
+  }
+
+  return { hashes, packages };
+}
+
+const scratch = mkdtempSync(join(tmpdir(), 'squad-team-isolation-'));
+const noTeamRoot = join(scratch, 'without-team');
+const syntheticTeamRoot = join(scratch, 'synthetic-team');
+const liveTeamRoot = join(scratch, 'live-team');
+
+try {
+  mkdirSync(noTeamRoot);
+  mkdirSync(syntheticTeamRoot);
+  mkdirSync(liveTeamRoot);
+  copyTrackedTree(noTeamRoot);
+  copyTrackedTree(syntheticTeamRoot);
+  copyTrackedTree(liveTeamRoot);
+  writeSyntheticTeam(syntheticTeamRoot);
+  const hasLiveTeam = copyLiveTeam(liveTeamRoot);
+
+  const withoutTeam = buildManifest(noTeamRoot);
+  const withSyntheticTeam = buildManifest(syntheticTeamRoot);
+
+  if (JSON.stringify(withoutTeam) !== JSON.stringify(withSyntheticTeam)) {
+    throw new Error('Product build or package output changed when synthetic .squad state was present');
+  }
+
+  if (hasLiveTeam) {
+    const withLiveTeam = buildManifest(liveTeamRoot);
+    if (JSON.stringify(withoutTeam) !== JSON.stringify(withLiveTeam)) {
+      throw new Error('Product build or package output changed when the repository .squad state was present');
+    }
+  }
+
+  console.log('Product build, templates, and package contents are identical without .squad and with a synthetic team.');
+} finally {
+  rmSync(scratch, { recursive: true, force: true });
+}

--- a/scripts/verify-team-isolation.mjs
+++ b/scripts/verify-team-isolation.mjs
@@ -92,6 +92,7 @@ function copyLiveTeam(destination) {
 function writeSyntheticTeam(destination) {
   const teamDir = join(destination, '.squad');
   mkdirSync(join(teamDir, 'agents', 'quartz-navigator'), { recursive: true });
+  mkdirSync(join(teamDir, 'agents', 'moss-verifier'), { recursive: true });
   mkdirSync(join(teamDir, 'casting'), { recursive: true });
   mkdirSync(join(teamDir, 'decisions', 'inbox'), { recursive: true });
   mkdirSync(join(teamDir, 'templates'), { recursive: true });
@@ -127,6 +128,10 @@ function writeSyntheticTeam(destination) {
   writeFileSync(
     join(teamDir, 'agents', 'quartz-navigator', 'charter.md'),
     `# Quartz Navigator\n\n${SYNTHETIC_MARKER}\n`,
+  );
+  writeFileSync(
+    join(teamDir, 'agents', 'moss-verifier', 'charter.md'),
+    `# Moss Verifier\n\n${SYNTHETIC_MARKER}\n`,
   );
   writeFileSync(
     join(teamDir, 'skills', 'synthetic-only', 'SKILL.md'),
@@ -204,7 +209,6 @@ function buildManifest(root) {
       'test/recast-identity-neutrality.test.ts',
       'test/template-extra-classification.test.ts',
       'test/template-sync.test.ts',
-      'test/cli-packaging-smoke.test.ts',
     ],
     root,
   );

--- a/scripts/verify-team-isolation.mjs
+++ b/scripts/verify-team-isolation.mjs
@@ -36,15 +36,6 @@ function trackedFiles() {
     .filter(file => file !== '.squad' && !file.startsWith('.squad/'));
 }
 
-function trackedTeamFiles() {
-  return execFileSync('git', ['ls-files', '-z', '--', '.squad'], {
-    cwd: ROOT,
-    encoding: 'utf8',
-  })
-    .split('\0')
-    .filter(Boolean);
-}
-
 function copyTrackedTree(destination) {
   for (const file of trackedFiles()) {
     const source = join(ROOT, file);
@@ -88,17 +79,14 @@ function linkDependencies(destination) {
 }
 
 function copyLiveTeam(destination) {
-  const files = trackedTeamFiles();
-  for (const file of files) {
-    const source = join(ROOT, file);
-    const target = join(destination, file);
-    mkdirSync(dirname(target), { recursive: true });
-    cpSync(source, target, {
-      dereference: false,
-      preserveTimestamps: true,
-    });
-  }
-  return files.length > 0;
+  const source = join(ROOT, '.squad');
+  if (!existsSync(source)) return false;
+  cpSync(source, join(destination, '.squad'), {
+    recursive: true,
+    dereference: false,
+    preserveTimestamps: true,
+  });
+  return true;
 }
 
 function writeSyntheticTeam(destination) {

--- a/templates/skills/model-selection/SKILL.md
+++ b/templates/skills/model-selection/SKILL.md
@@ -102,8 +102,8 @@ After resolving the model and including it in the spawn template, this skill is 
   "version": 1,
   "defaultModel": "claude-opus-4.6",
   "agentModelOverrides": {
-    "fenster": "claude-sonnet-4.6",
-    "mcmanus": "claude-haiku-4.5"
+    "agent-alpha": "claude-sonnet-4.6",
+    "agent-beta": "claude-haiku-4.5"
   }
 }
 ```

--- a/templates/workflows/squad-issue-assign.yml
+++ b/templates/workflows/squad-issue-assign.yml
@@ -26,7 +26,7 @@ jobs:
             const slugify = value => value
               .toLowerCase()
               .replace(/[^a-z0-9]+/g, '-')
-              .replace(/^-|-$/g, '');
+              .replace(/^-+|-+$/g, '');
             const findMemberBySlug = (lines, memberName) => {
               let inMembersTable = false;
               const matches = [];

--- a/templates/workflows/squad-issue-assign.yml
+++ b/templates/workflows/squad-issue-assign.yml
@@ -23,6 +23,10 @@ jobs:
             const fs = require('fs');
             const issue = context.payload.issue;
             const label = context.payload.label.name;
+            const slugify = value => value
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-|-$/g, '');
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -54,7 +58,7 @@ jobs:
                 }
                 if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
                   const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && cells[0].toLowerCase() === memberName) {
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
                     assignedMember = { name: cells[0], role: cells[1] };
                     break;
                   }

--- a/templates/workflows/squad-issue-assign.yml
+++ b/templates/workflows/squad-issue-assign.yml
@@ -27,6 +27,27 @@ jobs:
               .toLowerCase()
               .replace(/[^a-z0-9]+/g, '-')
               .replace(/^-|-$/g, '');
+            const findMemberBySlug = (lines, memberName) => {
+              let inMembersTable = false;
+              const matches = [];
+              for (const line of lines) {
+                if (line.match(/^##\s+(Members|Team Roster)/i)) {
+                  inMembersTable = true;
+                  continue;
+                }
+                if (inMembersTable && line.startsWith('## ')) break;
+                if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
+                  const cells = line.split('|').map(c => c.trim()).filter(Boolean);
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
+                    matches.push({ name: cells[0], role: cells[1] });
+                  }
+                }
+              }
+              return {
+                member: matches.length === 1 ? matches[0] : null,
+                ambiguous: matches.length > 1,
+              };
+            };
 
             // Extract member name from label (e.g., "squad:ripley" → "ripley")
             const memberName = label.replace('squad:', '').toLowerCase();
@@ -47,22 +68,17 @@ jobs:
             if (isCopilotAssignment) {
               assignedMember = { name: '@copilot', role: 'Coding Agent' };
             } else {
-              let inMembersTable = false;
-              for (const line of lines) {
-                if (line.match(/^##\s+(Members|Team Roster)/i)) {
-                  inMembersTable = true;
-                  continue;
-                }
-                if (inMembersTable && line.startsWith('## ')) {
-                  break;
-                }
-                if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
-                  const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
-                    assignedMember = { name: cells[0], role: cells[1] };
-                    break;
-                  }
-                }
+              const match = findMemberBySlug(lines, memberName);
+              assignedMember = match.member;
+              if (match.ambiguous) {
+                core.warning(`Multiple squad members map to label "${label}" — refusing ambiguous assignment`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `⚠️ Multiple squad members map to label \`${label}\`. Rename the colliding members in \`.squad/team.md\` before assigning work.`
+                });
+                return;
               }
             }
 

--- a/templates/workflows/sync-squad-labels.yml
+++ b/templates/workflows/sync-squad-labels.yml
@@ -153,6 +153,17 @@ jobs:
             ];
 
             function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+            function assertUniqueMemberSlugs(teamMembers) {
+              const memberBySlug = new Map();
+              for (const member of teamMembers) {
+                const slug = slugify(member.name);
+                if (memberBySlug.has(slug)) {
+                  throw new Error(`Squad member label slug "${slug}" is ambiguous: "${memberBySlug.get(slug)}" and "${member.name}"`);
+                }
+                memberBySlug.set(slug, member.name);
+              }
+            }
+            assertUniqueMemberSlugs(members);
 
             // Ensure the base "squad" triage label exists
             const labels = [

--- a/templates/workflows/sync-squad-labels.yml
+++ b/templates/workflows/sync-squad-labels.yml
@@ -152,7 +152,7 @@ jobs:
               { name: 'priority:p2', color: 'FBCA04', description: 'Next sprint' }
             ];
 
-            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
+            function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''); }
             function assertUniqueMemberSlugs(teamMembers) {
               const memberBySlug = new Map();
               for (const member of teamMembers) {

--- a/test/check-agent-binding.test.ts
+++ b/test/check-agent-binding.test.ts
@@ -15,6 +15,7 @@ const roster = parseRoster(`
 |------|------|
 | Kint | Lead |
 | McManus | Dev |
+| Quartz Navigator | Runtime |
 `);
 
 function labels(entries: Record<number, string[]>) {
@@ -240,6 +241,21 @@ Structured data:
     expect(validateBindings(input, roster, labels({
       6: ['squad', 'squad:copilot'],
       40: ['squad', 'squad:copilot'],
+    })).checked).toBe(1);
+  });
+
+  it('uses the same slug normalization as label synchronization for multi-word members', () => {
+    const input = artifact([
+      task({
+        issue: 41,
+        agent: 'Quartz Navigator',
+        label: 'squad:quartz-navigator',
+        epicLabel: 'squad:quartz-navigator',
+      }),
+    ]);
+    expect(validateBindings(input, roster, labels({
+      6: ['squad', 'squad:quartz-navigator'],
+      41: ['squad', 'squad:quartz-navigator'],
     })).checked).toBe(1);
   });
 

--- a/test/check-agent-binding.test.ts
+++ b/test/check-agent-binding.test.ts
@@ -269,6 +269,27 @@ Structured data:
     })).checked).toBe(1);
   });
 
+  it('trims leading and trailing hyphen runs from member labels', () => {
+    const edgedRoster = parseRoster(`
+## Members
+| Name | Role |
+| --- | --- |
+| ---Quartz Navigator--- | Runtime |
+`);
+    const input = artifact([
+      task({
+        issue: 42,
+        agent: '---Quartz Navigator---',
+        label: 'squad:quartz-navigator',
+        epicLabel: 'squad:quartz-navigator',
+      }),
+    ]);
+    expect(validateBindings(input, edgedRoster, labels({
+      6: ['squad', 'squad:quartz-navigator'],
+      42: ['squad', 'squad:quartz-navigator'],
+    })).checked).toBe(1);
+  });
+
   it('uses the full epic agent set for phased activation', () => {
     const input = artifact([
       task({

--- a/test/check-agent-binding.test.ts
+++ b/test/check-agent-binding.test.ts
@@ -18,6 +18,16 @@ const roster = parseRoster(`
 | Quartz Navigator | Runtime |
 `);
 
+it('rejects roster names that collide on the same member-label slug', () => {
+  expect(() => parseRoster(`
+## Members
+| Name | Role |
+| --- | --- |
+| Foo Bar | Runtime |
+| Foo-Bar | Quality |
+`)).toThrow('roster member label slug "foo-bar" is ambiguous');
+});
+
 function labels(entries: Record<number, string[]>) {
   return new Map(Object.entries(entries).map(([issue, issueLabels]) => [
     Number(issue),

--- a/test/gh-aw-activate-fast-path-label-provisioning.test.ts
+++ b/test/gh-aw-activate-fast-path-label-provisioning.test.ts
@@ -181,20 +181,20 @@ describe('#1959: fast-path add_labels targets an explicit, verified item', () =>
 
 describe('#1959: fast-path label sets stay at parity with squad-plan-activate', () => {
   it('applies the base squad label to every activated item', () => {
-    expect(acceptProse).toMatch(/Work item: `squad`, plus `squad:\{owner-slug\}`/);
-    expect(acceptProse).toMatch(/Phase issue: `squad`, plus `squad:\{owner-slug\}`/);
+    expect(acceptProse).toMatch(/Work item: `squad`, plus `squad:\{owner\}`/);
+    expect(acceptProse).toMatch(/Phase issue: `squad`, plus `squad:\{owner\}`/);
   });
 
-  it('slugifies the member label from that row\'s own frozen certified Owner', () => {
+  it('derives the member label from that row\'s own frozen certified Owner', () => {
     expect(acceptProse).toMatch(
-      /derived from that row's own frozen certified `Owner` by the slug rule above/i,
+      /derived from that row's own frozen certified `Owner`, lowercased/i,
     );
     expect(acceptProse).toMatch(
       /never inherit the phase issue's owner or carry the previous row's value forward/i,
     );
     // The Step 2 computation bullet must still name its certified binding source.
     const labelRule = acceptSkill.match(/^- Labels:.*$/m)?.[0] ?? '';
-    expect(labelRule).toMatch(/frozen row `Owner` by the slug rule above/i);
+    expect(labelRule).toMatch(/frozen row `Owner` lowercased/i);
     expect(labelRule).toMatch(/only from that task's certified binding/i);
   });
 

--- a/test/gh-aw-activate-fast-path-label-provisioning.test.ts
+++ b/test/gh-aw-activate-fast-path-label-provisioning.test.ts
@@ -181,20 +181,20 @@ describe('#1959: fast-path add_labels targets an explicit, verified item', () =>
 
 describe('#1959: fast-path label sets stay at parity with squad-plan-activate', () => {
   it('applies the base squad label to every activated item', () => {
-    expect(acceptProse).toMatch(/Work item: `squad`, plus `squad:\{owner\}`/);
-    expect(acceptProse).toMatch(/Phase issue: `squad`, plus `squad:\{owner\}`/);
+    expect(acceptProse).toMatch(/Work item: `squad`, plus `squad:\{owner-slug\}`/);
+    expect(acceptProse).toMatch(/Phase issue: `squad`, plus `squad:\{owner-slug\}`/);
   });
 
-  it('derives the member label from that row\'s own frozen certified Owner', () => {
+  it('slugifies the member label from that row\'s own frozen certified Owner', () => {
     expect(acceptProse).toMatch(
-      /derived from that row's own frozen certified `Owner`, lowercased/i,
+      /derived from that row's own frozen certified `Owner` by the slug rule above/i,
     );
     expect(acceptProse).toMatch(
       /never inherit the phase issue's owner or carry the previous row's value forward/i,
     );
     // The Step 2 computation bullet must still name its certified binding source.
     const labelRule = acceptSkill.match(/^- Labels:.*$/m)?.[0] ?? '';
-    expect(labelRule).toMatch(/frozen row `Owner` lowercased/i);
+    expect(labelRule).toMatch(/frozen row `Owner` by the slug rule above/i);
     expect(labelRule).toMatch(/only from that task's certified binding/i);
   });
 

--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -256,7 +256,7 @@ describe('#1903: fast-path planning binds certified roster owners end to end', (
     expect(finalCheck).toMatch(/Copy each row's `Depends On` value unchanged/i);
   });
 
-  it('freezes each accepted row and derives its lowercase member label without remapping', () => {
+  it('freezes each accepted row and derives its slugged member label without remapping', () => {
     const preflight = accept.match(/Before any `create-issue` call[\s\S]*?(?=\nFor each work item)/)?.[0] ?? '';
     expect(preflight, 'squad-plan-accept must validate bindings before mutation').not.toBe('');
     expect(preflight).toMatch(/original `Owner` and `Depends On` values/i);
@@ -264,7 +264,7 @@ describe('#1903: fast-path planning binds certified roster owners end to end', (
     expect(preflight).toMatch(/never\s+substitute, re-route, or fall back/i);
 
     const labelRule = accept.match(/^- Labels:.*$/m)?.[0] ?? '';
-    expect(labelRule).toMatch(/frozen row `Owner` lowercased/i);
+    expect(labelRule).toMatch(/frozen row `Owner` by the slug rule above/i);
     expect(labelRule).toMatch(/only from that task's certified binding/i);
   });
 

--- a/test/gh-aw-plan-lifecycle.test.ts
+++ b/test/gh-aw-plan-lifecycle.test.ts
@@ -256,7 +256,7 @@ describe('#1903: fast-path planning binds certified roster owners end to end', (
     expect(finalCheck).toMatch(/Copy each row's `Depends On` value unchanged/i);
   });
 
-  it('freezes each accepted row and derives its slugged member label without remapping', () => {
+  it('freezes each accepted row and derives its lowercase member label without remapping', () => {
     const preflight = accept.match(/Before any `create-issue` call[\s\S]*?(?=\nFor each work item)/)?.[0] ?? '';
     expect(preflight, 'squad-plan-accept must validate bindings before mutation').not.toBe('');
     expect(preflight).toMatch(/original `Owner` and `Depends On` values/i);
@@ -264,7 +264,7 @@ describe('#1903: fast-path planning binds certified roster owners end to end', (
     expect(preflight).toMatch(/never\s+substitute, re-route, or fall back/i);
 
     const labelRule = accept.match(/^- Labels:.*$/m)?.[0] ?? '';
-    expect(labelRule).toMatch(/frozen row `Owner` by the slug rule above/i);
+    expect(labelRule).toMatch(/frozen row `Owner` lowercased/i);
     expect(labelRule).toMatch(/only from that task's certified binding/i);
   });
 

--- a/test/recast-identity-neutrality.test.ts
+++ b/test/recast-identity-neutrality.test.ts
@@ -89,8 +89,8 @@ describe('product and team isolation', () => {
     expect(isolationCheck).toContain("['pack', '--dry-run', '--json', '--ignore-scripts']");
 
     const activationWorkflow = readFileSync('workflows/squad.md', 'utf8');
-    expect(activationWorkflow).toContain(
-      'replace each run of non-`a-z0-9` characters with `-`'
+    expect(activationWorkflow).toMatch(
+      /replace each run of non-`a-z0-9`\s+characters with `-`/
     );
     expect(activationWorkflow).toContain('"label":"squad:{slugged Agent cell}"');
     expect(activationWorkflow).not.toContain(

--- a/test/recast-identity-neutrality.test.ts
+++ b/test/recast-identity-neutrality.test.ts
@@ -254,6 +254,7 @@ describe('product and team isolation', () => {
       ];
 
       expect(helpers.slugify('Quartz Navigator')).toBe('quartz-navigator');
+      expect(helpers.slugify('---Quartz Navigator---')).toBe('quartz-navigator');
       expect(helpers.findMemberBySlug(roster, 'quartz-navigator')).toEqual({
         member: { name: 'Quartz Navigator', role: 'Runtime' },
         ambiguous: false,
@@ -275,6 +276,7 @@ describe('product and team isolation', () => {
     '%s rejects colliding member-label slugs before synchronization',
     file => {
       const helpers = labelSyncHelpers(readFileSync(file, 'utf8'));
+      expect(helpers.slugify('---Quartz Navigator---')).toBe('quartz-navigator');
       expect(() => helpers.assertUniqueMemberSlugs([
         { name: 'Quartz Navigator', role: 'Runtime' },
         { name: 'Moss Verifier', role: 'Quality' },

--- a/test/recast-identity-neutrality.test.ts
+++ b/test/recast-identity-neutrality.test.ts
@@ -10,6 +10,20 @@ const workflowCopies = [
   'packages/squad-cli/templates/workflows/squad-triage.yml',
   'packages/squad-sdk/templates/workflows/squad-triage.yml',
 ];
+const assignmentWorkflowCopies = [
+  '.github/workflows/squad-issue-assign.yml',
+  '.squad-templates/workflows/squad-issue-assign.yml',
+  'templates/workflows/squad-issue-assign.yml',
+  'packages/squad-cli/templates/workflows/squad-issue-assign.yml',
+  'packages/squad-sdk/templates/workflows/squad-issue-assign.yml',
+];
+const labelSyncWorkflowCopies = [
+  '.github/workflows/sync-squad-labels.yml',
+  '.squad-templates/workflows/sync-squad-labels.yml',
+  'templates/workflows/sync-squad-labels.yml',
+  'packages/squad-cli/templates/workflows/sync-squad-labels.yml',
+  'packages/squad-sdk/templates/workflows/sync-squad-labels.yml',
+];
 
 type Member = { name: string; role: string };
 type RoutingAssignment = { member: Member; workType: string | null };
@@ -21,6 +35,17 @@ type TriageHelpers = {
     members: Member[],
     lead: Member
   ) => RoutingAssignment;
+};
+type AssignmentHelpers = {
+  slugify: (value: string) => string;
+  findMemberBySlug: (
+    lines: string[],
+    memberName: string
+  ) => { member: Member | null; ambiguous: boolean };
+};
+type LabelSyncHelpers = {
+  slugify: (value: string) => string;
+  assertUniqueMemberSlugs: (members: Member[]) => void;
 };
 
 function manifestSkillNames(): string[] {
@@ -55,6 +80,42 @@ function triageHelpers(workflow: string): TriageHelpers {
   return context.result;
 }
 
+function assignmentHelpers(workflow: string): AssignmentHelpers {
+  const start = workflow.indexOf('            const slugify =');
+  const end = workflow.indexOf('            // Extract member name from label');
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  const context: { result?: AssignmentHelpers } = {};
+  runInNewContext(
+    `${workflow.slice(start, end)}
+     result = { slugify, findMemberBySlug };`,
+    context
+  );
+  if (!context.result) {
+    throw new Error('Unable to load assignment helpers from workflow');
+  }
+  return context.result;
+}
+
+function labelSyncHelpers(workflow: string): LabelSyncHelpers {
+  const start = workflow.indexOf('            function slugify');
+  const end = workflow.indexOf('            // Ensure the base "squad" triage label exists');
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+
+  const context: { members: Member[]; result?: LabelSyncHelpers } = { members: [] };
+  runInNewContext(
+    `${workflow.slice(start, end)}
+     result = { slugify, assertUniqueMemberSlugs };`,
+    context
+  );
+  if (!context.result) {
+    throw new Error('Unable to load label-sync helpers from workflow');
+  }
+  return context.result;
+}
+
 describe('product and team isolation', () => {
   it('keeps build and template synchronization independent of live .squad state', () => {
     const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
@@ -85,8 +146,15 @@ describe('product and team isolation', () => {
     const isolationCheck = readFileSync('scripts/verify-team-isolation.mjs', 'utf8');
     expect(isolationCheck).toContain("file !== '.squad' && !file.startsWith('.squad/')");
     expect(isolationCheck).toContain('writeSyntheticTeam(syntheticTeamRoot)');
+    expect(isolationCheck).toContain("join(teamDir, 'agents', 'moss-verifier')");
+    expect(isolationCheck).toContain("join(teamDir, 'agents', 'moss-verifier', 'charter.md')");
+    expect(isolationCheck).toMatch(
+      /cpSync\(source, join\(destination, '\.squad'\), \{\s*recursive: true/
+    );
+    expect(isolationCheck).not.toContain("['ls-files', '-z', '--', '.squad']");
     expect(isolationCheck).toContain('Product build or package output changed');
     expect(isolationCheck).toContain("['pack', '--dry-run', '--json', '--ignore-scripts']");
+    expect(isolationCheck).not.toContain("'test/cli-packaging-smoke.test.ts'");
 
     const activationWorkflow = readFileSync('workflows/squad.md', 'utf8');
     expect(activationWorkflow).toMatch(
@@ -95,6 +163,19 @@ describe('product and team isolation', () => {
     expect(activationWorkflow).toContain('"label":"squad:{slugged Agent cell}"');
     expect(activationWorkflow).not.toContain(
       '"label":"squad:{lowercased Agent cell}"'
+    );
+    const phaseLabels = activationWorkflow.match(
+      /\*\*Label set, per issue:\*\*([\s\S]*?)- The triggering intent issue/
+    )?.[1] ?? '';
+    expect(phaseLabels).toContain('emit `squad:{owner-slug}`');
+    expect(phaseLabels).toMatch(/Phase issue:[\s\S]*slugged as above/);
+
+    const labelPreflight = activationWorkflow.match(
+      /##### Label Pre-flight([\s\S]*?)##### Transient Failure Handling/
+    )?.[1] ?? '';
+    expect(labelPreflight).toContain('mint `squad:{agent-slug}`');
+    expect(labelPreflight).toMatch(
+      /replacing each run of\s+non-`a-z0-9` characters with `-`/
     );
 
     const testFiles = filesUnder('test').filter(file => file.endsWith('.ts'));
@@ -149,10 +230,61 @@ describe('product and team isolation', () => {
       const content = readFileSync(file, 'utf8');
       expect(content).toContain('"agent-alpha":');
       expect(content).toContain('"agent-beta":');
-      expect(content).not.toContain('"fenster":');
-      expect(content).not.toContain('"mcmanus":');
+      for (const formerName of ['Fenster', 'Redfoot', 'Keaton', 'McManus']) {
+        expect(content).not.toMatch(new RegExp(`\\b${formerName}\\b`, 'i'));
+      }
+    }
+
+    const activePolicy = readFileSync('.copilot/skills/model-selection/SKILL.md', 'utf8');
+    expect(activePolicy).toContain('Agent Alpha');
+    for (const formerName of ['Fenster', 'Redfoot', 'Keaton', 'McManus']) {
+      expect(activePolicy).not.toMatch(new RegExp(`\\b${formerName}\\b`, 'i'));
     }
   });
+
+  it.each(assignmentWorkflowCopies)(
+    '%s resolves multi-word labels and rejects colliding roster slugs',
+    file => {
+      const helpers = assignmentHelpers(readFileSync(file, 'utf8'));
+      const roster = [
+        '## Members',
+        '| Name | Role |',
+        '| --- | --- |',
+        '| Quartz Navigator | Runtime |',
+      ];
+
+      expect(helpers.slugify('Quartz Navigator')).toBe('quartz-navigator');
+      expect(helpers.findMemberBySlug(roster, 'quartz-navigator')).toEqual({
+        member: { name: 'Quartz Navigator', role: 'Runtime' },
+        ambiguous: false,
+      });
+
+      const collision = [
+        ...roster,
+        '| Foo Bar | Runtime |',
+        '| Foo-Bar | Quality |',
+      ];
+      expect(helpers.findMemberBySlug(collision, 'foo-bar')).toEqual({
+        member: null,
+        ambiguous: true,
+      });
+    }
+  );
+
+  it.each(labelSyncWorkflowCopies)(
+    '%s rejects colliding member-label slugs before synchronization',
+    file => {
+      const helpers = labelSyncHelpers(readFileSync(file, 'utf8'));
+      expect(() => helpers.assertUniqueMemberSlugs([
+        { name: 'Quartz Navigator', role: 'Runtime' },
+        { name: 'Moss Verifier', role: 'Quality' },
+      ])).not.toThrow();
+      expect(() => helpers.assertUniqueMemberSlugs([
+        { name: 'Foo Bar', role: 'Runtime' },
+        { name: 'Foo-Bar', role: 'Quality' },
+      ])).toThrow('Squad member label slug "foo-bar" is ambiguous');
+    }
+  );
 
   it.each(workflowCopies)('%s derives ownership from routing.md instead of role-name heuristics', file => {
     const workflow = readFileSync(file, 'utf8');

--- a/test/recast-identity-neutrality.test.ts
+++ b/test/recast-identity-neutrality.test.ts
@@ -70,6 +70,9 @@ describe('product and team isolation', () => {
 
     expect(packageJson.scripts.prebuild).not.toContain('sync-skill-templates');
     expect(packageJson.scripts.prebuild).not.toContain('sync-templates');
+    expect(packageJson.scripts['verify:team-isolation']).toBe(
+      'node scripts/verify-team-isolation.mjs'
+    );
     for (const input of buildInputs) {
       expect(input).not.toContain("join(rootDir, '.squad',");
       expect(input).not.toContain('.squad/skills');
@@ -77,6 +80,22 @@ describe('product and team isolation', () => {
 
     const ciWorkflow = readFileSync('.github/workflows/squad-ci.yml', 'utf8');
     expect(ciWorkflow).not.toMatch(/SDK_CLI_PATH_REGEX=.*\\\.squad\/agents/);
+    expect(ciWorkflow).toContain('run: npm run verify:team-isolation');
+
+    const isolationCheck = readFileSync('scripts/verify-team-isolation.mjs', 'utf8');
+    expect(isolationCheck).toContain("file !== '.squad' && !file.startsWith('.squad/')");
+    expect(isolationCheck).toContain('writeSyntheticTeam(syntheticTeamRoot)');
+    expect(isolationCheck).toContain('Product build or package output changed');
+    expect(isolationCheck).toContain("['pack', '--dry-run', '--json', '--ignore-scripts']");
+
+    const activationWorkflow = readFileSync('workflows/squad.md', 'utf8');
+    expect(activationWorkflow).toContain(
+      'replace each run of non-`a-z0-9` characters with `-`'
+    );
+    expect(activationWorkflow).toContain('"label":"squad:{slugged Agent cell}"');
+    expect(activationWorkflow).not.toContain(
+      '"label":"squad:{lowercased Agent cell}"'
+    );
 
     const testFiles = filesUnder('test').filter(file => file.endsWith('.ts'));
     for (const file of testFiles) {
@@ -118,6 +137,20 @@ describe('product and team isolation', () => {
           `${root}/${file} drifted from the product-owned canonical template`
         ).toEqual(readFileSync(join(canonicalRoot, file), 'utf8').replace(/\r\n/g, '\n'));
       }
+    }
+
+    const modelSelectionLocations = [
+      '.squad-templates/skills/model-selection/SKILL.md',
+      'templates/skills/model-selection/SKILL.md',
+      'packages/squad-cli/templates/skills/model-selection/SKILL.md',
+      'packages/squad-sdk/templates/skills/model-selection/SKILL.md',
+    ];
+    for (const file of modelSelectionLocations) {
+      const content = readFileSync(file, 'utf8');
+      expect(content).toContain('"agent-alpha":');
+      expect(content).toContain('"agent-beta":');
+      expect(content).not.toContain('"fenster":');
+      expect(content).not.toContain('"mcmanus":');
     }
   });
 

--- a/test/template-extra-classification.test.ts
+++ b/test/template-extra-classification.test.ts
@@ -1,0 +1,38 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SOURCE_DIR = '.squad-templates';
+const AGENT_TEMPLATE = 'squad.agent.md';
+
+const targetExtras = {
+  templates: ['ghost-protocol.md', 'loop.md', 'personal-charter.md'],
+  'packages/squad-cli/templates': ['loop.md'],
+  'packages/squad-sdk/templates': ['schedule.json'],
+} as const;
+
+function filesUnder(directory: string, base = ''): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const relativePath = base ? join(base, entry.name) : entry.name;
+    return entry.isDirectory()
+      ? filesUnder(join(directory, entry.name), relativePath)
+      : [relativePath];
+  });
+}
+
+describe('template destination extras', () => {
+  const canonicalFiles = new Set(
+    filesUnder(SOURCE_DIR).map(file =>
+      file === AGENT_TEMPLATE ? `${AGENT_TEMPLATE}.template` : file
+    ),
+  );
+
+  for (const [target, allowedExtras] of Object.entries(targetExtras)) {
+    it(`${target} contains only classified product-specific extras`, () => {
+      const extras = filesUnder(target)
+        .filter(file => !canonicalFiles.has(file))
+        .sort();
+      expect(extras).toEqual([...allowedExtras].sort());
+    });
+  }
+});

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1691,10 +1691,15 @@ only, omit the owner label, continue, and record the value under
 `Non-roster agent values` (Step 4). Never substitute, re-route, or fall back to
 another identity during acceptance.
 
+For every roster member label, derive the slug exactly as label synchronization
+does: lowercase the certified display name, replace each run of non-`a-z0-9`
+characters with `-`, then trim leading and trailing `-`. The special `@copilot`
+value maps to `squad:copilot` instead.
+
 For each work item, `create-issue`:
 - Title: work item title
 - Temporary ID: `temporary_id` is required on every `create-issue` call (`require-temporary-id: true`). Mint one per item: `#aw_ph{N}` for a phase issue and `#aw_wi{N}` for a work item, where `{N}` is that row's plan number with non-alphanumeric characters replaced by `_`. Must match `^#?aw_[A-Za-z0-9_]{3,12}$` and be unique in this run — gh-aw silently lets a duplicate's last writer own the mapping.
-- Labels: `squad` (color `9B8FCC`), plus `squad:{owner}` (color `9B8FCC`) where `{owner}` is the frozen row `Owner` lowercased. Map `@copilot` to `squad:copilot`; never `squad:@copilot` — `@copilot` is the one permitted non-roster value and it is mapped, not lowercased verbatim. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. An `Owner` certified by neither route gets `squad` alone: omit the owner label, continue, and record the value under `Non-roster agent values` (Step 4). On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster. This computes the label set; `add_labels` applies it (see Fast-Path Label Provisioning) — `create-issue`'s `labels:` field alone cannot land it on a fresh repository.
+- Labels: `squad` (color `9B8FCC`), plus `squad:{owner-slug}` (color `9B8FCC`) where `{owner-slug}` is derived from the frozen row `Owner` by the slug rule above. Map `@copilot` to `squad:copilot`; never `squad:@copilot` — `@copilot` is the one permitted non-roster value and it is mapped, not slugged verbatim. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. An `Owner` certified by neither route gets `squad` alone: omit the owner label, continue, and record the value under `Non-roster agent values` (Step 4). On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster. This computes the label set; `add_labels` applies it (see Fast-Path Label Provisioning) — `create-issue`'s `labels:` field alone cannot land it on a fresh repository.
 - Body: scope, acceptance criteria, context (parent, phase, size, depends on, owner), notes, footer
 - Parent: phase issue (hierarchical) or root (flat). For a phase issue created in this run, pass its `#aw_ph{N}` temporary ID — `create-issue` resolves it. The flat-plan root is the triggering issue's own real number. Never guess a number for an issue this run created.
 - Size: set Project field if available, else body `**Size:**` line
@@ -1736,8 +1741,8 @@ supported order.
 
 **Label set, per issue:**
 
-- Work item: `squad`, plus `squad:{owner}` derived from that row's own frozen
-  certified `Owner`, lowercased. `@copilot` maps to the existing `squad:copilot`
+- Work item: `squad`, plus `squad:{owner-slug}` derived from that row's own frozen
+  certified `Owner` by the slug rule above. `@copilot` maps to the existing `squad:copilot`
   routing label — never `squad:@copilot`. Re-read each row's frozen `Owner`; never
   inherit the phase issue's owner or carry the previous row's value forward.
 - Phase issue: `squad`, plus `squad:{owner}` only when every accepted row in that
@@ -2388,7 +2393,7 @@ Root → Epics → Tasks. Phase-specific: filter to matching phase heading.
 **2b. Create Epic Issues:** `create-issue` per epic (dedup by title `[Epic] {name}` if already exists from prior phase).
 - Title: `[Epic] {name}`
 - Temporary ID: `temporary_id: "#aw_epic{K}"` per the Temporary-ID Contract. Required — the call is rejected without it.
-- Labels: `squad` (0075ca), `squad:{agent}` (e4e669) where `{agent}` is **derived from this epic's own tasks**: collect the `Agent` values of every implementation-plan row whose `Epic` cell names this epic. Exactly one distinct roster value → mint `squad:{that agent}`; exactly `@copilot` → mint `squad:copilot`. Two or more → multi-owner epic: apply only `squad` and record it under `Non-roster agent values`. Never mint a single agent label for a multi-owner epic, and never choose one of several.
+- Labels: `squad` (0075ca), `squad:{agent-slug}` (e4e669) where `{agent-slug}` is **derived from this epic's own tasks**: collect the `Agent` values of every implementation-plan row whose `Epic` cell names this epic. Exactly one distinct roster value → mint its label using the lowercase/non-alphanumeric/hyphen slug rule above; exactly `@copilot` → mint `squad:copilot`. Two or more → multi-owner epic: apply only `squad` and record it under `Non-roster agent values`. Never mint a single agent label for a multi-owner epic, and never choose one of several.
 - Body: outcome, stories, epic-level acceptance criteria, context (parent, initiative, milestone, deps)
 - Parent: sub-issue of root intent issue — the triggering issue's own real number, which is known independently of this run's creations
 - Milestone: assigned
@@ -2404,7 +2409,7 @@ Root → Epics → Tasks. Phase-specific: filter to matching phase heading.
 
 - Title: task title
 - Temporary ID: `temporary_id: "#aw_task{N}"` per the Temporary-ID Contract. Required, and unique across every epic and task in this run.
-- Labels: `squad` (0075ca), `squad:{agent}` (e4e669) where `{agent}` is **this task's own `Agent` cell**, lowercased — read from the implementation-plan row whose `#` matches this task. Map `@copilot` to `squad:copilot`. Never inherit the parent epic's agent, and never carry the previous task's value forward: re-read the `Agent` cell for every task, because consecutive tasks under one epic routinely have different agents. No `size:*` labels unless policy says so.
+- Labels: `squad` (0075ca), `squad:{agent-slug}` (e4e669) where `{agent-slug}` is derived from **this task's own `Agent` cell** using the same lowercase/non-alphanumeric/hyphen slug rule as label synchronization — read from the implementation-plan row whose `#` matches this task. Map `@copilot` to `squad:copilot`. Never inherit the parent epic's agent, and never carry the previous task's value forward: re-read the `Agent` cell for every task, because consecutive tasks under one epic routinely have different agents. No `size:*` labels unless policy says so.
 - Body: one sentence describing scope; 1-2 acceptance criteria; one compact context line (parent epic, size, deps)
 - Parent: sub-issue of EPIC (not root). If 2b minted this epic in this run, pass its `#aw_epic{K}` temporary ID, which `create-issue`'s `parent` field accepts. If 2b instead matched a pre-existing epic by title, that epic has no temporary ID in this run — pass its verified real number. Never guess the epic's real number, and never pass a temporary ID that was not minted this run.
 - Milestone: same as parent epic
@@ -2445,7 +2450,7 @@ Phase artifact: `data: {"squad_artifact":"phases-activated","schema_version":"1"
 
 Every phase and full activation artifact body MUST include an `Activation bindings:` fenced JSON block containing a non-empty array built only from accepted activation operations. Emit one object per created/recognized task:
 
-`{"task":"{plan # cell}","issue":"{task issue reference}","epic":"{Epic cell}","epic_issue":"{epic issue reference}","agent":"{raw Agent cell}","epic_agents":["{all distinct lowercased Agent cells for this epic across the full accepted plan}"],"label":"squad:{lowercased Agent cell}","epic_label":"squad:{sole lowercased epic task agent}"}`. For `@copilot`, use `squad:copilot`. Every binding for one epic MUST carry the same complete `epic_agents` set, including agents assigned in other activation phases.
+`{"task":"{plan # cell}","issue":"{task issue reference}","epic":"{Epic cell}","epic_issue":"{epic issue reference}","agent":"{raw Agent cell}","epic_agents":["{all distinct lowercased Agent cells for this epic across the full accepted plan}"],"label":"squad:{slugged Agent cell}","epic_label":"squad:{slugged sole epic task agent}"}`. Slug both label fields with the lowercase/non-alphanumeric/hyphen rule used by label synchronization. For `@copilot`, use `squad:copilot`. Every binding for one epic MUST carry the same complete `epic_agents` set, including agents assigned in other activation phases.
 
 ###### Issue references in bindings — quoted, never bare
 

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1745,9 +1745,10 @@ supported order.
   certified `Owner` by the slug rule above. `@copilot` maps to the existing `squad:copilot`
   routing label — never `squad:@copilot`. Re-read each row's frozen `Owner`; never
   inherit the phase issue's owner or carry the previous row's value forward.
-- Phase issue: `squad`, plus `squad:{owner}` only when every accepted row in that
-  phase names one and the same owner. Two or more distinct owners is a multi-owner
-  phase: apply only `squad`, choose none of them, and record it under a
+- Phase issue: `squad`, plus `squad:{owner-slug}` only when every accepted row in
+  that phase names one and the same owner; derive the slug with the rule above.
+  Two or more distinct owners is a multi-owner phase: apply only `squad`, choose
+  none of them, and record it under a
   `Non-roster agent values` heading in the Step 4 summary.
 - The triggering intent issue is never an `add_labels` target. It is the flat-plan
   parent, not an activated item, and receives no owner label from this run.
@@ -1809,7 +1810,7 @@ and `phases-activated`.
 ###### Label operations accepted
 
 Identical semantics to `squad-plan-activate` Step 4. A label reaches an activated issue through exactly one route:
-an accepted `add_labels` operation targeting that issue. Report `squad:{owner}` only when
+an accepted `add_labels` operation targeting that issue. Report `squad:{owner-slug}` only when
 this run made an `add_labels` call carrying that label and targeting that same issue — by
 its own `temporary_id`, or by its verified real number for a reused issue. A successful
 `create-issue` is **not** evidence: its `labels:` field cannot land a label on a fresh

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -2338,8 +2338,10 @@ Step 2e, not the cap machinery, is what notices.
    value `@copilot` maps to the existing `squad:copilot` routing label — never
    `squad:@copilot`.
 5. A value matching no certified name and not `@copilot` MUST NOT become a
-   `squad:{agent-slug}` label: apply only `squad` for that issue and record the value under a
+   `squad:{agent}` label: apply only `squad` for that issue and record the value under a
    `Non-roster agent values` heading, naming the certified set it should come from.
+   Here `{agent}` denotes the rejected raw binding; certified emitted labels always use
+   the `{agent-slug}` derivation from Step 4.
 6. Completeness: when the plan names at least one roster `Agent`, at least one
    `squad:{agent-slug}` label MUST be applied across the created issues. Zero labels on a
    plan with roster owners is a binding failure, not a pass — report it, don't proceed

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1699,7 +1699,7 @@ value maps to `squad:copilot` instead.
 For each work item, `create-issue`:
 - Title: work item title
 - Temporary ID: `temporary_id` is required on every `create-issue` call (`require-temporary-id: true`). Mint one per item: `#aw_ph{N}` for a phase issue and `#aw_wi{N}` for a work item, where `{N}` is that row's plan number with non-alphanumeric characters replaced by `_`. Must match `^#?aw_[A-Za-z0-9_]{3,12}$` and be unique in this run — gh-aw silently lets a duplicate's last writer own the mapping.
-- Labels: `squad` (color `9B8FCC`), plus `squad:{owner-slug}` (color `9B8FCC`) where `{owner-slug}` is derived from the frozen row `Owner` by the slug rule above. Map `@copilot` to `squad:copilot`; never `squad:@copilot` — `@copilot` is the one permitted non-roster value and it is mapped, not slugged verbatim. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. An `Owner` certified by neither route gets `squad` alone: omit the owner label, continue, and record the value under `Non-roster agent values` (Step 4). On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster. This computes the label set; `add_labels` applies it (see Fast-Path Label Provisioning) — `create-issue`'s `labels:` field alone cannot land it on a fresh repository.
+- Labels: `squad` (color `9B8FCC`), plus `squad:{owner-slug}` (color `9B8FCC`) where `{owner-slug}` is derived from the frozen row `Owner` lowercased first, then normalized by the slug rule above. Map `@copilot` to `squad:copilot`; never `squad:@copilot` — `@copilot` is the one permitted non-roster value and it is mapped, not slugged verbatim. Mint the member label only from that task's certified binding; never re-read team.md, re-route the task, or carry another row's owner forward. An `Owner` certified by neither route gets `squad` alone: omit the owner label, continue, and record the value under `Non-roster agent values` (Step 4). On `ROSTER_UNREADABLE:`, stop and report that reason; never mint from a preset or remembered roster. This computes the label set; `add_labels` applies it (see Fast-Path Label Provisioning) — `create-issue`'s `labels:` field alone cannot land it on a fresh repository.
 - Body: scope, acceptance criteria, context (parent, phase, size, depends on, owner), notes, footer
 - Parent: phase issue (hierarchical) or root (flat). For a phase issue created in this run, pass its `#aw_ph{N}` temporary ID — `create-issue` resolves it. The flat-plan root is the triggering issue's own real number. Never guess a number for an issue this run created.
 - Size: set Project field if available, else body `**Size:**` line
@@ -1741,12 +1741,14 @@ supported order.
 
 **Label set, per issue:**
 
-- Work item: `squad`, plus `squad:{owner-slug}` derived from that row's own frozen
-  certified `Owner` by the slug rule above. `@copilot` maps to the existing `squad:copilot`
+- Work item: `squad`, plus `squad:{owner}` conceptually, where the emitted label is
+  `squad:{owner-slug}` derived from that row's own frozen certified `Owner`, lowercased
+  first and then normalized by the slug rule above. `@copilot` maps to the existing `squad:copilot`
   routing label — never `squad:@copilot`. Re-read each row's frozen `Owner`; never
   inherit the phase issue's owner or carry the previous row's value forward.
-- Phase issue: `squad`, plus `squad:{owner-slug}` only when every accepted row in
-  that phase names one and the same owner; derive the slug with the rule above.
+- Phase issue: `squad`, plus `squad:{owner}` conceptually, where the emitted label is
+  `squad:{owner-slug}` only when every accepted row in that phase names one and the
+  same owner; derive the slug with the rule above.
   Two or more distinct owners is a multi-owner phase: apply only `squad`, choose
   none of them, and record it under a
   `Non-roster agent values` heading in the Step 4 summary.
@@ -2322,22 +2324,24 @@ Step 2e, not the cap machinery, is what notices.
 **Roster binding gate — run this before any `create-issue` call.**
 
 1. Run Team Guard Step TG-2; its `ROSTER_MEMBER:` lines are the **certified roster
-   set** — the only valid source for a `squad:{agent}` label this run. Do not re-read
+   set** — the only valid source for a `squad:{agent-slug}` label this run. Do not re-read
    team.md or recall a name.
 2. If TG-2 emitted a `ROSTER_UNREADABLE:` line, STOP: report that named reason in the
-   activation summary and mint no `squad:{agent}` label. Never print a roster-provenance
+   activation summary and mint no `squad:{agent-slug}` label. Never print a roster-provenance
    sentence for a read that did not happen, and never fall back to a preset or
    remembered roster.
 3. Reproduce the certified `ROSTER_MEMBER:` lines verbatim in the summary as the
    provenance of the labels applied — the summary may name only values TG-2 emitted.
-4. For every `Agent` value, mint `squad:{agent}` only when its lowercased form matches
-   a certified `ROSTER_MEMBER:` name. The special value `@copilot` maps to the
-   existing `squad:copilot` routing label — never `squad:@copilot`.
+4. For every `Agent` value, certify its lowercased raw value against a
+   `ROSTER_MEMBER:` name, then mint `squad:{agent-slug}` by replacing each run of
+   non-`a-z0-9` characters with `-` and trimming leading and trailing `-`. The special
+   value `@copilot` maps to the existing `squad:copilot` routing label — never
+   `squad:@copilot`.
 5. A value matching no certified name and not `@copilot` MUST NOT become a
-   `squad:{agent}` label: apply only `squad` for that issue and record the value under a
+   `squad:{agent-slug}` label: apply only `squad` for that issue and record the value under a
    `Non-roster agent values` heading, naming the certified set it should come from.
 6. Completeness: when the plan names at least one roster `Agent`, at least one
-   `squad:{agent}` label MUST be applied across the created issues. Zero labels on a
+   `squad:{agent-slug}` label MUST be applied across the created issues. Zero labels on a
    plan with roster owners is a binding failure, not a pass — report it, don't proceed
    silently.
 7. **Correspondence — the label must match *this* issue's own row.** Steps 4-6 certify the
@@ -2347,7 +2351,7 @@ Step 2e, not the cap machinery, is what notices.
    `Agent` cell, an epic's derived task-set — and never from the row above it, the parent
    epic, or the previous call. Verify per issue; membership across the run is not evidence.
 8. **Report what was accepted, not what was intended.** The activation summary may name a
-   `squad:{agent}` label for an issue only after an `add_labels` call carrying that label
+   `squad:{agent-slug}` label for an issue only after an `add_labels` call carrying that label
    was accepted for that same issue — targeted by its own `temporary_id`, or by its verified
    real number for a reused issue. A successful `create-issue` is **not** evidence: its
    `labels:` field cannot land a label on a fresh repository, so a label is never "carried
@@ -2359,7 +2363,7 @@ Step 2e, not the cap machinery, is what notices.
    not happen. See Step 4's Label operations accepted section for the full contract.
 
 **Label provisioning.** The `add-labels` safe output (`allowed: [squad, "squad:*"]`,
-`create-if-missing: true`) auto-creates `squad` and any `squad:{agent}` label the first
+`create-if-missing: true`) auto-creates `squad` and any `squad:{agent-slug}` label the first
 time this run needs it — a fresh repository with zero Squad labels requires no manual
 provisioning and is never a prerequisite gap. `create-issue`'s own `labels:` field cannot
 do this: GitHub silently drops label names that do not already exist in the target
@@ -2369,7 +2373,7 @@ to land a label on a fresh repository.
 
 In the same turn as each `create-issue` call in Steps 2b/2c, call `add_labels` with
 `item_number` set to that call's `temporary_id` and exactly the label set Steps 4-8 computed
-for that issue — `squad` alone, or `squad` plus the one `squad:{agent}` label the
+for that issue — `squad` alone, or `squad` plus the one `squad:{agent-slug}` label the
 correspondence rule (Step 7) certified. Do not wait for a returned issue number; none
 arrives. gh-aw resolves `add_labels` after the `create-issue` that minted the ID, so that
 order is the supported one. `create-if-missing` creates any label that does not yet exist

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1741,14 +1741,12 @@ supported order.
 
 **Label set, per issue:**
 
-- Work item: `squad`, plus `squad:{owner}` conceptually, where the emitted label is
-  `squad:{owner-slug}` derived from that row's own frozen certified `Owner`, lowercased
-  first and then normalized by the slug rule above. `@copilot` maps to the existing `squad:copilot`
-  routing label — never `squad:@copilot`. Re-read each row's frozen `Owner`; never
-  inherit the phase issue's owner or carry the previous row's value forward.
-- Phase issue: `squad`, plus `squad:{owner}` conceptually, where the emitted label is
-  `squad:{owner-slug}` only when every accepted row in that phase names one and the
-  same owner; derive the slug with the rule above.
+- Work item: `squad`, plus `squad:{owner}` conceptually; emit `squad:{owner-slug}`,
+  derived from that row's own frozen certified `Owner`, lowercased then slugged as above.
+  `@copilot` maps to `squad:copilot`, never `squad:@copilot`. Never inherit the phase
+  issue's owner or carry the previous row's value forward.
+- Phase issue: `squad`, plus `squad:{owner}` conceptually; emit `squad:{owner-slug}`
+  only when every accepted row names the same owner, slugged as above.
   Two or more distinct owners is a multi-owner phase: apply only `squad`, choose
   none of them, and record it under a
   `Non-roster agent values` heading in the Step 4 summary.
@@ -2340,8 +2338,7 @@ Step 2e, not the cap machinery, is what notices.
 5. A value matching no certified name and not `@copilot` MUST NOT become a
    `squad:{agent}` label: apply only `squad` for that issue and record the value under a
    `Non-roster agent values` heading, naming the certified set it should come from.
-   Here `{agent}` denotes the rejected raw binding; certified emitted labels always use
-   the `{agent-slug}` derivation from Step 4.
+   `{agent}` is the rejected raw value; emitted labels use `{agent-slug}`.
 6. Completeness: when the plan names at least one roster `Agent`, at least one
    `squad:{agent-slug}` label MUST be applied across the created issues. Zero labels on a
    plan with roster owners is a binding failure, not a pass — report it, don't proceed

--- a/workflows/squad.md
+++ b/workflows/squad.md
@@ -1743,10 +1743,10 @@ supported order.
 
 - Work item: `squad`, plus `squad:{owner}` conceptually; emit `squad:{owner-slug}`,
   derived from that row's own frozen certified `Owner`, lowercased then slugged as above.
-  `@copilot` maps to `squad:copilot`, never `squad:@copilot`. Never inherit the phase
-  issue's owner or carry the previous row's value forward.
+  `@copilot` maps to the existing `squad:copilot` routing label — never `squad:@copilot`.
+  Never inherit the phase issue's owner or carry the previous row's value forward.
 - Phase issue: `squad`, plus `squad:{owner}` conceptually; emit `squad:{owner-slug}`
-  only when every accepted row names the same owner, slugged as above.
+  only when every accepted row in that phase names one and the same owner, slugged as above.
   Two or more distinct owners is a multi-owner phase: apply only `squad`, choose
   none of them, and record it under a
   `Non-roster agent values` heading in the Step 4 summary.


### PR DESCRIPTION
## Summary

- add a CI-enforced three-scenario build/package comparison with `.squad/**` absent, synthetic, and live
- make multi-word member labels use one slug contract across activation, assignment, and binding validation
- classify intentional destination-only templates so stale package assets fail tests
- remove dogfood cast identities from reusable policy and model-selection examples

## Validation

- static Node syntax checks and `git diff --check` pass locally
- local dependency restore was attempted only after configuring the required proxy; the proxy lacks `eslint@10.10.0`, and direct npm access is blocked, so the locked build/test suite is delegated to GitHub CI

The live `.squad/**` tree is unchanged.